### PR TITLE
Auto populate alert details by sanction type

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/SanctionTextLookup.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/SanctionTextLookup.cs
@@ -1,0 +1,43 @@
+namespace TeachingRecordSystem.Core.Dqt;
+
+public class SanctionTextLookup
+{
+    private readonly IDictionary<string, string> sanctionDefaultText = new Dictionary<string, string>();
+
+    public SanctionTextLookup()
+    {
+        sanctionDefaultText.Add("A13", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A14", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A18", "Conviction of a relevant offence. [01/01/2001]. Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A19", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A1A", "Unacceptable professional conduct. [01/01/2001]. Cannot teach in any maintained school, pupil referral unit or non-maintained special school.");
+        sanctionDefaultText.Add("A1B", "Unacceptable professional conduct. [01/01/2001]. Will be reviewed on [01/01/2022]. Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.");
+        sanctionDefaultText.Add("A2", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A20", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A21A", "Conviction of a relevant offence. [01/01/2001]. Cannot teach in any maintained school, pupil referral unit or non-maintained special school.");
+        sanctionDefaultText.Add("A21B", "Conviction of a relevant offence. [01/01/2001]. Will be reviewed on [01/01/2022].");
+        sanctionDefaultText.Add("A23", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A24", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A25A", "Breach of conditions. [01/01/2001]. Cannot teach in any maintained school, pupil referral unit or non-maintained special school.");
+        sanctionDefaultText.Add("A25B", "Breach of conditions. [01/01/2001]. Will be reviewed on [01/01/2022]. Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.");
+        sanctionDefaultText.Add("A3", "Unacceptable professional conduct. [01/01/2001]. Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A5A", "Serious professional incompetence. [01/01/2001]. Cannot teach in any maintained school, pupil referral unit or non-maintained special school.");
+        sanctionDefaultText.Add("A5B", "SSerious professional incompetence. [01/01/2001]. Will be reviewed on [01/01/2022]. Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.");
+        sanctionDefaultText.Add("A6", "Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("A7", "Serious professional incompetence.[01/01/2001]. Can only teach in maintained schools, pupil referral units and non-maintained special schools subject to the conditions of the sanction. Contact the Teaching Regulation Agency (TRA) on 0207 593 5393 to confirm the current status of the order.");
+        sanctionDefaultText.Add("B3", "[01/01/2001]. Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.");
+        sanctionDefaultText.Add("C1", "Failed probation. [01/02/2001]. Cannot teach in any maintained school, pupil referral unit or non-maintained special school.");
+        sanctionDefaultText.Add("C3", "Failed probation [01/01/2001]. Can carry out specified work for the same amount of time as a statutory induction period.");
+        sanctionDefaultText.Add("G1", "Contact DBS for more details. [Contact details]");
+        sanctionDefaultText.Add("T2", "Interim prohibition. [01/01/2001]. Investigation ongoing. Cannot teach in any school, including sixth-form colleges, relevant youth accommodation and children’s homes.");
+        sanctionDefaultText.Add("T3", "Deregistered by the General Teaching Council for Scotland (GTCS). [01/01/2001]. Cannot teach in any maintained school, pupil referral unit or non-maintained special school.");
+        sanctionDefaultText.Add("T4", "Contact the Education Workforce Council for more details.");
+        sanctionDefaultText.Add("T5", "Contact the General Teaching Council for Northern Ireland (GTCNI) for more details.");
+    }
+
+    public string? GetSanctionDefaultText(string sanctionCode)
+    {
+        sanctionDefaultText.TryGetValue(sanctionCode, out string? defaultText);
+        return defaultText;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml
@@ -14,8 +14,30 @@
     <script asp-add-nonce="true">
         window.onload = function () {
             accessibleAutocomplete.enhanceSelectElement({
-                selectElement: document.querySelector('#@nameof(Model.AlertTypeId)')
-            })            
+                selectElement: document.querySelector('#@nameof(Model.AlertTypeId)'),
+                onConfirm: function (selected) {
+                    if (!selected) {
+                        return;
+                    }
+
+                    var selectElement = document.querySelector('#@nameof(Model.AlertTypeId)-select');
+                    var selectOptions = Array.from(selectElement.options);
+                    var detailsElement = document.querySelector('#@nameof(Model.Details)');
+                    var previousAlertValue = detailsElement.dataset.alertvalue;
+                    var previousSelectedOption = previousAlertValue ? selectOptions.find(option => option.dataset.alertvalue === previousAlertValue) : undefined;
+                    var selectedOption = selectOptions.find(option => (option.textContent || option.innerText) === selected);
+                    // Need to do this as it doesn't get set if implementing an onConfirm function with enhanceSelectElement
+                    selectedOption.selected = true;
+
+                    if (!previousSelectedOption ||
+                            (detailsElement.value == "") ||
+                            (previousSelectedOption && detailsElement.value === previousSelectedOption.dataset.defaulttext)) {
+                        detailsElement.value = selectedOption.dataset.defaulttext;
+                    }
+
+                    detailsElement.dataset.alertvalue = selectedOption.dataset.alertvalue;                    
+                },
+            })
         }
     </script>
 }
@@ -33,7 +55,7 @@
                 <govuk-select-item value=""></govuk-select-item>
                 @foreach (var alertType in Model.AlertTypes!)
                 {
-                    <govuk-select-item value="@alertType.AlertTypeId">@alertType.Name</govuk-select-item>
+                    <govuk-select-item data-defaulttext="@alertType.DefaultText" data-alertvalue="@alertType.Value" value="@alertType.AlertTypeId">@alertType.Name</govuk-select-item>
                 }
             </govuk-select>
 
@@ -51,4 +73,3 @@
         </form>
     </div>
 </div>
-

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml.cs
@@ -15,15 +15,18 @@ public class IndexModel : PageModel
     private readonly TrsLinkGenerator _linkGenerator;
     private readonly ICrmQueryDispatcher _crmQueryDispatcher;
     private readonly ReferenceDataCache _referenceDataCache;
+    private readonly SanctionTextLookup _sanctionTextLookup;
 
     public IndexModel(
         TrsLinkGenerator linkGenerator,
         ICrmQueryDispatcher crmQueryDispatcher,
-        ReferenceDataCache referenceDataCache)
+        ReferenceDataCache referenceDataCache,
+        SanctionTextLookup sanctionTextLookup)
     {
         _linkGenerator = linkGenerator;
         _crmQueryDispatcher = crmQueryDispatcher;
         _referenceDataCache = referenceDataCache;
+        _sanctionTextLookup = sanctionTextLookup;
     }
 
     public JourneyInstance<AddAlertState>? JourneyInstance { get; set; }
