### PR TITLE
Fix up environment deployment concurrency

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -17,6 +17,7 @@ on:
         value: ${{ jobs.deploy.outputs.api_url }}
   workflow_dispatch:
 
+concurrency: deploy_preprod
 jobs:
   package:
     name: Package application
@@ -29,7 +30,6 @@ jobs:
     needs: package
     if: always() && (needs.package.result == 'success' || needs.package.result == 'skipped')
     runs-on: ubuntu-latest
-    concurrency: deploy_preprod
 
     outputs:
       api_url: ${{ steps.deploy.outputs.api_url }}
@@ -51,6 +51,8 @@ jobs:
 
   deploy_aks:
     name: Deploy to AKS
+    needs: package
+    if: always() && (needs.package.result == 'success' || needs.package.result == 'skipped')
     runs-on: ubuntu-latest
 
     environment:
@@ -63,7 +65,7 @@ jobs:
       id: deploy
       with:
         environment_name: pre-production
-        api_docker_image: ${{ inputs.api_docker_image }}
-        cli_docker_image: ${{ inputs.cli_docker_image }}
-        ui_docker_image: ${{ inputs.ui_docker_image }}
+        api_docker_image: ${{ inputs.api_docker_image || needs.package.outputs.api_docker_image }}
+        cli_docker_image: ${{ inputs.cli_docker_image || needs.package.outputs.cli_docker_image }}
+        ui_docker_image: ${{ inputs.ui_docker_image || needs.package.outputs.ui_docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,11 +16,11 @@ on:
       api_url:
         value: ${{ jobs.deploy.outputs.api_url }}
 
+concurrency: deploy_prod
 jobs:
   deploy:
     name: Deploy to PAAS
     runs-on: ubuntu-latest
-    concurrency: deploy_prod
 
     outputs:
       api_url: ${{ steps.deploy.outputs.api_url }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -16,11 +16,11 @@ on:
       api_url:
         value: ${{ jobs.deploy.outputs.api_url }}
 
+concurrency: deploy_test
 jobs:
   deploy:
     name: Deploy to PAAS
     runs-on: ubuntu-latest
-    concurrency: deploy_test
 
     outputs:
       api_url: ${{ steps.deploy.outputs.api_url }}


### PR DESCRIPTION
The `concurrency` elements for test, pre-prod and prod weren't moved up to the workflow level when we added AKS environments, this fixes that.

In addition, adds the `package` dependency for the pre-prod AKS deployment so that manual workflow runs work correctly.