### PR TITLE
Initial iteration of person view

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactDetail.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactDetail.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Models;
+
+public record ContactDetail(Contact Contact);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace TeachingRecordSystem.Core.Dqt.Models;
 
 public static class ContactExtensions
@@ -10,6 +12,37 @@ public static class ContactExtensions
 
     public static string ResolveLastName(this Contact contact) =>
         (contact.HasStatedNames() ? contact.dfeta_StatedLastName : contact.LastName) ?? string.Empty;
+
+    public static string ResolveFullName(this Contact contact, bool includeMiddleName = true)
+    {
+        var fullName = new StringBuilder(contact.ResolveFirstName());
+        if (includeMiddleName)
+        {
+            var middleName = contact.ResolveMiddleName();
+            if (!string.IsNullOrEmpty(middleName))
+            {
+                if (fullName.Length > 0)
+                {
+                    fullName.Append(" ");
+                }
+
+                fullName.Append(middleName);
+            }
+        }
+
+        var lastName = contact.ResolveLastName();
+        if (!string.IsNullOrEmpty(lastName))
+        {
+            if (fullName.Length > 0)
+            {
+                fullName.Append(" ");
+            }
+
+            fullName.Append(lastName);
+        }
+
+        return fullName.ToString();
+    }
 
     private static bool HasStatedNames(this Contact contact) =>
         !string.IsNullOrEmpty(contact.dfeta_StatedFirstName) ||

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByIdQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByIdQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetContactDetailByIdQuery(Guid ContactId, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class GetContactDetailByIdHandler : ICrmQueryHandler<GetContactDetailByIdQuery, ContactDetail?>
+{
+    public async Task<ContactDetail?> Execute(GetContactDetailByIdQuery query, IOrganizationServiceAsync organizationService)
+    {
+        var filter = new FilterExpression();
+        filter.AddCondition(Contact.PrimaryIdAttribute, ConditionOperator.Equal, query.ContactId);
+
+        var queryExpression = new QueryExpression(Contact.PrimaryIdAttribute)
+        {
+            ColumnSet = query.ColumnSet,
+            Criteria = filter
+        };
+
+        var response = await organizationService.RetrieveMultipleAsync(queryExpression);
+        var contact = response.Entities.SingleOrDefault()?.ToEntity<Contact>();
+        if (contact is null)
+        {
+            return null;
+        }
+
+        return new ContactDetail(contact);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
@@ -11,7 +11,7 @@ public class GetContactDetailByIdHandler : ICrmQueryHandler<GetContactDetailById
         var filter = new FilterExpression();
         filter.AddCondition(Contact.PrimaryIdAttribute, ConditionOperator.Equal, query.ContactId);
 
-        var queryExpression = new QueryExpression(Contact.PrimaryIdAttribute)
+        var queryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = query.ColumnSet,
             Criteria = filter

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactsByLastNameAndDateOfBirthHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactsByLastNameAndDateOfBirthHandler.cs
@@ -13,10 +13,9 @@ public class GetContactsByLastNameAndDateOfBirthHandler : ICrmQueryHandler<GetCo
         lastNameFilter.AddCondition(Contact.Fields.LastName, ConditionOperator.Equal, query.LastName);
         lastNameFilter.AddCondition(Contact.Fields.dfeta_PreviousLastName, ConditionOperator.Equal, query.LastName);
 
-        var queryExpression = new QueryExpression()
+        var queryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = query.ColumnSet,
-            EntityName = Contact.EntityLogicalName,
             Criteria = new FilterExpression(LogicalOperator.And)
             {
                 Conditions =

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
@@ -1,0 +1,5 @@
+@page "/persons"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.IndexModel
+@{
+    ViewBag.Title = "All records";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons;
+
+public class IndexModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -8,32 +8,32 @@
     <govuk-back-link href="@LinkGenerator.Persons()" />
 }
 
-<h1 class="govuk-heading-l">@ViewBag.Title</h1>
+<h1 class="govuk-heading-l" data-testid="page-title">@ViewBag.Title</h1>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <govuk-tabs>
             <govuk-tabs-item id="general" label="General">
-                <govuk-summary-list>
+                <govuk-summary-list data-testid="personal-details">
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@Model.Person.FullName</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="personal-details-name">@Model.Person.FullName</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@(Model.Person.DateOfBirth.HasValue ? Model.Person.DateOfBirth.Value.ToString("dd/MM/yyyy") : "Not provided")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="personal-details-date-of-birth">@(Model.Person.DateOfBirth.HasValue ? Model.Person.DateOfBirth.Value.ToString("dd/MM/yyyy") : "Not provided")</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.Person.Trn) ? Model.Person.Trn : "Not provided")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="personal-details-trn">@(!string.IsNullOrEmpty(Model.Person.Trn) ? Model.Person.Trn : "Not provided")</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.Person.Email) ? Model.Person.Email : "Not provided")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="personal-details-email">@(!string.IsNullOrEmpty(Model.Person.Email) ? Model.Person.Email : "Not provided")</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.Person.MobileNumber) ? Model.Person.MobileNumber : "Not provided")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="personal-details-mobile-number">@(!string.IsNullOrEmpty(Model.Person.MobileNumber) ? Model.Person.MobileNumber : "Not provided")</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                 </govuk-summary-list>
             </govuk-tabs-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -1,0 +1,42 @@
