### PR TITLE
Handle induction records without an AB

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -318,10 +318,12 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
             StartDate = inductionPeriod.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             EndDate = inductionPeriod.dfeta_EndDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             Terms = inductionPeriod.dfeta_Numberofterms,
-            AppropriateBody = new GetTeacherResponseInductionPeriodAppropriateBody()
-            {
-                Name = appropriateBody.Name
-            }
+            AppropriateBody = appropriateBody is not null ?
+                new GetTeacherResponseInductionPeriodAppropriateBody()
+                {
+                    Name = appropriateBody.Name
+                } :
+                null
         };
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
@@ -55,7 +55,7 @@ public record GetTeacherResponseInductionPeriod
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required int? Terms { get; init; }
-    public required GetTeacherResponseInductionPeriodAppropriateBody AppropriateBody { get; init; }
+    public required GetTeacherResponseInductionPeriodAppropriateBody? AppropriateBody { get; init; }
 }
 
 public record GetTeacherResponseInductionPeriodAppropriateBody


### PR DESCRIPTION
We've got an error in Sentry caused by an induction record having a `null` appropriate body.