### PR TITLE
Use paged queries for batch jobs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.GetEytsAwardeesForDateRange.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.GetEytsAwardeesForDateRange.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Xrm.Sdk.Query;
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
 
 namespace TeachingRecordSystem.Dqt;
 
 public partial class DataverseAdapter
 {
-    public async Task<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate)
+    public async IAsyncEnumerable<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate)
     {
         var filter = new FilterExpression(LogicalOperator.And);
         filter.AddCondition(dfeta_businesseventaudit.Fields.CreatedOn, ConditionOperator.GreaterEqual, startDate);
@@ -21,18 +22,37 @@ public partial class DataverseAdapter
                 dfeta_businesseventaudit.Fields.dfeta_NewValue,
                 dfeta_businesseventaudit.Fields.dfeta_OldValue,
                 dfeta_businesseventaudit.Fields.dfeta_Person),
-            Criteria = filter
+            Criteria = filter,
+            Orders =
+            {
+                new OrderExpression(dfeta_businesseventaudit.Fields.CreatedOn, OrderType.Ascending)
+            },
+            PageInfo = new()
+            {
+                PageNumber = 1,
+                Count = 500
+            }
         };
 
         AddContactLink(query);
 
-        var result = await _service.RetrieveMultipleAsync(query);
-        return result.Entities
-            .Select(e => e.ToEntity<dfeta_businesseventaudit>())
-            .Select(e => e.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute))
-            .GroupBy(c => c.ContactId)
-            .Select(g => MapContactToEytsAwardee(g.First()))
-            .ToArray();
+        EntityCollection response;
+
+        do
+        {
+            response = await _service.RetrieveMultipleAsync(query);
+
+            yield return response.Entities
+                .Select(e => e.ToEntity<dfeta_businesseventaudit>())
+                .Select(e => e.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute))
+                .GroupBy(c => c.ContactId)
+                .Select(g => MapContactToEytsAwardee(g.First()))
+                .ToArray();
+
+            query.PageInfo.PageNumber++;
+            query.PageInfo.PagingCookie = response.PagingCookie;
+        }
+        while (response.MoreRecords);
 
         static void AddContactLink(QueryExpression query)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.GetInductionCompleteesForDateRange.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.GetInductionCompleteesForDateRange.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Xrm.Sdk.Query;
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
 
 namespace TeachingRecordSystem.Dqt;
 
 public partial class DataverseAdapter
 {
-    public async Task<InductionCompletee[]> GetInductionCompleteesForDateRange(DateTime startDate, DateTime endDate)
+    public async IAsyncEnumerable<InductionCompletee[]> GetInductionCompleteesForDateRange(DateTime startDate, DateTime endDate)
     {
         var filter = new FilterExpression(LogicalOperator.And);
         filter.AddCondition(dfeta_businesseventaudit.Fields.CreatedOn, ConditionOperator.GreaterEqual, startDate);
@@ -21,18 +22,37 @@ public partial class DataverseAdapter
                 dfeta_businesseventaudit.Fields.dfeta_NewValue,
                 dfeta_businesseventaudit.Fields.dfeta_OldValue,
                 dfeta_businesseventaudit.Fields.dfeta_Person),
-            Criteria = filter
+            Criteria = filter,
+            Orders =
+            {
+                new OrderExpression(dfeta_businesseventaudit.Fields.CreatedOn, OrderType.Ascending)
+            },
+            PageInfo = new()
+            {
+                PageNumber = 1,
+                Count = 500
+            }
         };
 
         AddContactLink(query);
 
