### PR TITLE
Move handling of CRM rate limit exceptions into CrmEntityChangesService

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ExceptionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ExceptionExtensions.cs
@@ -1,0 +1,21 @@
+using System.ServiceModel;
+using Microsoft.Xrm.Sdk;
+
+namespace TeachingRecordSystem.Core.Dqt;
+
+public static class ExceptionExtensions
+{
+    public static bool IsCrmRateLimitException(this Exception exception, out TimeSpan retryAfter)
+    {
+        if (exception is FaultException<OrganizationServiceFault> fault &&
+            fault.Detail.ErrorDetails.TryGetValue("Retry-After", out var retryAfterObj) &&
+            retryAfterObj is TimeSpan retryAfterTs)
+        {
+            retryAfter = retryAfterTs;
+            return true;
+        }
+
+        retryAfter = default;
+        return false;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/CrmEntityChangesService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/CrmEntityChangesService.cs
@@ -96,6 +96,11 @@ public class CrmEntityChangesService : ICrmEntityChangesService
                     request.PageInfo.PagingCookie = null;
                     continue;
                 }
+                catch (Exception ex) when (ex.IsCrmRateLimitException(out var retryAfter))
+                {
+                    await Task.Delay(retryAfter, cancellationToken);
+                    continue;
+                }
 
                 gotData |= response.EntityChanges.Changes.Count > 0;
 


### PR DESCRIPTION
This logic should be in `CrmEntityChangesService` itself rather than being duplicated in consumers.