### PR TITLE
Added new columns to account introduced by evergreen update wave2 202…

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0008_EvergreenMissingColumns.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0008_EvergreenMissingColumns.sql
@@ -1,0 +1,31 @@
+--adx_createdbyipaddress
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'adx_createdbyipaddress')
+    alter table account add adx_createdbyipaddress nvarchar(100)
+
+--adx_createdbyusername
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'adx_createdbyusername')
+    alter table account add adx_createdbyusername nvarchar(100)
+
+--adx_modifiedbyipaddress
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'adx_modifiedbyipaddress')
+    alter table account add adx_modifiedbyipaddress nvarchar(100)
+
+--adx_modifiedbyusername
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'adx_modifiedbyusername')
+    alter table account add adx_modifiedbyusername nvarchar(100)
+
+--msa_managingpartnerid
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'msa_managingpartnerid')
+    alter table account add msa_managingpartnerid uniqueidentifier
+
+--msa_managingpartnerid_entitytype
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'msa_managingpartnerid_entitytype')
+    alter table account add msa_managingpartnerid_entitytype nvarchar(128)
+
+--msa_managingpartneridname
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'msa_managingpartneridname')
+    alter table account add msa_managingpartneridname nvarchar(160)
+
+--msa_managingpartneridyominame
+if not exists (select 1 from information_schema.columns where table_name = 'account' and column_name = 'msa_managingpartneridyominame')
+    alter table account add msa_managingpartneridyominame nvarchar(160)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -14,6 +14,7 @@
     <None Remove="Dqt\Services\DqtReporting\Migrations\0005_ContactSlugId.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0006_Incident_msdyn_copilotengaged.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0007_ContactAllowpiiUpdatesFromRegister.sql" />
+    <None Remove="Dqt\Services\DqtReporting\Migrations\0008_EvergreenMissingColumns.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,6 +25,7 @@
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0005_ContactSlugId.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0006_Incident_msdyn_copilotengaged.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0007_ContactAllowpiiUpdatesFromRegister.sql" />
+    <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0008_EvergreenMissingColumns.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
New columns have been added to account in the evergreen update. This is to fix the reporting database to match the schema.

- 'adx_createdbyipaddress'.
- 'adx_createdbyusername'.
- 'adx_modifiedbyipaddress'.
- 'adx_modifiedbyusername'.
- 'msa_managingpartnerid'.
- 'msa_managingpartnerid_entitytype'.
- 'msa_managingpartneridname'.
- 'msa_managingpartneridyominame'.

### Context

Include relevant motivation and context.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [] Tested by running locally
