### PR TITLE
Added ability to specify sort order for person/contact search results

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactSearchSortByOption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactSearchSortByOption.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.Core.Dqt.Models;
+
+public enum ContactSearchSortByOption
+{
+    [Display(Name = "Last name (A-Z)")]
+    LastNameAscending,
+    [Display(Name = "Last name (Z-A)")]
+    LastNameDescending,
+    [Display(Name = "First name (A-Z)")]
+    FirstNameAscending,
+    [Display(Name = "First name (Z-A)")]
+    FirstNameDescending,
+    [Display(Name = "Date of birth (ascending)")]
+    DateOfBirthAscending,
+    [Display(Name = "Date of birth (descending)")]
+    DateOfBirthDescending
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByDateOfBirthQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByDateOfBirthQuery.cs
@@ -2,4 +2,4 @@ using Microsoft.Xrm.Sdk.Query;
 
 namespace TeachingRecordSystem.Core.Dqt.Queries;
 
-public record GetContactsByDateOfBirthQuery(DateOnly DateOfBirth, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;
+public record GetContactsByDateOfBirthQuery(DateOnly DateOfBirth, ContactSearchSortByOption SortBy, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByNameQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByNameQuery.cs
@@ -2,4 +2,4 @@ using Microsoft.Xrm.Sdk.Query;
 
 namespace TeachingRecordSystem.Core.Dqt.Queries;
 
-public record GetContactsByNameQuery(string Name, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;
+public record GetContactsByNameQuery(string Name, ContactSearchSortByOption SortBy, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactsByDateOfBirthHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactsByDateOfBirthHandler.cs
@@ -16,6 +16,29 @@ public class GetContactsByDateOfBirthHandler : ICrmQueryHandler<GetContactsByDat
         };
         queryByAttribute.AddAttributeValue(Contact.Fields.StateCode, (int)ContactState.Active);
         queryByAttribute.AddAttributeValue(Contact.Fields.BirthDate, query.DateOfBirth.ToDateTime());
+        switch (query.SortBy)
+        {
+            case ContactSearchSortByOption.LastNameAscending:
+                queryByAttribute.AddOrder(Contact.Fields.LastName, OrderType.Ascending);
+                break;
+            case ContactSearchSortByOption.LastNameDescending:
+                queryByAttribute.AddOrder(Contact.Fields.LastName, OrderType.Descending);
+                break;
+            case ContactSearchSortByOption.FirstNameAscending:
+                queryByAttribute.AddOrder(Contact.Fields.FirstName, OrderType.Ascending);
+                break;
+            case ContactSearchSortByOption.FirstNameDescending:
+                queryByAttribute.AddOrder(Contact.Fields.FirstName, OrderType.Descending);
+                break;
+            case ContactSearchSortByOption.DateOfBirthAscending:
+                queryByAttribute.AddOrder(Contact.Fields.BirthDate, OrderType.Ascending);
+                break;
+            case ContactSearchSortByOption.DateOfBirthDescending:
+                queryByAttribute.AddOrder(Contact.Fields.BirthDate, OrderType.Descending);
+                break;
+            default:
+                break;
+        }
 
         var response = await organizationService.RetrieveMultipleAsync(queryByAttribute);
         return response.Entities.Select(e => e.ToEntity<Contact>()).ToArray();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactsByNameHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactsByNameHandler.cs
@@ -18,8 +18,32 @@ public class GetContactsByNameHandler : ICrmQueryHandler<GetContactsByNameQuery,
         {
             ColumnSet = query.ColumnSet,
             Criteria = filter,
-            TopCount = query.MaxRecordCount
+            TopCount = query.MaxRecordCount,
         };
+
+        switch (query.SortBy)
+        {
+            case ContactSearchSortByOption.LastNameAscending:
+                queryExpression.AddOrder(Contact.Fields.LastName, OrderType.Ascending);
+                break;
+            case ContactSearchSortByOption.LastNameDescending:
+                queryExpression.AddOrder(Contact.Fields.LastName, OrderType.Descending);
+                break;
+            case ContactSearchSortByOption.FirstNameAscending:
+                queryExpression.AddOrder(Contact.Fields.FirstName, OrderType.Ascending);
+                break;
+            case ContactSearchSortByOption.FirstNameDescending:
+                queryExpression.AddOrder(Contact.Fields.FirstName, OrderType.Descending);
+                break;
+            case ContactSearchSortByOption.DateOfBirthAscending:
+                queryExpression.AddOrder(Contact.Fields.BirthDate, OrderType.Ascending);
+                break;
+            case ContactSearchSortByOption.DateOfBirthDescending:
+                queryExpression.AddOrder(Contact.Fields.BirthDate, OrderType.Descending);
+                break;
+            default:
+                break;
+        }
 
         var response = await organizationService.RetrieveMultipleAsync(queryExpression);
         return response.Entities.Select(e => e.ToEntity<Contact>()).ToArray();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
@@ -22,7 +22,6 @@
                     <govuk-button class="moj-search__button" type="submit">Search</govuk-button>
                 </div>
                 <govuk-select asp-for="SortBy">
-                    <govuk-select-label>Sort by</govuk-select-label>
                     <govuk-select-item value="@ContactSearchSortByOption.LastNameAscending">@ContactSearchSortByOption.LastNameAscending.GetDisplayName()</govuk-select-item>
                     <govuk-select-item value="@ContactSearchSortByOption.LastNameDescending">@ContactSearchSortByOption.LastNameDescending.GetDisplayName()</govuk-select-item>
                     <govuk-select-item value="@ContactSearchSortByOption.FirstNameAscending">@ContactSearchSortByOption.FirstNameAscending.GetDisplayName()</govuk-select-item>
@@ -38,21 +37,6 @@
 {
     <div class="govuk-grid-row" data-testid="search-results">
         <div class="govuk-grid-column-full">
-            @if (Model.TotalKnownPages > 1)
-            {
-                <govuk-pagination>
-                    @if (Model.PreviousPage.HasValue)
-                    {
-                        <govuk-pagination-previous asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.PreviousPage" asp-route-sortby="@Model.SortBy" />
-                    }                
-
-                    @if (Model.NextPage.HasValue)
-                    {
-                        <govuk-pagination-next asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.NextPage" asp-route-sortby="@Model.SortBy" />
-                    }
-                </govuk-pagination>
-            }
-
             <table class="govuk-table">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
@@ -91,6 +75,21 @@
                     {
                         <govuk-pagination-previous asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.PreviousPage" asp-route-sortby="@Model.SortBy" />
                     }
+
+                    @if (Model.DisplayPageNumbers)
+                    {
+                        @for (int i = 0; i < Model.PaginationPages!.Length; i++)
+                        {
+                            var item = Model.PaginationPages[i];
+
+                            if (i > 0 && Model.PaginationPages[i - 1] != item - 1)
+                            {
+                                <govuk-pagination-ellipsis />
+                            }
+
+                            <govuk-pagination-item asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@item" is-current="@(item == Model.PageNumber)">@item</govuk-pagination-item>
+                        }
+                    }                    
 
                     @if (Model.NextPage.HasValue)
                     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
@@ -1,4 +1,5 @@
 @page "/persons"
+@using TeachingRecordSystem.Core.Dqt.Models;
 @model TeachingRecordSystem.SupportUi.Pages.Persons.IndexModel
 @{
     ViewBag.Title = "All records";
@@ -10,7 +11,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <div class="govuk-!-margin-bottom-6">
             <form trs-action="l => l.Persons()" method="get" data-testid="search-form">
-                <div class="moj-search trs-search">
+                <div class="moj-search trs-search govuk-!-margin-bottom-4">
                     <govuk-input asp-for="Search"
                                  input-class="moj-search__input"
                                  label-class="moj-search__label govuk-!-font-weight-bold"
@@ -19,7 +20,16 @@
                         <govuk-input-hint class="moj-search__hint">Search by: Name, TRN or date of birth (DD/MM/YYYY)</govuk-input-hint>
                     </govuk-input>
                     <govuk-button class="moj-search__button" type="submit">Search</govuk-button>
-                </div>                
+                </div>
+                <govuk-select asp-for="SortBy">
+                    <govuk-select-label>Sort by</govuk-select-label>
+                    <govuk-select-item value="@ContactSearchSortByOption.LastNameAscending">@ContactSearchSortByOption.LastNameAscending.GetDisplayName()</govuk-select-item>
+                    <govuk-select-item value="@ContactSearchSortByOption.LastNameDescending">@ContactSearchSortByOption.LastNameDescending.GetDisplayName()</govuk-select-item>
+                    <govuk-select-item value="@ContactSearchSortByOption.FirstNameAscending">@ContactSearchSortByOption.FirstNameAscending.GetDisplayName()</govuk-select-item>
+                    <govuk-select-item value="@ContactSearchSortByOption.FirstNameDescending">@ContactSearchSortByOption.FirstNameDescending.GetDisplayName()</govuk-select-item>
+                    <govuk-select-item value="@ContactSearchSortByOption.DateOfBirthAscending">@ContactSearchSortByOption.DateOfBirthAscending.GetDisplayName()</govuk-select-item>
+                    <govuk-select-item value="@ContactSearchSortByOption.DateOfBirthDescending">@ContactSearchSortByOption.DateOfBirthDescending.GetDisplayName()</govuk-select-item>
+                </govuk-select>
             </form>
         </div>
     </div>
@@ -33,12 +43,12 @@
                 <govuk-pagination>
                     @if (Model.PreviousPage.HasValue)
                     {
-                        <govuk-pagination-previous asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.PreviousPage" />
+                        <govuk-pagination-previous asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.PreviousPage" asp-route-sortby="@Model.SortBy" />
                     }                
 
                     @if (Model.NextPage.HasValue)
                     {
-                        <govuk-pagination-next asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.NextPage" />
+                        <govuk-pagination-next asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.NextPage" asp-route-sortby="@Model.SortBy" />
                     }
                 </govuk-pagination>
             }
@@ -64,7 +74,7 @@
                         @foreach (var personInfo in Model.SearchResults!)
                         {
                             <tr class="govuk-table__row" data-testid="person-@personInfo.PersonId">
-                                <td class="govuk-table__cell" data-testid="name"><a href="@LinkGenerator.PersonDetail(personInfo.PersonId, search: Model.Search, pageNumber: Model.PageNumber)" class="govuk-link">@personInfo.Name</a></td>
+                                <td class="govuk-table__cell" data-testid="name"><a href="@LinkGenerator.PersonDetail(personInfo.PersonId, search: Model.Search, sortBy: Model.SortBy, pageNumber: Model.PageNumber)" class="govuk-link">@personInfo.Name</a></td>
                                 <td class="govuk-table__cell" data-testid="date-of-birth">@(personInfo.DateOfBirth.HasValue ? personInfo.DateOfBirth.Value.ToString("dd/MM/yyyy") : "-")</td>
                                 <td class="govuk-table__cell" data-testid="trn">@(!string.IsNullOrEmpty(personInfo.Trn) ? personInfo.Trn : "-")</td>
                                 <td class="govuk-table__cell" data-testid="nino">@(!string.IsNullOrEmpty(personInfo.NationalInsuranceNumber) ? personInfo.NationalInsuranceNumber : "-")</td>
@@ -79,12 +89,12 @@
                 <govuk-pagination>
                     @if (Model.PreviousPage.HasValue)
                     {
-                        <govuk-pagination-previous asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.PreviousPage" />
+                        <govuk-pagination-previous asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.PreviousPage" asp-route-sortby="@Model.SortBy" />
                     }
 
                     @if (Model.NextPage.HasValue)
                     {
-                        <govuk-pagination-next asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.NextPage" />
+                        <govuk-pagination-next asp-page="Index" asp-route-search="@Model.Search" asp-route-pagenumber="@Model.NextPage" asp-route-sortby="@Model.SortBy" />
                     }
                 </govuk-pagination>
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -109,12 +109,12 @@ public partial class IndexModel : PageModel
         {
             DisplayPageNumbers = true;
             PaginationPages = Enumerable.Range(-2, 5).Select(offset => PageNumber!.Value + offset)
-            .Append(1)
-            .Append(TotalKnownPages)
-            .Where(page => page <= TotalKnownPages && page >= 1)
-            .Distinct()
-            .Order()
-            .ToArray();
+                .Append(1)
+                .Append(TotalKnownPages)
+                .Where(page => page <= TotalKnownPages && page >= 1)
+                .Distinct()
+                .Order()
+                .ToArray();
         }
 
         SearchResults = contacts

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -32,18 +32,23 @@ public partial class IndexModel : PageModel
     public string? Search { get; set; }
 
     [BindProperty(SupportsGet = true)]
+    [Display(Name = "Sort by")]
     public ContactSearchSortByOption SortBy { get; set; }
 
     [BindProperty(SupportsGet = true)]
     public int? PageNumber { get; set; }
 
-    public PersonInfo[]? SearchResults { get; set; }
+    public int[]? PaginationPages { get; set; }
 
     public int TotalKnownPages { get; set; }
+
+    public bool DisplayPageNumbers { get; set; }
 
     public int? PreviousPage { get; set; }
 
     public int? NextPage { get; set; }
+
+    public PersonInfo[]? SearchResults { get; set; }
 
     public async Task<IActionResult> OnGet()
     {
@@ -99,6 +104,18 @@ public partial class IndexModel : PageModel
 
         PreviousPage = PageNumber > 1 ? PageNumber - 1 : null;
         NextPage = PageNumber < TotalKnownPages ? PageNumber + 1 : null;
+
+        if (contacts.Length < MaxSearchResultCount)
+        {
+            DisplayPageNumbers = true;
+            PaginationPages = Enumerable.Range(-2, 5).Select(offset => PageNumber!.Value + offset)
+            .Append(1)
+            .Append(TotalKnownPages)
+            .Where(page => page <= TotalKnownPages && page >= 1)
+            .Distinct()
+            .Order()
+            .ToArray();
+        }
 
         SearchResults = contacts
             .Skip((PageNumber!.Value - 1) * PageSize)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -32,6 +32,9 @@ public partial class IndexModel : PageModel
     public string? Search { get; set; }
 
     [BindProperty(SupportsGet = true)]
+    public ContactSearchSortByOption SortBy { get; set; }
+
+    [BindProperty(SupportsGet = true)]
     public int? PageNumber { get; set; }
 
     public PersonInfo[]? SearchResults { get; set; }
@@ -72,15 +75,12 @@ public partial class IndexModel : PageModel
             Contact.Fields.dfeta_StatedFirstName,
             Contact.Fields.dfeta_StatedMiddleName,
             Contact.Fields.dfeta_StatedLastName,
-            Contact.Fields.EMailAddress1,
-            Contact.Fields.MobilePhone,
-            Contact.Fields.dfeta_NINumber,
-            Contact.Fields.dfeta_ActiveSanctions);
+            Contact.Fields.dfeta_NINumber);
 
         // Check if the search string is a date of birth, TRN or one or more names
         if (DateOnly.TryParse(Search, out var dateOfBirth))
         {
-            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByDateOfBirthQuery(dateOfBirth, MaxSearchResultCount, columnSet));
+            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByDateOfBirthQuery(dateOfBirth, SortBy, MaxSearchResultCount, columnSet));
         }
         else if (TrnRegex().IsMatch(Search!))
         {
@@ -92,7 +92,7 @@ public partial class IndexModel : PageModel
         }
         else
         {
-            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByNameQuery(Search!, MaxSearchResultCount, columnSet));
+            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByNameQuery(Search!, SortBy, MaxSearchResultCount, columnSet));
         }
 
         TotalKnownPages = Math.Max((int)Math.Ceiling((decimal)contacts!.Length / PageSize), 1);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons(Model.Search, Model.PageNumber)" />
+    <govuk-back-link href="@LinkGenerator.Persons(Model.Search, Model.SortBy, Model.PageNumber)" />
 }
 
 <h1 class="govuk-heading-l" data-testid="page-title">@ViewBag.Title</h1>
