### PR TITLE
Add tag helper to render empty content as a hyphen

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/UseEmptyFallbackTagHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/UseEmptyFallbackTagHelper.cs
@@ -1,0 +1,23 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TeachingRecordSystem.SupportUi.TagHelpers;
+
+[HtmlTargetElement("*", Attributes = "use-empty-fallback")]
+public class UseEmptyFallbackTagHelper : TagHelper
+{
+    public override int Order => -1;
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var content = await output.GetChildContentAsync();
+        output.Attributes.RemoveAll("use-empty-fallback");
+
+        if (content.IsEmptyOrWhiteSpace)
+        {
+            output.AddClass("trs-subtle-emphasis", HtmlEncoder.Default);
+            output.Content.SetContent("-");
+        }
+    }
+}


### PR DESCRIPTION
### Context

When there are null or empty values for fields in the UI we want a common approach to what gets displayed.

### Changes proposed in this pull request

Add a tag helper which can replace empty strings with a grey hyphen.

### Guidance to review

Simple change.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
