### PR TITLE
Don't wait for build & tests to complete before packaging

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -217,13 +217,12 @@ jobs:
 
   package:
     name: Package application
-    needs: [build, validate_terraform]
     uses: ./.github/workflows/package.yml
     secrets: inherit
 
   deploy_dev:
     name: Deploy dev environment
-    needs: package
+    needs: [build, validate_terraform, package]
     uses: ./.github/workflows/deploy-dev.yml
     with:
       api_docker_image: ${{ needs.package.outputs.api_docker_image }}


### PR DESCRIPTION
Previously were waiting until the main build & test job was completed before packaging. There's no need to do this; packaging is an independent process that has no dependency on the build job. This effectively shaves off ~ 3 minutes from our PR workflows.