### PR TITLE
Return TicketNumber from TestData.CreateIncident* methods

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/DataverseAdapterTests/GetActiveIncidentsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/DataverseAdapterTests/GetActiveIncidentsTests.cs
@@ -19,11 +19,12 @@ public class GetActiveIncidentsTests : IAsyncLifetime
     public async Task WhenCalled_ReturnsActiveIncidentsOnly()
     {
         // Arrange
-        var cancelledCreateNameChangeIncidentResult = await _dataScope.TestData.CreateNameChangeIncident((builder) => builder.WithCanceledStatus());
-        var activeCreateNameChangeIncidentResult = await _dataScope.TestData.CreateNameChangeIncident();
-        var rejectedCreateNameChangeIncidentResult = await _dataScope.TestData.CreateNameChangeIncident((builder) => builder.WithRejectedStatus());
-        var activeCreateDateOfBirthChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident();
-        var approvedCreateDateOfBirthChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident((builder) => builder.WithApprovedStatus());
+        var createPersonResult = await _dataScope.TestData.CreatePerson();
+        var cancelledCreateNameChangeIncidentResult = await _dataScope.TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId).WithCanceledStatus());
+        var activeCreateNameChangeIncidentResult = await _dataScope.TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+        var rejectedCreateNameChangeIncidentResult = await _dataScope.TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId).WithRejectedStatus());
+        var activeCreateDateOfBirthChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+        var approvedCreateDateOfBirthChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId).WithApprovedStatus());
 
         // Act
         var incidents = await _dataverseAdapter.GetActiveIncidents();


### PR DESCRIPTION
Also amended the builders to take in an existing contact ID rather than creating one. This is so that the `TestData` methods are easier to use together.

The `With*` methods are also amended to throw if the property they're setting has already been set (to something different). This is a useful pattern so that the builders can more-easily ensure the state they're setting up is valid, and it's consistent with what we're doing in `TestData.CreatePerson()`.