+@page "/persons/{personId}"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.IndexModel
+@{
+    ViewBag.Title = @Model.Person!.Name;
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.Persons()" />
+}
+
+<h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <govuk-tabs>
+            <govuk-tabs-item id="general" label="General">
+                <govuk-summary-list>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.Person.FullName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@(Model.Person.DateOfBirth.HasValue ? Model.Person.DateOfBirth.Value.ToString("dd/MM/yyyy") : "Not provided")</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.Person.Trn) ? Model.Person.Trn : "Not provided")</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.Person.Email) ? Model.Person.Email : "Not provided")</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.Person.MobileNumber) ? Model.Person.MobileNumber : "Not provided")</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                </govuk-summary-list>
+            </govuk-tabs-item>
+        </govuk-tabs>
+     </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+
+public class IndexModel : PageModel
+{
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public IndexModel(ICrmQueryDispatcher crmQueryDispatcher)
+    {
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
+    [FromRoute]
+    public Guid PersonId { get; set; }
+
+    public PersonInfo? Person { get; set; }
+
+    public async Task<IActionResult> OnGet()
+    {
+        var contactDetail = await _crmQueryDispatcher.ExecuteQuery(
+            new GetContactDetailByIdQuery(
+                PersonId,
+                new ColumnSet(
+                    Contact.Fields.dfeta_TRN,
+                    Contact.Fields.BirthDate,
+                    Contact.Fields.FirstName,
+                    Contact.Fields.MiddleName,
+                    Contact.Fields.LastName,
+                    Contact.Fields.dfeta_StatedFirstName,
+                    Contact.Fields.dfeta_StatedMiddleName,
+                    Contact.Fields.dfeta_StatedLastName,
+                    Contact.Fields.EMailAddress1,
+                    Contact.Fields.MobilePhone,
+                    Contact.Fields.dfeta_NINumber)));
+
+        if (contactDetail is null)
+        {
+            return NotFound();
+        }
+
+        Person = MapContact(contactDetail.Contact);
+
+        return Page();
+    }
+
+    private PersonInfo MapContact(Contact contact)
+    {
+        return new PersonInfo()
+        {
+            Name = contact.ResolveFullName(includeMiddleName: false),
+            FullName = contact.ResolveFullName(includeMiddleName: true),
+            DateOfBirth = contact.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false),
+            Trn = contact.dfeta_TRN,
+            NationalInsuranceNumber = contact.dfeta_NINumber,
+            Email = contact.EMailAddress1,
+            MobileNumber = contact.MobilePhone
+        };
+    }
+
+    public record PersonInfo
+    {
+        public required string Name { get; init; }
+        public required string FullName { get; init; }
+        public required DateOnly? DateOfBirth { get; init; }
+        public required string? Trn { get; init; }
+        public required string? NationalInsuranceNumber { get; init; }
+        public required string? Email { get; init; }
+        public required string? MobileNumber { get; init; }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -25,6 +25,10 @@ public class TrsLinkGenerator
 
     public string RejectCase(string ticketNumber) => GetRequiredPathByPage("/Cases/EditCase/Reject", routeValues: new { ticketNumber });
 
+    public string Persons() => GetRequiredPathByPage("/Persons/Index");
+
+    public string PersonDetail() => GetRequiredPathByPage("/Persons/PersonDetail/Index");
+
     public string Users() => GetRequiredPathByPage("/Users/Index");
 
     public string AddUser() => GetRequiredPathByPage("/Users/AddUser/Index");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactByTrnTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class GetContactByTrnTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public GetContactByTrnTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task WhenCalled_WithTrnForNonExistentContact_ReturnsNull()
+    {
+        // Arrange        
+        var trn = "DodgyTrn";
+
+        // Act
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactByTrnQuery(trn, new ColumnSet()));
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task WhenCalled_WithTrnForExistingContact_ReturnsContactDetail()
+    {
+        // Arrange        
+        var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
+
+        // Act
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactByTrnQuery(person.Trn!, new ColumnSet()));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Id, person.ContactId);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactDetailByIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactDetailByIdTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class GetContactDetailByIdTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public GetContactDetailByIdTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task WhenCalled_WithContactIdForNonExistentContact_ReturnsNull()
+    {
+        // Arrange        
+        var contactId = Guid.NewGuid();
+
+        // Act
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(contactId, new ColumnSet()));
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task WhenCalled_WithContactIdForExistingContact_ReturnsContactDetail()
+    {
+        // Arrange        
+        var person = await _dataScope.TestData.CreatePerson();
+
+        // Act
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(person.ContactId, new ColumnSet()));
+
+        // Assert
+        Assert.NotNull(results);
+        Assert.Equal(results.Contact.Id, person.ContactId);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
@@ -1,0 +1,80 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
+
+public class IndexTests : TestBase
+{
+    public IndexTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
+    {
+        // Arrange        
+        var nonExistentPersonId = Guid.NewGuid().ToString();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{nonExistentPersonId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithPersonIdForExistingPersonWithAllPropertiesSet_ReturnsExpectedContent()
+    {
+        // Arrange
+        var email = TestData.GenerateUniqueEmail();
+        var mobileNumber = TestData.GenerateUniqueMobileNumber();
+        var createPersonResult = await TestData.CreatePerson(b => b.WithEmail(email).WithMobileNumber(mobileNumber));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+
+        Assert.Equal($"{createPersonResult.FirstName} {createPersonResult.LastName}", doc.GetElementByTestId("page-title")!.TextContent);
+        var summaryList = doc.GetElementByTestId("personal-details");
+        Assert.NotNull(summaryList);
+        Assert.Equal($"{createPersonResult.FirstName} {createPersonResult.MiddleName} {createPersonResult.LastName}", summaryList.GetElementByTestId("personal-details-name")!.TextContent);
+        Assert.Equal(createPersonResult.DateOfBirth.ToString("dd/MM/yyyy"), summaryList.GetElementByTestId("personal-details-date-of-birth")!.TextContent);
+        Assert.Equal(createPersonResult.Trn, summaryList.GetElementByTestId("personal-details-trn")!.TextContent);
+        Assert.Equal(createPersonResult.Email, summaryList.GetElementByTestId("personal-details-email")!.TextContent);
+        Assert.Equal(createPersonResult.MobileNumber, summaryList.GetElementByTestId("personal-details-mobile-number")!.TextContent);
+    }
+
+    [Fact]
+    public async Task Get_WithPersonIdForExistingPersonWithMissingProperties_ReturnsExpectedContent()
+    {
+        // Arrange
+        var email = TestData.GenerateUniqueEmail();
+        var mobileNumber = TestData.GenerateUniqueMobileNumber();
+        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn(hasTrn: false));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+
+        Assert.Equal($"{createPersonResult.FirstName} {createPersonResult.LastName}", doc.GetElementByTestId("page-title")!.TextContent);
+        var summaryList = doc.GetElementByTestId("personal-details");
+        Assert.NotNull(summaryList);
+        Assert.Equal($"{createPersonResult.FirstName} {createPersonResult.MiddleName} {createPersonResult.LastName}", summaryList.GetElementByTestId("personal-details-name")!.TextContent);
+        Assert.Equal(createPersonResult.DateOfBirth.ToString("dd/MM/yyyy"), summaryList.GetElementByTestId("personal-details-date-of-birth")!.TextContent);
+        Assert.Equal("Not provided", summaryList.GetElementByTestId("personal-details-trn")!.TextContent);
+        Assert.Equal("Not provided", summaryList.GetElementByTestId("personal-details-email")!.TextContent);
+        Assert.Equal("Not provided", summaryList.GetElementByTestId("personal-details-mobile-number")!.TextContent);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
@@ -20,6 +20,8 @@ public partial class CrmTestData
         private bool? _hasTrn;
         private string? _lastName;
         private string? _previousLastName;
+        private string? _email;
+        private string? _mobileNumber;
         private readonly List<Sanction> _sanctions = new();
 
         public CreatePersonBuilder WithDateOfBirth(DateOnly dateOfBirth)
@@ -41,6 +43,28 @@ public partial class CrmTestData
             }
 
             _lastName = lastName;
+            return this;
+        }
+
+        public CreatePersonBuilder WithEmail(string email)
+        {
+            if (_email is not null && _email != email)
+            {
+                throw new InvalidOperationException("WithEmail cannot be changed after it's set.");
+            }
+
+            _email = email;
+            return this;
+        }
+
+        public CreatePersonBuilder WithMobileNumber(string mobileNumber)
+        {
+            if (_mobileNumber is not null && _mobileNumber != mobileNumber)
+            {
+                throw new InvalidOperationException("WithMobileNumber cannot be changed after it's set.");
+            }
+
+            _mobileNumber = mobileNumber;
             return this;
         }
 
@@ -104,6 +128,16 @@ public partial class CrmTestData
                 contact.dfeta_PreviousLastName = _previousLastName;
             }
 
+            if (_email is not null)
+            {
+                contact.EMailAddress1 = _email;
+            }
+
+            if (_mobileNumber is not null)
+            {
+                contact.MobilePhone = _mobileNumber;
+            }
+
             var txnRequestBuilder = RequestBuilder.CreateTransaction(testData.OrganizationService);
             txnRequestBuilder.AddRequest(new CreateRequest() { Target = contact });
 
@@ -136,6 +170,8 @@ public partial class CrmTestData
                 MiddleName = middleName,
                 LastName = lastName,
                 PreviousLastName = _previousLastName,
+                Email = _email,
+                MobileNumber = _mobileNumber,
                 Sanctions = _sanctions.ToImmutableArray()
             };
         }
