### PR TITLE
[635] Point dev domain at the AKS environment

### DIFF
--- a/terraform/domains/environment_domains/config/dev.tfvars.json
+++ b/terraform/domains/environment_domains/config/dev.tfvars.json
@@ -2,6 +2,5 @@
   "domains": ["dev"],
   "environment_short": "dv",
   "environment_tag": "dev",
-  "origin_hostname": "qualified-teachers-api-dev.london.cloudapps.digital",
-  "null_host_header":  true
+  "origin_hostname": "trs-dev-api.test.teacherservices.cloud"
 }


### PR DESCRIPTION
### Context
Migration of dev environment to AKS

### Changes proposed in this pull request
Update the custom domain configuration

### Guidance to review
This was deployed manually already: https://dev.teacher-qualifications-api.education.gov.uk/health