@@ -16,15 +16,15 @@
         <nav class="moj-sub-navigation" aria-label="Sub navigation">
             <ul class="moj-sub-navigation__list">
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.General ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.General, Model.Search, Model.PageNumber)">General</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.General ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.General, Model.Search, Model.SortBy, Model.PageNumber)">General</a>
                 </li>
 
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.Alerts ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.Alerts, Model.Search, Model.PageNumber)">Alerts</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.Alerts ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.Alerts, Model.Search, Model.SortBy, Model.PageNumber)">Alerts</a>
                 </li>
 
                 <li class="moj-sub-navigation__item">
-                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.ChangeLog ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.ChangeLog, Model.Search, Model.PageNumber)">Change log</a>
+                    <a class="moj-sub-navigation__link" aria-current="@(Model.SelectedTab == IndexModel.PersonSubNavigationTab.ChangeLog ? "page" : null)" href="@LinkGenerator.PersonDetail(Model.PersonId, IndexModel.PersonSubNavigationTab.ChangeLog, Model.Search, Model.SortBy, Model.PageNumber)">Change log</a>
                 </li>
             </ul>
         </nav>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -25,6 +25,9 @@ public class IndexModel : PageModel
     public int? PageNumber { get; set; }
 
     [FromQuery]
+    public ContactSearchSortByOption SortBy { get; set; }
+
+    [FromQuery]
     public PersonSubNavigationTab? SelectedTab { get; set; }
 
     public PersonInfo? Person { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -1,3 +1,4 @@
+using TeachingRecordSystem.Core.Dqt.Models;
 using static TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.IndexModel;
 
 namespace TeachingRecordSystem.SupportUi;
@@ -27,10 +28,11 @@ public class TrsLinkGenerator
 
     public string RejectCase(string ticketNumber) => GetRequiredPathByPage("/Cases/EditCase/Reject", routeValues: new { ticketNumber });
 
-    public string Persons(string? search = null, int? pageNumber = null) => GetRequiredPathByPage("/Persons/Index", routeValues: new { search, pageNumber });
+    public string Persons(string? search = null, ContactSearchSortByOption? sortBy = null, int? pageNumber = null) =>
+        GetRequiredPathByPage("/Persons/Index", routeValues: new { search, sortBy, pageNumber });
 
-    public string PersonDetail(Guid personId, PersonSubNavigationTab? selectedTab = null, string? search = null, int? pageNumber = null) =>
-        GetRequiredPathByPage("/Persons/PersonDetail/Index", routeValues: new { personId, selectedTab, search, pageNumber });
+    public string PersonDetail(Guid personId, PersonSubNavigationTab? selectedTab = null, string? search = null, ContactSearchSortByOption? sortBy = null, int? pageNumber = null) =>
+        GetRequiredPathByPage("/Persons/PersonDetail/Index", routeValues: new { personId, selectedTab, search, sortBy, pageNumber });
 
     public string Users() => GetRequiredPathByPage("/Users/Index");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactsByDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactsByDateOfBirthTests.cs
@@ -17,22 +17,89 @@ public class GetContactsByDateOfBirthTests : IAsyncLifetime
 
     public async Task DisposeAsync() => await _dataScope.DisposeAsync();
 
-    [Fact]
-    public async Task ReturnsMatchingContactsFromCrm()
+    public static TheoryData<ContactSearchSortScenarioData> GetContactSearchSortScenarioData()
+    {
+        return new TheoryData<ContactSearchSortScenarioData>
+        {
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.LastNameAscending,
+                Selector = (Contact c) => c.LastName,
+                IsAscending = true
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.LastNameDescending,
+                Selector = (Contact c) => c.LastName,
+                IsAscending = false
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.FirstNameAscending,
+                Selector = (Contact c) => c.FirstName,
+                IsAscending = true
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.FirstNameDescending,
+                Selector = (Contact c) => c.FirstName,
+                IsAscending = false
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.DateOfBirthAscending,
+                Selector = (Contact c) => c.BirthDate is null ? string.Empty : c.BirthDate.Value.ToString("yyyy-MM-dd"),
+                IsAscending = true
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.DateOfBirthDescending,
+                Selector = (Contact c) => c.BirthDate is null ? string.Empty : c.BirthDate.Value.ToString("yyyy-MM-dd"),
+                IsAscending = false
+            }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetContactSearchSortScenarioData))]
+    public async Task ReturnsMatchingContactsFromCrmInExpectedSortOrder(ContactSearchSortScenarioData testScenarioData)
     {
         // Arrange
         var dateOfBirth = new DateOnly(1990, 1, 1);
         var maxRecordCount = 3;
+        var columnSet = new ColumnSet(
+            Contact.Fields.dfeta_TRN,
+            Contact.Fields.BirthDate,
+            Contact.Fields.FirstName,
+            Contact.Fields.MiddleName,
+            Contact.Fields.LastName,
+            Contact.Fields.FullName);
+
 
         var person1 = await _dataScope.TestData.CreatePerson(b => b.WithDateOfBirth(dateOfBirth));
         var person2 = await _dataScope.TestData.CreatePerson(b => b.WithDateOfBirth(dateOfBirth));
         var person3 = await _dataScope.TestData.CreatePerson(b => b.WithDateOfBirth(dateOfBirth));
 
         // Act
-        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByDateOfBirthQuery(dateOfBirth, maxRecordCount, new ColumnSet()));
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByDateOfBirthQuery(dateOfBirth, testScenarioData.SortBy, maxRecordCount, columnSet));
 
         // Assert
         Assert.NotNull(results);
         Assert.Equal(maxRecordCount, results.Length);
