### PR TITLE
Ensure we don't send emails to a given user more than once

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EytsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EytsAwardedEmailsJobItemMapping.cs
@@ -18,5 +18,6 @@ public class EytsAwardedEmailsJobItemMapping : IEntityTypeConfiguration<EytsAwar
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.EytsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.EytsAwardedEmailsJobId);
+        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(EytsAwardedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionCompletedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionCompletedEmailsJobItemMapping.cs
@@ -18,5 +18,6 @@ public class InductionCompletedEmailsJobItemMapping : IEntityTypeConfiguration<I
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.InductionCompletedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.InductionCompletedEmailsJobId);
+        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(InductionCompletedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InternationalQtsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InternationalQtsAwardedEmailsJobItemMapping.cs
@@ -18,5 +18,6 @@ public class InternationalQtsAwardedEmailsJobItemMapping : IEntityTypeConfigurat
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.InternationalQtsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.InternationalQtsAwardedEmailsJobId);
+        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(InternationalQtsAwardedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QtsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QtsAwardedEmailsJobItemMapping.cs
@@ -18,5 +18,6 @@ public class QtsAwardedEmailsJobItemMapping : IEntityTypeConfiguration<QtsAwarde
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.QtsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.QtsAwardedEmailsJobId);
+        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(QtsAwardedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230726141836_EmailJobTrnUniqueConstraints.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230726141836_EmailJobTrnUniqueConstraints.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230726141836_EmailJobTrnUniqueConstraints")]
+    partial class EmailJobTrnUniqueConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230726141836_EmailJobTrnUniqueConstraints.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230726141836_EmailJobTrnUniqueConstraints.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EmailJobTrnUniqueConstraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_qts_awarded_emails_job_items_trn",
+                table: "qts_awarded_emails_job_items",
+                column: "trn",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_international_qts_awarded_emails_job_items_trn",
+                table: "international_qts_awarded_emails_job_items",
+                column: "trn",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_induction_completed_emails_job_items_trn",
+                table: "induction_completed_emails_job_items",
+                column: "trn",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_eyts_awarded_emails_job_items_trn",
+                table: "eyts_awarded_emails_job_items",
+                column: "trn",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_qts_awarded_emails_job_items_trn",
+                table: "qts_awarded_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_international_qts_awarded_emails_job_items_trn",
+                table: "international_qts_awarded_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_induction_completed_emails_job_items_trn",
+                table: "induction_completed_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_eyts_awarded_emails_job_items_trn",
+                table: "eyts_awarded_emails_job_items");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EytsAwardedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EytsAwardedEmailsJobItem.cs
@@ -3,6 +3,7 @@
 public class EytsAwardedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
+    public const string TrnUniqueIndexName = "ix_eyts_awarded_emails_job_items_trn";
 
     public required Guid EytsAwardedEmailsJobId { get; set; }
     public EytsAwardedEmailsJob? EytsAwardedEmailsJob { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InductionCompletedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InductionCompletedEmailsJobItem.cs
@@ -3,6 +3,7 @@
 public class InductionCompletedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
+    public const string TrnUniqueIndexName = "ix_induction_completed_emails_job_items_trn";
 
     public required Guid InductionCompletedEmailsJobId { get; set; }
     public InductionCompletedEmailsJob? InductionCompletedEmailsJob { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InternationalQtsAwardedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InternationalQtsAwardedEmailsJobItem.cs
@@ -3,6 +3,7 @@
 public class InternationalQtsAwardedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
+    public const string TrnUniqueIndexName = "ix_international_qts_awarded_emails_job_items_trn";
 
     public required Guid InternationalQtsAwardedEmailsJobId { get; set; }
     public InternationalQtsAwardedEmailsJob? InternationalQtsAwardedEmailsJob { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/QtsAwardedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/QtsAwardedEmailsJobItem.cs
@@ -3,6 +3,7 @@
 public class QtsAwardedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
+    public const string TrnUniqueIndexName = "ix_qts_awarded_emails_job_items_trn";
 
     public required Guid QtsAwardedEmailsJobId { get; set; }
     public QtsAwardedEmailsJob? QtsAwardedEmailsJob { get; set; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/EytsAwardedEmailJobDispatcherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/EytsAwardedEmailJobDispatcherTests.cs
@@ -30,7 +30,7 @@ public class EytsAwardedEmailJobDispatcherTests : EytsAwardedEmailJobTestBase
             { "last name", teacher1LastName },
         };
         var teacher2PersonId = Guid.NewGuid();
-        var teacher2Trn = "1234567";
+        var teacher2Trn = "1234568";
         var teacher2EmailAddress = Faker.Internet.Email();
         var teacher2FirstName = Faker.Name.First();
         var teacher2LastName = Faker.Name.Last();
@@ -40,7 +40,7 @@ public class EytsAwardedEmailJobDispatcherTests : EytsAwardedEmailJobTestBase
             { "last name", teacher1LastName },
         };
         var teacher3PersonId = Guid.NewGuid();
-        var teacher3Trn = "1234567";
+        var teacher3Trn = "1234569";
         var teacher3EmailAddress = Faker.Internet.Email();
         var teacher3FirstName = Faker.Name.First();
         var teacher3LastName = Faker.Name.Last();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/InductionCompletedEmailJobDispatcherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/InductionCompletedEmailJobDispatcherTests.cs
@@ -30,7 +30,7 @@ public class InductionCompletedEmailJobDispatcherTests : InductionCompletedEmail
             { "last name", teacher1LastName },
         };
         var teacher2PersonId = Guid.NewGuid();
-        var teacher2Trn = "1234567";
+        var teacher2Trn = "1234568";
         var teacher2EmailAddress = Faker.Internet.Email();
         var teacher2FirstName = Faker.Name.First();
         var teacher2LastName = Faker.Name.Last();
@@ -40,7 +40,7 @@ public class InductionCompletedEmailJobDispatcherTests : InductionCompletedEmail
             { "last name", teacher1LastName },
         };
         var teacher3PersonId = Guid.NewGuid();
