### PR TITLE
Fix TRS UI docker image to handle GMT timezone

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Dockerfile
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Dockerfile
@@ -5,5 +5,13 @@ ENV GitSha ${GIT_SHA}
 COPY src/TeachingRecordSystem.SupportUi/bin/Release/net7.0/publish/ App/
 WORKDIR /App
 
+# Install Culture prerequisities
+RUN apk add --no-cache \
+        icu-data-full \
+        icu-libs
+
+# Enable all cultures
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
 ENTRYPOINT ["dotnet", "/App/TeachingRecordSystem.SupportUi.dll"]
 EXPOSE 80


### PR DESCRIPTION
### Context

Currently the dev deployment of TRS UI falls over on some screens which do date / time manipulation due to the base Alpine image not supporting cultures.

### Changes proposed in this pull request

Enable cultures in the docker image used for the TRS UI as per
[alpine images have no cultures installed · Issue #533 · dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker/issues/533#issuecomment-1240514745)

### Guidance to review

Dockerfile change

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
