### PR TITLE
Added migration script to add dfeta_detailslink to dfeta_sanction in reporting DB

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0010_SanctionDetailsLink.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0010_SanctionDetailsLink.sql
@@ -1,0 +1,2 @@
+if not exists (select 1 from information_schema.columns where table_name = 'dfeta_sanction' and column_name = 'dfeta_detailslink')
+    alter table dfeta_sanction add dfeta_detailslink nvarchar(1000)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -16,6 +16,7 @@
     <None Remove="Dqt\Services\DqtReporting\Migrations\0007_ContactAllowpiiUpdatesFromRegister.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0008_EvergreenMissingColumns.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0009_EvergreenMissingColumns2.sql" />
+    <None Remove="Dqt\Services\DqtReporting\Migrations\0010_SanctionDetailsLink.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +29,7 @@
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0007_ContactAllowpiiUpdatesFromRegister.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0008_EvergreenMissingColumns.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0009_EvergreenMissingColumns2.sql" />
+    <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0010_SanctionDetailsLink.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context

A new field dfeta_detailslink has been added to the dfeta_sanction table in CRM but not in the reporting database.

### Changes proposed in this pull request

Add a migration script to add the missing column to the reporting DB.

### Guidance to review

simple change.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
