### PR TITLE
Migrate Core.Tests project to new TestFramework

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: extractions/setup-just@v1
+
     - uses: Azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -81,8 +83,7 @@ jobs:
         secrets: INTEGRATION-TEST-CONFIG
 
     - name: Install tools
-      run: |
-        dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json >/dev/null
+      run: just install-tools
 
     - name: Create test reporting database
       run: docker exec $(docker ps --latest --quiet) /opt/mssql-tools/bin/sqlcmd -U "sa" -P "$MSSQL_PASSWORD" -Q "create database $MSSQL_DB; alter database $MSSQL_DB set ALLOW_SNAPSHOT_ISOLATION on;"
@@ -104,7 +105,7 @@ jobs:
         INCLUDE_ARG="--include $(echo "$CHANGED_FILES" | tr '\n' ' ')"
         echo "::notice::Linting changed files only"
 
-        dotnet-format --no-restore --verify-no-changes $INCLUDE_ARG
+        dotnet format --no-restore --verify-no-changes $INCLUDE_ARG
       working-directory: TeachingRecordSystem
 
     - name: Build
@@ -126,13 +127,8 @@ jobs:
       shell: bash
 
     - name: Core Tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests
-        report_name: "Core test results"
-        dotnet_test_args: >-
-          --no-build
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=qtapi;Database=qtapi"
+      run: dotnet fixie --configuration Release --no-build
+      working-directory: TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests
 
     - name: API Tests
       uses: ./.github/workflows/actions/test

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ If you're working on infrastructure you will also need:
 - Terraform;
 - bash.
 
+### Local tools setup
+
+dotnet-format and fixie are required for linting and running tests, respectively. A `just` recipe will install them:
+```shell
+just install-tools
+```
+
 ### Database setup
 
 Install Postgres then set a connection string configuration entry in user secrets for both the `TeachingRecordSystem.Api` and `TeachingRecordSystem.Api.Tests` projects.

--- a/TeachingRecordSystem/.config/dotnet-tools.json
+++ b/TeachingRecordSystem/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fixie.console": {
+      "version": "3.3.0",
+      "commands": [
+        "fixie"
+      ]
+    },
+    "dotnet-format": {
+      "version": "7.4.431902",
+      "commands": [
+        "dotnet-format"
+      ]
+    }
+  }
+}

--- a/TeachingRecordSystem/TeachingRecordSystem.sln
+++ b/TeachingRecordSystem/TeachingRecordSystem.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{725CB1F7-790A-4659-AC2F-38051CC34685}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
+		nuget.config = nuget.config
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TeachingRecordSystem.TestCommon", "tests\TeachingRecordSystem.TestCommon\TeachingRecordSystem.TestCommon.csproj", "{DFE6654C-3222-4B20-A871-79581928D3B2}"

--- a/TeachingRecordSystem/nuget.config
+++ b/TeachingRecordSystem/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Certificates/CertificateGeneratorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Certificates/CertificateGeneratorTests.cs
@@ -6,9 +6,10 @@ using TeachingRecordSystem.Core.Services.Certificates;
 
 namespace TeachingRecordSystem.Core.Tests.Services.Certificates;
 