@@ -151,6 +187,8 @@ public partial class CrmTestData
         public required string MiddleName { get; init; }
         public required string LastName { get; init; }
         public required string? PreviousLastName { get; init; }
+        public required string? Email { get; init; }
+        public required string? MobileNumber { get; init; }
         public required ImmutableArray<Sanction> Sanctions { get; init; }
 
         public Contact ToContact() => new()
@@ -163,7 +201,10 @@ public partial class CrmTestData
             dfeta_StatedMiddleName = MiddleName,
             dfeta_StatedLastName = LastName,
             BirthDate = DateOfBirth.FromDateOnlyWithDqtBstFix(isLocalTime: false),
-            dfeta_TRN = Trn
+            dfeta_TRN = Trn,
+            dfeta_PreviousLastName = PreviousLastName,
+            EMailAddress1 = Email,
+            MobilePhone = MobileNumber
         };
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.cs
@@ -7,6 +7,7 @@ public partial class CrmTestData
 {
     private static readonly object _gate = new();
     private static readonly HashSet<string> _emails = new();
+    private static readonly HashSet<string> _mobileNumbers = new();
 
     private readonly Func<Task<string>> _generateTrn;
 
@@ -86,6 +87,22 @@ public partial class CrmTestData
         }
 
         return email;
+    }
+
+    public string GenerateUniqueMobileNumber()
+    {
+        string mobileNumber;
+
+        lock (_gate)
+        {
+            do
+            {
+                mobileNumber = Faker.Phone.Number();
+            }
+            while (!_mobileNumbers.Add(mobileNumber));
+        }
+
+        return mobileNumber;
     }
 
     public virtual Task<string> GenerateTrn() => _generateTrn();


### PR DESCRIPTION
### Context

We need a way for support staff to view a person’s record in TRS.

### Changes proposed in this pull request

Add a new page at /persons/{personId}.

Within the General tab, show the name (first, middle & last), date of birth, TRN, email address and mobile number. For any empty fields, show ‘Not provided’. Change links are out of scope of this ticket.

The back link should go to /persons (a stub page).

If there is no contact in DQT with the specified personId (personId == DQT contact ID) return a 404.

The Alerts and Change log tabs are out of scope of this ticket.

For now, every user can access this page.

### Guidance to review

Crm Query + UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
