### PR TITLE
Filter out entity changes that have already been processed

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/ICrmEntityChangesService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/ICrmEntityChangesService.cs
@@ -10,6 +10,7 @@ public interface ICrmEntityChangesService
         string crmClientName,
         string entityLogicalName,
         ColumnSet columns,
+        DateTime? modifiedSince,
         int pageSize = 1000,
         CancellationToken cancellationToken = default);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/DqtReportingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/DqtReporting/DqtReportingService.cs
@@ -171,7 +171,8 @@ public partial class DqtReportingService : BackgroundService
 
         try
         {
-            var changesEnumerable = _crmEntityChangesService.GetEntityChanges(ChangesKey, CrmClientName, entityLogicalName, columns, PageSize)
+            // We don't populate modifiedSince here since it's so slow to query in the reporting DB
+            var changesEnumerable = _crmEntityChangesService.GetEntityChanges(ChangesKey, CrmClientName, entityLogicalName, columns, modifiedSince: null, PageSize)
                 .WithCancellation(cancellationToken);
 
             await foreach (var changes in changesEnumerable)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/TrsDataSync/TrsDataSyncService.cs
@@ -87,7 +87,9 @@ public class TrsDataSyncService : BackgroundService
 
         var columns = new ColumnSet(_trsDataSyncHelper.GetSyncedAttributeNames(entityLogicalName));
 
-        var changesEnumerable = _crmEntityChangesService.GetEntityChanges(ChangesKey, CrmClientName, entityLogicalName, columns, PageSize)
+        var modifiedSince = await _trsDataSyncHelper.GetLastModifiedOnForEntity(entityLogicalName);
+
+        var changesEnumerable = _crmEntityChangesService.GetEntityChanges(ChangesKey, CrmClientName, entityLogicalName, columns, modifiedSince, PageSize)
             .WithCancellation(cancellationToken);
 
         await foreach (var changes in changesEnumerable)


### PR DESCRIPTION
Adds a `modifiedSince` parameter to the `ICrmEntityChangesService`.`GetEntityChanges` method so that a caller can specify the `modifiedon` of the last record it processed and have records before that filtered out.

There are two drivers for this. The first is full resyncs; when we do a full resync (because our data token is invalidated due to a schema change) we end up going all the way back to the beginning of the change log and replaying everything, even though we've already processed it 99% of the data. With this new change, we can skip that redundant processing.

The second reason is to work better with back-fill jobs. When we run a back-fill job then enable the continuous updates we don't want to re-process records that the back-fill job has already populated.