### PR TITLE
Consume qualification not found error

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -227,6 +227,11 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
             $"{nameof(GetOrCreateTrnRequest.InitialTeacherTraining)}.{nameof(GetOrCreateTrnRequest.InitialTeacherTraining.TrainingCountryCode)}",
             ErrorRegistry.CountryNotFound().Title);
 
+        ConsumeReason(
+            CreateTeacherFailedReasons.QualificationNotFound,
+            $"{nameof(GetOrCreateTrnRequest.Qualification)}.{nameof(GetOrCreateTrnRequest.Qualification.HeQualificationType)}",
+            ErrorRegistry.HeQualificationNotFound().Title);
+
         if (failedReasons != CreateTeacherFailedReasons.None)
         {
             throw new NotImplementedException($"Unknown {nameof(CreateTeacherFailedReasons)}: '{failedReasons}.");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -456,6 +456,22 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
         var requestId = Guid.NewGuid().ToString();
         var heQualificationType = (HeQualificationType)(-1);
 
+        // Act
+        var response = await HttpClientWithApiKey.PutAsync(
+            $"v2/trn-requests/{requestId}",
+            CreateRequest(req => req.Qualification.HeQualificationType = heQualificationType));
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Given_invalid_qualificationtype_not_found_returns_error()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+        var heQualificationType = HeQualificationType.BachelorOfCommerce;
+
         DataverseAdapterMock
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Failed(CreateTeacherFailedReasons.QualificationNotFound));
@@ -466,7 +482,10 @@ public class GetOrCreateTrnRequestTests : ApiTestBase
             CreateRequest(req => req.Qualification.HeQualificationType = heQualificationType));
 
         // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.JsonResponseHasValidationErrorForProperty(
+            response,
+            propertyName: $"{nameof(GetOrCreateTrnRequest.Qualification)}.{nameof(GetOrCreateTrnRequest.Qualification.HeQualificationType)}",
+            expectedError: Properties.StringResources.Errors_10013_Title);
     }
 
     [Theory]


### PR DESCRIPTION
### Context

Consume when a qualification is not found and stop endpoint from throwing an exception.

- Added code to consume error.
- Added test to handle when the createteacher returning QualificationNotFound
- changed existing test because it was invalid. It errors for a different reason - before getting to the createteacher code (json could not be convertered to type e.g.

```
	"errors": {
		"$.qualification.heQualificationType": [
			"The JSON value could not be converted to System.Nullable`1[TeachingRecordSystem.Api.V2.ApiModels.HeQualificationType]. Path: $.qualification.heQualificationType | LineNumber: 35 | BytePositionInLine: 32."
		] 
```

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
