### PR TITLE
Change person name from detail person view

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateContactNameQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateContactNameQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record UpdateContactNameQuery(Guid ContactId, string? FirstName, string? MiddleName, string? LastName) : ICrmQuery<bool>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateContactNameHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateContactNameHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class UpdateContactNameHandler : ICrmQueryHandler<UpdateContactNameQuery, bool>
+{
+    public async Task<bool> Execute(UpdateContactNameQuery query, IOrganizationServiceAsync organizationService)
+    {
+        await organizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = query.ContactId,
+                FirstName = query.FirstName,
+                MiddleName = query.MiddleName,
+                LastName = query.LastName
+            }
+        });
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -1,14 +1,15 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
-public class CheckPersonExistsFilter : IAsyncPageFilter
+public class CheckPersonExistsFilter : IAsyncResourceFilter, IOrderedFilter
 {
-    public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public int Order => -200;
+
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
     {
         var personId = context.RouteData.Values["personId"] as string;
         if (personId is not null)
@@ -24,6 +25,4 @@ public class CheckPersonExistsFilter : IAsyncPageFilter
 
         await next();
     }
-
-    public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context) => Task.CompletedTask;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -4,4 +4,5 @@ public static class JourneyNames
 {
     public const string AddAlert = nameof(AddAlert);
     public const string CloseAlert = nameof(CloseAlert);
+    public const string EditName = nameof(EditName);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Confirm.cshtml
@@ -12,7 +12,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form method="post">
+        <form action="@LinkGenerator.AlertAddConfirm(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Alert type</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Confirm.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml
@@ -50,7 +50,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form method="post">
+        <form action="@LinkGenerator.AlertAdd(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
             <govuk-select asp-for="AlertTypeId" label-class="govuk-label--m">
                 <govuk-select-item value=""></govuk-select-item>
                 @foreach (var alertType in Model.AlertTypes!)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.SupportUi.Pages.Common;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.SupportUi.Pages.Common;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <h1 class="govuk-heading-l">@ViewBag.Title</h1>
-        <form method="post">
+        <form action="@LinkGenerator.PersonEditNameConfirm(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Current</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml
@@ -1,0 +1,29 @@
+@page "/persons/{personId}/edit-name/confirm"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName.ConfirmModel
+@{
+    ViewBag.Title = "Confirm name changes";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.PersonEditName(Model.PersonId, Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+        <form method="post">
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Current</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="current-value">@Model.CurrentValue</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Change to</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="new-value">@Model.NewValue</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Confirm</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
@@ -47,6 +47,13 @@ public class ConfirmModel : PageModel
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
+        var state = JourneyInstance!.State;
+        if (!state.IsComplete)
+        {
+            context.Result = Redirect(_linkGenerator.PersonEditName(PersonId, JourneyInstance!.InstanceId));
+            return;
+        }
+
         var person = await _crmQueryDispatcher.ExecuteQuery(
             new GetContactDetailByIdQuery(
                 PersonId,
@@ -55,14 +62,6 @@ public class ConfirmModel : PageModel
                     Contact.Fields.FirstName,
                     Contact.Fields.MiddleName,
                     Contact.Fields.LastName)));
-
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(_linkGenerator.PersonEditName(PersonId, JourneyInstance!.InstanceId));
-            return;
-        }
-
-        var state = JourneyInstance!.State;
 
         CurrentValue = string.IsNullOrEmpty(person!.Contact.MiddleName)
             ? $"{person.Contact.FirstName} {person.Contact.LastName}"

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName;
+
+[Journey(JourneyNames.EditName), RequireJourneyInstance]
+public class ConfirmModel : PageModel
+{
+    private readonly TrsLinkGenerator _linkGenerator;
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public ConfirmModel(
+        TrsLinkGenerator linkGenerator,
+        ICrmQueryDispatcher crmQueryDispatcher)
+    {
+        _linkGenerator = linkGenerator;
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
+    public JourneyInstance<EditNameState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid PersonId { get; set; }
+
+    public string? CurrentValue { get; set; }
+
+    public string? NewValue { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await _crmQueryDispatcher.ExecuteQuery(
+            new UpdateContactNameQuery(
+                PersonId,
+                JourneyInstance!.State.FirstName,
+                JourneyInstance!.State.MiddleName,
+                JourneyInstance!.State.LastName));
+
+        await JourneyInstance!.CompleteAsync();
+
+        TempData.SetFlashSuccess("Record has been updated");
+
+        return Redirect(_linkGenerator.PersonDetail(PersonId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var person = await _crmQueryDispatcher.ExecuteQuery(
+            new GetContactDetailByIdQuery(
+                PersonId,
+                new ColumnSet(
+                    Contact.PrimaryIdAttribute,
+                    Contact.Fields.FirstName,
+                    Contact.Fields.MiddleName,
+                    Contact.Fields.LastName)));
+
+        if (!JourneyInstance!.State.IsComplete)
+        {
+            context.Result = Redirect(_linkGenerator.PersonEditName(PersonId, JourneyInstance!.InstanceId));
+            return;
+        }
+
+        var state = JourneyInstance!.State;
+
+        CurrentValue = string.IsNullOrEmpty(person!.Contact.MiddleName)
+            ? $"{person.Contact.FirstName} {person.Contact.LastName}"
+            : $"{person.Contact.FirstName} {person.Contact.MiddleName} {person.Contact.LastName}";
+
+        NewValue = string.IsNullOrEmpty(state.MiddleName)
+            ? $"{state.FirstName} {state.LastName}"
+            : $"{state.FirstName} {state.MiddleName} {state.LastName}";
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/EditNameState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/EditNameState.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName;
+
+public class EditNameState
+{
+    public bool Initialized { get; set; }
+
+    public string? FirstName { get; set; }
+
+    public string? MiddleName { get; set; }
+
+    public string? LastName { get; set; }
+
+    [JsonIgnore]
+    [MemberNotNullWhen(true, nameof(FirstName), nameof(LastName))]
+    public bool IsComplete => !string.IsNullOrWhiteSpace(FirstName) && !string.IsNullOrWhiteSpace(LastName);
+
+    public async Task EnsureInitialized(ICrmQueryDispatcher crmQueryDispatcher, Guid personId)
+    {
+        if (Initialized)
+        {
+            return;
+        }
+
+        var person = await crmQueryDispatcher.ExecuteQuery(
+            new GetContactDetailByIdQuery(
+                personId,
+                new ColumnSet(
+                    Contact.PrimaryIdAttribute,
+                    Contact.Fields.FirstName,
+                    Contact.Fields.MiddleName,
+                    Contact.Fields.LastName)));
+        FirstName = person!.Contact.FirstName;
+        MiddleName = person.Contact.MiddleName;
+        LastName = person!.Contact.LastName;
+        Initialized = true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Index.cshtml
@@ -12,11 +12,11 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form method="post">
+        <form action="@LinkGenerator.PersonEditName(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
             <govuk-input asp-for="FirstName" data-testid="first-name" label-class="govuk-label--m" />
             <govuk-input asp-for="MiddleName" data-testid="middle-name" label-class="govuk-label--m" />
             <govuk-input asp-for="LastName" data-testid="last-name" label-class="govuk-label--m" />
-            <govuk-button>Continue</govuk-button>
+            <govuk-button type ="submit">Continue</govuk-button>
         </form>
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Index.cshtml
@@ -1,0 +1,22 @@
+@page "/persons/{personId}/edit-name"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName.IndexModel
+@{
+    ViewBag.Title = "Edit name";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.PersonDetail(Model.PersonId)">Back</govuk-back-link>
+}
+
+<h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form method="post">
+            <govuk-input asp-for="FirstName" data-testid="first-name" label-class="govuk-label--m" />
+            <govuk-input asp-for="MiddleName" data-testid="middle-name" label-class="govuk-label--m" />
+            <govuk-input asp-for="LastName" data-testid="last-name" label-class="govuk-label--m" />
+            <govuk-button>Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Index.cshtml.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName;
+
+[Journey(JourneyNames.EditName), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel : PageModel
+{
+    private readonly TrsLinkGenerator _linkGenerator;
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public IndexModel(
+        TrsLinkGenerator linkGenerator,
+        ICrmQueryDispatcher crmQueryDispatcher)
+    {
+        _linkGenerator = linkGenerator;
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
+    public JourneyInstance<EditNameState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid PersonId { get; set; }
+
+    [BindProperty]
+    [Display(Name = "First name")]
+    [MaxLength(100, ErrorMessage = "First name must be 100 characters or less")]
+    public string? FirstName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Middle name")]
+    [MaxLength(100, ErrorMessage = "Middle name must be 100 characters or less")]
+    public string? MiddleName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Last name")]
+    [MaxLength(100, ErrorMessage = "Last name must be 100 characters or less")]
+    public string? LastName { get; set; }
+
+    public void OnGet()
+    {
+        FirstName ??= JourneyInstance!.State.FirstName;
+        MiddleName ??= JourneyInstance!.State.MiddleName;
+        LastName ??= JourneyInstance!.State.LastName;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (string.IsNullOrWhiteSpace(FirstName))
+        {
+            ModelState.AddModelError(nameof(FirstName), "Enter a first name");
+        }
+
+        if (string.IsNullOrWhiteSpace(LastName))
+        {
+            ModelState.AddModelError(nameof(LastName), "Enter a last name");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(s =>
+        {
+            s.FirstName = FirstName;
+            s.MiddleName = MiddleName;
+            s.LastName = LastName;
+        });
+
+        return Redirect(_linkGenerator.PersonEditNameConfirm(PersonId, JourneyInstance!.InstanceId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        await JourneyInstance!.State.EnsureInitialized(_crmQueryDispatcher, PersonId);
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -28,6 +28,9 @@
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
             <govuk-summary-list-row-value data-testid="personal-details-name">@Model.Person.FullName</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action href="@LinkGenerator.PersonEditName(Model.PersonId, null)" visually-hidden-text="change name" data-testid="name-change-link">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
         </govuk-summary-list-row>
         @if (Model.Person.PreviousNames.Length > 0)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Xrm.Sdk.Query;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -111,7 +111,7 @@ builder.Services
             model =>
             {
                 model.Filters.Add(new CheckPersonExistsFilter());
-            });
+            });        
     })
     .AddMvcOptions(options =>
     {
@@ -197,6 +197,12 @@ builder.Services
             JourneyNames.CloseAlert,
             typeof(TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.CloseAlertState),
             requestDataKeys: new[] { "alertId" },
+            appendUniqueKey: true));
+
+        options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
+            JourneyNames.EditName,
+            typeof(TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName.EditNameState),
+            requestDataKeys: new[] { "personId" },
             appendUniqueKey: true));
     });
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -111,7 +111,7 @@ builder.Services
             model =>
             {
                 model.Filters.Add(new CheckPersonExistsFilter());
-            });        
+            });
     })
     .AddMvcOptions(options =>
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -59,6 +59,10 @@ public class TrsLinkGenerator
     public string PersonChangeLog(Guid personId, string? search = null, ContactSearchSortByOption? sortBy = null, int? pageNumber = null) =>
         GetRequiredPathByPage("/Persons/PersonDetail/ChangeLog", routeValues: new { personId, search, sortBy, pageNumber });
 
+    public string PersonEditName(Guid personId, JourneyInstanceId? journeyInstanceId) => GetRequiredPathByPage("/Persons/PersonDetail/EditName/Index", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+
+    public string PersonEditNameConfirm(Guid personId, JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/Persons/PersonDetail/EditName/Confirm", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+
     public string Users() => GetRequiredPathByPage("/Users/Index");
 
     public string AddUser() => GetRequiredPathByPage("/Users/AddUser/Index");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/UpdateContactNameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/UpdateContactNameTests.cs
@@ -1,0 +1,46 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class UpdateContactNameTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public UpdateContactNameTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = _dataScope.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var person = await _dataScope.TestData.CreatePerson();
+
+        var newFirstName = _dataScope.TestData.GenerateChangedFirstName(person.FirstName);
+        var newMiddleName = _dataScope.TestData.GenerateChangedMiddleName(person.MiddleName);
+        var newLastName = _dataScope.TestData.GenerateChangedLastName(person.LastName);
+
+        var query = new UpdateContactNameQuery(
+            person.ContactId,
+            newFirstName,
+            newMiddleName,
+            newLastName);
+
+        // Act
+        await _crmQueryDispatcher.ExecuteQuery(query);
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+
+        var updatedContact = ctx.ContactSet.SingleOrDefault(c => c.GetAttributeValue<Guid>(Contact.PrimaryIdAttribute) == person.ContactId);
+        Assert.NotNull(updatedContact);
+        Assert.Equal(newFirstName, updatedContact.FirstName);
+        Assert.Equal(newMiddleName, updatedContact.MiddleName);
+        Assert.Equal(newLastName, updatedContact.LastName);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -20,6 +20,14 @@ public static class PageExtensions
     {
         await page.GotoAsync($"/persons/{personId}/alerts");
     }
+    
+    public static async Task GoToPersonDetailPage(this IPage page, Guid personId)
+    {
+        await page.GotoAsync($"/persons/{personId}");
+    }
+
+    public static Task ClickLinkForElementWithTestId(this IPage page, string testId) =>
+        page.GetByTestId(testId).ClickAsync();
 
     public static async Task ClickAddAlertPersonAlertsPage(this IPage page)
     {
@@ -66,6 +74,11 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/cases/{caseReference}/reject");
     }
 
+    public static async Task AssertOnPersonDetailPage(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}");
+    }
+
     public static async Task AssertOnPersonAlertsPage(this IPage page, Guid personId)
     {
         await page.WaitForUrlPathAsync($"/persons/{personId}/alerts");
@@ -95,6 +108,16 @@ public static class PageExtensions
     {
         await page.WaitForUrlPathAsync($"/alerts/{alertId}/close/confirm");
     }
+    
+    public static async Task AssertOnPersonEditNamePage(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}/edit-name");
+    }
+
+    public static async Task AssertOnPersonEditNameConfirmPage(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}/edit-name/confirm");
+    }
 
     public static async Task AssertFlashMessage(this IPage page, string expectedHeader)
     {
@@ -106,6 +129,13 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Day')", date.Day.ToString());
         await page.FillAsync("label:text-is('Month')", date.Month.ToString());
         await page.FillAsync("label:text-is('Year')", date.Year.ToString());
+    }
+    
+    public static async Task FillNameInputs(this IPage page, string firstName, string middleName, string lastName)
+    {
+        await page.FillAsync("text=First Name", firstName);
+        await page.FillAsync("text=Middle Name", middleName);
+        await page.FillAsync("text=Last Name", lastName);
     }
 
     public static async Task SubmitAddAlertIndexPage(this IPage page, string alertType, string? details, string link, DateOnly startDate)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -20,7 +20,7 @@ public static class PageExtensions
     {
         await page.GotoAsync($"/persons/{personId}/alerts");
     }
-    
+
     public static async Task GoToPersonDetailPage(this IPage page, Guid personId)
     {
         await page.GotoAsync($"/persons/{personId}");
@@ -108,7 +108,7 @@ public static class PageExtensions
     {
         await page.WaitForUrlPathAsync($"/alerts/{alertId}/close/confirm");
     }
-    
+
     public static async Task AssertOnPersonEditNamePage(this IPage page, Guid personId)
     {
         await page.WaitForUrlPathAsync($"/persons/{personId}/edit-name");
@@ -130,7 +130,7 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Month')", date.Month.ToString());
         await page.FillAsync("label:text-is('Year')", date.Year.ToString());
     }
-    
+
     public static async Task FillNameInputs(this IPage page, string firstName, string middleName, string lastName)
     {
         await page.FillAsync("text=First Name", firstName);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
@@ -1,0 +1,42 @@
+namespace TeachingRecordSystem.SupportUi.EndToEndTests;
+
+public class PersonTests : TestBase
+{
+    public PersonTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task EditName()
+    {
+        var person = await TestData.CreatePerson();
+        var personId = person.ContactId;
+        var newFirstName = TestData.GenerateChangedFirstName(person.FirstName);
+        var newMiddleName = TestData.GenerateChangedMiddleName(person.MiddleName);
+        var newLastName = TestData.GenerateChangedLastName(person.LastName);
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonDetailPage(personId);
+
+        await page.AssertOnPersonDetailPage(personId);
+
+        await page.ClickLinkForElementWithTestId("name-change-link");
+
+        await page.AssertOnPersonEditNamePage(personId);
+
+        await page.FillNameInputs(newFirstName, newMiddleName, newLastName);
+        
+        await page.ClickContinueButton();
+
+        await page.AssertOnPersonEditNameConfirmPage(personId);
+
+        await page.ClickConfirmButton();
+
+        await page.AssertOnPersonDetailPage(personId);
+
+        await page.AssertFlashMessage("Record has been updated");
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
@@ -28,7 +28,7 @@ public class PersonTests : TestBase
         await page.AssertOnPersonEditNamePage(personId);
 
         await page.FillNameInputs(newFirstName, newMiddleName, newLastName);
-        
+
         await page.ClickContinueButton();
 
         await page.AssertOnPersonEditNameConfirmPage(personId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/ConfirmTests.cs
@@ -1,0 +1,165 @@
+using FakeXrmEasy;
+using FormFlow;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.EditName;
+
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
+    {
+        // Arrange
+        var personId = Guid.NewGuid();
+
+        var journeyInstance = await CreateJourneyInstance(personId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{personId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("NewFirstName", null, null)]
+    [InlineData(null, "NewMiddleName", null)]
+    [InlineData(null, null, "NewLastName")]
+    public async Task Get_StateHasMissingRequiredData_RedirectsToIndex(string? firstName, string? middleName, string? lastName)
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var editNameState = new EditNameState();
+        if (firstName is not null)
+        {
+            editNameState.FirstName = firstName;
+        }
+
+        if (middleName is not null)
+        {
+            editNameState.MiddleName = middleName;
+        }
+
+        if (lastName is not null)
+        {
+            editNameState.LastName = lastName;
+        }
+
+        var journeyInstance = await CreateJourneyInstance(
+            person.PersonId,
+            editNameState);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/edit-name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newFirstName = TestData.GenerateChangedFirstName(person.FirstName);
+        var newMiddleName = TestData.GenerateChangedMiddleName(person.MiddleName);
+        var newLastName = TestData.GenerateChangedLastName(person.LastName);
+        var journeyInstance = await CreateJourneyInstance(
+            person.PersonId,
+            new EditNameState()
+            {
+                Initialized = true,
+                FirstName = newFirstName,
+                MiddleName = newMiddleName,
+                LastName = newLastName,
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal($"{person.FirstName} {person.MiddleName} {person.LastName}", doc.GetElementByTestId("current-value")!.TextContent);
+        Assert.Equal($"{newFirstName} {newMiddleName} {newLastName}", doc.GetElementByTestId("new-value")!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_WithPersonIdForNonExistentPerson_ReturnsNotFound()
+    {
+        // Arrange
+        var personId = Guid.NewGuid();
+
+        var journeyInstance = await CreateJourneyInstance(personId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{personId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesNameAndCompletesJourney()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newFirstName = TestData.GenerateChangedFirstName(person.FirstName);
+        var newMiddleName = TestData.GenerateChangedMiddleName(person.MiddleName);
+        var newLastName = TestData.GenerateChangedLastName(person.LastName);
+        var journeyInstance = await CreateJourneyInstance(
+            person.PersonId,
+            new EditNameState()
+            {
+                Initialized = true,
+                FirstName = newFirstName,
+                MiddleName = newMiddleName,
+                LastName = newLastName,
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var updatedContact = XrmFakedContext.GetEntityById<Contact>(person.ContactId);
+        Assert.Equal(newFirstName, updatedContact.FirstName);
+        Assert.Equal(newMiddleName, updatedContact.MiddleName);
+        Assert.Equal(newLastName, updatedContact.LastName);
+
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "Record has been updated");
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.True(journeyInstance.Completed);
+    }
+    
+
+    private async Task<JourneyInstance<EditNameState>> CreateJourneyInstance(Guid personId, EditNameState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.EditName,
+            state ?? new EditNameState(),
+            new KeyValuePair<string, object>("personId", personId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/ConfirmTests.cs
@@ -1,4 +1,3 @@
-using FakeXrmEasy;
 using FormFlow;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName;
@@ -155,7 +154,7 @@ public class ConfirmTests : TestBase
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.True(journeyInstance.Completed);
     }
-    
+
 
     private async Task<JourneyInstance<EditNameState>> CreateJourneyInstance(Guid personId, EditNameState? state = null) =>
         await CreateJourneyInstance(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/IndexTests.cs
@@ -73,7 +73,7 @@ public class IndexTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
-        var doc = await response.GetDocument();        
+        var doc = await response.GetDocument();
         Assert.Equal(newFirstName, doc.GetElementById("FirstName")!.GetAttribute("value"));
         Assert.Equal(newMiddleName, doc.GetElementById("MiddleName")!.GetAttribute("value"));
         Assert.Equal(newLastName, doc.GetElementById("LastName")!.GetAttribute("value"));
@@ -134,7 +134,7 @@ public class IndexTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/persons/{person.PersonId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);        
+        Assert.Equal($"/persons/{person.PersonId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     public static TheoryData<string, string, string, string, string> InvalidNamesData { get; } = new()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditName/IndexTests.cs
@@ -1,0 +1,184 @@
+using FormFlow;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.EditName;
+
+public class IndexTests : TestBase
+{
+    public IndexTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
+    {
+        // Arrange
+        var personId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{personId}/edit-name");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForNewJourney_PopulatesModelFromDqt()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-name");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+
+        var doc = await redirectResponse.GetDocument();
+        Assert.Equal(person.FirstName, doc.GetElementById("FirstName")!.GetAttribute("value"));
+        Assert.Equal(person.MiddleName, doc.GetElementById("MiddleName")!.GetAttribute("value"));
+        Assert.Equal(person.LastName, doc.GetElementById("LastName")!.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newFirstName = TestData.GenerateChangedFirstName(person.FirstName);
+        var newMiddleName = TestData.GenerateChangedMiddleName(person.MiddleName);
+        var newLastName = TestData.GenerateChangedLastName(person.LastName);
+        var journeyInstance = await CreateJourneyInstance(
+            person.PersonId,
+            new EditNameState()
+            {
+                Initialized = true,
+                FirstName = newFirstName,
+                MiddleName = newMiddleName,
+                LastName = newLastName,
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();        
+        Assert.Equal(newFirstName, doc.GetElementById("FirstName")!.GetAttribute("value"));
+        Assert.Equal(newMiddleName, doc.GetElementById("MiddleName")!.GetAttribute("value"));
+        Assert.Equal(newLastName, doc.GetElementById("LastName")!.GetAttribute("value"));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidNamesData))]
+    public async Task Post_WithInvalidData_ReturnsExpectedErrors(
+        string firstName,
+        string middleName,
+        string lastName,
+        string expectedErrorElementId,
+        string expectedErrorMessage)
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string?>
+            {
+                { "FirstName", firstName },
+                { "MiddleName", middleName },
+                { "LastName", lastName },
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, expectedErrorElementId, expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_WithValidData_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newFirstName = TestData.GenerateChangedFirstName(person.FirstName);
+        var newMiddleName = TestData.GenerateChangedMiddleName(person.MiddleName);
+        var newLastName = TestData.GenerateChangedLastName(person.LastName);
+        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string?>
+            {
+                { "FirstName", newFirstName },
+                { "MiddleName", newMiddleName },
+                { "LastName", newLastName },
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/edit-name/confirm?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);        
+    }
+
+    public static TheoryData<string, string, string, string, string> InvalidNamesData { get; } = new()
+    {
+        {
+            "Joe",
+            "",
+            "",
+            "LastName",
+            "Enter a last name"
+        },
+        {
+            "",
+            "",
+            "Bloggs",
+            "FirstName",
+            "Enter a first name"
+        },
+        {
+            new string('x', 101),
+            "",
+            "Bloggs",
+            "FirstName",
+            "First name must be 100 characters or less"
+        },
+        {
+            "Joe",
+            "",
+            new string('x', 101),
+            "LastName",
+            "Last name must be 100 characters or less"
+        },
+        {
+            "Joe",
+            new string('x', 101),
+            "Bloggs",
+            "MiddleName",
+            "Middle name must be 100 characters or less"
+        }
+    };
+
+    private async Task<JourneyInstance<EditNameState>> CreateJourneyInstance(Guid personId, EditNameState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.EditName,
+            state ?? new EditNameState(),
+            new KeyValuePair<string, object>("personId", personId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.cs
@@ -57,7 +57,7 @@ public partial class CrmTestData
     }
 
     public string GenerateMiddleName() => Faker.Name.Middle();
-    
+
     public string GenerateChangedMiddleName(string currentMiddleName)
     {
         string newMiddleName;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.cs
@@ -43,7 +43,33 @@ public partial class CrmTestData
 
     public string GenerateFirstName() => Faker.Name.First();
 
+    public string GenerateChangedFirstName(string currentFirstName)
+    {
+        string newFirstName;
+
+        do
+        {
+            newFirstName = GenerateLastName();
+        }
+        while (newFirstName == currentFirstName);
+
+        return newFirstName;
+    }
+
     public string GenerateMiddleName() => Faker.Name.Middle();
+    
+    public string GenerateChangedMiddleName(string currentMiddleName)
+    {
+        string newMiddleName;
+
+        do
+        {
+            newMiddleName = GenerateMiddleName();
+        }
+        while (newMiddleName == currentMiddleName);
+
+        return newMiddleName;
+    }
 
     public string GenerateLastName() => Faker.Name.Last();
 


### PR DESCRIPTION
### Context

Support agents need a way to change a person’s name when the request has not come via a Change of name request.

### Changes proposed in this pull request

Create new pages at /persons/{personId}/edit-name and /persons/{personId}/edit-name/confirm following the designs in Figma
 If no active person exists with {personId} return a 404. The initial field values should be the existing first, middle and last names.

If first name is not specified, show an error ‘Enter a first name’.

If last name is not specified, show an error ‘Enter a last name’.

If first/middle/last name is greater than 100 characters, show an error ‘First/Middle/Last name must be 100 characters or less’.

After the record has been updated, redirect to /persons/{personId} with a flash message ‘Record has been updated’

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
