### PR TITLE
Fix pre-production environment name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     name: Check environment deployments
     runs-on: ubuntu-latest
     outputs:
-      deploy_preprod: ${{ steps.check_preprod_deployment.outputs.deploy_preprod}}
+      deploy_preprod: ${{ steps.check_preprod_deployment.outputs.deploy_preprod }}
     steps:
       - uses: actions/github-script@v6
         id: check_preprod_deployment
@@ -31,7 +31,7 @@ jobs:
             // If the current pre-prod deployment is not main then we don't want to overwrite it
 
             const { owner, repo } = context.repo;
-            const preprodEnvironmentName = "pre-production";
+            const preprodEnvironmentName = "pre-production_aks";
 
             const deployments = await github.rest.repos.listDeployments({ owner, repo, environment: preprodEnvironmentName, per_page: 1 });
             const lastDeploymentBranch = deployments.data[0].ref;


### PR DESCRIPTION
The script that checks for non-main deployments on pre-prod hasn't been updated following the AKS move; this fixes it.