### PR TITLE
Change person date of birth from detail person view

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateContactDateOfBirthQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateContactDateOfBirthQuery.cs
@@ -1,0 +1,4 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record UpdateContactDateOfBirthQuery(Guid ContactId, DateOnly? DateOfBirth) : ICrmQuery<bool>;
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateContactDateOfBirthHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateContactDateOfBirthHandler.cs
@@ -1,0 +1,22 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class UpdateContactDateOfBirthHandler : ICrmQueryHandler<UpdateContactDateOfBirthQuery, bool>
+{
+    public async Task<bool> Execute(UpdateContactDateOfBirthQuery query, IOrganizationServiceAsync organizationService)
+    {
+        await organizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = query.ContactId,
+                BirthDate = query.DateOfBirth.FromDateOnlyWithDqtBstFix(isLocalTime: false)
+            }
+        });
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -5,4 +5,5 @@ public static class JourneyNames
     public const string AddAlert = nameof(AddAlert);
     public const string CloseAlert = nameof(CloseAlert);
     public const string EditName = nameof(EditName);
+    public const string EditDateOfBirth = nameof(EditDateOfBirth);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml
@@ -1,0 +1,29 @@
+@page "/persons/{personId}/edit-date-of-birth/confirm"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth.ConfirmModel
+@{
+    ViewBag.Title = "Confirm date of birth change";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.PersonEditDateOfBirth(Model.PersonId, Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+        <form action="@LinkGenerator.PersonEditDateOfBirthConfirm(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Current</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="current-value">@Model.CurrentValue</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Change to</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="new-value">@Model.NewValue</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Confirm</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth;
+
+[Journey(JourneyNames.EditDateOfBirth), RequireJourneyInstance]
+public class ConfirmModel : PageModel
+{
+    private readonly TrsLinkGenerator _linkGenerator;
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public ConfirmModel(
+        TrsLinkGenerator linkGenerator,
+        ICrmQueryDispatcher crmQueryDispatcher)
+    {
+        _linkGenerator = linkGenerator;
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
+    public JourneyInstance<EditDateOfBirthState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid PersonId { get; set; }
+
+    public string? CurrentValue { get; set; }
+
+    public string? NewValue { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await _crmQueryDispatcher.ExecuteQuery(
+            new UpdateContactDateOfBirthQuery(
+                PersonId,
+                JourneyInstance!.State.DateOfBirth));
+
+        await JourneyInstance!.CompleteAsync();
+
+        TempData.SetFlashSuccess("Record has been updated");
+
+        return Redirect(_linkGenerator.PersonDetail(PersonId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var state = JourneyInstance!.State;
+        if (!state.IsComplete)
+        {
+            context.Result = Redirect(_linkGenerator.PersonEditDateOfBirth(PersonId, JourneyInstance!.InstanceId));
+            return;
+        }
+
+        var person = await _crmQueryDispatcher.ExecuteQuery(
+            new GetContactDetailByIdQuery(
+                PersonId,
+                new ColumnSet(
+                    Contact.PrimaryIdAttribute,
+                    Contact.Fields.BirthDate)));
+
+        CurrentValue = person!.Contact.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false)!.Value.ToString("dd/MM/yyyy");
+        NewValue = state.DateOfBirth!.Value.ToString("dd/MM/yyyy");
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/EditDateOfBirthState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/EditDateOfBirthState.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth;
+
+public class EditDateOfBirthState
+{
+    public bool Initialized { get; set; }
+
+    public DateOnly? DateOfBirth { get; set; }
+
+    [JsonIgnore]
+    [MemberNotNullWhen(true, nameof(DateOfBirth))]
+    public bool IsComplete => DateOfBirth.HasValue;
+
+    public async Task EnsureInitialized(ICrmQueryDispatcher crmQueryDispatcher, Guid personId)
+    {
+        if (Initialized)
+        {
+            return;
+        }
+
+        var person = await crmQueryDispatcher.ExecuteQuery(
+            new GetContactDetailByIdQuery(
+                personId,
+                new ColumnSet(
+                    Contact.PrimaryIdAttribute,
+                    Contact.Fields.BirthDate)));
+        DateOfBirth = person!.Contact.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false);
+        Initialized = true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Index.cshtml
@@ -1,0 +1,25 @@
+@page "/persons/{personId}/edit-date-of-birth"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth.IndexModel
+@{
+    ViewBag.Title = "Change date of birth";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.PersonDetail(Model.PersonId)">Back</govuk-back-link>
+}
+
+<h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.PersonEditDateOfBirth(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-date-input asp-for="DateOfBirth">
+                <govuk-date-input-fieldset>
+                    <govuk-date-input-fieldset-legend class="govuk-fieldset__legend--m" />
+                </govuk-date-input-fieldset>
+            </govuk-date-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Index.cshtml.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth;
+
+[Journey(JourneyNames.EditDateOfBirth), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel : PageModel
+{
+    private readonly TrsLinkGenerator _linkGenerator;
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+
+    public IndexModel(
+        TrsLinkGenerator linkGenerator,
+        ICrmQueryDispatcher crmQueryDispatcher)
+    {
+        _linkGenerator = linkGenerator;
+        _crmQueryDispatcher = crmQueryDispatcher;
+    }
+
+    public JourneyInstance<EditDateOfBirthState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid PersonId { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Date of birth")]
+    public DateOnly? DateOfBirth { get; set; }
+
+    public void OnGet()
+    {
+        DateOfBirth ??= JourneyInstance!.State.DateOfBirth;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (DateOfBirth is null)
+        {
+            ModelState.AddModelError(nameof(DateOfBirth), "Enter a date of birth");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(s => s.DateOfBirth = DateOfBirth);
+
+        return Redirect(_linkGenerator.PersonEditDateOfBirthConfirm(PersonId, JourneyInstance!.InstanceId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        await JourneyInstance!.State.EnsureInitialized(_crmQueryDispatcher, PersonId);
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -49,6 +49,9 @@
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
             <govuk-summary-list-row-value data-testid="personal-details-date-of-birth" use-empty-fallback>@(Model.Person.DateOfBirth.HasValue ? Model.Person.DateOfBirth.Value.ToString("dd/MM/yyyy") : string.Empty)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action href="@LinkGenerator.PersonEditDateOfBirth(Model.PersonId, null)" visually-hidden-text="change date of birth" data-testid="date-of-birth-change-link">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
         </govuk-summary-list-row>
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -204,6 +204,12 @@ builder.Services
             typeof(TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditName.EditNameState),
             requestDataKeys: new[] { "personId" },
             appendUniqueKey: true));
+
+        options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
+            JourneyNames.EditDateOfBirth,
+            typeof(TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth.EditDateOfBirthState),
+            requestDataKeys: new[] { "personId" },
+            appendUniqueKey: true));
     });
 
 builder.Services

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -63,6 +63,10 @@ public class TrsLinkGenerator
 
     public string PersonEditNameConfirm(Guid personId, JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/Persons/PersonDetail/EditName/Confirm", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
+    public string PersonEditDateOfBirth(Guid personId, JourneyInstanceId? journeyInstanceId) => GetRequiredPathByPage("/Persons/PersonDetail/EditDateOfBirth/Index", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+
+    public string PersonEditDateOfBirthConfirm(Guid personId, JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/Persons/PersonDetail/EditDateOfBirth/Confirm", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+
     public string Users() => GetRequiredPathByPage("/Users/Index");
 
     public string AddUser() => GetRequiredPathByPage("/Users/AddUser/Index");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/UpdateContactDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/UpdateContactDateOfBirthTests.cs
@@ -1,0 +1,39 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class UpdateContactDateOfBirthTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public UpdateContactDateOfBirthTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = _dataScope.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var person = await _dataScope.TestData.CreatePerson();
+        var newDateOfBirth = _dataScope.TestData.GenerateChangedDateOfBirth(person.DateOfBirth);
+
+        var query = new UpdateContactDateOfBirthQuery(
+            person.ContactId,
+            newDateOfBirth);
+
+        // Act
+        await _crmQueryDispatcher.ExecuteQuery(query);
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+
+        var updatedContact = ctx.ContactSet.SingleOrDefault(c => c.GetAttributeValue<Guid>(Contact.PrimaryIdAttribute) == person.ContactId);
+        Assert.NotNull(updatedContact);
+        Assert.Equal(newDateOfBirth, updatedContact.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false));
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -119,6 +119,16 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/persons/{personId}/edit-name/confirm");
     }
 
+    public static async Task AssertOnPersonEditDateOfBirthPage(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}/edit-date-of-birth");
+    }
+
+    public static async Task AssertOnPersonEditDateOfBirthConfirmPage(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}/edit-date-of-birth/confirm");
+    }
+
     public static async Task AssertFlashMessage(this IPage page, string expectedHeader)
     {
         Assert.Equal(expectedHeader, await page.InnerTextAsync($".govuk-notification-banner__heading:text-is('{expectedHeader}')"));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
@@ -39,4 +39,35 @@ public class PersonTests : TestBase
 
         await page.AssertFlashMessage("Record has been updated");
     }
+
+    [Fact]
+    public async Task EditDateOfBirth()
+    {
+        var person = await TestData.CreatePerson();
+        var personId = person.ContactId;
+        var newDateOfBirth = TestData.GenerateChangedDateOfBirth(person.DateOfBirth);
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonDetailPage(personId);
+
+        await page.AssertOnPersonDetailPage(personId);
+
+        await page.ClickLinkForElementWithTestId("date-of-birth-change-link");
+
+        await page.AssertOnPersonEditDateOfBirthPage(personId);
+
+        await page.FillDateInput(newDateOfBirth);
+
+        await page.ClickContinueButton();
+
+        await page.AssertOnPersonEditDateOfBirthConfirmPage(personId);
+
+        await page.ClickConfirmButton();
+
+        await page.AssertOnPersonDetailPage(personId);
+
+        await page.AssertFlashMessage("Record has been updated");
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDateOfBirth/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDateOfBirth/ConfirmTests.cs
@@ -1,0 +1,134 @@
+using FormFlow;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.EditDateOfBirth;
+
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
+    {
+        // Arrange
+        var personId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{personId}/edit-date-of-birth/confirm");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_StateHasNoDateOfBirth_RedirectsToIndex()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var editDateOfBirthState = new EditDateOfBirthState();
+
+        var journeyInstance = await CreateJourneyInstance(
+           person.PersonId,
+           editDateOfBirthState);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-date-of-birth/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/edit-date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newDateOfBirth = TestData.GenerateChangedDateOfBirth(person.DateOfBirth);
+        var journeyInstance = await CreateJourneyInstance(
+            person.PersonId,
+            new EditDateOfBirthState()
+            {
+                Initialized = true,
+                DateOfBirth = newDateOfBirth,
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-date-of-birth/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal(person.DateOfBirth.ToString("dd/MM/yyyy"), doc.GetElementByTestId("current-value")!.TextContent);
+        Assert.Equal(newDateOfBirth.ToString("dd/MM/yyyy"), doc.GetElementByTestId("new-value")!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_WithPersonIdForNonExistentPerson_ReturnsNotFound()
+    {
+        // Arrange
+        var personId = Guid.NewGuid();
+
+        var journeyInstance = await CreateJourneyInstance(personId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{personId}/edit-date-of-birth/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesDateOfBirthAndCompletesJourney()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newDateOfBirth = TestData.GenerateChangedDateOfBirth(person.DateOfBirth);
+        var journeyInstance = await CreateJourneyInstance(
+            person.PersonId,
+            new EditDateOfBirthState()
+            {
+                Initialized = true,
+                DateOfBirth = newDateOfBirth,
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-date-of-birth/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var updatedContact = XrmFakedContext.GetEntityById<Contact>(person.ContactId);
+        Assert.Equal(newDateOfBirth, updatedContact.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false));
+
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "Record has been updated");
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.True(journeyInstance.Completed);
+    }
+
+    private async Task<JourneyInstance<EditDateOfBirthState>> CreateJourneyInstance(Guid personId, EditDateOfBirthState? state = null) =>
+    await CreateJourneyInstance(
+        JourneyNames.EditDateOfBirth,
+        state ?? new EditDateOfBirthState(),
+        new KeyValuePair<string, object>("personId", personId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDateOfBirth/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDateOfBirth/IndexTests.cs
@@ -1,0 +1,205 @@
+using FormFlow;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDateOfBirth;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.EditDateOfBirth;
+
+public class IndexTests : TestBase
+{
+    public IndexTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
+    {
+        // Arrange
+        var personId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{personId}/edit-date-of-birth");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForNewJourney_PopulatesModelFromDqt()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-date-of-birth");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+
+        var doc = await redirectResponse.GetDocument();
+        Assert.Equal($"{person.DateOfBirth:%d}", doc.GetElementById("DateOfBirth.Day")!.GetAttribute("value"));
+        Assert.Equal($"{person.DateOfBirth:%M}", doc.GetElementById("DateOfBirth.Month")!.GetAttribute("value"));
+        Assert.Equal($"{person.DateOfBirth:yyyy}", doc.GetElementById("DateOfBirth.Year")!.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newDateOfBirth = TestData.GenerateChangedDateOfBirth(person.DateOfBirth);
+        var journeyInstance = await CreateJourneyInstance(
+            person.PersonId,
+            new EditDateOfBirthState()
+            {
+                Initialized = true,
+                DateOfBirth = newDateOfBirth,
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal($"{newDateOfBirth:%d}", doc.GetElementById("DateOfBirth.Day")!.GetAttribute("value"));
+        Assert.Equal($"{newDateOfBirth:%M}", doc.GetElementById("DateOfBirth.Month")!.GetAttribute("value"));
+        Assert.Equal($"{newDateOfBirth:yyyy}", doc.GetElementById("DateOfBirth.Year")!.GetAttribute("value"));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidDateOfBirthData))]
+    public async Task Post_WithInvalidData_ReturnsError(
+        string day,
+        string month,
+        string year,
+        string expectedErrorElementId,
+        string expectedErrorMessage)
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string?>
+            {
+                { "DateOfBirth.Day", day },
+                { "DateOfBirth.Month", month },
+                { "DateOfBirth.Year", year },
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, expectedErrorElementId, expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_WithValidData_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var newDateOfBirth = TestData.GenerateChangedDateOfBirth(person.DateOfBirth);
+        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string?>
+            {
+                { "DateOfBirth.Day", $"{newDateOfBirth:%d}" },
+                { "DateOfBirth.Month", $"{newDateOfBirth:%M}" },
+                { "DateOfBirth.Year", $"{newDateOfBirth:yyyy}" },
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/edit-date-of-birth/confirm?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    public static TheoryData<string, string, string, string, string> InvalidDateOfBirthData { get; } = new()
+    {
+        {
+            "",
+            "",
+            "",
+            "DateOfBirth",
+            "Enter a date of birth"
+        },
+        {
+            "",
+            "10",
+            "1969",
+            "DateOfBirth",
+            "Date of birth must include a day"
+        },
+        {
+            "10",
+            "",
+            "1969",
+            "DateOfBirth",
+            "Date of birth must include a month"
+        },
+        {
+            "10",
+            "10",
+            "",
+            "DateOfBirth",
+            "Date of birth must include a year"
+        },
+        {
+            "",
+            "",
+            "1969",
+            "DateOfBirth",
+            "Date of birth must include a day and month"
+        },
+        {
+            "",
+            "10",
+            "",
+            "DateOfBirth",
+            "Date of birth must include a day and year"
+        },
+        {
+            "10",
+            "",
+            "",
+            "DateOfBirth",
+            "Date of birth must include a month and year"
+        },
+        {
+            "32",
+            "10",
+            "1969",
+            "DateOfBirth",
+            "Date of birth must be a real date"
+        },
+        {
+            "Blah",
+            "Blah",
+            "Blah",
+            "DateOfBirth",
+            "Date of birth must be a real date"
+        },
+    };
+
+    private async Task<JourneyInstance<EditDateOfBirthState>> CreateJourneyInstance(Guid personId, EditDateOfBirthState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.EditDateOfBirth,
+            state ?? new EditDateOfBirthState(),
+            new KeyValuePair<string, object>("personId", personId));
+}


### PR DESCRIPTION
### Context

Support agents need a way to change a person’s date of birth when the request has not come via a Change of date of birth request.

### Changes proposed in this pull request

Create new pages at /persons/{personId}/edit-date-of-birth and /persons/{personId}/edit-date-of-birth/confirm following the designs in Figma If no active person exists with {personId} return a 404. The initial field values should be the existing date of birth.

If date of birth first name is not specified, show an error ‘Enter a date of birth’.

After the record has been updated, redirect to /persons/{personId} with a flash message ‘Record has been updated’

### Guidance to review

CRM + UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
