### PR TITLE
Handle missing first/last names in v3 endpoints

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -192,15 +192,9 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 .Intersect(Constants.ExposableSanctionCodes);
         }
 
-        var firstName = teacher.FirstName;
-        var middleName = teacher.MiddleName ?? string.Empty;
-        var lastName = teacher.LastName;
-        if (!string.IsNullOrEmpty(teacher.dfeta_StatedFirstName) && !string.IsNullOrEmpty(teacher.dfeta_StatedLastName))
-        {
-            firstName = teacher.dfeta_StatedFirstName;
-            middleName = teacher.dfeta_StatedMiddleName ?? string.Empty;
-            lastName = teacher.dfeta_StatedLastName;
-        }
+        var firstName = teacher.ResolveFirstName();
+        var middleName = teacher.ResolveMiddleName();
+        var lastName = teacher.ResolveLastName();
 
         var qtsAwardedInWalesStatus = await _dataverseAdapter.GetTeacherStatus(QtsAwardedInWalesTeacherStatusValue, null);
         var qtsRegistrations = await _dataverseAdapter.GetQtsRegistrationsByTeacher(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
@@ -3,15 +3,15 @@
 public static class ContactExtensions
 {
     public static string ResolveFirstName(this Contact contact) =>
-        (contact.HasStatedNames() ? contact.dfeta_StatedFirstName : contact.FirstName) ?? throw new Exception("Contact is missing first name.");
+        (contact.HasStatedNames() ? contact.dfeta_StatedFirstName : contact.FirstName) ?? string.Empty;
 
     public static string ResolveMiddleName(this Contact contact) =>
         (contact.HasStatedNames() ? contact.dfeta_StatedMiddleName : contact.MiddleName) ?? string.Empty;
 
     public static string ResolveLastName(this Contact contact) =>
-        (contact.HasStatedNames() ? contact.dfeta_StatedLastName : contact.LastName) ?? throw new Exception("Contact is missing last name.");
+        (contact.HasStatedNames() ? contact.dfeta_StatedLastName : contact.LastName) ?? string.Empty;
 
     private static bool HasStatedNames(this Contact contact) =>
-        !string.IsNullOrEmpty(contact.dfeta_StatedFirstName) &&
+        !string.IsNullOrEmpty(contact.dfeta_StatedFirstName) ||
         !string.IsNullOrEmpty(contact.dfeta_StatedLastName);
 }


### PR DESCRIPTION
We've previously assumed that `contact` records will always have a first and last name but it turns out that's not always true. This amends our name resolution methods to not throw when first and/or last name is missing.

I've also updated one call site to use the helper methods where it wasn't before.