### PR TITLE
Add Email to v3 Teacher responses

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -35,7 +35,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 Contact.Fields.BirthDate,
                 Contact.Fields.dfeta_NINumber,
                 Contact.Fields.dfeta_QTSDate,
-                Contact.Fields.dfeta_EYTSDate
+                Contact.Fields.dfeta_EYTSDate,
+                Contact.Fields.EMailAddress1
             });
 
         if (teacher is null)
@@ -224,6 +225,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             PendingDateOfBirthChange = request.Include.HasFlag(GetTeacherRequestIncludes.PendingDetailChanges) ? Option.Some(pendingDateOfBirthChange) : default,
             Qts = MapQts(teacher.dfeta_QTSDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), qtsAwardedInWales, request.AccessMode),
             Eyts = MapEyts(teacher.dfeta_EYTSDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), request.AccessMode),
+            Email = teacher.EMailAddress1,
             Induction = request.Include.HasFlag(GetTeacherRequestIncludes.Induction) ?
                 Option.Some(MapInduction(induction!, inductionPeriods!, request.AccessMode)) :
                 default,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
@@ -14,6 +14,7 @@ public record GetTeacherResponse
     public required string? NationalInsuranceNumber { get; init; }
     public required Option<bool> PendingNameChange { get; init; }
     public required Option<bool> PendingDateOfBirthChange { get; init; }
+    public required string? Email { get; set; }
     public required GetTeacherResponseQts? Qts { get; init; }
     public required GetTeacherResponseEyts? Eyts { get; init; }
     public required Option<GetTeacherResponseInduction?> Induction { get; init; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -69,7 +69,8 @@ public abstract class GetTeacherTestBase : ApiTestBase
             {
                 awarded = contact.dfeta_EYTSDate?.ToString("yyyy-MM-dd"),
                 certificateUrl = "/v3/certificates/eyts"
-            }
+            },
+            email = contact.EMailAddress1
         })!;
 
         if (!expectQtsCertificateUrl)
@@ -122,7 +123,8 @@ public abstract class GetTeacherTestBase : ApiTestBase
             {
                 awarded = contact.dfeta_EYTSDate?.ToString("yyyy-MM-dd"),
                 certificateUrl = "/v3/certificates/eyts"
-            }
+            },
+            email = contact.EMailAddress1
         })!;
 
         if (!expectCertificateUrls)
@@ -654,6 +656,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
         var middleName = Faker.Name.Middle();
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var nino = Faker.Identification.UkNationalInsuranceNumber();
+        var email = Faker.Internet.Email();
 
         var qtsDate = new DateOnly(1997, 4, 23);
         var eytsDate = new DateOnly(1995, 5, 14);
@@ -671,7 +674,8 @@ public abstract class GetTeacherTestBase : ApiTestBase
             BirthDate = dateOfBirth.ToDateTime(),
             dfeta_NINumber = nino,
             dfeta_QTSDate = qtsDate.ToDateTime(),
-            dfeta_EYTSDate = eytsDate.ToDateTime()
+            dfeta_EYTSDate = eytsDate.ToDateTime(),
+            EMailAddress1 = email
         };
 
         return teacher;


### PR DESCRIPTION
The ID support console needs to display the DQT email before a TRN is assigned. This adds an `Email` property to the response object.