### PR TITLE
Alert detail page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateSanctionStateQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateSanctionStateQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record UpdateSanctionStateQuery(Guid SanctionId, dfeta_sanctionState State) : ICrmQuery<bool>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateSanctionStateHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateSanctionStateHandler.cs
@@ -1,0 +1,22 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class UpdateSanctionStateHandler : ICrmQueryHandler<UpdateSanctionStateQuery, bool>
+{
+    public async Task<bool> Execute(UpdateSanctionStateQuery query, IOrganizationServiceAsync organizationService)
+    {
+        await organizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new dfeta_sanction()
+            {
+                Id = query.SanctionId,
+                StateCode = query.State
+            }
+        });
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml
@@ -8,7 +8,7 @@
     <govuk-back-link href="@LinkGenerator.PersonAlerts(Model.PersonId!.Value)">Back</govuk-back-link>
 }
 
-<h1 class="govuk-heading-l">@ViewBag.Title</h1>
+<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -22,9 +22,9 @@
             </thead>
             <tbody class="govuk-table__body">
                 <tr class="govuk-table__row" data-testid="alert-header">
-                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="start-date-@Model.Alert.AlertId" use-empty-fallback>@(Model.Alert.StartDate.HasValue ? Model.Alert.StartDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
-                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="end-date-@Model.Alert.AlertId" use-empty-fallback>@(Model.Alert.EndDate.HasValue ? Model.Alert.EndDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
-                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="status-@Model.Alert.AlertId">@Model.Alert.Status</td>
+                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="start-date" use-empty-fallback>@(Model.Alert.StartDate.HasValue ? Model.Alert.StartDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
+                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="end-date" use-empty-fallback>@(Model.Alert.EndDate.HasValue ? Model.Alert.EndDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
+                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="status">@Model.Alert.Status</td>
                 </tr>
             </tbody>
         </table>
@@ -38,7 +38,7 @@
         <h3 class="govuk-heading-s">Details</h3>
         @if (!string.IsNullOrEmpty(@Model.Alert.Details))
         {
-            <p class="govuk-body">
+            <p class="govuk-body" data-testid="alert-details">
             @{var lines = @Model.Alert.Details.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             @for (int i = 0; i < lines.Length; i++)
             {
@@ -50,16 +50,15 @@
             }
             }
             </p>
-        }
-        <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank" date-testid="see-full-case-details">See full case details (opens in new tab)</a>
+        }        
         <form action="@LinkGenerator.Alert(Model.AlertId)" method="post">
             @if (Model.IsActive)
             {
-                <govuk-button type="submit" class="govuk-!-margin-top-9">Mark alert as inactive</govuk-button>
+                <govuk-button type="submit" class="govuk-!-margin-top-9" data-testid="deactivate-button">Mark alert as inactive</govuk-button>
             }
             else
             {
-                <govuk-button type="submit" class="govuk-button--warning govuk-!-margin-top-9">Remove inactive status</govuk-button>
+                <govuk-button type="submit" class="govuk-button--warning govuk-!-margin-top-9" data-testid="reactivate-button">Remove inactive status</govuk-button>
             }
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml
@@ -38,28 +38,19 @@
         <h3 class="govuk-heading-s">Details</h3>
         @if (!string.IsNullOrEmpty(@Model.Alert.Details))
         {
-            <p class="govuk-body" data-testid="alert-details">
-            @{var lines = @Model.Alert.Details.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-            @for (int i = 0; i < lines.Length; i++)
-            {
-                <span>@lines[i]</span>
-                @if (i < lines.Length - 1)
-                {
-                    <br />
-                }
-            }
-            }
-            </p>
-        }        
-        <form action="@LinkGenerator.Alert(Model.AlertId)" method="post">
+            <multi-line-text data-testid="alert-details" text="@Model.Alert.Details"/>
+        }               
             @if (Model.IsActive)
             {
-                <govuk-button type="submit" class="govuk-!-margin-top-9" data-testid="deactivate-button">Mark alert as inactive</govuk-button>
+                <form asp-page-handler="SetInactive" method="post">
+                    <govuk-button type="submit" class="govuk-!-margin-top-9" data-testid="deactivate-button">Mark alert as inactive</govuk-button>
+                </form>
             }
             else
             {
-                <govuk-button type="submit" class="govuk-button--warning govuk-!-margin-top-9" data-testid="reactivate-button">Remove inactive status</govuk-button>
-            }
-        </form>
+                <form asp-page-handler="SetActive" method="post">
+                    <govuk-button type="submit" class="govuk-button--warning govuk-!-margin-top-9" data-testid="reactivate-button">Remove inactive status</govuk-button>
+                </form>
+            }        
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml
@@ -1,7 +1,66 @@
 @page "/alerts/{alertId}"
 @model IndexModel
 @{
-    ViewBag.Title = "Alert";
+    ViewBag.Title = Model.Alert!.Description;
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.PersonAlerts(Model.PersonId!.Value)">Back</govuk-back-link>
 }
 
 <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <table class="govuk-table trs-table--no-border govuk-!-margin-bottom-1">
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header trs-table__header--no-border">Start date</th>
+                    <th scope="col" class="govuk-table__header trs-table__header--no-border">End date</th>
+                    <th scope="col" class="govuk-table__header trs-table__header--no-border">Status</th>
+                </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+                <tr class="govuk-table__row" data-testid="alert-header">
+                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="start-date-@Model.Alert.AlertId" use-empty-fallback>@(Model.Alert.StartDate.HasValue ? Model.Alert.StartDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
+                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="end-date-@Model.Alert.AlertId" use-empty-fallback>@(Model.Alert.EndDate.HasValue ? Model.Alert.EndDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
+                    <td class="govuk-table__cell trs-table__cell--no-border" data-testid="status-@Model.Alert.AlertId">@Model.Alert.Status</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h3 class="govuk-heading-s">Details</h3>
+        @if (!string.IsNullOrEmpty(@Model.Alert.Details))
+        {
+            <p class="govuk-body">
+            @{var lines = @Model.Alert.Details.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            @for (int i = 0; i < lines.Length; i++)
+            {
+                <span>@lines[i]</span>
+                @if (i < lines.Length - 1)
+                {
+                    <br />
+                }
+            }
+            }
+            </p>
+        }
+        <a href="#" class="govuk-link" rel="noreferrer noopener" target="_blank" date-testid="see-full-case-details">See full case details (opens in new tab)</a>
+        <form action="@LinkGenerator.Alert(Model.AlertId)" method="post">
+            @if (Model.IsActive)
+            {
+                <govuk-button type="submit" class="govuk-!-margin-top-9">Mark alert as inactive</govuk-button>
+            }
+            else
+            {
+                <govuk-button type="submit" class="govuk-button--warning govuk-!-margin-top-9">Remove inactive status</govuk-button>
+            }
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml.cs
@@ -29,12 +29,22 @@ public class IndexModel : PageModel
 
     public Guid? PersonId { get; set; }
 
-    public async Task<IActionResult> OnPost()
+    public async Task<IActionResult> OnPostSetActive()
     {
-        await _crmQueryDispatcher.ExecuteQuery(new UpdateSanctionStateQuery(AlertId, IsActive ? dfeta_sanctionState.Inactive : dfeta_sanctionState.Active));
+        await _crmQueryDispatcher.ExecuteQuery(new UpdateSanctionStateQuery(AlertId, dfeta_sanctionState.Active));
 
-        IsActive = !IsActive;
-        TempData.SetFlashSuccess($"{(IsActive ? "Inactive status removed" : "Status changed to inactive")}");
+        IsActive = true;
+        TempData.SetFlashSuccess("Inactive status removed");
+
+        return Redirect(_linkGenerator.Alert(AlertId));
+    }
+
+    public async Task<IActionResult> OnPostSetInactive()
+    {
+        await _crmQueryDispatcher.ExecuteQuery(new UpdateSanctionStateQuery(AlertId, dfeta_sanctionState.Inactive));
+
+        IsActive = false;
+        TempData.SetFlashSuccess("Status changed to inactive");
 
         return Redirect(_linkGenerator.Alert(AlertId));
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml.cs
@@ -1,10 +1,74 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+using static TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.AlertsModel;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.Alert;
 
 public class IndexModel : PageModel
 {
-    public void OnGet()
+    private readonly TrsLinkGenerator _linkGenerator;
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public IndexModel(
+        TrsLinkGenerator linkGenerator,
+        ICrmQueryDispatcher crmQueryDispatcher)
     {
+        _linkGenerator = linkGenerator;
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    public AlertInfo? Alert { get; set; }
+
+    public bool IsActive { get; set; }
+
+    public Guid? PersonId { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await _crmQueryDispatcher.ExecuteQuery(new UpdateSanctionStateQuery(AlertId, IsActive ? dfeta_sanctionState.Inactive : dfeta_sanctionState.Active));
+
+        IsActive = !IsActive;
+        TempData.SetFlashSuccess($"{(IsActive ? "Inactive status removed" : "Status changed to inactive")}");
+
+        return Redirect(_linkGenerator.Alert(AlertId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var sanction = await _crmQueryDispatcher.ExecuteQuery(new GetSanctionDetailsBySanctionIdQuery(AlertId));
+        if (sanction is null)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        Alert = MapSanction(sanction);
+        IsActive = sanction.Sanction.StateCode == dfeta_sanctionState.Active;
+        PersonId = sanction.Sanction.dfeta_PersonId.Id;
+
+        await next();
+    }
+
+    private AlertInfo MapSanction(SanctionDetailResult sanction)
+    {
+        var alertStatus = sanction.Sanction.StateCode == dfeta_sanctionState.Inactive ? AlertStatus.Inactive :
+            sanction.Sanction.dfeta_EndDate is null ? AlertStatus.Active :
+            AlertStatus.Closed;
+
+        return new AlertInfo()
+        {
+            AlertId = sanction.Sanction.Id,
+            Description = sanction.Description,
+            Details = sanction.Sanction.dfeta_SanctionDetails,
+            StartDate = sanction.Sanction.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+            EndDate = sanction.Sanction.dfeta_EndDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+            Status = alertStatus
+        };
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Alert/Index.cshtml.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
-using static TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.AlertsModel;
+using TeachingRecordSystem.SupportUi.Pages.Common;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.Alert;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertInfo.cs
@@ -1,14 +1,11 @@
-namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+namespace TeachingRecordSystem.SupportUi.Pages.Common;
 
-public partial class AlertsModel
+public record AlertInfo
 {
-    public record AlertInfo
-    {
-        public required Guid AlertId { get; init; }
-        public required string Description { get; init; }
-        public required string Details { get; init; }
-        public required DateOnly? StartDate { get; init; }
-        public required DateOnly? EndDate { get; init; }
-        public required AlertStatus Status { get; init; }
-    }
+    public required Guid AlertId { get; init; }
+    public required string Description { get; init; }
+    public required string Details { get; init; }
+    public required DateOnly? StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+    public required AlertStatus Status { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertInfo.cs
@@ -1,0 +1,14 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+
+public partial class AlertsModel
+{
+    public record AlertInfo
+    {
+        public required Guid AlertId { get; init; }
+        public required string Description { get; init; }
+        public required string Details { get; init; }
+        public required DateOnly? StartDate { get; init; }
+        public required DateOnly? EndDate { get; init; }
+        public required AlertStatus Status { get; init; }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertStatus.cs
@@ -1,11 +1,8 @@
-namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+namespace TeachingRecordSystem.SupportUi.Pages.Common;
 
-public partial class AlertsModel
+public enum AlertStatus
 {
-    public enum AlertStatus
-    {
-        Active,
-        Inactive,
-        Closed
-    }
+    Active,
+    Inactive,
+    Closed
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertStatus.cs
@@ -1,0 +1,11 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+
+public partial class AlertsModel
+{
+    public enum AlertStatus
+    {
+        Active,
+        Inactive,
+        Closed
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -45,7 +45,7 @@ else
                                     <br />
                                 }
                             }
-                        }                        
+                        }
                         </govuk-summary-list-row-value>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -36,15 +36,7 @@ else
                     <govuk-summary-list-row-value data-testid="current-alert-details-@alert.AlertId">
                         @if (!string.IsNullOrEmpty(@alert.Details))
                         {
-                            var lines = @alert.Details.Split(new string[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-                            @for (int i = 0; i < lines.Length; i++)
-                            {
-                                <span>@lines[i]</span>
-                                @if (i < lines.Length - 1)
-                                {
-                                    <br />
-                                }
-                            }
+                            <multi-line-text text="@alert.Details" />                  
                         }
                         </govuk-summary-list-row-value>
                 </govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -71,7 +71,7 @@ else
             @foreach (var alert in Model.PreviousAlerts)
             {
                 <tr class="govuk-table__row" data-testid="previous-alert-@alert.AlertId">
-                    <td class="govuk-table__cell" data-testid="previous-alert-description-@alert.AlertId"><a href="@LinkGenerator.Alert(alert.AlertId)" class="govuk-link">@alert.Description</a></td>
+                    <td class="govuk-table__cell" data-testid="previous-alert-description-@alert.AlertId"><a href="@LinkGenerator.Alert(alert.AlertId)" class="govuk-link" data-testid="view-alert-link-@alert.AlertId">@alert.Description</a></td>
                     <td class="govuk-table__cell" data-testid="previous-alert-start-date-@alert.AlertId" use-empty-fallback>@(alert.StartDate.HasValue ? alert.StartDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
                     <td class="govuk-table__cell" data-testid="previous-alert-end-date-@alert.AlertId" use-empty-fallback>@(alert.EndDate.HasValue ? alert.EndDate.Value.ToString("dd/MM/yyyy") : string.Empty)</td>
                     <td class="govuk-table__cell" data-testid="previous-alert-status-@alert.AlertId">@alert.Status</td>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.SupportUi.Pages.Common;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
-public class AlertsModel : PageModel
+public partial class AlertsModel : PageModel
 {
     private readonly ICrmQueryDispatcher _crmQueryDispatcher;
 
@@ -80,22 +80,5 @@ public class AlertsModel : PageModel
             EndDate = sanction.Sanction.dfeta_EndDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             Status = alertStatus
         };
-    }
-
-    public record AlertInfo
-    {
-        public required Guid AlertId { get; init; }
-        public required string Description { get; init; }
-        public required string Details { get; init; }
-        public required DateOnly? StartDate { get; init; }
-        public required DateOnly? EndDate { get; init; }
-        public required AlertStatus Status { get; init; }
-    }
-
-    public enum AlertStatus
-    {
-        Active,
-        Inactive,
-        Closed
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/MultiLineTextTagHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/MultiLineTextTagHelper.cs
@@ -1,0 +1,31 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TeachingRecordSystem.SupportUi.TagHelpers;
+
+public class MultiLineTextTagHelper : TagHelper
+{
+    public string Text { get; set; } = string.Empty;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = "p";
+        output.AddClass("govuk-body", HtmlEncoder.Default);
+
+        if (!string.IsNullOrWhiteSpace(Text))
+        {
+            var lines = Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                output.Content.Append(lines[i]);
+                if (i < lines.Length - 1)
+                {
+                    output.Content.AppendHtml("<br />");
+                }
+            }
+        }
+
+        output.TagMode = TagMode.StartTagAndEndTag;
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/CloseSanctionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/CloseSanctionTests.cs
@@ -1,0 +1,40 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class CloseSanctionTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public CloseSanctionTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var sanctionCode = "G1";
+        var startDate = new DateOnly(2020, 01, 01);
+        var endDate = new DateOnly(2021, 03, 09);
+        var createPersonResult = await _dataScope.TestData.CreatePerson(x => x.WithSanction(sanctionCode, startDate: startDate));
+        var sanction = createPersonResult.Sanctions.Single();
+
+        // Act
+        _ = await _crmQueryDispatcher.ExecuteQuery(new CloseSanctionQuery(sanction.SanctionId, endDate));
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+
+        var closedSanction = ctx.dfeta_sanctionSet.SingleOrDefault(s => s.GetAttributeValue<Guid>(dfeta_sanction.PrimaryIdAttribute) == sanction.SanctionId);
+        Assert.NotNull(closedSanction);
+        Assert.Equal(dfeta_sanctionState.Active, closedSanction.StateCode);
+        Assert.Equal(endDate.FromDateOnlyWithDqtBstFix(isLocalTime: true), closedSanction.dfeta_EndDate);
+        Assert.True(closedSanction.dfeta_Spent);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/UpdateSanctionStateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/UpdateSanctionStateTests.cs
@@ -1,0 +1,38 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class UpdateSanctionStateTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public UpdateSanctionStateTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task QueryExecutesSuccessfully(bool setActive)
+    {
+        // Arrange
+        var sanctionCode = "G1";
+        var startDate = new DateOnly(2020, 01, 01);
+        var createPersonResult = await _dataScope.TestData.CreatePerson(x => x.WithSanction(sanctionCode, startDate: startDate, isActive: !setActive));
+        var sanction = createPersonResult.Sanctions.Single();
+
+        // Act
+        _ = await _crmQueryDispatcher.ExecuteQuery(new UpdateSanctionStateQuery(sanction.SanctionId, setActive ? dfeta_sanctionState.Active : dfeta_sanctionState.Inactive));
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+        var updatedSanction = ctx.dfeta_sanctionSet.SingleOrDefault(s => s.GetAttributeValue<Guid>(dfeta_sanction.PrimaryIdAttribute) == sanction.SanctionId);
+        Assert.NotNull(updatedSanction);
+        Assert.Equal(setActive ? dfeta_sanctionState.Active : dfeta_sanctionState.Inactive, updatedSanction.StateCode);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
@@ -39,4 +39,40 @@ public class AlertTests : TestBase
 
         await page.AssertFlashMessage("Alert closed");
     }
+
+    [Theory]
+    [InlineData(true, "Status changed to inactive")]
+    [InlineData(false, "Inactive status removed")]
+    public async Task ViewAlert(bool isActive, string expectedFlashMessage)
+    {
+        var startDate = new DateOnly(2021, 10, 01);
+        var endDate = new DateOnly(2023, 08, 02);
+        var createPersonResult = await TestData.CreatePerson(b => b.WithSanction("G1", startDate: startDate, endDate: endDate, spent: true, isActive: isActive));
+        var personId = createPersonResult.ContactId;
+        var alertId = createPersonResult.Sanctions.Single().SanctionId;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonAlertsPage(personId);
+
+        await page.AssertOnPersonAlertsPage(personId);
+
+        await page.ClickViewAlertPersonAlertsPage(alertId);
+
+        await page.AssertOnAlertDetailPage(alertId);
+
+        if (isActive)
+        {
+            await page.ClickDeactivateButton();
+        }
+        else
+        {
+            await page.ClickReactivateButton();
+        }
+
+        await page.AssertOnAlertDetailPage(alertId);
+
+        await page.AssertFlashMessage(expectedFlashMessage);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -26,6 +26,11 @@ public static class PageExtensions
         await page.GetByTestId($"close-{alertId}").ClickAsync();
     }
 
+    public static async Task ClickViewAlertPersonAlertsPage(this IPage page, Guid alertId)
+    {
+        await page.GetByTestId($"view-alert-link-{alertId}").ClickAsync();
+    }
+
     public static async Task ClickOpenCasesLinkInNavigationBar(this IPage page)
     {
         await page.ClickAsync("a:text-is('Open cases')");
@@ -61,6 +66,11 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/persons/{personId}/alerts");
     }
 
+    public static async Task AssertOnAlertDetailPage(this IPage page, Guid alertId)
+    {
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}");
+    }
+
     public static async Task AssertOnCloseAlertPage(this IPage page, Guid alertId)
     {
         await page.WaitForUrlPathAsync($"/alerts/{alertId}/close");
@@ -94,6 +104,12 @@ public static class PageExtensions
 
     public static Task ClickContinueButton(this IPage page)
         => ClickButton(page, "Continue");
+
+    public static Task ClickDeactivateButton(this IPage page)
+        => ClickButton(page, "Mark alert as inactive");
+
+    public static Task ClickReactivateButton(this IPage page)
+        => ClickButton(page, "Remove inactive status");
 
     private static Task ClickButton(this IPage page, string text) =>
         page.ClickAsync($".govuk-button:text-is('{text}')");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/Alert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/Alert/IndexTests.cs
@@ -1,0 +1,70 @@
+using TeachingRecordSystem.SupportUi.Pages.Common;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.Alert;
+
+public class IndexTests : TestBase
+{
+    public IndexTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentAlertId = Guid.NewGuid().ToString();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{nonExistentAlertId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("2021-01-01", "2022-03-05", true, true, AlertStatus.Closed)]
+    [InlineData("2021-01-01", null, false, true, AlertStatus.Active)]
+    [InlineData("2021-01-01", null, false, false, AlertStatus.Inactive)]
+    [InlineData("2021-01-01", "2022-03-05", true, false, AlertStatus.Inactive)]
+    public async Task Get_ValidRequest_RendersExpectedContent(string startDateString, string? endDateString, bool isSpent, bool isActive, AlertStatus expectedAlertStatus)
+    {
+        // Arrange
+        var sanctionCode = "G1";
+        var sanctionCodeName = (await TestData.ReferenceDataCache.GetSanctionCodeByValue(sanctionCode)).dfeta_name;
+        var startDate = DateOnly.Parse(startDateString);
+        DateOnly? endDate = endDateString is not null ? DateOnly.Parse(endDateString) : null;
+        var person = await TestData.CreatePerson(x => x.WithSanction(sanctionCode, startDate: startDate, endDate: endDate, spent: isSpent, isActive: isActive));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{person.Sanctions.Single().SanctionId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+
+        Assert.Equal(sanctionCodeName, doc.GetElementByTestId("title")!.TextContent);
+
+        var alertHeader = doc.GetElementByTestId("alert-header");
+        Assert.NotNull(alertHeader);
+        Assert.Equal(startDate.ToString("dd/MM/yyyy"), alertHeader.GetElementByTestId("start-date")!.TextContent);
+        Assert.Equal(endDate is not null ? endDate.Value.ToString("dd/MM/yyyy") : "-", alertHeader.GetElementByTestId("end-date")!.TextContent);
+        Assert.Equal(expectedAlertStatus.ToString(), alertHeader.GetElementByTestId("status")!.TextContent);
+        Assert.NotNull(doc.GetElementByTestId("alert-details"));
+        if (isActive)
+        {
+            Assert.NotNull(doc.GetElementByTestId("deactivate-button"));
+            Assert.Null(doc.GetElementByTestId("reactivate-button"));
+        }
+        else
+        {
+            Assert.Null(doc.GetElementByTestId("deactivate-button"));
+            Assert.NotNull(doc.GetElementByTestId("reactivate-button"));
+        }
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ConfirmTests.cs
@@ -11,9 +11,9 @@ public class ConfirmTests : TestBase
     public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
-        var nonExistentActivityId = Guid.NewGuid().ToString();
+        var nonExistentAlertId = Guid.NewGuid().ToString();
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{nonExistentActivityId}/close/confirm");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{nonExistentAlertId}/close/confirm");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -29,7 +29,7 @@ public class ConfirmTests : TestBase
         var sanctionCode = "G1";
         var sanctionCodeName = (await TestData.ReferenceDataCache.GetSanctionCodeByValue(sanctionCode)).dfeta_name;
         var startDate = new DateOnly(2021, 01, 01);
-        var endDate = new DateOnly(2020, 01, 01);
+        var endDate = new DateOnly(2022, 03, 05);
         var person = await TestData.CreatePerson(x => x.WithSanction(sanctionCode, startDate: startDate));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{person.Sanctions.Single().SanctionId}/close/confirm?endDate={endDate:yyyy-MM-dd}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
@@ -99,9 +99,10 @@ public partial class CrmTestData
             DateOnly? endDate = null,
             DateOnly? reviewDate = null,
             bool spent = false,
-            string details = "lorem ipsum")
+            string details = "lorem ipsum",
+            bool isActive = true)
         {
-            _sanctions.Add(new(Guid.NewGuid(), sanctionCode, startDate, endDate, reviewDate, spent, details));
+            _sanctions.Add(new(Guid.NewGuid(), sanctionCode, startDate, endDate, reviewDate, spent, details, isActive));
             return this;
         }
 
@@ -194,9 +195,22 @@ public partial class CrmTestData
                         dfeta_StartDate = sanction.StartDate?.FromDateOnlyWithDqtBstFix(isLocalTime: true),
                         dfeta_EndDate = sanction.EndDate?.FromDateOnlyWithDqtBstFix(isLocalTime: true),
                         dfeta_NoReAppuntildate = sanction.ReviewDate?.FromDateOnlyWithDqtBstFix(isLocalTime: true),
-                        dfeta_Spent = sanction.Spent
+                        dfeta_Spent = sanction.Spent,
+                        dfeta_SanctionDetails = sanction.Details
                     }
                 });
+
+                if (!sanction.IsActive)
+                {
+                    txnRequestBuilder.AddRequest(new UpdateRequest()
+                    {
+                        Target = new dfeta_sanction()
+                        {
+                            Id = sanction.SanctionId,
+                            StateCode = dfeta_sanctionState.Inactive
+                        }
+                    });
+                }
             }
 
             await txnRequestBuilder.Execute();
@@ -251,5 +265,5 @@ public partial class CrmTestData
         };
     }
 
-    public record Sanction(Guid SanctionId, string SanctionCode, DateOnly? StartDate, DateOnly? EndDate, DateOnly? ReviewDate, bool Spent, string Details);
+    public record Sanction(Guid SanctionId, string SanctionCode, DateOnly? StartDate, DateOnly? EndDate, DateOnly? ReviewDate, bool Spent, string Details, bool IsActive);
 }


### PR DESCRIPTION
### Context

Users of the TRS Console need to be able to view details of alerts.

### Changes proposed in this pull request

Populate the /alerts/{alertId} page following the designs within the ‘Closed alert’ section ofthe Figma design (note that active alerts should be visible here too).

If no alert exists with the specified alertId return a 404.

The back link should go back to /persons/{personId}/alerts where {personId} is the ID of the person linked to the current alert.

### Guidance to review

CRM queries + UI + tests
Excluding detaillink functionality at the moment until CRM changes are done.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
