### PR TITLE
Fix to stop induction records from being created when not required

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.SetIttResultForTeacher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.SetIttResultForTeacher.cs
@@ -170,17 +170,20 @@ public partial class DataverseAdapter
                 });
                 Debug.Assert(teacherStatus != null);
 
+                if (!lookupData.Teacher.dfeta_QTSDate.HasValue)
+                {
+                    txnRequest.Requests.Add(new CreateRequest()
+                    {
+                        Target = new dfeta_induction()
+                        {
+                            dfeta_PersonId = teacherId.ToEntityReference(Contact.EntityLogicalName),
+                            dfeta_InductionStatus = dfeta_InductionStatus.RequiredtoComplete
+                        }
+                    });
+                }
+
                 qtsUpdate.dfeta_TeacherStatusId = teacherStatus.Id.ToEntityReference(dfeta_teacherstatus.EntityLogicalName);
                 qtsUpdate.dfeta_QTSDate = qtsDate.Value.ToDateTime();
-
-                txnRequest.Requests.Add(new CreateRequest()
-                {
-                    Target = new dfeta_induction()
-                    {
-                        dfeta_PersonId = teacherId.ToEntityReference(Contact.EntityLogicalName),
-                        dfeta_InductionStatus = dfeta_InductionStatus.RequiredtoComplete
-                    }
-                });
             }
         }
         else


### PR DESCRIPTION
### Context

With the endpoint being idempotent, when calling the endpoint with a pass result - a change should not have been creating a new induction result every time it was called. This change only creates a new induction record when the teacher does not already have qts (no dfeta_qtsdate set).

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