-        var result = await _service.RetrieveMultipleAsync(query);
-        return result.Entities
-            .Select(e => e.ToEntity<dfeta_businesseventaudit>())
-            .Select(e => e.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute))
-            .GroupBy(c => c.ContactId)
-            .Select(g => MapContactToInductionCompletee(g.First()))
-            .ToArray();
+        EntityCollection response;
+
+        do
+        {
+            response = await _service.RetrieveMultipleAsync(query);
+
+            yield return response.Entities
+                .Select(e => e.ToEntity<dfeta_businesseventaudit>())
+                .Select(e => e.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute))
+                .GroupBy(c => c.ContactId)
+                .Select(g => MapContactToInductionCompletee(g.First()))
+                .ToArray();
+
+            query.PageInfo.PageNumber++;
+            query.PageInfo.PagingCookie = response.PagingCookie;
+        }
+        while (response.MoreRecords);
 
         static void AddContactLink(QueryExpression query)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.GetInternationalQtsAwardeesForDateRange.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.GetInternationalQtsAwardeesForDateRange.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Xrm.Sdk.Query;
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
 
 namespace TeachingRecordSystem.Dqt;
 
 public partial class DataverseAdapter
 {
-    public async Task<InternationalQtsAwardee[]> GetInternationalQtsAwardeesForDateRange(DateTime startDate, DateTime endDate)
+    public async IAsyncEnumerable<InternationalQtsAwardee[]> GetInternationalQtsAwardeesForDateRange(DateTime startDate, DateTime endDate)
     {
         var filter = new FilterExpression(LogicalOperator.And);
         filter.AddCondition(dfeta_businesseventaudit.Fields.CreatedOn, ConditionOperator.GreaterEqual, startDate);
@@ -21,18 +22,37 @@ public partial class DataverseAdapter
                 dfeta_businesseventaudit.Fields.dfeta_NewValue,
                 dfeta_businesseventaudit.Fields.dfeta_OldValue,
                 dfeta_businesseventaudit.Fields.dfeta_Person),
-            Criteria = filter
+            Criteria = filter,
+            Orders =
+            {
+                new OrderExpression(dfeta_businesseventaudit.Fields.CreatedOn, OrderType.Ascending)
+            },
+            PageInfo = new()
+            {
+                PageNumber = 1,
+                Count = 500
+            }
         };
 
         AddContactLink(query);
 
-        var result = await _service.RetrieveMultipleAsync(query);
-        return result.Entities
-            .Select(e => e.ToEntity<dfeta_businesseventaudit>())
-            .Select(e => e.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute))
-            .GroupBy(c => c.ContactId)
-            .Select(g => MapContactToInternationalQtsAwardee(g.First()))
-            .ToArray();
+        EntityCollection response;
+
+        do
+        {
+            response = await _service.RetrieveMultipleAsync(query);
+
+            yield return response.Entities
+                .Select(e => e.ToEntity<dfeta_businesseventaudit>())
+                .Select(e => e.Extract<Contact>(Contact.EntityLogicalName, Contact.PrimaryIdAttribute))
+                .GroupBy(c => c.ContactId)
+                .Select(g => MapContactToInternationalQtsAwardee(g.First()))
+                .ToArray();
+
+            query.PageInfo.PageNumber++;
+            query.PageInfo.PagingCookie = response.PagingCookie;
+        }
+        while (response.MoreRecords);
 
         static void AddContactLink(QueryExpression query)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/IDataverseAdapter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/IDataverseAdapter.cs
@@ -97,13 +97,13 @@ public interface IDataverseAdapter
 
     Task<Contact[]> GetTeachersByInitialTeacherTrainingSlugId(string slugId, string[] columnNames, RequestBuilder requestBuilder, bool activeOnly = true);
 
-    Task<QtsAwardee[]> GetQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
+    IAsyncEnumerable<QtsAwardee[]> GetQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 
-    Task<InternationalQtsAwardee[]> GetInternationalQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
+    IAsyncEnumerable<InternationalQtsAwardee[]> GetInternationalQtsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 
-    Task<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate);
+    IAsyncEnumerable<EytsAwardee[]> GetEytsAwardeesForDateRange(DateTime startDate, DateTime endDate);
 
