### PR TITLE
Update tab styles on Person view page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -12,8 +12,26 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <govuk-tabs>
-            <govuk-tabs-item id="general" label="General">
+        
+        <nav class="moj-sub-navigation" aria-label="Sub navigation">
+            <ul class="moj-sub-navigation__list">
+                <li class="moj-sub-navigation__item">
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonPage.General ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonPage.General.ToString())">General</a>
+                </li>
+
+                <li class="moj-sub-navigation__item">
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonPage.Alerts ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonPage.Alerts.ToString())">Alerts</a>
+                </li>
+
+                <li class="moj-sub-navigation__item">
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonPage.ChangeLog ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonPage.ChangeLog.ToString())">Change log</a>
+                </li>
+            </ul>
+        </nav>
+        @if (Model.SelectedTab == IndexModel.PersonPage.General)
+        {
+            <govuk-summary-card>
+                <govuk-summary-card-title>Personal Details</govuk-summary-card-title>
                 <govuk-summary-list data-testid="personal-details">
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
@@ -36,7 +54,7 @@
                         <govuk-summary-list-row-value data-testid="personal-details-mobile-number">@(!string.IsNullOrEmpty(Model.Person.MobileNumber) ? Model.Person.MobileNumber : "Not provided")</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                 </govuk-summary-list>
-            </govuk-tabs-item>
-        </govuk-tabs>
+            </govuk-summary-card>            
+        }        
      </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -16,19 +16,19 @@
         <nav class="moj-sub-navigation" aria-label="Sub navigation">
             <ul class="moj-sub-navigation__list">
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonPage.General ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonPage.General.ToString())">General</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.General ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.General.ToString())">General</a>
                 </li>
 
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonPage.Alerts ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonPage.Alerts.ToString())">Alerts</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.Alerts ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.Alerts.ToString())">Alerts</a>
                 </li>
 
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonPage.ChangeLog ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonPage.ChangeLog.ToString())">Change log</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.ChangeLog ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.ChangeLog.ToString())">Change log</a>
                 </li>
             </ul>
         </nav>
-        @if (Model.SelectedTab == IndexModel.PersonPage.General)
+        @if (Model.SelectedTab == IndexModel.PersonSubNavigationTab.General)
         {
             <govuk-summary-card>
                 <govuk-summary-card-title>Personal Details</govuk-summary-card-title>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -16,15 +16,15 @@
         <nav class="moj-sub-navigation" aria-label="Sub navigation">
             <ul class="moj-sub-navigation__list">
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.General ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.General.ToString())">General</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.General ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.General)">General</a>
                 </li>
 
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.Alerts ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.Alerts.ToString())">Alerts</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.Alerts ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.Alerts)">Alerts</a>
                 </li>
 
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.ChangeLog ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.ChangeLog.ToString())">Change log</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.ChangeLog ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.ChangeLog)">Change log</a>
                 </li>
             </ul>
         </nav>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -19,13 +19,13 @@ public class IndexModel : PageModel
     public Guid PersonId { get; set; }
 
     [FromQuery]
-    public PersonPage? SelectedTab { get; set; }
+    public PersonSubNavigationTab? SelectedTab { get; set; }
 
     public PersonInfo? Person { get; set; }
 
     public async Task<IActionResult> OnGet()
     {
-        SelectedTab ??= PersonPage.General;
+        SelectedTab ??= PersonSubNavigationTab.General;
 
         var contactDetail = await _crmQueryDispatcher.ExecuteQuery(
             new GetContactDetailByIdQuery(
@@ -78,7 +78,7 @@ public class IndexModel : PageModel
         public required string? MobileNumber { get; init; }
     }
 
-    public enum PersonPage
+    public enum PersonSubNavigationTab
     {
         General,
         Alerts,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -18,10 +18,15 @@ public class IndexModel : PageModel
     [FromRoute]
     public Guid PersonId { get; set; }
 
+    [FromQuery]
+    public PersonPage? SelectedTab { get; set; }
+
     public PersonInfo? Person { get; set; }
 
     public async Task<IActionResult> OnGet()
     {
+        SelectedTab ??= PersonPage.General;
+
         var contactDetail = await _crmQueryDispatcher.ExecuteQuery(
             new GetContactDetailByIdQuery(
                 PersonId,
@@ -71,5 +76,12 @@ public class IndexModel : PageModel
         public required string? NationalInsuranceNumber { get; init; }
         public required string? Email { get; init; }
         public required string? MobileNumber { get; init; }
+    }
+
+    public enum PersonPage
+    {
+        General,
+        Alerts,
+        ChangeLog
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
@@ -13,7 +13,8 @@
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="7.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="7.0.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.2" />
-    <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.1.0" />
+    <PackageReference Include="Flurl" Version="3.0.7" />
+    <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.2.0" />
     <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.10" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -1,4 +1,5 @@
 using Flurl;
+using static TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.IndexModel;
 
 namespace TeachingRecordSystem.SupportUi;
 
@@ -29,7 +30,7 @@ public class TrsLinkGenerator
 
     public string Persons() => GetRequiredPathByPage("/Persons/Index");
 
-    public string PersonDetail(Guid personId, string? selectedTab = null) =>
+    public string PersonDetail(Guid personId, PersonSubNavigationTab? selectedTab = null) =>
         GetRequiredPathByPage("/Persons/PersonDetail/Index", routeValues: new { personId })
             .SetQueryParam("selectedTab", selectedTab);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -1,3 +1,5 @@
+using Flurl;
+
 namespace TeachingRecordSystem.SupportUi;
 
 public class TrsLinkGenerator
@@ -27,7 +29,9 @@ public class TrsLinkGenerator
 
     public string Persons() => GetRequiredPathByPage("/Persons/Index");
 
-    public string PersonDetail() => GetRequiredPathByPage("/Persons/PersonDetail/Index");
+    public string PersonDetail(Guid personId, string? selectedTab = null) =>
+        GetRequiredPathByPage("/Persons/PersonDetail/Index", routeValues: new { personId })
+            .SetQueryParam("selectedTab", selectedTab);
 
     public string Users() => GetRequiredPathByPage("/Users/Index");
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/libman.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/libman.json
@@ -5,6 +5,9 @@
     {
       "library": "govuk-frontend@4.5.0",
       "destination": "wwwroot/lib/govuk-frontend/"
-    }
-  ]
+    },
+    {
+      "library": "@ministryofjustice/frontend@1.8.0",
+      "destination": "wwwroot/lib/ministryofjustice/frontend/"
+    }]
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -1,4 +1,10 @@
-@use '../lib/govuk-frontend/govuk/all.scss';
+@import '../lib/govuk-frontend/govuk/all.scss';
+@import "../lib/ministryofjustice/frontend/moj/settings/all";
+@import "../lib/ministryofjustice/frontend/moj/helpers/all";
+@import "../lib/ministryofjustice/frontend/moj/objects/all";
+/* If needing more components then add them individually .. unfortunately the cookie-banner component references node_modules in the @import so we can't just import components/all !!  */
+@import "../lib/ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
+@import "../lib/ministryofjustice/frontend/moj/utilities/all";
 
 .trs-table__header--no-border,
 .trs-table__cell--no-border,


### PR DESCRIPTION
### Context

The designs use the ‘sub navigation’ component from MOJ styles rather than the stock GDS Tabs component. Now that we have SASS setup, we can add these component styles and update the UI.

### Changes proposed in this pull request

Add the relevant styles from https://design-patterns.service.justice.gov.uk/components/sub-navigation/  and update the Person view page to use them.

### Guidance to review

Simplish change

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
