### PR TITLE
Add [dfeta_allowpiiupdatesfromregister] field to reporting database

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0007_ContactAllowpiiUpdatesFromRegister.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0007_ContactAllowpiiUpdatesFromRegister.sql
@@ -1,0 +1,1 @@
+alter table contact add dfeta_allowpiiupdatesfromregister bit;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -13,6 +13,7 @@
     <None Remove="Dqt\Services\DqtReporting\Migrations\0004_ContactAdditionalAttributes.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0005_ContactSlugId.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0006_Incident_msdyn_copilotengaged.sql" />
+    <None Remove="Dqt\Services\DqtReporting\Migrations\0007_ContactAllowpiiUpdatesFromRegister.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,6 +23,7 @@
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0004_ContactAdditionalAttributes.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0005_ContactSlugId.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0006_Incident_msdyn_copilotengaged.sql" />
+    <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0007_ContactAllowpiiUpdatesFromRegister.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CRM is going to be changed to include a new field - dfeta_allowpiiupdatesfromregister, therefore the reporting database needs to be updated to include the new field.

### Context

Include relevant motivation and context.

### Changes proposed in this pull request

https://trello.com/c/q1cEHrN5/1132-ensure-pii-updates-are-not-overwritten

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
