### PR TITLE
Filter out records without a TRN for backfill

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -89,7 +89,8 @@ public class TrsDataSyncHelper
     {
         var entitySyncInfo = GetEntitySyncInfo(Contact.EntityLogicalName);
 
-        // For now, only sync records that have TRNs
+        // For now, only sync records that have TRNs.
+        // Keep this in sync with the filter in the SyncAllContactsFromCrmJob job.
         var toSync = entities.Where(e => !string.IsNullOrEmpty(e.dfeta_TRN));
 
         if (ignoreInvalid)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllContactsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllContactsFromCrmJob.cs
@@ -28,10 +28,20 @@ public class SyncAllContactsFromCrmJob
         var serviceClient = _crmServiceClientProvider.GetClient(TrsDataSyncService.CrmClientName);
         var columns = new ColumnSet(_trsDataSyncHelper.GetSyncedAttributeNames(Contact.EntityLogicalName));
 
+        // Ensure this is kept in sync with the predicate in TrsDataSyncHelper.SyncContacts
+        var filter = new FilterExpression(LogicalOperator.And)
+        {
+            Conditions =
+            {
+                new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.NotNull),
+                new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.NotEqual, ""),
+            }
+        };
+
         var query = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = columns,
-            NoLock = true,  // Any changes that we miss because of this be picked up by the change log sync
+            Criteria = filter,
             Orders =
             {
                 new OrderExpression(Contact.Fields.CreatedOn, OrderType.Ascending)


### PR DESCRIPTION
We discard any records without a TRN when syncing to the TRS DB. It's much more efficient for the backfill jobs to have the CRM DB do that filtering for us.

This also removes `nolock` from the query; we don't want to sync changes that were uncommitted.