-        var teacher3Trn = "1234567";
+        var teacher3Trn = "1234569";
         var teacher3EmailAddress = Faker.Internet.Email();
         var teacher3FirstName = Faker.Name.First();
         var teacher3LastName = Faker.Name.Last();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/InternationalQtsAwardedEmailJobDispatcherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/InternationalQtsAwardedEmailJobDispatcherTests.cs
@@ -30,7 +30,7 @@ public class InternationalQtsAwardedEmailJobDispatcherTests : InternationalQtsAw
             { "last name", teacher1LastName },
         };
         var teacher2PersonId = Guid.NewGuid();
-        var teacher2Trn = "1234567";
+        var teacher2Trn = "1234568";
         var teacher2EmailAddress = Faker.Internet.Email();
         var teacher2FirstName = Faker.Name.First();
         var teacher2LastName = Faker.Name.Last();
@@ -40,7 +40,7 @@ public class InternationalQtsAwardedEmailJobDispatcherTests : InternationalQtsAw
             { "last name", teacher1LastName },
         };
         var teacher3PersonId = Guid.NewGuid();
-        var teacher3Trn = "1234567";
+        var teacher3Trn = "1234569";
         var teacher3EmailAddress = Faker.Internet.Email();
         var teacher3FirstName = Faker.Name.First();
         var teacher3LastName = Faker.Name.Last();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/QtsAwardedEmailJobDispatcherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Jobs/QtsAwardedEmailJobDispatcherTests.cs
@@ -30,7 +30,7 @@ public class QtsAwardedEmailJobDispatcherTests : QtsAwardedEmailJobTestBase
             { "last name", teacher1LastName },
         };
         var teacher2PersonId = Guid.NewGuid();
-        var teacher2Trn = "1234567";
+        var teacher2Trn = "1234568";
         var teacher2EmailAddress = Faker.Internet.Email();
         var teacher2FirstName = Faker.Name.First();
         var teacher2LastName = Faker.Name.Last();
@@ -40,7 +40,7 @@ public class QtsAwardedEmailJobDispatcherTests : QtsAwardedEmailJobTestBase
             { "last name", teacher1LastName },
         };
         var teacher3PersonId = Guid.NewGuid();
-        var teacher3Trn = "1234567";
+        var teacher3Trn = "1234569";
         var teacher3EmailAddress = Faker.Internet.Email();
         var teacher3FirstName = Faker.Name.First();
         var teacher3LastName = Faker.Name.Last();


### PR DESCRIPTION
Adds a unique constraint on `TRN` for each email job plus an explicit check. It would have been nice to have some kind of `TryAdd()` method on the `DbSet` but EF doesn't have one and adding one proved to be non-trivial.