### PR TITLE
Expose more sanction details on Find endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/SanctionInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/SanctionInfo.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.Responses;
+
+public record SanctionInfo
+{
+    public required string Code { get; init; }
+    public required DateOnly? StartDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
@@ -1,8 +1,10 @@
+using System.Collections.Immutable;
+
 namespace TeachingRecordSystem.Api.V3;
 
 public static class Constants
 {
-    public static IReadOnlyCollection<string> ExposableSanctionCodes { get; } = new[]
+    public static ImmutableArray<string> ExposableSanctionCodes { get; } = new[]
     {
         "G1",
         "A18",
@@ -35,5 +37,5 @@ public static class Constants
         "A2",
         "A24",
         "A23",
-    }.AsReadOnly();
+    }.ToImmutableArray();
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/FindTeachersHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/FindTeachersHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using MediatR;
 using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Api.V3.Requests;
@@ -50,10 +51,17 @@ public class FindTeachersHandler : IRequestHandler<FindTeachersRequest, FindTeac
                 FirstName = r.ResolveFirstName(),
                 MiddleName = r.ResolveMiddleName(),
                 LastName = r.ResolveLastName(),
-                Sanctions = sanctions[r.Id].Select(s => s.SanctionCode).ToArray()
+                Sanctions = sanctions[r.Id]
+                    .Where(s => Constants.ExposableSanctionCodes.Contains(s.SanctionCode))
+                    .Select(s => new SanctionInfo()
+                    {
+                        Code = s.SanctionCode,
+                        StartDate = s.Sanction.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true)
+                    })
+                    .ToImmutableArray()
             })
             .OrderBy(c => c.Trn)
-            .ToArray()
+            .ToImmutableArray()
         };
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -187,7 +187,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             pendingDateOfBirthChange = incidents.Any(i => i.SubjectId.Id == dateOfBirthChangeSubject.Id);
         }
 
-        IEnumerable<GetTeacherResponseSanction>? sanctions = null;
+        IEnumerable<SanctionInfo>? sanctions = null;
 
         if (request.Include.HasFlag(GetTeacherRequestIncludes.Sanctions))
         {
@@ -198,7 +198,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
 
             sanctions = (await _crmQueryDispatcher.ExecuteQuery(getSanctionsQuery))[teacher.Id]
                 .Where(s => Constants.ExposableSanctionCodes.Contains(s.SanctionCode))
-                .Select(s => new GetTeacherResponseSanction()
+                .Select(s => new SanctionInfo()
                 {
                     Code = s.SanctionCode,
                     StartDate = s.Sanction.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/FindTeachersResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/FindTeachersResponse.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using TeachingRecordSystem.Api.V3.Requests;
 
 namespace TeachingRecordSystem.Api.V3.Responses;
@@ -6,7 +7,7 @@ public record FindTeachersResponse
 {
     public required int Total { get; init; }
     public required FindTeachersRequest Query { get; init; }
-    public required IReadOnlyCollection<FindTeachersResponseResult> Results { get; init; }
+    public required ImmutableArray<FindTeachersResponseResult> Results { get; init; }
 }
 
 public record FindTeachersResponseResult
@@ -16,5 +17,5 @@ public record FindTeachersResponseResult
     public required string FirstName { get; init; }
     public required string MiddleName { get; init; }
     public required string LastName { get; init; }
-    public required string[] Sanctions { get; init; }
+    public required ImmutableArray<SanctionInfo> Sanctions { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
@@ -22,7 +22,7 @@ public record GetTeacherResponse
     public required Option<IEnumerable<GetTeacherResponseNpqQualificationsQualification>> NpqQualifications { get; init; }
     public required Option<IEnumerable<GetTeacherResponseMandatoryQualificationsQualification>> MandatoryQualifications { get; init; }
     public required Option<IEnumerable<GetTeacherResponseHigherEducationQualificationsQualification>> HigherEducationQualifications { get; init; }
-    public required Option<IEnumerable<GetTeacherResponseSanction>> Sanctions { get; init; }
+    public required Option<IEnumerable<SanctionInfo>> Sanctions { get; init; }
 }
 
 public record GetTeacherResponseQts
@@ -128,10 +128,4 @@ public record GetTeacherResponseHigherEducationQualificationsQualificationSubjec
 {
     public required string Code { get; init; }
     public required string Name { get; init; }
-}
-
-public record GetTeacherResponseSanction
-{
-    public required string Code { get; init; }
-    public required DateOnly? StartDate { get; init; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Microsoft.Xrm.Sdk.Messages;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Models;
@@ -135,7 +136,7 @@ public partial class CrmTestData
                 MiddleName = middleName,
                 LastName = lastName,
                 PreviousLastName = _previousLastName,
-                Sanctions = _sanctions
+                Sanctions = _sanctions.ToImmutableArray()
             };
         }
     }
@@ -150,7 +151,7 @@ public partial class CrmTestData
         public required string MiddleName { get; init; }
         public required string LastName { get; init; }
         public required string? PreviousLastName { get; init; }
-        public required IReadOnlyCollection<Sanction> Sanctions { get; init; }
+        public required ImmutableArray<Sanction> Sanctions { get; init; }
 
         public Contact ToContact() => new()
         {


### PR DESCRIPTION
This makes the `sanctions` property consistent with the detail endpoint. Also fixes and issue where we were returning sanction codes that we shouldn't have been.

I've started to move over collection types to `ImmutableArray<T>` too as discussed separately.