### PR TITLE
Add a /_readonlymode endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -332,6 +332,13 @@ public class Program
             await context.Response.WriteAsync("OK");
         });
 
+        app.MapGet("/_readonlymode", async context =>
+        {
+            var configuration = context.RequestServices.GetRequiredService<IConfiguration>();
+            var readOnlyMode = configuration.GetValue<bool>("ReadOnlyMode");
+            await context.Response.WriteAsync(readOnlyMode.ToString());
+        });
+
         app.MapWebHookEndpoints();
 
         if (platform == "PAAS")


### PR DESCRIPTION
When we're migrating environments from PAAS to AKS and flipping read-only mode on and off it would be useful to be able to query whether a particular environment is in read-only mode. This adds a `/_readonlymode` endpoint which outputs `true` or `false`, as appropriate.