### PR TITLE
Add e2e tests for accepting rejecting cancelling cases

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/CaseTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/CaseTests.cs
@@ -1,5 +1,108 @@
+using TeachingRecordSystem.TestCommon;
+
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
-public class CaseTests
+public class CaseTests : TestBase
 {
+    public CaseTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task SelectCaseAndApprove()
+    {
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+        var caseReference = createIncidentResult.TicketNumber;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToHomePage();
+
+        await page.ClickOpenCasesLinkInNavigationBar();
+
+        await page.AssertOnOpenCasesPage();
+
+        await page.ClickCaseReferenceLinkOpenCasesPage(caseReference);
+
+        await page.AssertOnCaseDetailPage(caseReference);
+
+        await page.ClickAcceptChangeButton();
+
+        await page.AssertOnAcceptCasePage(caseReference);
+
+        await page.ClickConfirmButton();
+
+        await page.AssertOnOpenCasesPage();
+
+        await page.AssertFlashMessage("The request has been accepted");
+    }
+
+    [Fact]
+    public async Task SelectCaseAndReject()
+    {
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+        var caseReference = createIncidentResult.TicketNumber;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToHomePage();
+
+        await page.ClickOpenCasesLinkInNavigationBar();
+
+        await page.AssertOnOpenCasesPage();
+
+        await page.ClickCaseReferenceLinkOpenCasesPage(caseReference);
+
+        await page.AssertOnCaseDetailPage(caseReference);
+
+        await page.ClickRejectChangeButton();
+
+        await page.AssertOnRejectCasePage(caseReference);
+
+        await page.CheckAsync("label:text-is('Request and proof don’t match')");
+
+        await page.ClickConfirmButton();
+
+        await page.AssertOnOpenCasesPage();
+
+        await page.AssertFlashMessage("The request has been rejected");
+    }
+
+    [Fact]
+    public async Task SelectCaseAndCancel()
+    {
+        var createPersonResult = await TestData.CreatePerson();
+        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+        var caseReference = createIncidentResult.TicketNumber;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToHomePage();
+
+        await page.ClickOpenCasesLinkInNavigationBar();
+
+        await page.AssertOnOpenCasesPage();
+
+        await page.ClickCaseReferenceLinkOpenCasesPage(caseReference);
+
+        await page.AssertOnCaseDetailPage(caseReference);
+
+        await page.ClickRejectChangeButton();
+
+        await page.AssertOnRejectCasePage(caseReference);
+
+        await page.CheckAsync("label:text-is('Change no longer required')");
+
+        await page.ClickConfirmButton();
+
+        await page.AssertOnOpenCasesPage();
+
+        await page.AssertFlashMessage("The request has been cancelled");
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/CaseTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/CaseTests.cs
@@ -9,12 +9,23 @@ public class CaseTests : TestBase
     {
     }
 
-    [Fact]
-    public async Task SelectCaseAndApprove()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SelectCaseAndApprove(bool isNameChange)
     {
         var createPersonResult = await TestData.CreatePerson();
-        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
-        var caseReference = createIncidentResult.TicketNumber;
+        string caseReference;
+        if (isNameChange)
+        {
+            var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+            caseReference = createIncidentResult.TicketNumber;
+        }
+        else
+        {
+            var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+            caseReference = createIncidentResult.TicketNumber;
+        }
 
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -40,12 +51,23 @@ public class CaseTests : TestBase
         await page.AssertFlashMessage("The request has been accepted");
     }
 
-    [Fact]
-    public async Task SelectCaseAndReject()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SelectCaseAndReject(bool isNameChange)
     {
         var createPersonResult = await TestData.CreatePerson();
-        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
-        var caseReference = createIncidentResult.TicketNumber;
+        string caseReference;
+        if (isNameChange)
+        {
+            var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+            caseReference = createIncidentResult.TicketNumber;
+        }
+        else
+        {
+            var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+            caseReference = createIncidentResult.TicketNumber;
+        }
 
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -73,12 +95,23 @@ public class CaseTests : TestBase
         await page.AssertFlashMessage("The request has been rejected");
     }
 
-    [Fact]
-    public async Task SelectCaseAndCancel()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SelectCaseAndCancel(bool isNameChange)
     {
         var createPersonResult = await TestData.CreatePerson();
-        var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
-        var caseReference = createIncidentResult.TicketNumber;
+        string caseReference;
+        if (isNameChange)
+        {
+            var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+            caseReference = createIncidentResult.TicketNumber;
+        }
+        else
+        {
+            var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
+            caseReference = createIncidentResult.TicketNumber;
+        }
 
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/CaseTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/CaseTests.cs
@@ -1,0 +1,5 @@
+namespace TeachingRecordSystem.SupportUi.EndToEndTests;
+
+public class CaseTests
+{
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -71,6 +71,8 @@ public sealed class HostFixture : IAsyncDisposable, IStartupTask
                     services.AddSingleton<CurrentUserProvider>();
                     services.AddTransient<TestUsers.CreateUsersStartupTask>();
                     services.AddStartupTask<TestUsers.CreateUsersStartupTask>();
+                    services.AddSingleton<TestData>();
+                    services.AddFakeXrm();
                 });
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -1,0 +1,65 @@
+using Microsoft.Playwright;
+
+namespace TeachingRecordSystem.SupportUi.EndToEndTests;
+
+public static class PageExtensions
+{
+    public static Task WaitForUrlPathAsync(this IPage page, string path) =>
+        page.WaitForURLAsync(url =>
+        {
+            var asUri = new Uri(url);
+            return asUri.LocalPath == path;
+        });
+
+    public static async Task GoToHomePage(this IPage page)
+    {
+        await page.GotoAsync("/");
+    }
+
+    public static async Task ClickOpenCasesLinkInNavigationBar(this IPage page)
+    {
+        await page.ClickAsync("a:text-is('Open cases')");
+    }
+
+    public static async Task AssertOnOpenCasesPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/cases");
+    }
+
+    public static async Task ClickCaseReferenceLinkOpenCasesPage(this IPage page, string caseReference)
+    {
+        await page.ClickAsync($"a:text-is('{caseReference}')");
+    }
+
+    public static async Task AssertOnCaseDetailPage(this IPage page, string caseReference)
+    {
+        await page.WaitForUrlPathAsync($"/cases/{caseReference}");
+    }
+
+    public static async Task AssertOnAcceptCasePage(this IPage page, string caseReference)
+    {
+        await page.WaitForUrlPathAsync($"/cases/{caseReference}/accept");
+    }
+
+    public static async Task AssertOnRejectCasePage(this IPage page, string caseReference)
+    {
+        await page.WaitForUrlPathAsync($"/cases/{caseReference}/reject");
+    }
+
+    public static async Task AssertFlashMessage(this IPage page, string expectedHeader)
+    {
+        Assert.Equal(expectedHeader, await page.InnerTextAsync($".govuk-notification-banner__heading:text-is('{expectedHeader}')"));
+    }
+
+    public static Task ClickAcceptChangeButton(this IPage page)
+        => ClickButton(page, "Accept change");
+
+    public static Task ClickRejectChangeButton(this IPage page)
+        => ClickButton(page, "Reject change");
+
+    public static Task ClickConfirmButton(this IPage page)
+        => ClickButton(page, "Confirm");
+
+    private static Task ClickButton(this IPage page, string text) =>
+        page.ClickAsync($".govuk-button:text-is('{text}')");
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestBase.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.EndToEndTests.Infrastructure.Security;
+using TeachingRecordSystem.TestCommon;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
@@ -13,6 +14,8 @@ public abstract class TestBase
     }
 
     public HostFixture HostFixture { get; }
+
+    public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 
     protected void SetCurrentUser(User user)
     {


### PR DESCRIPTION
### Context

Now that have we have all the pages implemented for the change of name/DOB cases resolution process we should add some e2e tests.

### Changes proposed in this pull request

Add e2e tests that cover accepting, rejecting and cancelling a change of DOB/name case, starting from the case list screen.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
