### PR TITLE
Add Prohibition Alerts to v3 teacher response

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/AlertInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/AlertInfo.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.ApiModels;
+
+public record AlertInfo
+{
+    public required AlertType AlertType { get; init; }
+    public required string DqtSanctionCode { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/AlertType.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.ApiModels;
+
+public enum AlertType
+{
+    Prohibition,
+    // Only exposing Prohibitions for now
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
@@ -38,4 +38,27 @@ public static class Constants
         "A24",
         "A23",
     }.ToImmutableArray();
+
+    public static ImmutableArray<string> ProhibitionSanctionCodes { get; } = new[]
+    {
+        "G1",
+        "B1",
+        "G2",
+        "B6",
+        "T2",
+        "B3",
+        "B5",
+        "T3",
+        "T5",
+        "T4",
+        "T1",
+        "A25B",
+        "A25A",
+        "A21B",
+        "A21A",
+        "A5B",
+        "A5A",
+        "A1B",
+        "A1A",
+    }.ToImmutableArray();
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Requests/GetTeacherRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Requests/GetTeacherRequest.cs
@@ -24,6 +24,7 @@ public enum GetTeacherRequestIncludes
     PendingDetailChanges = 1 << 4,
     HigherEducationQualifications = 1 << 5,
     Sanctions = 1 << 6,
+    Alerts = 1 << 7,
 
-    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges | HigherEducationQualifications | Sanctions
+    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges | HigherEducationQualifications | Sanctions | Alerts
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
@@ -23,6 +23,7 @@ public record GetTeacherResponse
     public required Option<IEnumerable<GetTeacherResponseMandatoryQualificationsQualification>> MandatoryQualifications { get; init; }
     public required Option<IEnumerable<GetTeacherResponseHigherEducationQualificationsQualification>> HigherEducationQualifications { get; init; }
     public required Option<IEnumerable<SanctionInfo>> Sanctions { get; init; }
+    public required Option<IEnumerable<AlertInfo>> Alerts { get; init; }
 }
 
 public record GetTeacherResponseQts

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
@@ -135,4 +135,13 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
 
         return ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(HttpClientWithApiKey, baseUrl, trn);
     }
+
+    [Fact]
+    public Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
+    {
+        var trn = "1234567";
+        var baseUrl = $"/v3/teachers/{trn}";
+
+        return ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(HttpClientWithApiKey, baseUrl, trn);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
@@ -132,4 +132,14 @@ public class GetTeacherTests : GetTeacherTestBase
 
         return ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(httpClient, baseUrl, trn);
     }
+
+    [Fact]
+    public Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
+    {
+        var trn = "1234567";
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var baseUrl = "v3/teacher";
+
+        return ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(httpClient, baseUrl, trn);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
@@ -59,5 +59,11 @@ public class SeedCrmReferenceData : IStartupTask
             dfeta_Value = "A18",
             dfeta_name = "A18 Description"
         });
+
+        _xrmFakedContext.CreateEntity(new dfeta_sanctioncode()
+        {
+            dfeta_Value = "B1",
+            dfeta_name = "B1 Description"
+        });
     }
 }


### PR DESCRIPTION
ID needs to know what teachers have prohibitions so it can block access to some services. This adds an `alerts` property to the v3 teacher response which contains prohibition-level alerts only (for now).