### PR TITLE
Added previous names, nino and gender to person view

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactDetail.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactDetail.cs
@@ -1,3 +1,3 @@
 namespace TeachingRecordSystem.Core.Dqt.Models;
 
-public record ContactDetail(Contact Contact);
+public record ContactDetail(Contact Contact, dfeta_previousname[] PreviousNames);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
@@ -23,7 +23,7 @@ public static class ContactExtensions
             {
                 if (fullName.Length > 0)
                 {
-                    fullName.Append(" ");
+                    fullName.Append(' ');
                 }
 
                 fullName.Append(middleName);
@@ -35,7 +35,7 @@ public static class ContactExtensions
         {
             if (fullName.Length > 0)
             {
-                fullName.Append(" ");
+                fullName.Append(' ');
             }
 
             fullName.Append(lastName);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Queries;
 
@@ -8,22 +9,53 @@ public class GetContactDetailByIdHandler : ICrmQueryHandler<GetContactDetailById
 {
     public async Task<ContactDetail?> Execute(GetContactDetailByIdQuery query, IOrganizationServiceAsync organizationService)
     {
-        var filter = new FilterExpression();
-        filter.AddCondition(Contact.PrimaryIdAttribute, ConditionOperator.Equal, query.ContactId);
-
-        var queryExpression = new QueryExpression(Contact.EntityLogicalName)
+        var contactFilter = new FilterExpression();
+        contactFilter.AddCondition(Contact.PrimaryIdAttribute, ConditionOperator.Equal, query.ContactId);
+        var contactQueryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = query.ColumnSet,
-            Criteria = filter
+            Criteria = contactFilter
         };
 
-        var response = await organizationService.RetrieveMultipleAsync(queryExpression);
-        var contact = response.Entities.SingleOrDefault()?.ToEntity<Contact>();
+        var contactRequest = new RetrieveMultipleRequest()
+        {
+            Query = contactQueryExpression
+        };
+
+        var previousNameFilter = new FilterExpression();
+        previousNameFilter.AddCondition(dfeta_previousname.Fields.dfeta_PersonId, ConditionOperator.Equal, query.ContactId);
+        previousNameFilter.AddCondition(dfeta_previousname.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_documentState.Active);
+        previousNameFilter.AddCondition(dfeta_previousname.Fields.dfeta_Type, ConditionOperator.NotEqual, (int)dfeta_NameType.Title);
+        var previousNameQueryExpression = new QueryExpression(dfeta_previousname.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+                dfeta_previousname.PrimaryIdAttribute,
+                dfeta_previousname.Fields.CreatedOn,
+                dfeta_previousname.Fields.dfeta_ChangedOn,
+                dfeta_previousname.Fields.dfeta_name,
+                dfeta_previousname.Fields.dfeta_Type),
+            Criteria = previousNameFilter
+        };
+
+        var previousNameRequest = new RetrieveMultipleRequest()
+        {
+            Query = previousNameQueryExpression
+        };
+
+        var requestBuilder = RequestBuilder.CreateMultiple(organizationService);
+        var contactResponse = requestBuilder.AddRequest<RetrieveMultipleResponse>(contactRequest);
+        var previousNameResponse = requestBuilder.AddRequest<RetrieveMultipleResponse>(previousNameRequest);
+
+        await requestBuilder.Execute();
+
+        var contact = (await contactResponse.GetResponseAsync()).EntityCollection.Entities.FirstOrDefault()?.ToEntity<Contact>();
+        var previousNames = (await previousNameResponse.GetResponseAsync()).EntityCollection.Entities.Select(e => e.ToEntity<dfeta_previousname>()).ToArray();
+
         if (contact is null)
         {
             return null;
         }
 
-        return new ContactDetail(contact);
+        return new ContactDetail(contact, previousNames);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
@@ -59,9 +59,9 @@
                         {
                             <tr class="govuk-table__row" data-testid="person-@personInfo.PersonId">
                                 <td class="govuk-table__cell" data-testid="name"><a href="@LinkGenerator.PersonDetail(personInfo.PersonId, search: Model.Search, sortBy: Model.SortBy, pageNumber: Model.PageNumber)" class="govuk-link">@personInfo.Name</a></td>
-                                <td class="govuk-table__cell" data-testid="date-of-birth">@(personInfo.DateOfBirth.HasValue ? personInfo.DateOfBirth.Value.ToString("dd/MM/yyyy") : "-")</td>
-                                <td class="govuk-table__cell" data-testid="trn">@(!string.IsNullOrEmpty(personInfo.Trn) ? personInfo.Trn : "-")</td>
-                                <td class="govuk-table__cell" data-testid="nino">@(!string.IsNullOrEmpty(personInfo.NationalInsuranceNumber) ? personInfo.NationalInsuranceNumber : "-")</td>
+                                <td class="govuk-table__cell" data-testid="date-of-birth" use-empty-fallback>@(personInfo.DateOfBirth.HasValue ? personInfo.DateOfBirth.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
+                                <td class="govuk-table__cell" data-testid="trn"><span use-empty-fallback>@personInfo.Trn</span></td>
+                                <td class="govuk-table__cell" data-testid="nino"><span use-empty-fallback>@personInfo.NationalInsuranceNumber</span></td>
                             </tr>
                         }
                     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml
@@ -60,8 +60,8 @@
                             <tr class="govuk-table__row" data-testid="person-@personInfo.PersonId">
                                 <td class="govuk-table__cell" data-testid="name"><a href="@LinkGenerator.PersonDetail(personInfo.PersonId, search: Model.Search, sortBy: Model.SortBy, pageNumber: Model.PageNumber)" class="govuk-link">@personInfo.Name</a></td>
                                 <td class="govuk-table__cell" data-testid="date-of-birth" use-empty-fallback>@(personInfo.DateOfBirth.HasValue ? personInfo.DateOfBirth.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
-                                <td class="govuk-table__cell" data-testid="trn"><span use-empty-fallback>@personInfo.Trn</span></td>
-                                <td class="govuk-table__cell" data-testid="nino"><span use-empty-fallback>@personInfo.NationalInsuranceNumber</span></td>
+                                <td class="govuk-table__cell" data-testid="trn" use-empty-fallback>@personInfo.Trn</td>
+                                <td class="govuk-table__cell" data-testid="nino" use-empty-fallback>@personInfo.NationalInsuranceNumber</td>
                             </tr>
                         }
                     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -21,8 +21,7 @@ public partial class IndexModel : PageModel
 
     public IndexModel(
         TrsLinkGenerator linkGenerator,
-        ICrmQueryDispatcher crmQueryDispatcher,
-        IConfiguration configuration)
+        ICrmQueryDispatcher crmQueryDispatcher)
     {
         _linkGenerator = linkGenerator;
         _crmQueryDispatcher = crmQueryDispatcher;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -21,7 +21,8 @@ public partial class IndexModel : PageModel
 
     public IndexModel(
         TrsLinkGenerator linkGenerator,
-        ICrmQueryDispatcher crmQueryDispatcher)
+        ICrmQueryDispatcher crmQueryDispatcher,
+        IConfiguration configuration)
     {
         _linkGenerator = linkGenerator;
         _crmQueryDispatcher = crmQueryDispatcher;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -29,7 +29,7 @@ else
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="current-alert-start-date-@alert.AlertId">@(alert.StartDate.HasValue ? alert.StartDate.Value.ToString("dd/MM/yyyy") : "-")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value data-testid="current-alert-start-date-@alert.AlertId" use-empty-fallback>@(alert.StartDate.HasValue ? alert.StartDate.Value.ToString("dd/MM/yyyy") : string.Empty)</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Details</govuk-summary-list-row-key>
@@ -72,8 +72,8 @@ else
             {
                 <tr class="govuk-table__row" data-testid="previous-alert-@alert.AlertId">
                     <td class="govuk-table__cell" data-testid="previous-alert-description-@alert.AlertId"><a href="@LinkGenerator.Alert(alert.AlertId)" class="govuk-link">@alert.Description</a></td>
-                    <td class="govuk-table__cell" data-testid="previous-alert-start-date-@alert.AlertId">@(alert.StartDate.HasValue ? alert.StartDate.Value.ToString("dd/MM/yyyy") : "-")</td>
-                    <td class="govuk-table__cell" data-testid="previous-alert-end-date-@alert.AlertId">@(alert.EndDate.HasValue ? alert.EndDate.Value.ToString("dd/MM/yyyy") : "-")</td>
+                    <td class="govuk-table__cell" data-testid="previous-alert-start-date-@alert.AlertId" use-empty-fallback>@(alert.StartDate.HasValue ? alert.StartDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
+                    <td class="govuk-table__cell" data-testid="previous-alert-end-date-@alert.AlertId" use-empty-fallback>@(alert.EndDate.HasValue ? alert.EndDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
                     <td class="govuk-table__cell" data-testid="previous-alert-status-@alert.AlertId">@alert.Status</td>
                 </tr>
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -31,13 +31,17 @@
         </govuk-summary-list-row>
         @if (Model.Person.PreviousNames.Length > 0)
         {
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Previous name(s)</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>
+                    <ul class="govuk-list">
             @for (int i = 0; i < Model.Person.PreviousNames.Length; i++)
             {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>@(i == 0 ? "Previous name(s)" : string.Empty)</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="personal-details-previous-names-@i">@Model.Person.PreviousNames[i]</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
+                        <li data-testid="personal-details-previous-names-@i">@Model.Person.PreviousNames[i]</li>                
             }
+                    </ul>
+                </govuk-summary-list-row-value>
+            </govuk-summary-list-row>
         }
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -7,8 +7,19 @@
     ViewBag.PersonId = Model.PersonId;
     ViewBag.Search = Model.Search;
     ViewBag.SortBy = Model.SortBy;
-    ViewBag.PageNumber = Model.PageNumber;    
+    ViewBag.PageNumber = Model.PageNumber;
     ViewBag.Title = Model.Person!.Name;
+}
+
+@if (Model.Person.HasAlerts)
+{
+    <govuk-notification-banner>
+        <p class="govuk-notification-banner__heading">
+            Alert on record.
+            <a class="govuk-notification-banner__link" href="@LinkGenerator.PersonAlerts(Model.PersonId, Model.Search, Model.SortBy, Model.PageNumber)">View alert</a>.
+        </p>
+    </govuk-notification-banner>
+
 }
 
 <govuk-summary-card>
@@ -18,21 +29,39 @@
             <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
             <govuk-summary-list-row-value data-testid="personal-details-name">@Model.Person.FullName</govuk-summary-list-row-value>
         </govuk-summary-list-row>
+        @if (Model.Person.PreviousNames.Length > 0)
+        {
+            @for (int i = 0; i < Model.Person.PreviousNames.Length; i++)
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>@(i == 0 ? "Previous name(s)" : string.Empty)</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="personal-details-previous-names-@i">@Model.Person.PreviousNames[i]</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+        }
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-date-of-birth">@(Model.Person.DateOfBirth.HasValue ? Model.Person.DateOfBirth.Value.ToString("dd/MM/yyyy") : "Not provided")</govuk-summary-list-row-value>
+            <govuk-summary-list-row-value data-testid="personal-details-date-of-birth" use-empty-fallback>@(Model.Person.DateOfBirth.HasValue ? Model.Person.DateOfBirth.Value.ToString("dd/MM/yyyy") : string.Empty)</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value data-testid="personal-details-gender" use-empty-fallback>@Model.Person.Gender</govuk-summary-list-row-value>
         </govuk-summary-list-row>
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-trn">@(!string.IsNullOrEmpty(Model.Person.Trn) ? Model.Person.Trn : "Not provided")</govuk-summary-list-row-value>
+            <govuk-summary-list-row-value data-testid="personal-details-trn" use-empty-fallback>@Model.Person.Trn</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value data-testid="personal-details-nino" use-empty-fallback>@Model.Person.NationalInsuranceNumber</govuk-summary-list-row-value>
         </govuk-summary-list-row>
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-email">@(!string.IsNullOrEmpty(Model.Person.Email) ? Model.Person.Email : "Not provided")</govuk-summary-list-row-value>
+            <govuk-summary-list-row-value data-testid="personal-details-email" use-empty-fallback>@Model.Person.Email</govuk-summary-list-row-value>
         </govuk-summary-list-row>
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-mobile-number">@(!string.IsNullOrEmpty(Model.Person.MobileNumber) ? Model.Person.MobileNumber : "Not provided")</govuk-summary-list-row-value>
+            <govuk-summary-list-row-value data-testid="personal-details-mobile-number" use-empty-fallback>@Model.Person.MobileNumber</govuk-summary-list-row-value>
         </govuk-summary-list-row>
     </govuk-summary-list>
 </govuk-summary-card>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Testing.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Testing.json
@@ -1,0 +1,3 @@
+{
+  "ConcurrentNameChangeWindowSeconds": 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
@@ -11,5 +11,6 @@
     "CallbackPath": "/signin-oidc",
     "SignedOutCallbackPath": "/signout-oidc"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConcurrentNameChangeWindowSeconds": 5 
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -17,3 +17,7 @@
   align-items: flex-end;
   display: flex;
 }
+
+.trs-subtle-emphasis {
+  color: govuk-colour("mid-grey");
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactDetailByIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactDetailByIdTests.cs
@@ -42,5 +42,25 @@ public class GetContactDetailByIdTests : IAsyncLifetime
         // Assert
         Assert.NotNull(results);
         Assert.Equal(results.Contact.Id, person.ContactId);
+        Assert.Empty(results.PreviousNames);
+    }
+
+    [Fact]
+    public async Task WhenCalled_WithContactIdForExistingContactWithPreviousName_ReturnsContactDetailIncludingPreviousNames()
+    {
+        // Arrange
+        var updatedFirstName = _dataScope.TestData.GenerateFirstName();
+        var updatedMiddleName = _dataScope.TestData.GenerateMiddleName();
+        var updatedLastName = _dataScope.TestData.GenerateLastName();
+        var person = await _dataScope.TestData.CreatePerson();
+        await _dataScope.TestData.UpdatePerson(b => b.WithPersonId(person.ContactId).WithUpdatedName(updatedFirstName, updatedMiddleName, updatedLastName));
+
+        // Act
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(person.ContactId, new ColumnSet()));
+
+        // Assert
+        Assert.NotNull(results);
+        Assert.Equal(results.Contact.Id, person.ContactId);
+        Assert.Equal(3, results.PreviousNames.Length);
     }
 }


### PR DESCRIPTION
### Context

Users of the support desk need gender and NINO to help identify the correct record.

### Changes proposed in this pull request

Add NINO, Gender and previous name(s) to the summary list on the person view, as per the designs.

### Guidance to review

CRM query changes + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
