### PR TITLE
Add script to add missing metadata for High Potential ITT to reporting db

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0011_AddHighProfileProgrammeType.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/Migrations/0011_AddHighProfileProgrammeType.sql
@@ -1,0 +1,4 @@
+IF EXISTS (select 1 from information_schema.tables where table_name = 'GlobalOptionSetMetadata')
+BEGIN
+    INSERT INTO [dbo].[GlobalOptionSetMetadata](OptionSetName,[Option],IsUserLocalizedLabel,LocalizedLabelLanguageCode,LocalizedLabel) values('dfeta_programmetype',389040024,0,1033,'high potential ITT');
+END

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -17,6 +17,7 @@
     <None Remove="Dqt\Services\DqtReporting\Migrations\0008_EvergreenMissingColumns.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0009_EvergreenMissingColumns2.sql" />
     <None Remove="Dqt\Services\DqtReporting\Migrations\0010_SanctionDetailsLink.sql" />
+    <None Remove="Dqt\Services\DqtReporting\Migrations\0011_AddHighProfileProgrammeType.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +31,7 @@
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0008_EvergreenMissingColumns.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0009_EvergreenMissingColumns2.sql" />
     <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0010_SanctionDetailsLink.sql" />
+    <EmbeddedResource Include="Dqt\Services\DqtReporting\Migrations\0011_AddHighProfileProgrammeType.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When High potential ITT programme type was added in august, it wasn't added to the reporting database. This is to add the label to the reporting db so that it can be reported on.

### Context

Include relevant motivation and context.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