+[TestClass]
 public class CertificateGeneratorTests
 {
-    [Fact]
+    [Test]
     public async Task GenerateCertificate_GetsTemplateFromBlobStorageAndSetFieldValuesAsExpected()
     {
         // Arrange

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TeachingRecordSystem.Core.Tests.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TeachingRecordSystem.Core.Tests.csproj
@@ -14,21 +14,14 @@
 
   <ItemGroup>
     <PackageReference Include="Faker.Net" Version="2.0.154" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Fixie.TestAdapter" Version="3.3.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.assert" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\TeachingRecordSystem.Core\TeachingRecordSystem.Core.csproj" />
+    <ProjectReference Include="..\TeachingRecordSystem.TestFramework\TeachingRecordSystem.TestFramework.csproj" />
   </ItemGroup>
 
 </Project>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TestProject.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TestProject.cs
@@ -1,0 +1,11 @@
+﻿using Fixie;
+
+namespace TeachingRecordSystem.Core.Tests;
+
+public class TestProject : ITestProject
+{
+    public void Configure(TestConfiguration configuration, TestEnvironment environment)
+    {
+        configuration.AddTrsTestFrameworkConventions(environment);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TestStartup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TestStartup.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TeachingRecordSystem.Core.Tests;
+
+public class TestStartup : ITestStartup
+{
+    public void ConfigureConfiguration(IConfigurationBuilder builder)
+    {
+    }
+
+    public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Usings.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Usings.cs
@@ -1,2 +1,3 @@
 global using Moq;
+global using TeachingRecordSystem.TestFramework;
 global using Xunit;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestFramework/GitHubReport.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestFramework/GitHubReport.cs
@@ -1,0 +1,63 @@
+﻿using Fixie;
+using Fixie.Reports;
+using static System.Environment;
+
+namespace TeachingRecordSystem.TestFramework;
+
+internal class GitHubReport : IReport, IHandler<ExecutionStarted>, IHandler<ExecutionCompleted>
+{
+    private readonly TestEnvironment _environment;
+
+    public GitHubReport(TestEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public async Task Handle(ExecutionStarted message)
+    {
+        var assembly = Path.GetFileNameWithoutExtension(_environment.Assembly.Location);
+
+        await AppendToJobSummary($"## {assembly}{NewLine}{NewLine}");
+    }
+
+    public async Task Handle(ExecutionCompleted message)
+    {
+        string detail;
+
+        if (message.Total == 0)
+        {
+            detail = "No tests found.";
+        }
+        else
+        {
+            var parts = new List<string>();
+
+            if (message.Passed > 0)
+            {
+                parts.Add($"{message.Passed} passed");
+            }
+
+            if (message.Skipped > 0)
+            {
+                parts.Add($"{message.Skipped} skipped");
+            }
+
+            if (message.Failed > 0)
+            {
+                parts.Add($"{message.Failed} failed");
+            }
+
+            detail = string.Join(", ", parts);
+        }
+
+        await AppendToJobSummary($"{detail}{NewLine}{NewLine}");
+    }
+
+    private static async Task AppendToJobSummary(string summary)
+    {
+        if (GetEnvironmentVariable("GITHUB_STEP_SUMMARY") is string summaryFile)
+        {
+            await File.AppendAllTextAsync(summaryFile, summary);
+        }
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestFramework/TestConfigurationExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestFramework/TestConfigurationExtensions.cs
@@ -4,11 +4,16 @@ namespace TeachingRecordSystem.TestFramework;
 
 public static class TestConfigurationExtensions
 {
-    public static void AddTrsTestFrameworkConventions(this TestConfiguration testConfiguration, TestEnvironment environment)
+    public static void AddTrsTestFrameworkConventions(this TestConfiguration configuration, TestEnvironment environment)
     {
         var discovery = new Discovery();
         var execution = new Execution(environment);
 
-        testConfiguration.Conventions.Add(discovery, execution);
+        configuration.Conventions.Add(discovery, execution);
+
+        if (environment.IsContinuousIntegration())
+        {
+            configuration.Reports.Add(new GitHubReport(environment));
+        }
     }
 }

--- a/justfile
+++ b/justfile
@@ -5,6 +5,10 @@ solution-root := "TeachingRecordSystem"
 default:
   @just --list
 
+# Install .NET local tools
+install-tools:
+  @cd {{solution-root}} && dotnet tool restore
+
 # Run the trscli
 cli *ARGS:
   @cd {{solution-root / "src" / "TeachingRecordSystem.Cli"}} && dotnet {{"bin" / "Release" / "net7.0" / "trscli.dll"}} {{ARGS}}
@@ -15,6 +19,7 @@ build:
 
 # Test the .NET solution
 test:
+  @cd {{solution-root / "tests" / "TeachingRecordSystem.Core.Tests"}} && dotnet fixie
   @cd {{solution-root}} && dotnet test
 
 # Format the .NET solution and Terraform code


### PR DESCRIPTION
Also adds fixie and dotnet-format to a tool manifest and adds a just recipe to install them.