### PR TITLE
Fix NRE for programmetype on update endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/DataStore/Crm/DataverseAdapter.UpdateTeacher.cs
@@ -41,7 +41,7 @@ public partial class DataverseAdapter
             return (UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.AlreadyHaveQtsDate), null);
         }
 
-        if (itt != null && itt.dfeta_ProgrammeType.Value.IsEarlyYears() != command.InitialTeacherTraining.ProgrammeType.IsEarlyYears())
+        if (itt != null && itt.dfeta_ProgrammeType?.IsEarlyYears() != command.InitialTeacherTraining.ProgrammeType.IsEarlyYears())
         {
             return (UpdateTeacherResult.Failed(UpdateTeacherFailedReasons.CannotChangeProgrammeType), null);
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.Designer.cs
@@ -268,7 +268,7 @@ namespace TeachingRecordSystem.Api.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ProgrammeType cannot be change.
+        ///   Looks up a localized string similar to ProgrammeType cannot be changed.
         /// </summary>
         public static string Errors_10011_Title {
             get {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.resx
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.resx
@@ -187,7 +187,7 @@
     <value>Country not found</value>
   </data>
   <data name="Errors.10011.Title" xml:space="preserve">
-    <value>ProgrammeType cannot be change</value>
+    <value>ProgrammeType cannot be changed</value>
   </data>
   <data name="Errors.10012.Title" xml:space="preserve">
     <value>ITT qualification not found</value>


### PR DESCRIPTION
### Context

ITT records that do not have a programme type causes a NRE. This PR fixes it.

### Changes proposed in this pull request

- stop NRE
- Fixed StringResources typo.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