+        if (testScenarioData.IsAscending)
+        {
+            Assert.Equal(results.Select(testScenarioData.Selector).OrderBy(x => x).ToArray(), results.Select(testScenarioData.Selector).ToArray());
+        }
+        else
+        {
+            Assert.Equal(results.Select(testScenarioData.Selector).OrderByDescending(x => x).ToArray(), results.Select(testScenarioData.Selector).ToArray());
+        }
+    }
+
+    public class ContactSearchSortScenarioData
+    {
+        public required ContactSearchSortByOption SortBy { get; init; }
+        public required Func<Contact, string> Selector { get; init; }
+        public required bool IsAscending { get; init; }
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactsByNameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactsByNameTests.cs
@@ -17,18 +17,84 @@ public class GetContactsByNameTests : IAsyncLifetime
 
     public async Task DisposeAsync() => await _dataScope.DisposeAsync();
 
-    [Fact]
-    public async Task ReturnsMatchingContactsFromCrm()
+    public static TheoryData<ContactSearchSortScenarioData> GetContactSearchSortScenarioData()
+    {
+        return new TheoryData<ContactSearchSortScenarioData>
+        {
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.LastNameAscending,
+                Selector = (Contact c) => c.LastName,
+                IsAscending = true
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.LastNameDescending,
+                Selector = (Contact c) => c.LastName,
+                IsAscending = false
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.FirstNameAscending,
+                Selector = (Contact c) => c.FirstName,
+                IsAscending = true
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.FirstNameDescending,
+                Selector = (Contact c) => c.FirstName,
+                IsAscending = false
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.DateOfBirthAscending,
+                Selector = (Contact c) => c.BirthDate is null ? string.Empty : c.BirthDate.Value.ToString("yyyy-MM-dd"),
+                IsAscending = true
+            },
+            new ContactSearchSortScenarioData
+            {
+                SortBy = ContactSearchSortByOption.DateOfBirthDescending,
+                Selector = (Contact c) => c.BirthDate is null ? string.Empty : c.BirthDate.Value.ToString("yyyy-MM-dd"),
+                IsAscending = false
+            }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetContactSearchSortScenarioData))]
+    public async Task ReturnsMatchingContactsFromCrmInExpectedSortOrder(ContactSearchSortScenarioData testScenarioData)
     {
         // Arrange
-        var name = "smith";
-        var maxRecordCount = 4; // pretty safe bet there will always be at least 4 smiths in the dev CRM database
+        var name = "andrew";
+        var maxRecordCount = 4; // pretty safe bet there will always be at least 4 andrew names in the dev CRM database
+        var columnSet = new ColumnSet(
+            Contact.Fields.dfeta_TRN,
+            Contact.Fields.BirthDate,
+            Contact.Fields.FirstName,
+            Contact.Fields.MiddleName,
+            Contact.Fields.LastName,
+            Contact.Fields.FullName);
 
         // Act
-        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByNameQuery(name, maxRecordCount, new ColumnSet()));
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByNameQuery(name, testScenarioData.SortBy, maxRecordCount, columnSet));
 
         // Assert
         Assert.NotNull(results);
         Assert.Equal(maxRecordCount, results.Length);
+        if (testScenarioData.IsAscending)
+        {
+            Assert.Equal(results.Select(testScenarioData.Selector).OrderBy(x => x).ToArray(), results.Select(testScenarioData.Selector).ToArray());
+        }
+        else
+        {
+            Assert.Equal(results.Select(testScenarioData.Selector).OrderByDescending(x => x).ToArray(), results.Select(testScenarioData.Selector).ToArray());
+        }
+    }
+
+    public class ContactSearchSortScenarioData
+    {
+        public required ContactSearchSortByOption SortBy { get; init; }
+        public required Func<Contact, string> Selector { get; init; }
+        public required bool IsAscending { get; init; }
     }
 }


### PR DESCRIPTION
### Context

Users need to be able to sort person search results so that they can more quickly identify the person they’re looking for.

### Changes proposed in this pull request

Add a ‘Sort by’ drop down following the designs in Figma.

Add the following options:

Last name (A-Z)
Last name (Z-A)
First name (A-Z)
First name (Z-A)
Date of birth (ascending)
Date of birth (descending)
Update the queries to honour the requested sort by option. The chosen option should be passed around as a query parameter.

‘Last name (A-Z)' should be the default option.

### Guidance to review

CRM Query changes + UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
