### PR TITLE
changed script to change namespace of generatedcode to match where it's stored

### DIFF
--- a/scripts/Generate-CrmModels.ps1
+++ b/scripts/Generate-CrmModels.ps1
@@ -50,9 +50,9 @@ function Set-Configuration {
 
 Set-Configuration
 
-$namespace = "TeachingRecordSystem.Dqt.Models"
-$entitiesOutput = Join-Path -Path $PSScriptRoot -ChildPath ".." TeachingRecordSystem src TeachingRecordSystem.Dqt Models GeneratedCode.cs
-$optionSetsOutput = Join-Path -Path $PSScriptRoot -ChildPath ".." TeachingRecordSystem src TeachingRecordSystem.Dqt Models GeneratedOptionSets.cs
+$namespace = "TeachingRecordSystem.Core.Dqt.Models"
+$entitiesOutput = Join-Path -Path $PSScriptRoot -ChildPath ".." TeachingRecordSystem src TeachingRecordSystem.Core Dqt Models GeneratedCode.cs
+$optionSetsOutput = Join-Path -Path $PSScriptRoot -ChildPath ".." TeachingRecordSystem src TeachingRecordSystem.Core Dqt Models GeneratedOptionSets.cs
 mkdir (Split-Path $entitiesOutput) -Force | Out-Null
 
 $crmSvcUtil = Join-Path -Path $coreToolsFolder -ChildPath "CrmSvcUtil.exe"


### PR DESCRIPTION
### Context

Running .\gEnerate-CrmModels.ps1 creates a new generated code different to where the GeneratedCode.cs is currently. This PR fixes the namespace to where GeneratedCode is now.


### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
