### PR TITLE
Bugfix for slugid fallback

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Dqt/DataverseAdapter.SetIttResultForTeacher.cs
@@ -342,19 +342,26 @@ public partial class DataverseAdapter
             Guid ittProviderId,
             string slugId = null)
         {
-            // if SlugId is not passed in
-            // Find an active ITT record for the specified ITT Provider.
-            // otherwise find active ITT for the slugid (which should be one).
+            // if SlugId is passed in, use slugid for matching
+            // otherwise fallback to matching on establishmet
             // if ProgrammeType is AssessmentOnlyRoute, result should be UnderAssessment,Withdrawn or Deferrred otherwise
             // record should be InTraining,WithDrawn or Deferred
             List<dfeta_initialteachertraining> matching = new List<dfeta_initialteachertraining>();
+            var activeForProvider = Array.Empty<dfeta_initialteachertraining>();
 
-            var activeForProvider = string.IsNullOrEmpty(slugId) ? ittRecords
-                .Where(r => r.dfeta_EstablishmentId?.Id == ittProviderId && r.StateCode == dfeta_initialteachertrainingState.Active)
-                .ToArray() :
-                ittRecords
-                .Where(r => r.dfeta_SlugId == slugId && r.dfeta_EstablishmentId?.Id == ittProviderId && r.StateCode == dfeta_initialteachertrainingState.Active)
-                .ToArray();
+            if (!string.IsNullOrEmpty(slugId))
+            {
+                activeForProvider = ittRecords
+                    .Where(r => r.dfeta_SlugId == slugId && r.dfeta_EstablishmentId?.Id == ittProviderId && r.StateCode == dfeta_initialteachertrainingState.Active)
+                    .ToArray();
+            }
+
+            if (activeForProvider.Length == 0)
+            {
+                activeForProvider = ittRecords
+                    .Where(r => r.dfeta_EstablishmentId?.Id == ittProviderId && string.IsNullOrEmpty(r.dfeta_SlugId) && r.StateCode == dfeta_initialteachertrainingState.Active)
+                    .ToArray();
+            }
 
             foreach (var itt in activeForProvider)
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/SetIttOutcomeForTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Dqt.Tests/DataverseAdapterTests/SetIttOutcomeForTeacherTests.cs
@@ -589,7 +589,7 @@ public class SetIttOutcomeForTeacherTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Given_itt_does_not_exist_for_slugid_return_error()
+    public async Task Given_itt_does_not_exist_for_slugid_fallback_to_establishment_matching_return_success()
     {
         // Arrange
         var slugId = Guid.NewGuid().ToString();
@@ -603,7 +603,7 @@ public class SetIttOutcomeForTeacherTests : IAsyncLifetime
             Target = new dfeta_initialteachertraining()
             {
                 Id = ittId,
-                dfeta_SlugId = "some slug that doesn't exist",
+                dfeta_SlugId = string.Empty,
             }
         });
 
@@ -616,8 +616,7 @@ public class SetIttOutcomeForTeacherTests : IAsyncLifetime
             slugId);
 
         // Assert
-        Assert.False(result.Succeeded);
-        Assert.Equal(SetIttResultForTeacherFailedReason.NoMatchingIttRecord, result.FailedReason);
+        Assert.True(result.Succeeded);
     }
 
     [Fact]
@@ -640,37 +639,6 @@ public class SetIttOutcomeForTeacherTests : IAsyncLifetime
             {
                 Id = ittId,
                 dfeta_EstablishmentId = new EntityReference(Account.EntityLogicalName, AccountId2)
-            }
-        });
-
-        // Act
-        var (result, _) = await _dataverseAdapter.SetIttResultForTeacherImpl(
-            createPersonResult.TeacherId,
-            createPersonResult.IttProviderUkprn,
-            ittResult,
-            assessmentDate,
-            slugId);
-
-        // Assert
-        Assert.False(result.Succeeded);
-        Assert.Equal(SetIttResultForTeacherFailedReason.NoMatchingIttRecord, result.FailedReason);
-    }
-
-    [Fact]
-    public async Task Given_itt_matches_on_establishmentid_but_not_slugid_return_error()
-    {
-        // Arrange
-        var slugId = Guid.NewGuid().ToString();
-        var createPersonResult = await _testDataHelper.CreatePerson(earlyYears: false, withActiveSanction: false, slugId: slugId);
-        var ittResult = dfeta_ITTResult.Pass;
-        var assessmentDate = _clock.Today;
-        var ittId = createPersonResult.InitialTeacherTrainingId;
-        await _organizationService.ExecuteAsync(new UpdateRequest()
-        {
-            Target = new dfeta_initialteachertraining()
-            {
-                Id = ittId,
-                dfeta_SlugId = "SOME RANDOM SLUG"
             }
         });
 


### PR DESCRIPTION
### Context

This bugfix addresses problems with dead jobs that register received last night after they implemented the slugid changes. This PR introduces a fallback so that when slugid is passed and there isn't a match, it drops back to what it was doing previously before the slugid changes.

### Changes proposed in this pull request

- updated tests.
- updated datavers method.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
