### PR TITLE
Expose configuration for migrating from PAAS to AKS as tfvars

### DIFF
--- a/terraform/aks/app.tf
+++ b/terraform/aks/app.tf
@@ -58,8 +58,8 @@ module "api_application_configuration" {
     PlatformEnvironment             = var.environment_name
     DistributedLockContainerName    = azurerm_storage_container.locks.name
     DqtReporting__RunService        = var.run_dqt_reporting_service
-    RecurringJobs__Enabled          = "false"
-    ReadOnlyMode                    = "true"
+    RecurringJobs__Enabled          = var.run_recurring_jobs
+    ReadOnlyMode                    = var.readonly_mode
     DataProtectionKeysContainerName = azurerm_storage_container.keys.name
   }
 

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -68,6 +68,13 @@ variable "deploy_dqt_reporting_server" {
 }
 
 variable "run_dqt_reporting_service" {
-  type    = bool
-  default = false
+  type = bool
+}
+
+variable "run_recurring_jobs" {
+  type = bool
+}
+
+variable "readonly_mode" {
+  type = bool
 }

--- a/terraform/aks/workspace_variables/dev.tfvars.json
+++ b/terraform/aks/workspace_variables/dev.tfvars.json
@@ -5,5 +5,7 @@
   "resource_group_name": "s189t01-trs-dv-rg",
   "enable_monitoring": false,
   "deploy_dqt_reporting_server": true,
-  "run_dqt_reporting_service": true
+  "run_dqt_reporting_service": true,
+  "run_recurring_jobs": false,
+  "readonly_mode": true
 }

--- a/terraform/aks/workspace_variables/pre-production.tfvars.json
+++ b/terraform/aks/workspace_variables/pre-production.tfvars.json
@@ -5,5 +5,7 @@
   "resource_group_name": "s189t01-trs-pp-rg",
   "enable_monitoring": false,
   "deploy_dqt_reporting_server": false,
-  "run_dqt_reporting_service": false
+  "run_dqt_reporting_service": false,
+  "run_recurring_jobs": false,
+  "readonly_mode": true
 }

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -5,5 +5,7 @@
   "resource_group_name": "s189p01-trs-pd-rg",
   "enable_monitoring": true,
   "deploy_dqt_reporting_server": false,
-  "run_dqt_reporting_service": false
+  "run_dqt_reporting_service": false,
+  "run_recurring_jobs": false,
+  "readonly_mode": true
 }

--- a/terraform/aks/workspace_variables/test.tfvars.json
+++ b/terraform/aks/workspace_variables/test.tfvars.json
@@ -5,5 +5,7 @@
   "resource_group_name": "s189t01-trs-ts-rg",
   "enable_monitoring": false,
   "deploy_dqt_reporting_server": true,
-  "run_dqt_reporting_service": true
+  "run_dqt_reporting_service": true,
+  "run_recurring_jobs": false,
+  "readonly_mode": true
 }

--- a/terraform/paas/app.tf
+++ b/terraform/paas/app.tf
@@ -20,8 +20,10 @@ locals {
         "PlatformEnvironment"                  = var.environment_name,
         "StorageConnectionString"              = "DefaultEndpointsProtocol=https;AccountName=${azurerm_storage_account.app-storage.name};AccountKey=${azurerm_storage_account.app-storage.primary_access_key}",
         "Platform"                             = "PAAS",
-        "ReadOnlyMode"                         = "false",
-        "DataProtectionKeysContainerName"      = azurerm_storage_container.keys.name
+        "ReadOnlyMode"                         = var.readonly_mode,
+        "DataProtectionKeysContainerName"      = azurerm_storage_container.keys.name,
+        "DqtReporting__RunService"             = var.run_dqt_reporting_service,
+        "RecurringJobs__Enabled"               = var.run_recurring_jobs
       }
     ))
   }

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -109,6 +109,18 @@ variable "reporting_db_name" {
   default = ""
 }
 
+variable "run_dqt_reporting_service" {
+  type = bool
+}
+
+variable "run_recurring_jobs" {
+  type = bool
+}
+
+variable "readonly_mode" {
+  type = bool
+}
+
 locals {
   api_routes = flatten([
     cloudfoundry_route.api_public,

--- a/terraform/paas/workspace_variables/dev.tfvars.json
+++ b/terraform/paas/workspace_variables/dev.tfvars.json
@@ -13,5 +13,8 @@
   "prometheus_app": "prometheus-tra-monitoring-dev",
   "app_storage_account_name": "s165d01dqtapiappdv",
   "reporting_db_server_name": "s165d01-dqt-api-dev-db-reportserver",
-  "reporting_db_name": "s165d01-dqt-api-dev-db-reportdb"
+  "reporting_db_name": "s165d01-dqt-api-dev-db-reportdb",
+  "run_dqt_reporting_service": false,
+  "run_recurring_jobs": true,
+  "readonly_mode": false
 }

--- a/terraform/paas/workspace_variables/pre-production.tfvars.json
+++ b/terraform/paas/workspace_variables/pre-production.tfvars.json
@@ -18,5 +18,8 @@
       "confirmations": 2
     }
   },
-  "app_storage_account_name": "s165t01dqtapiapppp"
+  "app_storage_account_name": "s165t01dqtapiapppp",
+  "run_dqt_reporting_service": true,
+  "run_recurring_jobs": true,
+  "readonly_mode": false
 }

--- a/terraform/paas/workspace_variables/production.tfvars.json
+++ b/terraform/paas/workspace_variables/production.tfvars.json
@@ -22,5 +22,8 @@
     }
   },
   "prometheus_app": "prometheus-tra-monitoring-prod",
-  "app_storage_account_name": "s165p01dqtapiapppd"
+  "app_storage_account_name": "s165p01dqtapiapppd",
+  "run_dqt_reporting_service": true,
+  "run_recurring_jobs": true,
+  "readonly_mode": false
 }

--- a/terraform/paas/workspace_variables/test.tfvars.json
+++ b/terraform/paas/workspace_variables/test.tfvars.json
@@ -20,5 +20,8 @@
   },
   "app_storage_account_name": "s165t01dqtapiappts",
   "reporting_db_server_name": "s165t01-dqt-api-test-db-reportserver",
-  "reporting_db_name": "s165t01-dqt-api-test-db-reportdb"
+  "reporting_db_name": "s165t01-dqt-api-test-db-reportdb",
+  "run_dqt_reporting_service": false,
+  "run_recurring_jobs": true,
+  "readonly_mode": false
 }


### PR DESCRIPTION
When we're switching from PAAS to AKS for a particular environment we need to flip the platform that's running DQT Reporting Service, recurring jobs and in read only mode. This change exposes the three config values that control those things as tfvars for both AKS and PAAS environments.