### PR TITLE
Disable rate limiting for unauthenticated endpoints

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -298,7 +298,9 @@ public class Program
 
         if (env.IsProduction())
         {
-            app.UseRateLimiter();
+            // Apply rate limiting to authenticated endpoints
+            // (i.e. everywhere except health check, status endpoints etc.)
+            app.UseWhen(ctx => ctx.User.Identity?.IsAuthenticated == true, x => x.UseRateLimiter());
         }
 
         app.Use((ctx, next) =>


### PR DESCRIPTION
While looking at the production environment I noticed our API pods had restarted. I suspect this is due to some Redis timeouts that mean the health check has failed. This change disables rate limiting any unauthenticated endpoints.