### PR TITLE
Remove unique constraints - existing data means we can't apply them

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EytsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EytsAwardedEmailsJobItemMapping.cs
@@ -18,6 +18,5 @@ public class EytsAwardedEmailsJobItemMapping : IEntityTypeConfiguration<EytsAwar
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.EytsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.EytsAwardedEmailsJobId);
-        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(EytsAwardedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionCompletedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionCompletedEmailsJobItemMapping.cs
@@ -18,6 +18,5 @@ public class InductionCompletedEmailsJobItemMapping : IEntityTypeConfiguration<I
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.InductionCompletedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.InductionCompletedEmailsJobId);
-        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(InductionCompletedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InternationalQtsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InternationalQtsAwardedEmailsJobItemMapping.cs
@@ -18,6 +18,5 @@ public class InternationalQtsAwardedEmailsJobItemMapping : IEntityTypeConfigurat
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.InternationalQtsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.InternationalQtsAwardedEmailsJobId);
-        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(InternationalQtsAwardedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QtsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QtsAwardedEmailsJobItemMapping.cs
@@ -18,6 +18,5 @@ public class QtsAwardedEmailsJobItemMapping : IEntityTypeConfiguration<QtsAwarde
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.QtsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.QtsAwardedEmailsJobId);
-        builder.HasIndex(i => i.Trn).IsUnique().HasDatabaseName(QtsAwardedEmailsJobItem.TrnUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230727111104_RemoveEmailJobTrnUniqueConstraints.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230727111104_RemoveEmailJobTrnUniqueConstraints.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230727111104_RemoveEmailJobTrnUniqueConstraints")]
+    partial class RemoveEmailJobTrnUniqueConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230727111104_RemoveEmailJobTrnUniqueConstraints.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20230727111104_RemoveEmailJobTrnUniqueConstraints.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveEmailJobTrnUniqueConstraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_qts_awarded_emails_job_items_trn",
+                table: "qts_awarded_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_international_qts_awarded_emails_job_items_trn",
+                table: "international_qts_awarded_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_induction_completed_emails_job_items_trn",
+                table: "induction_completed_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_eyts_awarded_emails_job_items_trn",
+                table: "eyts_awarded_emails_job_items");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_qts_awarded_emails_job_items_trn",
+                table: "qts_awarded_emails_job_items",
+                column: "trn",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_international_qts_awarded_emails_job_items_trn",
+                table: "international_qts_awarded_emails_job_items",
+                column: "trn",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_induction_completed_emails_job_items_trn",
+                table: "induction_completed_emails_job_items",
+                column: "trn",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_eyts_awarded_emails_job_items_trn",
+                table: "eyts_awarded_emails_job_items",
+                column: "trn",
+                unique: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EytsAwardedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EytsAwardedEmailsJobItem.cs
@@ -3,7 +3,6 @@
 public class EytsAwardedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
-    public const string TrnUniqueIndexName = "ix_eyts_awarded_emails_job_items_trn";
 
     public required Guid EytsAwardedEmailsJobId { get; set; }
     public EytsAwardedEmailsJob? EytsAwardedEmailsJob { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InductionCompletedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InductionCompletedEmailsJobItem.cs
@@ -3,7 +3,6 @@
 public class InductionCompletedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
-    public const string TrnUniqueIndexName = "ix_induction_completed_emails_job_items_trn";
 
     public required Guid InductionCompletedEmailsJobId { get; set; }
     public InductionCompletedEmailsJob? InductionCompletedEmailsJob { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InternationalQtsAwardedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InternationalQtsAwardedEmailsJobItem.cs
@@ -3,7 +3,6 @@
 public class InternationalQtsAwardedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
-    public const string TrnUniqueIndexName = "ix_international_qts_awarded_emails_job_items_trn";
 
     public required Guid InternationalQtsAwardedEmailsJobId { get; set; }
     public InternationalQtsAwardedEmailsJob? InternationalQtsAwardedEmailsJob { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/QtsAwardedEmailsJobItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/QtsAwardedEmailsJobItem.cs
@@ -3,7 +3,6 @@
 public class QtsAwardedEmailsJobItem
 {
     public const int EmailAddressMaxLength = 200;
-    public const string TrnUniqueIndexName = "ix_qts_awarded_emails_job_items_trn";
 
     public required Guid QtsAwardedEmailsJobId { get; set; }
     public QtsAwardedEmailsJob? QtsAwardedEmailsJob { get; set; }


### PR DESCRIPTION
We'll rely on the explicit checks in the jobs instead.