@@ -117,6 +120,7 @@ public class IndexModel : PageModel
         {
             AlertTypeId = sanctionCode.dfeta_sanctioncodeId!.Value,
             Value = sanctionCode.dfeta_Value,
-            Name = sanctionCode.dfeta_name
+            Name = sanctionCode.dfeta_name,
+            DefaultText = _sanctionTextLookup.GetSanctionDefaultText(sanctionCode.dfeta_Value) ?? string.Empty
         };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Common/AlertType.cs
@@ -5,4 +5,5 @@ public record AlertType
     public required Guid AlertTypeId { get; init; }
     public required string Name { get; init; }
     public required string Value { get; init; }
+    public required string DefaultText { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -206,6 +206,7 @@ builder.Services
     .AddSingleton<IClock, Clock>()
     .AddSupportUiServices(builder.Configuration, builder.Environment)
     .AddSingleton<ReferenceDataCache>()
+    .AddSingleton<SanctionTextLookup>()
     .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>();
 
 var app = builder.Build();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
@@ -98,7 +98,7 @@ public class AlertTests : TestBase
 
         await page.AssertOnAddAlertPage();
 
-        await page.SubmitAddAlertIndexPage(personId, sanctionCode.dfeta_name, details, link, startDate);
+        await page.SubmitAddAlertIndexPage(sanctionCode.dfeta_name, details, link, startDate);
 
         await page.AssertOnAddAlertConfirmPage();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
@@ -76,12 +76,14 @@ public class AlertTests : TestBase
         await page.AssertFlashMessage(expectedFlashMessage);
     }
 
-    [Fact]
-    public async Task AddAlert()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AddAlert(bool setDetailsManually)
     {
         var sanctionCodeValue = "G1";
         var sanctionCode = await TestData.ReferenceDataCache.GetSanctionCodeByValue(sanctionCodeValue);
-        var details = "These are some test details";
+        var details = setDetailsManually ? "These are some test details" : null;
         var link = "http://www.gov.uk";
         var startDate = new DateOnly(2021, 10, 01);
         var createPersonResult = await TestData.CreatePerson();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -108,7 +108,7 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Year')", date.Year.ToString());
     }
 
-    public static async Task SubmitAddAlertIndexPage(this IPage page, Guid personId, string alertType, string details, string link, DateOnly startDate)
+    public static async Task SubmitAddAlertIndexPage(this IPage page, string alertType, string details, string link, DateOnly startDate)
     {
         await page.AssertOnAddAlertPage();
         await page.FillAsync("label:text-is('Alert type')", alertType);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -108,11 +108,15 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Year')", date.Year.ToString());
     }
 
-    public static async Task SubmitAddAlertIndexPage(this IPage page, string alertType, string details, string link, DateOnly startDate)
+    public static async Task SubmitAddAlertIndexPage(this IPage page, string alertType, string? details, string link, DateOnly startDate)
     {
         await page.AssertOnAddAlertPage();
         await page.FillAsync("label:text-is('Alert type')", alertType);
-        await page.FillAsync("label:text-is('Details')", details);
+        if (details != null)
+        {
+            await page.FillAsync("label:text-is('Details')", details);
+        }
+
         await page.FillAsync("label:text-is('Link')", link);
         await page.FillDateInput(startDate);
         await page.ClickContinueButton();


### PR DESCRIPTION
### Context

For some alert types, users have been copy/pasting default text into the details attribute. We should auto-populate the details field for these alert types.

### Changes proposed in this pull request

When creating an alert, when the alert type is changed, if the Details textbox is empty (or contains pre-populated text for the existing alert type) overwrite the Details textbox with the value from column F in the spreadsheet in the trello card for the selected alert type.

### Guidance to review

Helper for static data + UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
