### PR TITLE
Disable background jobs on test environment

### DIFF
--- a/terraform/paas/workspace_variables/test.tfvars.json
+++ b/terraform/paas/workspace_variables/test.tfvars.json
@@ -22,6 +22,6 @@
   "reporting_db_server_name": "s165t01-dqt-api-test-db-reportserver",
   "reporting_db_name": "s165t01-dqt-api-test-db-reportdb",
   "run_dqt_reporting_service": false,
-  "run_recurring_jobs": true,
+  "run_recurring_jobs": false,
   "readonly_mode": false
 }


### PR DESCRIPTION
We don't have schedule configuration defined here so the service is blowing up on startup.