### PR TITLE
Handle, but ignore, UserMergedMessages

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/Messages/UserMergedMessage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/Messages/UserMergedMessage.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Api.Endpoints.IdentityWebHooks.Messages;
+
+public class UserMergedMessage : INotificationMessage
+{
+    public const string MessageTypeName = "UserMerged";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/NotificationEnvelopeConverter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/NotificationEnvelopeConverter.cs
@@ -104,6 +104,9 @@ public class NotificationEnvelopeConverter : JsonConverter<NotificationEnvelope>
                         case UserUpdatedMessage.MessageTypeName:
                             message = JsonSerializer.Deserialize<UserUpdatedMessage>(ref reader, options);
                             break;
+                        case UserMergedMessage.MessageTypeName:
+                            message = JsonSerializer.Deserialize<UserMergedMessage>(ref reader, options);
+                            break;
                         default:
                             throw new JsonException($"{nameof(NotificationEnvelope.MessageType)} '{messageType}' is not supported");
                     }


### PR DESCRIPTION
We've used the user merge feature on ID for the first time so we're seeing messages we haven't had to handle before.