### PR TITLE
Accept change of dob or name page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/ApproveIncidentQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/ApproveIncidentQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record ApproveIncidentQuery(Guid IncidentId) : ICrmQuery<bool>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/ApproveIncidentHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/ApproveIncidentHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class ApproveIncidentHandler : ICrmQueryHandler<ApproveIncidentQuery, bool>
+{
+    public async Task<bool> Execute(ApproveIncidentQuery query, IOrganizationServiceAsync organizationService)
+    {
+        await organizationService.ExecuteAsync(new CloseIncidentRequest()
+        {
+            IncidentResolution = new IncidentResolution()
+            {
+                IncidentId = new EntityReference(Incident.EntityLogicalName, query.IncidentId),
+                Subject = "Approved",
+            },
+            Status = new OptionSetValue((int)Incident_StatusCode.Approved),
+        });
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml
@@ -7,3 +7,23 @@
 @section BeforeContent {
     <govuk-back-link href="@LinkGenerator.EditCase(Model.TicketNumber)" />
 }
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+        <form action="@LinkGenerator.AcceptCase(Model.TicketNumber)" method="post" asp-antiforgery="true">
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Current</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.CurrentValue</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Change to</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.NewValue</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Confirm</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml
@@ -1,7 +1,9 @@
 @page "/cases/{ticketNumber}/accept"
 @model TeachingRecordSystem.SupportUi.Pages.Cases.EditCase.AcceptModel
 @{
-    ViewBag.Title = "Accept change";
+    ViewBag.Title = "Are you sure you want to accept this change?";
 }
 
-<p>Accept</p>
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.EditCase(Model.TicketNumber)" />
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
@@ -7,6 +8,9 @@ namespace TeachingRecordSystem.SupportUi.Pages.Cases.EditCase;
 [Authorize(Policy = AuthorizationPolicies.CaseManagement)]
 public class AcceptModel : PageModel
 {
+    [FromRoute]
+    public string TicketNumber { get; set; } = null!;
+
     public void OnGet()
     {
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Cases/EditCase/Accept.cshtml.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Cases.EditCase;
@@ -8,10 +10,73 @@ namespace TeachingRecordSystem.SupportUi.Pages.Cases.EditCase;
 [Authorize(Policy = AuthorizationPolicies.CaseManagement)]
 public class AcceptModel : PageModel
 {
+    private readonly TrsLinkGenerator _linkGenerator;
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public AcceptModel(
+        TrsLinkGenerator linkGenerator,
+        ICrmQueryDispatcher crmQueryDispatcher)
+    {
+        _linkGenerator = linkGenerator;
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
     [FromRoute]
     public string TicketNumber { get; set; } = null!;
 
-    public void OnGet()
+    public string? CurrentValue { get; set; }
+
+    public string? NewValue { get; set; }
+
+    public async Task<IActionResult> OnGet()
     {
+        (Incident Incident, dfeta_document[] Documents)? incidentAndDocuments = await GetIncidentAndDocuments();
+        if (incidentAndDocuments is null)
+        {
+            return NotFound();
+        }
+
+        if (incidentAndDocuments.Value.Incident.StateCode != IncidentState.Active)
+        {
+            return BadRequest();
+        }
+
+        SetModelFromIncident(incidentAndDocuments.Value.Incident);
+
+        return Page();
     }
+
+    public async Task<IActionResult> OnPost()
+    {
+        (Incident Incident, dfeta_document[] Documents)? incidentAndDocuments = await GetIncidentAndDocuments();
+
+        _ = await _crmQueryDispatcher.ExecuteQuery(new ApproveIncidentQuery(incidentAndDocuments.Value.Incident.Id));
+
+        TempData.SetFlashSuccess(
+            $"The request has been accepted",
+            "The user’s record has been changed and they have been notified.");
+
+        return Redirect(_linkGenerator.Cases());
+    }
+
+    private void SetModelFromIncident(Incident incident)
+    {
+        var customer = incident.Extract<Contact>("contact", Contact.PrimaryIdAttribute);
+        var subject = incident.Extract<Subject>("subject", Subject.PrimaryIdAttribute);
+
+        if (subject.Title == DqtConstants.NameChangeSubjectTitle)
+        {
+            CurrentValue = string.IsNullOrEmpty(customer.MiddleName) ? $"{customer.FirstName} {customer.LastName}" : $"{customer.FirstName} {customer.MiddleName} {customer.LastName}";
+            NewValue = string.IsNullOrEmpty(incident.dfeta_NewMiddleName) ? $"{incident.dfeta_NewFirstName} {incident.dfeta_NewLastName}" : $"{incident.dfeta_NewFirstName} {incident.dfeta_NewMiddleName} {incident.dfeta_NewLastName}";
+        }
+
+        if (subject.Title == DqtConstants.DateOfBirthChangeSubjectTitle)
+        {
+            CurrentValue = customer.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false)!.Value.ToString("dd/MM/yyyy");
+            NewValue = incident.dfeta_NewDateofBirth.ToDateOnlyWithDqtBstFix(isLocalTime: true)!.Value.ToString("dd/MM/yyyy");
+        }
+    }
+
+    private Task<(Incident Incident, dfeta_document[] Documents)?> GetIncidentAndDocuments() =>
+        _crmQueryDispatcher.ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/ApproveIncidentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/ApproveIncidentTests.cs
@@ -1,0 +1,36 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class ApproveIncidentTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public ApproveIncidentTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var createPersonResult = await _dataScope.TestData.CreatePerson();
+        var createNameChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        // Act
+        _ = await _crmQueryDispatcher.ExecuteQuery(new ApproveIncidentQuery(createNameChangeIncidentResult.IncidentId));
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+
+        var approvedIncident = ctx.IncidentSet.SingleOrDefault(i => i.GetAttributeValue<Guid>(Incident.PrimaryIdAttribute) == createNameChangeIncidentResult.IncidentId);
+        Assert.NotNull(approvedIncident);
+        Assert.Equal(IncidentState.Resolved, approvedIncident.StateCode);
+        Assert.Equal(Incident_StatusCode.Approved, approvedIncident.StatusCode);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Cases/EditCase/AcceptTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Cases/EditCase/AcceptTests.cs
@@ -1,0 +1,120 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Cases.EditCase;
+
+public class AcceptTests : TestBase
+{
+    public AcceptTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WhenUserHasNoRoles_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{createIncidentResult.TicketNumber}/accept");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WhenUserDoesNotHaveHelpdeskOrAdministratorRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.UnusedRole);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{createIncidentResult.TicketNumber}/accept");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithTicketNumberForNonExistentIncident_ReturnsNotFound()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var nonExistentTicketNumber = Guid.NewGuid().ToString();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{nonExistentTicketNumber}/accept");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithTicketNumberForInactiveIncident_ReturnsBadRequest()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId).WithCanceledStatus());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/cases/{createIncidentResult.TicketNumber}/accept");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenUserDoesNotHaveHelpdeskOrAdministratorRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.UnusedRole);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/cases/{createIncidentResult.TicketNumber}/accept")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_RedirectsWithFlashMessage()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.Helpdesk);
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/cases/{createIncidentResult.TicketNumber}/accept")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "The request has been accepted");
+    }
+}


### PR DESCRIPTION
### Context

We’re moving the view/approve/decline change of name & DOB processes into the new TRS Support Console.

### Changes proposed in this pull request

Add the /cases/{id}/accept page following the designs in Figma .

The back link should go to /cases/{id}.

If the specified case does not exist, return a 404.

If the specified case’s state is not Active, return a 400.

Show a summary list with the current and requested names or DOBs, as appropriate.

When Confirm is clicked, set the case’s status to Approved with an incident resolution status of Approvedand redirect to /cases with a success notification banner, as shown in the designs.

### Guidance to review

UI + CRM query + tests.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
