### PR TITLE
Use alpine base image for CLI

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Dockerfile
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/dotnet/sdk:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine3.18
 COPY src/TeachingRecordSystem.Cli/bin/Release/net7.0/publish/ TrsCli/
 WORKDIR /TrsCli
 ENV PATH="${PATH}:/TrsCli"


### PR DESCRIPTION
We switched to alpine for the UI image so we could `konduit.sh` into it to run the DB backups. (The API has custom fonts installed into its image so switching to alpine there would have taken more time.) The change amends the CLI image to use alpine and reverts the UI to a regular Debian base.