### PR TITLE
Remove RequestBuilder from CRM query handler interface

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmQueryDispatcher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmQueryDispatcher.cs
@@ -14,7 +14,7 @@ public class CrmQueryDispatcher : ICrmQueryDispatcher
         _organizationServiceAsync = organizationServiceAsync;
     }
 
-    public async Task<TResult> ExecuteQuery<TResult>(ICrmQuery<TResult> query, RequestBuilder? requestBuilder = null)
+    public async Task<TResult> ExecuteQuery<TResult>(ICrmQuery<TResult> query)
     {
         var handlerType = typeof(ICrmQueryHandler<,>).MakeGenericType(query.GetType(), typeof(TResult));
         var handler = _serviceProvider.GetRequiredService(handlerType);
@@ -22,12 +22,12 @@ public class CrmQueryDispatcher : ICrmQueryDispatcher
         var wrapperHandlerType = typeof(QueryHandler<,>).MakeGenericType(query.GetType(), typeof(TResult));
         var wrappedHandler = (QueryHandler<TResult>)Activator.CreateInstance(wrapperHandlerType, handler)!;
 
-        return await wrappedHandler.Execute(query, _organizationServiceAsync, requestBuilder);
+        return await wrappedHandler.Execute(query, _organizationServiceAsync);
     }
 
     private abstract class QueryHandler<T>
     {
-        public abstract Task<T> Execute(ICrmQuery<T> query, IOrganizationServiceAsync organizationService, RequestBuilder? requestBuilder);
+        public abstract Task<T> Execute(ICrmQuery<T> query, IOrganizationServiceAsync organizationService);
     }
 
     private class QueryHandler<TQuery, TResult> : QueryHandler<TResult>
@@ -40,9 +40,9 @@ public class CrmQueryDispatcher : ICrmQueryDispatcher
             _innerHandler = innerHandler;
         }
 
-        public override Task<TResult> Execute(ICrmQuery<TResult> query, IOrganizationServiceAsync organizationService, RequestBuilder? requestBuilder)
+        public override Task<TResult> Execute(ICrmQuery<TResult> query, IOrganizationServiceAsync organizationService)
         {
-            return _innerHandler.Execute((TQuery)query, organizationService, requestBuilder);
+            return _innerHandler.Execute((TQuery)query, organizationService);
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmQueryDispatcher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmQueryDispatcher.cs
@@ -2,5 +2,5 @@ namespace TeachingRecordSystem.Core.Dqt;
 
 public interface ICrmQueryDispatcher
 {
-    Task<TResult> ExecuteQuery<TResult>(ICrmQuery<TResult> query, RequestBuilder? requestBuilder = null);
+    Task<TResult> ExecuteQuery<TResult>(ICrmQuery<TResult> query);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmQueryHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmQueryHandler.cs
@@ -5,5 +5,5 @@ namespace TeachingRecordSystem.Core.Dqt;
 public interface ICrmQueryHandler<TQuery, TResult>
     where TQuery : ICrmQuery<TResult>
 {
-    Task<TResult> Execute(TQuery query, IOrganizationServiceAsync organizationService, RequestBuilder? requestBuilder);
+    Task<TResult> Execute(TQuery query, IOrganizationServiceAsync organizationService);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactByTrnHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactByTrnHandler.cs
@@ -7,10 +7,8 @@ namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
 public class GetContactByTrnHandler : ICrmQueryHandler<GetContactByTrn, Contact?>
 {
-    public async Task<Contact?> Execute(GetContactByTrn query, IOrganizationServiceAsync organizationService, RequestBuilder? requestBuilder)
+    public async Task<Contact?> Execute(GetContactByTrn query, IOrganizationServiceAsync organizationService)
     {
-        requestBuilder ??= RequestBuilder.CreateSingle(organizationService);
-
         var queryByAttribute = new QueryByAttribute()
         {
             EntityName = Contact.EntityLogicalName,
@@ -24,8 +22,8 @@ public class GetContactByTrnHandler : ICrmQueryHandler<GetContactByTrn, Contact?
             Query = queryByAttribute
         };
 
-        var response = await requestBuilder.AddRequest<RetrieveMultipleResponse>(request).GetResponseAsync();
+        var response = await organizationService.RetrieveMultipleAsync(queryByAttribute);
 
-        return response.EntityCollection.Entities.SingleOrDefault()?.ToEntity<Contact>();
+        return response.Entities.SingleOrDefault()?.ToEntity<Contact>();
     }
 }


### PR DESCRIPTION
There's really no safe way to use `RequestBuilder` with these new handlers.