### PR TITLE
Added SASS to the UI and build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Authorization: Bearer your_api_key
 The API is an ASP.NET Core 7 web application. To develop locally you will need the following installed:
 - Visual Studio 2022 (or the .NET 7 SDK an alternative IDE/editor);
 - a local Postgres 13+ instance.
+- [SASS]( https://sass-lang.com/install).
 
 A `justfile` defines various recipes for development. Ensure [just](https://just.systems/) is installed and available on your `$PATH` as well as [PowerShell](https://microsoft.com/PowerShell).
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/.gitignore
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/.gitignore
@@ -1,0 +1,3 @@
+wwwroot/lib
+wwwroot/Styles/*.css
+wwwroot/Styles/*.css.map

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/.gitignore
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/.gitignore
@@ -1,3 +1,2 @@
 wwwroot/lib
-wwwroot/Styles/*.css
 wwwroot/Styles/*.css.map

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/.gitignore
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/.gitignore
@@ -1,2 +1,3 @@
 wwwroot/lib
+wwwroot/Styles/*.css
 wwwroot/Styles/*.css.map

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
@@ -7,8 +7,7 @@
 }
 
 @section Head {
-    @PageTemplateHelper.GenerateStyleImports()
-    <link rel="stylesheet" asp-href-include="~/Styles/site.css">
+    <link rel="stylesheet" asp-href-include="~/Styles/*.css">
     @RenderSection("Styles", required: false)
     @RenderSection("Scripts", required: false)
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="2.13.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.10" />
     <PackageReference Include="Microsoft.Identity.Web.GraphServiceClientBeta" Version="2.13.2" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
@@ -5,6 +5,10 @@
     <UserSecretsId>TeachingRecordSystemSupportUi</UserSecretsId>
   </PropertyGroup>
 
+  <Target Name="CompileSass" BeforeTargets="Build">
+    <Exec Command="sass -q wwwroot/Styles/site.scss wwwroot/Styles/site.css" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="7.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="7.0.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/libman.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/libman.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "defaultProvider": "jsdelivr",
+  "libraries": [
+    {
+      "library": "govuk-frontend@4.5.0",
+      "destination": "wwwroot/lib/govuk-frontend/"
+    }
+  ]
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.css
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.css
@@ -1,0 +1,5 @@
+.trs-table__header--no-border,
+.trs-table__cell--no-border,
+.trs-table--no-border {
+  border: 0;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.css
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.css
@@ -1,5 +1,0 @@
-.trs-table__header--no-border,
-.trs-table__cell--no-border,
-.trs-table--no-border {
-  border: 0;
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -1,4 +1,4 @@
-
+@use '../lib/govuk-frontend/govuk/all.scss';
 
 .trs-table__header--no-border,
 .trs-table__cell--no-border,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -1,3 +1,5 @@
+
+
 .trs-table__header--no-border,
 .trs-table__cell--no-border,
 .trs-table--no-border {

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ default:
 # Install .NET local tools
 install-tools:
   @cd {{solution-root}} && dotnet tool restore
+  @cd {{solution-root}} && npm install -g sass 
 
 # Run the trscli
 cli *ARGS:

--- a/justfile
+++ b/justfile
@@ -5,10 +5,10 @@ solution-root := "TeachingRecordSystem"
 default:
   @just --list
 
-# Install .NET local tools
+# Install local tools
 install-tools:
   @cd {{solution-root}} && dotnet tool restore
-  @cd {{solution-root}} && npm install -g sass 
+  npm install -g sass 
 
 # Run the trscli
 cli *ARGS:
@@ -81,7 +81,7 @@ docker-build-cli *ARGS:
 
 # Build the Support UI Docker image
 docker-build-ui *ARGS:
-  @cd {{solution-root}} && npm install -g sass
+  npm install -g sass
   @cd {{solution-root / "src" / "TeachingRecordSystem.SupportUi"}} && dotnet publish -c Release
   @cd {{solution-root}} && docker build . -f {{"src" / "TeachingRecordSystem.SupportUi" / "Dockerfile"}} {{ARGS}}
 

--- a/justfile
+++ b/justfile
@@ -81,6 +81,7 @@ docker-build-cli *ARGS:
 
 # Build the Support UI Docker image
 docker-build-ui *ARGS:
+  @cd {{solution-root}} && npm install -g sass
   @cd {{solution-root / "src" / "TeachingRecordSystem.SupportUi"}} && dotnet publish -c Release
   @cd {{solution-root}} && docker build . -f {{"src" / "TeachingRecordSystem.SupportUi" / "Dockerfile"}} {{ARGS}}
 


### PR DESCRIPTION
### Context

We need a way to define styles that can use variables from the base GDS library as well as, potentially, importing components from other design systems e.g. MOJ.

### Changes proposed in this pull request

Add SASS to the SupportUi in the same way it’s set up in [GitHub - DFE-Digital/get-an-identity](https://github.com/DFE-Digital/get-an-identity)

The project file, build workflow, docs will all need updating. Use libman to reference the GDS library.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
