### PR TITLE
Reject change of dob or name page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CancelIncidentQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CancelIncidentQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record CancelIncidentQuery(Guid IncidentId) : ICrmQuery<bool>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/RejectIncidentQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/RejectIncidentQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record RejectIncidentQuery(Guid IncidentId, string RejectionReason) : ICrmQuery<bool>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CancelIncidentHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CancelIncidentHandler.cs
@@ -1,0 +1,23 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class CancelIncidentHandler : ICrmQueryHandler<CancelIncidentQuery, bool>
+{
+    public async Task<bool> Execute(CancelIncidentQuery query, IOrganizationServiceAsync organizationService)
+    {
+        await organizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new Incident()
+            {
+                Id = query.IncidentId,
+                StateCode = IncidentState.Canceled,
+                StatusCode = Incident_StatusCode.Canceled
+            }
+        });
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/RejectIncidentHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/RejectIncidentHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class RejectIncidentHandler : ICrmQueryHandler<RejectIncidentQuery, bool>
+{
+    public async Task<bool> Execute(RejectIncidentQuery query, IOrganizationServiceAsync organizationService)
+    {
+        await organizationService.ExecuteAsync(new CloseIncidentRequest()
+        {
+            IncidentResolution = new IncidentResolution()
+            {
+                IncidentId = new EntityReference(Incident.EntityLogicalName, query.IncidentId),
+                Subject = query.RejectionReason,
+            },
+            Status = new OptionSetValue((int)Incident_StatusCode.Rejected),
+        });
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumExtensions.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace TeachingRecordSystem.Core;
+
+public static class EnumExtensions
+{
+    public static string? GetDisplayName(this Enum enumValue)
+    {
+        var displayAttribute = enumValue.GetType()
+          .GetMember(enumValue.ToString())
+          .First()
+          .GetCustomAttribute<DisplayAttribute>();
+
+        return displayAttribute is null ? enumValue.ToString() : displayAttribute.GetName();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Reject.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Reject.cshtml
@@ -1,7 +1,39 @@
 @page "/cases/{ticketNumber}/reject"
+@using static TeachingRecordSystem.SupportUi.Pages.Cases.EditCase.RejectModel;
 @model TeachingRecordSystem.SupportUi.Pages.Cases.EditCase.RejectModel
 @{
-    ViewBag.Title = "Reject change";
+    ViewBag.Title = "Are you sure you want to reject this change?";
 }
 
-<p>Reject</p>
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.EditCase(Model.TicketNumber)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+        <form action="@LinkGenerator.RejectCase(Model.TicketNumber)" method="post" asp-antiforgery="true">
+            <govuk-radios asp-for="RejectionReasonChoice">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend>
+                        <h3 class="govuk-heading-m">Reason for rejecting</h3>
+                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-item value="@CaseRejectionReasonOption.RequestAndProofDontMatch">
+                        @CaseRejectionReasonOption.RequestAndProofDontMatch.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@CaseRejectionReasonOption.WrongTypeOfDocument">
+                        @CaseRejectionReasonOption.WrongTypeOfDocument.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@CaseRejectionReasonOption.ImageQuality">
+                        @CaseRejectionReasonOption.ImageQuality.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@CaseRejectionReasonOption.ChangeNoLongerRequired">
+                        @CaseRejectionReasonOption.ChangeNoLongerRequired.GetDisplayName()
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Confirm</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Reject.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Reject.cshtml.cs
@@ -56,11 +56,11 @@ public class RejectModel : PageModel
         (Incident Incident, dfeta_document[] Documents)? incidentAndDocuments = await GetIncidentAndDocuments();
 
         var requestStatus = "rejected";
-        var flashMessage = "The user's record has not been changed and they have been notified.";
+        var flashMessage = "The user’s record has not been changed and they have been notified.";
         if (RejectionReasonChoice!.Value == CaseRejectionReasonOption.ChangeNoLongerRequired)
         {
             requestStatus = "cancelled";
-            flashMessage = "The user's record has not been changed and they have not been notified.";
+            flashMessage = "The user’s record has not been changed and they have not been notified.";
 
             _ = await _crmQueryDispatcher.ExecuteQuery(new CancelIncidentQuery(incidentAndDocuments.Value.Incident.Id));
         }
@@ -81,7 +81,7 @@ public class RejectModel : PageModel
 
     public enum CaseRejectionReasonOption
     {
-        [Display(Name = "Request and proof don't match")]
+        [Display(Name = "Request and proof don’t match")]
         RequestAndProofDontMatch,
         [Display(Name = "Wrong type of document")]
         WrongTypeOfDocument,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Reject.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Reject.cshtml.cs
@@ -1,5 +1,9 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Cases.EditCase;
@@ -7,7 +11,83 @@ namespace TeachingRecordSystem.SupportUi.Pages.Cases.EditCase;
 [Authorize(Policy = AuthorizationPolicies.CaseManagement)]
 public class RejectModel : PageModel
 {
-    public void OnGet()
+    private readonly TrsLinkGenerator _linkGenerator;
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public RejectModel(
+        TrsLinkGenerator linkGenerator,
+        ICrmQueryDispatcher crmQueryDispatcher)
     {
+        _linkGenerator = linkGenerator;
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
+    [FromRoute]
+    public string TicketNumber { get; set; } = null!;
+
+    [BindProperty]
+    [Display(Name = " ")]
+    [Required(ErrorMessage = "Select the reason for rejecting this change")]
+    public CaseRejectionReasonOption? RejectionReasonChoice { get; set; }
+
+    public async Task<IActionResult> OnGet()
+    {
+        (Incident Incident, dfeta_document[] Documents)? incidentAndDocuments = await GetIncidentAndDocuments();
+        if (incidentAndDocuments is null)
+        {
+            return NotFound();
+        }
+
+        if (incidentAndDocuments.Value.Incident.StateCode != IncidentState.Active)
+        {
+            return BadRequest();
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        (Incident Incident, dfeta_document[] Documents)? incidentAndDocuments = await GetIncidentAndDocuments();
+
+        var requestStatus = "rejected";
+        var flashMessage = "The user's record has not been changed and they have been notified.";
+        if (RejectionReasonChoice!.Value == CaseRejectionReasonOption.ChangeNoLongerRequired)
+        {
+            requestStatus = "cancelled";
+            flashMessage = "The user's record has not been changed and they have not been notified.";
+
+            _ = await _crmQueryDispatcher.ExecuteQuery(new CancelIncidentQuery(incidentAndDocuments.Value.Incident.Id));
+        }
+        else
+        {
+            _ = await _crmQueryDispatcher.ExecuteQuery(new RejectIncidentQuery(incidentAndDocuments.Value.Incident.Id, RejectionReasonChoice.Value.GetDisplayName()!));
+        }
+
+        TempData.SetFlashSuccess(
+            $"The request has been {requestStatus}",
+            flashMessage);
+
+        return Redirect(_linkGenerator.Cases());
+    }
+
+    private Task<(Incident Incident, dfeta_document[] Documents)?> GetIncidentAndDocuments() =>
+        _crmQueryDispatcher.ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
+
+    public enum CaseRejectionReasonOption
+    {
+        [Display(Name = "Request and proof don't match")]
+        RequestAndProofDontMatch,
+        [Display(Name = "Wrong type of document")]
+        WrongTypeOfDocument,
+        [Display(Name = "Image quality")]
+        ImageQuality,
+        [Display(Name = "Change no longer required")]
+        ChangeNoLongerRequired
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/CancelIncidentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/CancelIncidentTests.cs
@@ -1,0 +1,36 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class CancelIncidentTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public CancelIncidentTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var createPersonResult = await _dataScope.TestData.CreatePerson();
+        var createNameChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        // Act
+        _ = await _crmQueryDispatcher.ExecuteQuery(new CancelIncidentQuery(createNameChangeIncidentResult.IncidentId));
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+
+        var canceledIncident = ctx.IncidentSet.SingleOrDefault(i => i.GetAttributeValue<Guid>(Incident.PrimaryIdAttribute) == createNameChangeIncidentResult.IncidentId);
+        Assert.NotNull(canceledIncident);
+        Assert.Equal(IncidentState.Canceled, canceledIncident.StateCode);
+        Assert.Equal(Incident_StatusCode.Canceled, canceledIncident.StatusCode);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/RejectIncidentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/RejectIncidentTests.cs
@@ -1,0 +1,36 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class RejectIncidentTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public RejectIncidentTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var createPersonResult = await _dataScope.TestData.CreatePerson();
+        var createNameChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        // Act
+        _ = await _crmQueryDispatcher.ExecuteQuery(new RejectIncidentQuery(createNameChangeIncidentResult.IncidentId, "Computer says no"));
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+
+        var rejectedIncident = ctx.IncidentSet.SingleOrDefault(i => i.GetAttributeValue<Guid>(Incident.PrimaryIdAttribute) == createNameChangeIncidentResult.IncidentId);
+        Assert.NotNull(rejectedIncident);
+        Assert.Equal(IncidentState.Resolved, rejectedIncident.StateCode);
+        Assert.Equal(Incident_StatusCode.Rejected, rejectedIncident.StatusCode);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Cases/EditCase/RejectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Cases/EditCase/RejectTests.cs
@@ -1,0 +1,173 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Cases.EditCase;
+
+public class RejectTests : TestBase
+{
+    public RejectTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WhenUserHasNoRoles_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{createIncidentResult.TicketNumber}/reject");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WhenUserDoesNotHaveHelpdeskOrAdministratorRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.UnusedRole);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{createIncidentResult.TicketNumber}/reject");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithTicketNumberForNonExistentIncident_ReturnsNotFound()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var nonExistentTicketNumber = Guid.NewGuid().ToString();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{nonExistentTicketNumber}/reject");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithTicketNumberForInactiveIncident_ReturnsBadRequest()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId).WithCanceledStatus());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{createIncidentResult.TicketNumber}/reject");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenRejectionReasonChoiceHasNoSelection_ReturnsError()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/cases/{createIncidentResult.TicketNumber}/reject")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "RejectionReasonChoice", "Select the reason for rejecting this change");
+    }
+
+    [Fact]
+    public async Task Post_WhenUserDoesNotHaveHelpdeskOrAdministratorRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.UnusedRole);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/cases/{createIncidentResult.TicketNumber}/reject")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "RejectionReasonChoice", "RequestAndProofDontMatch" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenRejectionReasonChoiceIsNotChangeNoLongerRequired_RedirectsWithFlashMessage()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/cases/{createIncidentResult.TicketNumber}/reject")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "RejectionReasonChoice", "RequestAndProofDontMatch" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "The request has been rejected");
+    }
+
+    [Fact]
+    public async Task Post_WhenRejectionReasonChoiceIsChangeNoLongerRequired_RedirectsWithFlashMessage()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/cases/{createIncidentResult.TicketNumber}/reject")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "RejectionReasonChoice", "ChangeNoLongerRequired" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "The request has been cancelled");
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/FakeXrmEasy/FakeMessageExecutors/WorkaroundCloseIncidentRequestExecutor.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/FakeXrmEasy/FakeMessageExecutors/WorkaroundCloseIncidentRequestExecutor.cs
@@ -1,0 +1,79 @@
+using FakeXrmEasy;
+using FakeXrmEasy.Abstractions;
+using FakeXrmEasy.Abstractions.FakeMessageExecutors;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+
+namespace TeachingRecordSystem.TestCommon.Infrastructure.FakeXrmEasy.FakeMessageExecutors;
+
+/// <summary>
+/// This fake executor is needed as a workaround to the built in one which has a bug in the GetResponsibleRequestType method which returns the wrong type!
+/// </summary>
+/// <remarks>
+/// The original code this is based on is at https://github.com/DynamicsValue/fake-xrm-easy-messages/blob/3x/src/FakeXrmEasy.Messages/FakeMessageExecutors/CloseIncidentRequestExecutor.cs
+/// </remarks>
+public class WorkaroundCloseIncidentRequestExecutor : IFakeMessageExecutor
+{
+    private const string AttributeIncidentId = "incidentid";
+    private const string AttributeSubject = "subject";
+    private const string IncidentLogicalName = "incident";
+    private const string IncidentResolutionLogicalName = "incidentresolution";
+    private const int StateResolved = 1;
+
+    public bool CanExecute(OrganizationRequest request)
+    {
+        return request is CloseIncidentRequest;
+    }
+
+    public OrganizationResponse Execute(OrganizationRequest request, IXrmFakedContext ctx)
+    {
+        var service = ctx.GetOrganizationService();
+        var closeIncidentRequest = (CloseIncidentRequest)request;
+
+        var incidentResolution = closeIncidentRequest.IncidentResolution;
+        if (incidentResolution == null)
+        {
+            throw FakeOrganizationServiceFaultFactory.New("Cannot close incident without incident resolution.");
+        }
+
+        var status = closeIncidentRequest.Status;
+        if (status == null)
+        {
+            throw FakeOrganizationServiceFaultFactory.New("Cannot close incident without status.");
+        }
+
+        var incidentId = (EntityReference)incidentResolution[AttributeIncidentId];
+        if (!ctx.ContainsEntity(IncidentLogicalName, incidentId.Id))
+        {
+            throw FakeOrganizationServiceFaultFactory.New(string.Format("Incident with id {0} not found.", incidentId.Id));
+        }
+
+        var newIncidentResolution = new Entity
+        {
+            LogicalName = IncidentResolutionLogicalName,
+            Attributes = new AttributeCollection
+                {
+                    { "description", incidentResolution[AttributeSubject] },
+                    { AttributeSubject, incidentResolution[AttributeSubject] },
+                    { AttributeIncidentId, incidentId }
+                }
+        };
+        service.Create(newIncidentResolution);
+
+        var setState = new SetStateRequest
+        {
+            EntityMoniker = incidentId,
+            Status = status,
+            State = new OptionSetValue(StateResolved)
+        };
+
+        service.Execute(setState);
+
+        return new CloseIncidentResponse();
+    }
+
+    public Type GetResponsibleRequestType()
+    {
+        return typeof(CloseIncidentRequest);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
@@ -6,10 +6,12 @@ using FakeXrmEasy.Middleware;
 using FakeXrmEasy.Middleware.Crud;
 using FakeXrmEasy.Middleware.Messages;
 using FakeXrmEasy.Middleware.Pipeline;
+using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.TestCommon.Infrastructure.FakeXrmEasy.FakeMessageExecutors;
 using TeachingRecordSystem.TestCommon.Infrastructure.FakeXrmEasy.Plugins;
 
 namespace TeachingRecordSystem.TestCommon;
@@ -22,6 +24,7 @@ public static class ServiceCollectionExtensions
             .New()
             .AddCrud()
             .AddFakeMessageExecutors(Assembly.GetAssembly(typeof(ExecuteTransactionExecutor)))
+            .AddFakeMessageExecutor<CloseIncidentRequest>(new WorkaroundCloseIncidentRequestExecutor())
             .AddPipelineSimulation()
             .UsePipelineSimulation()
             .UseCrud()


### PR DESCRIPTION
### Context

We’re moving the view/approve/decline change of name & DOB processes into the new TRS Support Console.

### Changes proposed in this pull request

Add the /cases/{id}/reject page following the designs in Figma.

The back link should go to /cases/{id}.

If the specified case does not exist, return a 404.

If the specified case’s state is not Active, return a 400.

Show a selection of radio buttons with rejection reasons, as per the designs. If Confirm is clicked without an option being selected, show an error ‘Select the reason for rejecting this change’.

When Confirm is clicked, set the case’s status to Rejected with an incident resolution status matching the selected rejected reason, and redirect to /cases with a success notification banner, as shown in the designs.

Change no longer required is a special case which should cause the case's status to be changed to Canceled

### Guidance to review

CRM queries + UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