-    Task<InductionCompletee[]> GetInductionCompleteesForDateRange(DateTime startDate, DateTime endDate);
+    IAsyncEnumerable<InductionCompletee[]> GetInductionCompleteesForDateRange(DateTime startDate, DateTime endDate);
 
     Task<Contact[]> GetTeachersBySlugIdAndTrn(string slugId, string trn, string[] columnNames, bool activeOnly = true);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendEytsAwardedEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendEytsAwardedEmailsJobTests.cs
@@ -98,7 +98,7 @@ public class BatchSendEytsAwardedEmailsJobTests : EytsAwardedEmailJobTestBase
         DateTime endActual = DateTime.MaxValue;
         dataverseAdapter
             .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new EytsAwardee[] { })
+            .ReturnsAsyncEnumerable(new EytsAwardee[] { })
             .Callback<DateTime, DateTime>(
                 (start, end) =>
                 {
@@ -154,7 +154,7 @@ public class BatchSendEytsAwardedEmailsJobTests : EytsAwardedEmailJobTestBase
 
         dataverseAdapter
             .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(eytsAwardees);
+            .ReturnsAsyncEnumerable(eytsAwardees);
 
         var job = new BatchSendEytsAwardedEmailsJob(
             jobOptions,
@@ -200,7 +200,7 @@ public class BatchSendEytsAwardedEmailsJobTests : EytsAwardedEmailJobTestBase
 
         dataverseAdapter
             .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new EytsAwardee[] { });
+            .ReturnsAsyncEnumerable(new EytsAwardee[] { });
 
         var job = new BatchSendEytsAwardedEmailsJob(
             jobOptions,
@@ -253,7 +253,7 @@ public class BatchSendEytsAwardedEmailsJobTests : EytsAwardedEmailJobTestBase
 
         dataverseAdapter
             .Setup(d => d.GetEytsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(eytsAwardees);
+            .ReturnsAsyncEnumerable(eytsAwardees);
 
         backgroundJobScheduler
             .Setup(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<EytsAwardedEmailJobDispatcher, Task>>>()))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
@@ -98,7 +98,7 @@ public class BatchSendInductionCompletedEmailsJobTests : InductionCompletedEmail
         DateTime endActual = DateTime.MaxValue;
         dataverseAdapter
             .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new InductionCompletee[] { })
+            .ReturnsAsyncEnumerable(new InductionCompletee[] { })
             .Callback<DateTime, DateTime>(
                 (start, end) =>
                 {
@@ -154,7 +154,7 @@ public class BatchSendInductionCompletedEmailsJobTests : InductionCompletedEmail
 
         dataverseAdapter
             .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(inductionCompletees);
+            .ReturnsAsyncEnumerable(inductionCompletees);
 
         var job = new BatchSendInductionCompletedEmailsJob(
             jobOptions,
@@ -200,7 +200,7 @@ public class BatchSendInductionCompletedEmailsJobTests : InductionCompletedEmail
 
         dataverseAdapter
             .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new InductionCompletee[] { });
+            .ReturnsAsyncEnumerable(new InductionCompletee[] { });
 
         var job = new BatchSendInductionCompletedEmailsJob(
             jobOptions,
@@ -253,7 +253,7 @@ public class BatchSendInductionCompletedEmailsJobTests : InductionCompletedEmail
 
         dataverseAdapter
             .Setup(d => d.GetInductionCompleteesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(inductionCompletees);
+            .ReturnsAsyncEnumerable(inductionCompletees);
 
         backgroundJobScheduler
             .Setup(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<InductionCompletedEmailJobDispatcher, Task>>>()))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendInternationalQtsAwardedEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendInternationalQtsAwardedEmailsJobTests.cs
@@ -98,7 +98,7 @@ public class BatchSendInternationalQtsAwardedEmailsJobTests : InternationalQtsAw
         DateTime endActual = DateTime.MaxValue;
         dataverseAdapter
             .Setup(d => d.GetInternationalQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new InternationalQtsAwardee[] { })
+            .ReturnsAsyncEnumerable(new InternationalQtsAwardee[] { })
             .Callback<DateTime, DateTime>(
                 (start, end) =>
                 {
@@ -154,7 +154,7 @@ public class BatchSendInternationalQtsAwardedEmailsJobTests : InternationalQtsAw
 
         dataverseAdapter
             .Setup(d => d.GetInternationalQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(qtsAwardees);
+            .ReturnsAsyncEnumerable(qtsAwardees);
 
         var job = new BatchSendInternationalQtsAwardedEmailsJob(
             jobOptions,
@@ -200,7 +200,7 @@ public class BatchSendInternationalQtsAwardedEmailsJobTests : InternationalQtsAw
 
         dataverseAdapter
             .Setup(d => d.GetInternationalQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(Array.Empty<InternationalQtsAwardee>());
+            .ReturnsAsyncEnumerable(Array.Empty<InternationalQtsAwardee>());
 
         var job = new BatchSendInternationalQtsAwardedEmailsJob(
             jobOptions,
@@ -253,7 +253,7 @@ public class BatchSendInternationalQtsAwardedEmailsJobTests : InternationalQtsAw
 
         dataverseAdapter
             .Setup(d => d.GetInternationalQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(qtsAwardees);
+            .ReturnsAsyncEnumerable(qtsAwardees);
 
         backgroundJobScheduler
             .Setup(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<InternationalQtsAwardedEmailJobDispatcher, Task>>>()))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendQtsAwardedEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/BatchSendQtsAwardedEmailsJobTests.cs
@@ -98,7 +98,7 @@ public class BatchSendQtsAwardedEmailsJobTests : QtsAwardedEmailJobTestBase
         DateTime endActual = DateTime.MaxValue;
         dataverseAdapter
             .Setup(d => d.GetQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new QtsAwardee[] { })
+            .ReturnsAsyncEnumerable(new QtsAwardee[] { })
             .Callback<DateTime, DateTime>(
                 (start, end) =>
                 {
@@ -154,7 +154,7 @@ public class BatchSendQtsAwardedEmailsJobTests : QtsAwardedEmailJobTestBase
 
         dataverseAdapter
             .Setup(d => d.GetQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(qtsAwardees);
+            .ReturnsAsyncEnumerable(qtsAwardees);
 
         var job = new BatchSendQtsAwardedEmailsJob(
             jobOptions,
@@ -200,7 +200,7 @@ public class BatchSendQtsAwardedEmailsJobTests : QtsAwardedEmailJobTestBase
 
         dataverseAdapter
             .Setup(d => d.GetQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(new QtsAwardee[] { });
+            .ReturnsAsyncEnumerable(new QtsAwardee[] { });
 
         var job = new BatchSendQtsAwardedEmailsJob(
             jobOptions,
@@ -253,7 +253,7 @@ public class BatchSendQtsAwardedEmailsJobTests : QtsAwardedEmailJobTestBase
 
         dataverseAdapter
             .Setup(d => d.GetQtsAwardeesForDateRange(It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .ReturnsAsync(qtsAwardees);
+            .ReturnsAsyncEnumerable(qtsAwardees);
 
         backgroundJobScheduler
             .Setup(s => s.Enqueue(It.IsAny<System.Linq.Expressions.Expression<Func<QtsAwardedEmailJobDispatcher, Task>>>()))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetEytsAwardeesForDateRangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetEytsAwardeesForDateRangeTests.cs
@@ -30,7 +30,7 @@ public class GetEytsAwardeesForDateRangeTests : IAsyncLifetime
         var expectedCount = 18;
 
         // Act
-        var eytsAwardees = await _dataverseAdapter.GetEytsAwardeesForDateRange(startDate, endDate);
+        var eytsAwardees = (await _dataverseAdapter.GetEytsAwardeesForDateRange(startDate, endDate).ToListAsync()).Single();
 
         // Assert
         Assert.Equal(expectedCount, eytsAwardees.Count());
@@ -150,7 +150,7 @@ public class GetEytsAwardeesForDateRangeTests : IAsyncLifetime
             teacher5EarlyYearsStatusValue);
 
         // Act
-        var eytsAwardees = await _dataverseAdapter.GetEytsAwardeesForDateRange(startDate, endDate);
+        var eytsAwardees = (await _dataverseAdapter.GetEytsAwardeesForDateRange(startDate, endDate).ToListAsync()).Single();
 
         // Assert
         Assert.Equal(3, eytsAwardees.Count());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetInductionCompleteesForDateRangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetInductionCompleteesForDateRangeTests.cs
@@ -153,7 +153,7 @@ public class GetInductionCompleteesForDateRangeTests : IAsyncLifetime
             teacher5FinalInductionStatus);
 
         // Act
-        var inductionCompletees = await _dataverseAdapter.GetInductionCompleteesForDateRange(startDate, endDate);
+        var inductionCompletees = (await _dataverseAdapter.GetInductionCompleteesForDateRange(startDate, endDate).ToListAsync()).Single();
 
         // Assert
         Assert.Equal(3, inductionCompletees.Count());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetInternationalQtsAwardeesForDateRangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetInternationalQtsAwardeesForDateRangeTests.cs
@@ -137,7 +137,7 @@ public class GetInternationalQtsAwardeesForDateRangeTests : IAsyncLifetime
             teacher5StatusValue);
 
         // Act
-        var qtsAwardees = await _dataverseAdapter.GetInternationalQtsAwardeesForDateRange(startDate, endDate);
+        var qtsAwardees = (await _dataverseAdapter.GetInternationalQtsAwardeesForDateRange(startDate, endDate).ToListAsync()).Single();
 
         // Assert
         Assert.Equal(2, qtsAwardees.Count());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetQtsAwardeesForDateRangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/GetQtsAwardeesForDateRangeTests.cs
@@ -31,7 +31,7 @@ public class GetQtsAwardeesForDateRangeTests : IAsyncLifetime
         var expectedCount = 8;
 
         // Act
-        var qtsAwardees = await _dataverseAdapter.GetQtsAwardeesForDateRange(startDate, endDate);
+        var qtsAwardees = (await _dataverseAdapter.GetQtsAwardeesForDateRange(startDate, endDate).ToListAsync()).Single();
 
         // Assert
         Assert.Equal(expectedCount, qtsAwardees.Count());
@@ -152,7 +152,7 @@ public class GetQtsAwardeesForDateRangeTests : IAsyncLifetime
             teacher5StatusValue);
 
         // Act
-        var qtsAwardees = await _dataverseAdapter.GetQtsAwardeesForDateRange(startDate, endDate);
+        var qtsAwardees = (await _dataverseAdapter.GetQtsAwardeesForDateRange(startDate, endDate).ToListAsync()).Single();
 
         // Assert
         Assert.Equal(3, qtsAwardees.Count());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/MockExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/MockExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Moq.Language.Flow;
+
+namespace TeachingRecordSystem.TestCommon;
+
+public static class MockExtensions
+{
+    public static IReturnsResult<T> ReturnsAsyncEnumerable<T, TResult>(
+            this ISetup<T, IAsyncEnumerable<TResult>> setup,
+            params TResult[] items)
+        where T : class
+    {
+        return setup.Returns(GetAsyncEnumerable(items));
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        static async IAsyncEnumerable<R> GetAsyncEnumerable<R>(IEnumerable<R> enumerable)
+        {
+            foreach (var item in enumerable)
+            {
+                yield return item;
+            }
+        }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TeachingRecordSystem.TestCommon.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TeachingRecordSystem.TestCommon.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Respawn" Version="6.1.0" />
     <PackageReference Include="xunit.assert" Version="2.5.0" />
   </ItemGroup>


### PR DESCRIPTION
The CRM API can only return 5000 results in a single hit; we've gone over that limit for our first run of the QTS awardee jobs but we didn't have paged queries in place to get the next batch(es) of results.

This changes the queries over to use paged queries. I've dropped the page size down a little too to avoid pulling back too much into memory at once.