### PR TITLE
Remove the columnNames parameter from GetSubjectByTitle

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -172,8 +172,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
 
         if (request.Include.HasFlag(GetTeacherRequestIncludes.PendingDetailChanges))
         {
-            var nameChangeSubject = await _dataverseAdapter.GetSubjectByTitle("Change of Name", columnNames: Array.Empty<string>());
-            var dateOfBirthChangeSubject = await _dataverseAdapter.GetSubjectByTitle("Change of Date of Birth", columnNames: Array.Empty<string>());
+            var nameChangeSubject = await _dataverseAdapter.GetSubjectByTitle("Change of Name");
+            var dateOfBirthChangeSubject = await _dataverseAdapter.GetSubjectByTitle("Change of Date of Birth");
 
             var incidents = await _dataverseAdapter.GetIncidentsByContactId(
                 teacher.Id,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.DetailChangeIncidents.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.DetailChangeIncidents.cs
@@ -6,7 +6,7 @@ public partial class DataverseAdapter
 {
     public async Task<Guid> CreateNameChangeIncident(CreateNameChangeIncidentCommand command)
     {
-        var subject = await GetSubjectByTitle("Change of Name", columnNames: Array.Empty<string>());
+        var subject = await GetSubjectByTitle("Change of Name");
 
         var incident = new Incident()
         {
@@ -57,7 +57,7 @@ public partial class DataverseAdapter
 
     public async Task<Guid> CreateDateOfBirthChangeIncident(CreateDateOfBirthChangeIncidentCommand command)
     {
-        var subject = await GetSubjectByTitle("Change of Date of Birth", columnNames: Array.Empty<string>());
+        var subject = await GetSubjectByTitle("Change of Date of Birth");
 
         var incident = new Incident()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.cs
@@ -1291,7 +1291,7 @@ public partial class DataverseAdapter : IDataverseAdapter
         });
     }
 
-    public async Task<Subject> GetSubjectByTitle(string title, string[] columnNames)
+    public async Task<Subject> GetSubjectByTitle(string title)
     {
         return await _cache.GetOrCreateAsync(CacheKeys.GetSubjectTitleKey(title), async _ =>
         {
@@ -1300,7 +1300,7 @@ public partial class DataverseAdapter : IDataverseAdapter
 
             var query = new QueryExpression(Subject.EntityLogicalName)
             {
-                ColumnSet = new(columnNames),
+                ColumnSet = new(allColumns: true),
                 Criteria = filter
             };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/IDataverseAdapter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/IDataverseAdapter.cs
@@ -90,7 +90,7 @@ public interface IDataverseAdapter
 
     Task<Guid> CreateDateOfBirthChangeIncident(CreateDateOfBirthChangeIncidentCommand command);
 
-    Task<Subject> GetSubjectByTitle(string title, string[] columnNames);
+    Task<Subject> GetSubjectByTitle(string title);
 
     Task<Incident[]> GetIncidentsByContactId(Guid contactId, IncidentState? state, string[] columnNames);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -563,7 +563,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
         string[]? sanctions = null)
     {
         DataverseAdapterMock
-            .Setup(mock => mock.GetSubjectByTitle("Change of Name", It.IsAny<string[]>()))
+            .Setup(mock => mock.GetSubjectByTitle("Change of Name"))
             .ReturnsAsync(new Subject()
             {
                 Id = _changeOfNameSubjectId,
@@ -571,7 +571,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             });
 
         DataverseAdapterMock
-            .Setup(mock => mock.GetSubjectByTitle("Change of Date of Birth", It.IsAny<string[]>()))
+            .Setup(mock => mock.GetSubjectByTitle("Change of Date of Birth"))
             .ReturnsAsync(new Subject()
             {
                 Id = _changeOfDateOfBirthSubjectId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/DataverseAdapterTests/GetSubjectByTitleTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/DataverseAdapterTests/GetSubjectByTitleTests.cs
@@ -24,7 +24,7 @@ public class GetSubjectByTitleTests : IAsyncLifetime
         var title = "Change of Name";
 
         // Act
-        var result = await _dataverseAdapter.GetSubjectByTitle(title, columnNames: new[] { Subject.Fields.Title });
+        var result = await _dataverseAdapter.GetSubjectByTitle(title);
 
         // Assert
         Assert.NotNull(result);
@@ -38,7 +38,7 @@ public class GetSubjectByTitleTests : IAsyncLifetime
         var subjectCode = "XXXX";
 
         // Act
-        var result = await _dataverseAdapter.GetSubjectByTitle(subjectCode, columnNames: new[] { Subject.Fields.Title });
+        var result = await _dataverseAdapter.GetSubjectByTitle(subjectCode);
 
         // Assert
         Assert.Null(result);


### PR DESCRIPTION
We're caching this entity so need to ensure we're retrieving all columns.