### PR TITLE
Retry with a smaller page size on InsufficientMemoryException

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/CrmEntityChangesService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/CrmEntityChangesService.cs
@@ -89,6 +89,13 @@ public class CrmEntityChangesService : ICrmEntityChangesService
                     request.DataVersion = null;
                     continue;
                 }
+                catch (InsufficientMemoryException) when (request.PageInfo.Count > 1)
+                {
+                    request.PageInfo.Count /= 2;
+                    request.PageInfo.PageNumber = 1;
+                    request.PageInfo.PagingCookie = null;
+                    continue;
+                }
 
                 gotData |= response.EntityChanges.Changes.Count > 0;
 


### PR DESCRIPTION
We have a Sentry error caused by an `InsufficientMemoryException` retrieving entity changes for the reporting service. This adds additional error handling for that exception by reducing the page size and retrying the query.