### PR TITLE
added functionality to deactivate a user

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserActivationEventChanges.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserActivationEventChanges.cs
@@ -1,7 +1,0 @@
-namespace TeachingRecordSystem.Core.Events;
-
-[Flags]
-public enum UserActivationEventChanges
-{
-    Deactivated = 0
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserActivationEventChanges.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserActivationEventChanges.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Events;
+
+[Flags]
+public enum UserActivationEventChanges
+{
+    Deactivated = 0
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record UserDeactivatedEvent : EventBase
+{
+    public required User User { get; init; }
+
+    public required Guid UpdatedByUserId { get; init; }
+
+    public required UserActivationEventChanges Changes { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
@@ -4,7 +4,13 @@ public record UserDeactivatedEvent : EventBase
 {
     public required User User { get; init; }
 
-    public required Guid UpdatedByUserId { get; init; }
+    public required Guid DeactivatedByUserId { get; init; }
 
-    public required UserActivationEventChanges Changes { get; init; }
+    public required UserDeactivatedEventChanges Changes { get; init; }
+}
+
+[Flags]
+public enum UserDeactivatedEventChanges
+{
+    Deactivated = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml
@@ -1,4 +1,4 @@
-@page "/users/{userid}"
+@page "/users/{userid}/{handler?}"
 @using TeachingRecordSystem.Core
 @model TeachingRecordSystem.SupportUi.Pages.Users.EditUser
 @{
@@ -12,18 +12,24 @@
 
             <govuk-input asp-for="Email" type="email" disabled />
 
-            <govuk-input asp-for="Name" />
+            <govuk-input asp-for="Name" disabled="@(!Model.IsActiveUser)" />
 
             <govuk-checkboxes asp-for="Roles">
                 <govuk-checkboxes-fieldset>
                     @foreach (var role in UserRoles.All)
                     {
-                        <govuk-checkboxes-item value="@role">@UserRoles.GetDisplayNameForRole(role)</govuk-checkboxes-item>
+                        <govuk-checkboxes-item value="@role" disabled="@(!Model.IsActiveUser)">@UserRoles.GetDisplayNameForRole(role)</govuk-checkboxes-item>
                     }
                 </govuk-checkboxes-fieldset>
             </govuk-checkboxes>
 
-            <govuk-button type="submit">Save and continue</govuk-button>
+            @if (Model.IsActiveUser)
+            {
+                <div class="govuk-button-group">
+                    <govuk-button class="govuk-button" type="submit">Save and continue</govuk-button>
+                    <govuk-button class="govuk-button govuk-button--secondary" type="submit" asp-page-handler="deactivate">Deactivate</govuk-button>
+                </div>
+            }
         </form>
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
@@ -96,12 +96,7 @@ public class EditUser : PageModel
 
     public async Task<IActionResult> OnPostDeactivate()
     {
-        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == UserId);
-
-        if (user is null)
-        {
-            return NotFound();
-        }
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == UserId);
 
         if (!user.Active)
         {
@@ -113,9 +108,9 @@ public class EditUser : PageModel
         _dbContext.AddEvent(new UserDeactivatedEvent
         {
             User = Core.Events.User.FromModel(user),
-            UpdatedByUserId = User.GetUserId(),
+            DeactivatedByUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow,
-            Changes = UserActivationEventChanges.Deactivated
+            Changes = UserDeactivatedEventChanges.Deactivated
         });
 
         await _dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
@@ -209,5 +209,66 @@ public class EditUserTests : TestBase
         AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "User updated");
     }
 
+    [Fact]
+    public async Task Post_UserDoesNotExistForDeactivation_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{GetRequestPath(Guid.NewGuid())}/deactivate");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserExistsButIsAlreadyDeactivated_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(active: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{GetRequestPath(user.UserId)}/deactivate");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_DeactivatesUsersEmitsEventAndRedirectsWithFlashMessage()
+    {
+        // Arrange
+        var currentUser = await TestData.CreateUser();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{GetRequestPath(currentUser.UserId)}/deactivate");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedUser = await WithDbContext(dbContext =>
+            dbContext.Users.SingleOrDefaultAsync(u => u.UserId == currentUser.UserId));
+        Assert.NotNull(updatedUser);
+
+        Assert.False(updatedUser.Active);
+
+        EventObserver.AssertEventsSaved(e =>
+        {
+            var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
+            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(userCreatedEvent.UpdatedByUserId, GetCurrentUserId());
+            Assert.Equal(UserType.Person, userCreatedEvent.User.UserType);
+            Assert.Equal(UserActivationEventChanges.Deactivated, userCreatedEvent.Changes);
+        });
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "User deactivated");
+    }
+
     private static string GetRequestPath(Guid userId) => $"/users/{userId}";
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
@@ -210,19 +210,6 @@ public class EditUserTests : TestBase
     }
 
     [Fact]
-    public async Task Post_UserDoesNotExistForDeactivation_ReturnsNotFound()
-    {
-        // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Post, $"{GetRequestPath(Guid.NewGuid())}/deactivate");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
     public async Task Post_UserExistsButIsAlreadyDeactivated_ReturnsBadRequest()
     {
         // Arrange
@@ -260,9 +247,9 @@ public class EditUserTests : TestBase
         {
             var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
             Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
-            Assert.Equal(userCreatedEvent.UpdatedByUserId, GetCurrentUserId());
+            Assert.Equal(userCreatedEvent.DeactivatedByUserId, GetCurrentUserId());
             Assert.Equal(UserType.Person, userCreatedEvent.User.UserType);
-            Assert.Equal(UserActivationEventChanges.Deactivated, userCreatedEvent.Changes);
+            Assert.Equal(UserDeactivatedEventChanges.Deactivated, userCreatedEvent.Changes);
         });
 
         var redirectResponse = await response.FollowRedirect(HttpClient);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateUser.cs
@@ -6,19 +6,21 @@ namespace TeachingRecordSystem.TestCommon;
 public partial class TestData
 {
     public Task<User> CreateUser(
+        bool? active = null,
         string? name = null,
         string? email = null,
         string[]? roles = null)
     {
         return WithDbContext(async dbContext =>
         {
+            active ??= true;
             name ??= GenerateName();
             email ??= GenerateUniqueEmail();
             roles ??= new[] { UserRoles.Helpdesk };
 
             var user = new User()
             {
-                Active = true,
+                Active = active.Value,
                 Name = name,
                 Email = email,
                 Roles = roles,


### PR DESCRIPTION
### Context

We need to be able to deactivate users who should no longer have access to the TRS Support Console.

### Changes proposed in this pull request

- added changes to deactivate a user
- added relevant test

### Guidance to review

I've had to use the prefix `OnPost` as per the [MS Docs](https://learn.microsoft.com/en-gb/aspnet/core/razor-pages/?view=aspnetcore-7.0&tabs=visual-studio#multiple-handlers-per-page) for the new method (`OnPostDeactivate`). Also made use of `asp-page-handler` which will render as `formaction` in the markup

### Checklist

-   [#1180] Attach to Trello card
