### PR TITLE
Add config to register TrsDataSync ServiceClient without running service

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Production.json
@@ -21,5 +21,8 @@
   },
   "DqtReporting": {
     "RunService": true
+  },
+  "TrsSyncService": {
+    "RegisterServiceClient": true
   }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/TrsDataSync/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/TrsDataSync/ServiceCollectionExtensions.cs
@@ -12,14 +12,20 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        if (configuration.GetValue<bool>("TrsSyncService:RunService"))
+        var runService = configuration.GetValue<bool>("TrsSyncService:RunService");
+
+        if (runService ||
+            configuration.GetValue<bool>("TrsSyncService:RegisterServiceClient"))
         {
             services.AddOptions<TrsDataSyncServiceOptions>()
                 .Bind(configuration.GetSection("TrsSyncService"))
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
 
-            services.AddSingleton<IHostedService, TrsDataSyncService>();
+            if (runService)
+            {
+                services.AddSingleton<IHostedService, TrsDataSyncService>();
+            }
 
             services.AddServiceClient(
                 TrsDataSyncService.CrmClientName,


### PR DESCRIPTION
We need the service client to run the back-fill job, but we don't want the service that captures changes running until after the back-fill job is done.