### PR TITLE
[636] Migrate preproduction domain from PaaS to AKS

### DIFF
--- a/terraform/domains/environment_domains/config/pre-production.tfvars.json
+++ b/terraform/domains/environment_domains/config/pre-production.tfvars.json
@@ -2,6 +2,5 @@
   "domains": ["preprod"],
   "environment_short": "pp",
   "environment_tag": "pre-prod",
-  "origin_hostname": "qualified-teachers-api-preprod.london.cloudapps.digital",
-  "null_host_header":  true
+  "origin_hostname": "trs-pre-production-api.test.teacherservices.cloud"
 }


### PR DESCRIPTION
### Context
Migration of the preproduction environment

### Changes proposed in this pull request
Point preprod.teacher-qualifications-api.education.gov.uk at AKS

### Guidance to review
Access https://preprod.teacher-qualifications-api.education.gov.uk/health
