### PR TITLE
Added previous names to v3 endpoint including tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/NameInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/ApiModels/NameInfo.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Api.V3.ApiModels;
+
+public record NameInfo
+{
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Requests/GetTeacherRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Requests/GetTeacherRequest.cs
@@ -25,6 +25,7 @@ public enum GetTeacherRequestIncludes
     HigherEducationQualifications = 1 << 5,
     Sanctions = 1 << 6,
     Alerts = 1 << 7,
+    PreviousNames = 1 << 8,
 
-    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges | HigherEducationQualifications | Sanctions | Alerts
+    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges | HigherEducationQualifications | Sanctions | Alerts | PreviousNames
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
@@ -24,6 +24,7 @@ public record GetTeacherResponse
     public required Option<IEnumerable<GetTeacherResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
     public required Option<IEnumerable<SanctionInfo>> Sanctions { get; init; }
     public required Option<IEnumerable<AlertInfo>> Alerts { get; init; }
+    public required Option<IEnumerable<NameInfo>> PreviousNames { get; init; }
 }
 
 public record GetTeacherResponseQts

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
@@ -12,5 +12,6 @@
         "Microsoft.AspNetCore": "Fatal"
       }
     }
-  }
+  },
+  "ConcurrentNameChangeWindowSeconds": 1
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.json
@@ -83,5 +83,6 @@
     "ProcessAllEntityTypesConcurrently": true,
     "IgnoreInvalidData": false,
     "RunService": false
-  }
+  },
+  "ConcurrentNameChangeWindowSeconds": 5
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllEarlyYearsStatusesQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllEarlyYearsStatusesQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetAllEarlyYearsStatusesQuery : ICrmQuery<dfeta_earlyyearsstatus[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByTrnQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByTrnQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetContactDetailByTrnQuery(string Trn, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllEarlyYearsStatusesHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllEarlyYearsStatusesHandler.cs
@@ -1,0 +1,30 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class GetAllEarlyYearsStatusesHandler : ICrmQueryHandler<GetAllEarlyYearsStatusesQuery, dfeta_earlyyearsstatus[]>
+{
+    public async Task<dfeta_earlyyearsstatus[]> Execute(GetAllEarlyYearsStatusesQuery query, IOrganizationServiceAsync organizationService)
+    {
+        var queryExpression = new QueryExpression()
+        {
+            EntityName = dfeta_earlyyearsstatus.EntityLogicalName,
+            ColumnSet = new ColumnSet(
+                dfeta_earlyyearsstatus.Fields.dfeta_name,
+                dfeta_earlyyearsstatus.Fields.dfeta_Value)
+        };
+        queryExpression.Criteria.AddCondition(dfeta_earlyyearsstatus.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_earlyyearsStatusState.Active);
+
+        var request = new RetrieveMultipleRequest()
+        {
+            Query = queryExpression
+        };
+
+        var response = await organizationService.RetrieveMultipleAsync(queryExpression);
+
+        return response.Entities.Select(e => e.ToEntity<dfeta_earlyyearsstatus>()).ToArray();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByTrnHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByTrnHandler.cs
@@ -1,0 +1,74 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class GetContactDetailByTrnHandler : ICrmQueryHandler<GetContactDetailByTrnQuery, ContactDetail?>
+{
+    public async Task<ContactDetail?> Execute(GetContactDetailByTrnQuery query, IOrganizationServiceAsync organizationService)
+    {
+        var contactFilter = new FilterExpression();
+        contactFilter.AddCondition(Contact.Fields.dfeta_TRN, ConditionOperator.Equal, query.Trn);
+        var contactQueryExpression = new QueryExpression(Contact.EntityLogicalName)
+        {
+            ColumnSet = query.ColumnSet,
+            Criteria = contactFilter
+        };
+
+        var contactRequest = new RetrieveMultipleRequest()
+        {
+            Query = contactQueryExpression
+        };
+
+        var previousNameFilter = new FilterExpression();
+        previousNameFilter.AddCondition(dfeta_previousname.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_documentState.Active);
+        previousNameFilter.AddCondition(dfeta_previousname.Fields.dfeta_Type, ConditionOperator.NotEqual, (int)dfeta_NameType.Title);
+        var previousNameQueryExpression = new QueryExpression(dfeta_previousname.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+                dfeta_previousname.PrimaryIdAttribute,
+                dfeta_previousname.Fields.dfeta_PersonId,
+                dfeta_previousname.Fields.CreatedOn,
+                dfeta_previousname.Fields.dfeta_ChangedOn,
+                dfeta_previousname.Fields.dfeta_name,
+                dfeta_previousname.Fields.dfeta_Type),
+            Criteria = previousNameFilter
+        };
+
+        var contactLink = previousNameQueryExpression.AddLink(
+            Contact.EntityLogicalName,
+            dfeta_previousname.Fields.dfeta_PersonId,
+            Contact.PrimaryIdAttribute,
+            JoinOperator.Inner);
+
+        contactLink.Columns = new ColumnSet(
+            Contact.PrimaryIdAttribute,
+            Contact.Fields.dfeta_TRN);
+
+        contactLink.EntityAlias = Contact.EntityLogicalName;
+        contactLink.LinkCriteria = contactFilter;
+
+        var previousNameRequest = new RetrieveMultipleRequest()
+        {
+            Query = previousNameQueryExpression
+        };
+
+        var requestBuilder = RequestBuilder.CreateMultiple(organizationService);
+        var contactResponse = requestBuilder.AddRequest<RetrieveMultipleResponse>(contactRequest);
+        var previousNameResponse = requestBuilder.AddRequest<RetrieveMultipleResponse>(previousNameRequest);
+
+        await requestBuilder.Execute();
+
+        var contact = (await contactResponse.GetResponseAsync()).EntityCollection.Entities.FirstOrDefault()?.ToEntity<Contact>();
+        var previousNames = (await previousNameResponse.GetResponseAsync()).EntityCollection.Entities.Select(e => e.ToEntity<dfeta_previousname>()).ToArray();
+
+        if (contact is null)
+        {
+            return null;
+        }
+
+        return new ContactDetail(contact, previousNames);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
@@ -67,7 +67,6 @@ public class ReferenceDataCache
             ref _getTeacherStatusesTask,
             () => _crmQueryDispatcher.ExecuteQuery(new GetAllTeacherStatusesQuery()));
 
-    // ensure early years statuses
     private Task<dfeta_earlyyearsstatus[]> EnsureEarlyYearsStatuses() =>
         LazyInitializer.EnsureInitialized(
             ref _getEarlyYearsStatusesTask,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
@@ -8,6 +8,7 @@ public class ReferenceDataCache
     private Task<dfeta_sanctioncode[]>? _getSanctionCodesTask;
     private Task<Subject[]>? _getSubjectsTask;
     private Task<dfeta_teacherstatus[]>? _getTeacherStatusesTask;
+    private Task<dfeta_earlyyearsstatus[]>? _getEarlyYearsStatusesTask;
 
     public ReferenceDataCache(ICrmQueryDispatcher crmQueryDispatcher)
     {
@@ -45,6 +46,12 @@ public class ReferenceDataCache
         return teacherStatuses.Single(ts => ts.dfeta_Value == value);
     }
 
+    public async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatusByValue(string value)
+    {
+        var earlyYearsStatuses = await EnsureEarlyYearsStatuses();
+        return earlyYearsStatuses.Single(ey => ey.dfeta_Value == value);
+    }
+
     private Task<dfeta_sanctioncode[]> EnsureSanctionCodes() =>
         LazyInitializer.EnsureInitialized(
             ref _getSanctionCodesTask,
@@ -59,4 +66,10 @@ public class ReferenceDataCache
         LazyInitializer.EnsureInitialized(
             ref _getTeacherStatusesTask,
             () => _crmQueryDispatcher.ExecuteQuery(new GetAllTeacherStatusesQuery()));
+
+    // ensure early years statuses
+    private Task<dfeta_earlyyearsstatus[]> EnsureEarlyYearsStatuses() =>
+        LazyInitializer.EnsureInitialized(
+            ref _getEarlyYearsStatusesTask,
+            () => _crmQueryDispatcher.ExecuteQuery(new GetAllEarlyYearsStatusesQuery()));
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
@@ -40,19 +40,19 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
     [Fact]
     public async Task Get_ValidRequest_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact();
+        var contact = await CreateContact(qualifiedInWales: false);
         var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, qualifiedInWales: false, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
+        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
     }
 
     [Fact]
     public async Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact();
+        var contact = await CreateContact(qualifiedInWales: true);
         var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, qualifiedInWales: true, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
+        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
@@ -38,110 +38,119 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
     }
 
     [Fact]
-    public Task Get_ValidRequest_ReturnsExpectedResponse()
+    public async Task Get_ValidRequest_ReturnsExpectedResponse()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, trn, qualifiedInWales: false, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
+        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, qualifiedInWales: false, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
     }
 
     [Fact]
-    public Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
+    public async Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, trn, qualifiedInWales: true, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
+        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, qualifiedInWales: true, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
     }
 
     [Fact]
-    public Task Get_ValidRequestForContactWithMultiWordFirstName_ReturnsExpectedResponse()
+    public async Task Get_ValidRequestForContactWithMultiWordFirstName_ReturnsExpectedResponse()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
+        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectCertificateUrls: false);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
+    public async Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestWithInduction_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
+        await ValidRequestWithInduction_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, contact, expectCertificateUrls: false);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
+    public async Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(HttpClientWithApiKey, baseUrl, trn);
+        await ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(HttpClientWithApiKey, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
+    public async Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(HttpClientWithApiKey, baseUrl, trn, expectCertificateUrls: false);
+        await ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(HttpClientWithApiKey, baseUrl, contact, expectCertificateUrls: false);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
+    public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent(HttpClientWithApiKey, baseUrl, trn);
+        await ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent(HttpClientWithApiKey, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
+    public async Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(HttpClientWithApiKey, baseUrl, trn);
+        await ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(HttpClientWithApiKey, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
+    public async Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(HttpClientWithApiKey, baseUrl, trn);
+        await ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(HttpClientWithApiKey, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
+    public async Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(HttpClientWithApiKey, baseUrl, trn);
+        await ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(HttpClientWithApiKey, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithSanctions_ReturnsExpectedSanctionsContent()
+    public async Task Get_ValidRequestWithSanctions_ReturnsExpectedSanctionsContent()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(HttpClientWithApiKey, baseUrl, trn);
+        await ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(HttpClientWithApiKey, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
+    public async Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
     {
-        var trn = "1234567";
-        var baseUrl = $"/v3/teachers/{trn}";
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        return ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(HttpClientWithApiKey, baseUrl, trn);
+        await ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(HttpClientWithApiKey, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
+
+        await ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent(HttpClientWithApiKey, baseUrl, contact);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -21,14 +21,12 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestForTeacher_ReturnsExpectedContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn,
+        Contact contact,
         bool qualifiedInWales,
         bool expectQtsCertificateUrl,
         bool expectEysCertificateUrl)
     {
-        // Arrange
-        var contact = await CreateContact(trn);
-
+        // Arrange        
         dfeta_qtsregistration[]? qtsRegistrations = null;
         if (qualifiedInWales)
         {
@@ -42,7 +40,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             };
         }
 
-        await ConfigureMocks(trn, contact, qtsRegistrations: qtsRegistrations);
+        await ConfigureMocks(contact, qtsRegistrations: qtsRegistrations);
 
         var request = new HttpRequestMessage(HttpMethod.Get, baseUrl);
 
@@ -55,7 +53,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             firstName = contact.FirstName,
             lastName = contact.LastName,
             middleName = contact.MiddleName,
-            trn = trn,
+            trn = contact.dfeta_TRN,
             dateOfBirth = contact.BirthDate?.ToString("yyyy-MM-dd"),
             nationalInsuranceNumber = contact.dfeta_NINumber,
             qts = new
@@ -90,13 +88,11 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn,
+        Contact contact,
         bool expectCertificateUrls)
     {
         // Arrange
-        var contact = await CreateContact(trn, hasMultiWordFirstName: true);
-
-        await ConfigureMocks(trn, contact);
+        await ConfigureMocks(contact);
 
         var request = new HttpRequestMessage(HttpMethod.Get, baseUrl);
 
@@ -109,7 +105,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             firstName = contact.dfeta_StatedFirstName,
             lastName = contact.dfeta_StatedLastName,
             middleName = contact.dfeta_StatedMiddleName,
-            trn = trn,
+            trn = contact.dfeta_TRN,
             dateOfBirth = contact.BirthDate?.ToString("yyyy-MM-dd"),
             nationalInsuranceNumber = contact.dfeta_NINumber,
             qts = new
@@ -140,15 +136,14 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestWithInduction_ReturnsExpectedInductionContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn,
+        Contact contact,
         bool expectCertificateUrls)
     {
         // Arrange
-        var contact = await CreateContact(trn);
         var induction = CreateInduction();
         var inductionPeriods = CreateInductionPeriods();
 
-        await ConfigureMocks(trn, contact, induction: induction, inductionPeriods: inductionPeriods);
+        await ConfigureMocks(contact, induction: induction, inductionPeriods: inductionPeriods);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=Induction");
 
@@ -191,13 +186,12 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn)
+        Contact contact)
     {
         // Arrange
-        var contact = await CreateContact(trn);
         var itt = CreateItt(contact);
 
-        await ConfigureMocks(trn, contact, itt);
+        await ConfigureMocks(contact, itt);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=InitialTeacherTraining");
 
@@ -257,12 +251,10 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn,
+        Contact contact,
         bool expectCertificateUrls)
     {
         // Arrange
-        var contact = await CreateContact(trn);
-
         var npqQualificationNoAwardDate = CreateQualification(dfeta_qualification_dfeta_Type.NPQLL, null, dfeta_qualificationState.Active, null);
         var npqQualificationInactive = CreateQualification(dfeta_qualification_dfeta_Type.NPQSL, new DateTime(2022, 5, 6), dfeta_qualificationState.Inactive, null);
         var npqQualificationValid = CreateQualification(dfeta_qualification_dfeta_Type.NPQEYL, new DateTime(2022, 3, 4), dfeta_qualificationState.Active, null);
@@ -274,7 +266,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             npqQualificationValid
         };
 
-        await ConfigureMocks(trn, contact, qualifications: qualifications);
+        await ConfigureMocks(contact, qualifications: qualifications);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=NpqQualifications");
 
@@ -310,11 +302,9 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn)
+        Contact contact)
     {
         // Arrange
-        var contact = await CreateContact(trn);
-
         var mandatoryQualificationNoAwardDate = CreateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, null, dfeta_qualificationState.Active, "Visual Impairment");
         var mandatoryQualificationNoSpecialism = CreateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 2, 3), dfeta_qualificationState.Active, null);
         var mandatoryQualificationValid = CreateQualification(dfeta_qualification_dfeta_Type.MandatoryQualification, new DateTime(2022, 4, 6), dfeta_qualificationState.Active, "Hearing");
@@ -328,7 +318,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             mandatoryQualificationInactive
         };
 
-        await ConfigureMocks(trn, contact, qualifications: qualifications);
+        await ConfigureMocks(contact, qualifications: qualifications);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=MandatoryQualifications");
 
@@ -354,10 +344,9 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn)
+        Contact contact)
     {
         // Arrange
-        var contact = await CreateContact(trn);
         var qualification1AwardDate = new DateTime(2022, 4, 6);
         var qualification1Name = "My HE Qual 1";
         var qualification1Subject1 = (Code: "Qualification1Subject1", Name: "Qualification 1 Subject 1");
@@ -418,7 +407,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             heQualificationInactive
         };
 
-        await ConfigureMocks(trn, contact, qualifications: qualifications);
+        await ConfigureMocks(contact, qualifications: qualifications);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=HigherEducationQualifications");
 
@@ -468,11 +457,9 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(
         HttpClient httpClient,
         string baseUrl,
-        string trn)
+        Contact contact)
     {
         // Arrange
-        var contact = await CreateContact(trn);
-
         var incidents = new[]
         {
             new Incident()
@@ -483,7 +470,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             }
         };
 
-        await ConfigureMocks(trn, contact, incidents: incidents);
+        await ConfigureMocks(contact, incidents: incidents);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=PendingDetailChanges");
 
@@ -498,11 +485,9 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(
         HttpClient httpClient,
         string baseUrl,
-        string trn)
+        Contact contact)
     {
         // Arrange
-        var contact = await CreateContact(trn);
-
         var incidents = new[]
         {
             new Incident()
@@ -513,7 +498,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             }
         };
 
-        await ConfigureMocks(trn, contact, incidents: incidents);
+        await ConfigureMocks(contact, incidents: incidents);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=PendingDetailChanges");
 
@@ -528,11 +513,9 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn)
+        Contact contact)
     {
         // Arrange
-        var contact = await CreateContact(trn);
-
         var sanctions = new (string SanctionCode, DateOnly? StartDate)[]
         {
             new("A18", null),
@@ -540,7 +523,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
         };
         Debug.Assert(sanctions.Select(s => s.SanctionCode).All(TeachingRecordSystem.Api.V3.Constants.ExposableSanctionCodes.Contains));
 
-        await ConfigureMocks(trn, contact, sanctions: sanctions);
+        await ConfigureMocks(contact, sanctions: sanctions);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=Sanctions");
 
@@ -571,11 +554,9 @@ public abstract class GetTeacherTestBase : ApiTestBase
     protected async Task ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(
         HttpClient httpClient,
         string baseUrl,
-        string trn)
+        Contact contact)
     {
         // Arrange
-        var contact = await CreateContact(trn);
-
         var sanctions = new (string SanctionCode, DateOnly? StartDate)[]
         {
             new("B1", null),
@@ -583,7 +564,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
         };
         Debug.Assert(sanctions.Select(s => s.SanctionCode).All(TeachingRecordSystem.Api.V3.Constants.ProhibitionSanctionCodes.Contains));
 
-        await ConfigureMocks(trn, contact, sanctions: sanctions);
+        await ConfigureMocks(contact, sanctions: sanctions);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=Alerts");
 
@@ -611,8 +592,67 @@ public abstract class GetTeacherTestBase : ApiTestBase
             responseAlerts);
     }
 
+    protected async Task ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var updatedFirstName = TestData.GenerateFirstName();
+        var updatedMiddleName = TestData.GenerateMiddleName();
+        var updatedLastName = TestData.GenerateLastName();
+        var updatedNames = new[]
+        {
+            (FirstName: updatedFirstName, MiddleName: updatedMiddleName, LastName: contact.LastName),
+            (FirstName: updatedFirstName, MiddleName: updatedMiddleName, LastName: updatedLastName)
+        };
+
+        await ConfigureMocks(contact, updatedNames: updatedNames!);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=PreviousNames");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responsePreviousNames = jsonResponse.RootElement.GetProperty("previousNames");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    firstName = updatedFirstName,
+                    middleName = updatedMiddleName,
+                    lastName = contact.LastName,
+                },
+                new
+                {
+                    firstName = contact.FirstName,
+                    middleName = contact.MiddleName,
+                    lastName = contact.LastName,
+                }
+            },
+            responsePreviousNames);
+    }
+
+    protected async Task<Contact> CreateContact(bool hasMultiWordFirstName = false)
+    {
+        var qtsDate = new DateOnly(1997, 4, 23);
+        var eytsDate = new DateOnly(1995, 5, 14);
+        var firstName = hasMultiWordFirstName ? $"{Faker.Name.First()} {Faker.Name.First()}" : Faker.Name.First();
+
+        var person = await TestData.CreatePerson(
+            b => b.WithFirstName(firstName)
+                .WithTrn()
+                .WithQtsDate(qtsDate)
+                .WithEytsDate(eytsDate));
+
+        return person.ToContact();
+    }
+
     private async Task ConfigureMocks(
-        string trn,
         Contact contact,
         dfeta_initialteachertraining? itt = null,
         dfeta_induction? induction = null,
@@ -620,6 +660,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
         dfeta_qualification[]? qualifications = null,
         Incident[]? incidents = null,
         dfeta_qtsregistration[]? qtsRegistrations = null,
+        (string FirstName, string? MiddleName, string LastName)[]? updatedNames = null,
         (string SanctionCode, DateOnly? StartDate)[]? sanctions = null)
     {
         DataverseAdapterMock
@@ -639,7 +680,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             });
 
         DataverseAdapterMock
-            .Setup(mock => mock.GetTeacherByTrn(trn, /* columnNames: */ It.IsAny<string[]>(), /* activeOnly: */ true))
+            .Setup(mock => mock.GetTeacherByTrn(contact.dfeta_TRN, /* columnNames: */ It.IsAny<string[]>(), /* activeOnly: */ true))
             .ReturnsAsync(contact);
 
         DataverseAdapterMock
@@ -711,42 +752,12 @@ public abstract class GetTeacherTestBase : ApiTestBase
                 dfeta_StartDate = sanction.StartDate?.FromDateOnlyWithDqtBstFix(isLocalTime: true)
             });
         }
-    }
 
-    private async Task<Contact> CreateContact(string trn, bool hasMultiWordFirstName = false)
-    {
-        var contactId = Guid.NewGuid();
-        var firstName1 = Faker.Name.First();
-        var firstName2 = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-        var middleName = Faker.Name.Middle();
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-        var nino = Faker.Identification.UkNationalInsuranceNumber();
-        var email = Faker.Internet.Email();
-
-        var qtsDate = new DateOnly(1997, 4, 23);
-        var eytsDate = new DateOnly(1995, 5, 14);
-
-        var teacher = new Contact()
+        foreach (var updatedName in updatedNames ?? Array.Empty<(string, string?, string)>())
         {
-            Id = contactId,
-            dfeta_TRN = trn,
-            FirstName = firstName1,
-            MiddleName = hasMultiWordFirstName ? $"{firstName2} {middleName}" : middleName,
-            LastName = lastName,
-            dfeta_StatedFirstName = hasMultiWordFirstName ? $"{firstName1} {firstName2}" : firstName1,
-            dfeta_StatedMiddleName = middleName,
-            dfeta_StatedLastName = lastName,
-            BirthDate = dateOfBirth.ToDateTime(),
-            dfeta_NINumber = nino,
-            dfeta_QTSDate = qtsDate.ToDateTime(),
-            dfeta_EYTSDate = eytsDate.ToDateTime(),
-            EMailAddress1 = email
-        };
-
-        await TestData.OrganizationService.CreateAsync(teacher);
-
-        return teacher;
+            await TestData.UpdatePerson(b => b.WithPersonId(contact.Id).WithUpdatedName(updatedName.FirstName, updatedName.MiddleName, updatedName.LastName));
+            await Task.Delay(2000);
+        }
     }
 
     private static dfeta_initialteachertraining CreateItt(Contact teacher)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
@@ -26,21 +26,21 @@ public class GetTeacherTests : GetTeacherTestBase
     [Fact]
     public async Task Get_ValidRequest_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact();
+        var contact = await CreateContact(qualifiedInWales: false);
         var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qualifiedInWales: false, expectQtsCertificateUrl: true, expectEysCertificateUrl: true);
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: true, expectEysCertificateUrl: true);
     }
 
     [Fact]
     public async Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact();
+        var contact = await CreateContact(qualifiedInWales: true);
         var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qualifiedInWales: true, expectQtsCertificateUrl: false, expectEysCertificateUrl: true);
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: true);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
@@ -24,122 +24,132 @@ public class GetTeacherTests : GetTeacherTestBase
     }
 
     [Fact]
-    public Task Get_ValidRequest_ReturnsExpectedResponse()
+    public async Task Get_ValidRequest_ReturnsExpectedResponse()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, trn, qualifiedInWales: false, expectQtsCertificateUrl: true, expectEysCertificateUrl: true);
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qualifiedInWales: false, expectQtsCertificateUrl: true, expectEysCertificateUrl: true);
     }
 
     [Fact]
-    public Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
+    public async Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, trn, qualifiedInWales: true, expectQtsCertificateUrl: false, expectEysCertificateUrl: true);
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qualifiedInWales: true, expectQtsCertificateUrl: false, expectEysCertificateUrl: true);
     }
 
     [Fact]
-    public Task Get_ValidRequestForContactWithMultiWordFirstName_ReturnsExpectedResponse()
+    public async Task Get_ValidRequestForContactWithMultiWordFirstName_ReturnsExpectedResponse()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact(hasMultiWordFirstName: true);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
+        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(httpClient, baseUrl, contact, expectCertificateUrls: true);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
+    public async Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
+        await ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, contact, expectCertificateUrls: true);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
+    public async Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(httpClient, baseUrl, trn);
+        await ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(httpClient, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
+    public async Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(httpClient, baseUrl, trn, expectCertificateUrls: true);
+        await ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(httpClient, baseUrl, contact, expectCertificateUrls: true);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
+    public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent(httpClient, baseUrl, trn);
+        await ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent(httpClient, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
+    public async Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        return ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(httpClient, baseUrl, trn);
+        await ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(httpClient, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
+    public async Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "v3/teacher";
 
-        return ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(httpClient, baseUrl, trn);
+        await ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(httpClient, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
+    public async Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "v3/teacher";
 
-        return ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(httpClient, baseUrl, trn);
+        await ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(httpClient, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithSanctions_ReturnsExpectedSanctionsContent()
+    public async Task Get_ValidRequestWithSanctions_ReturnsExpectedSanctionsContent()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "v3/teacher";
 
-        return ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(httpClient, baseUrl, trn);
+        await ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(httpClient, baseUrl, contact);
     }
 
     [Fact]
-    public Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
+    public async Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
     {
-        var trn = "1234567";
-        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "v3/teacher";
 
-        return ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(httpClient, baseUrl, trn);
+        await ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(httpClient, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "v3/teacher";
+
+        await ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent(httpClient, baseUrl, contact);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetAllEarlyYearsStatusesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetAllEarlyYearsStatusesTests.cs
@@ -1,0 +1,24 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class GetAllEarlyYearsStatusesTests
+{
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public GetAllEarlyYearsStatusesTests(CrmClientFixture crmClientFixture)
+    {
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var query = new GetAllEarlyYearsStatusesQuery();
+
+        // Act
+        var result = await _crmQueryDispatcher.ExecuteQuery(query);
+
+        // Assert
+        Assert.NotEmpty(result);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactDetailByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/GetContactDetailByTrnTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class GetContactDetailByTrnTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public GetContactDetailByTrnTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task WhenCalled_WithTrnForNonExistentContact_ReturnsNull()
+    {
+        // Arrange
+        var trn = "DodgyTrn";
+
+        // Act
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByTrnQuery(trn, new ColumnSet()));
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task WhenCalled_WithTrnForExistingContact_ReturnsContactDetail()
+    {
+        // Arrange
+        var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
+
+        // Act
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Contact.Id, person.ContactId);
+        Assert.Empty(result.PreviousNames);
+    }
+
+    [Fact]
+    public async Task WhenCalled_WithTrnForExistingContactWithPreviousName_ReturnsContactDetailIncludingPreviousNames()
+    {
+        // Arrange
+        var updatedFirstName = _dataScope.TestData.GenerateFirstName();
+        var updatedMiddleName = _dataScope.TestData.GenerateMiddleName();
+        var updatedLastName = _dataScope.TestData.GenerateLastName();
+        var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
+        await _dataScope.TestData.UpdatePerson(b => b.WithPersonId(person.ContactId).WithUpdatedName(updatedFirstName, updatedMiddleName, updatedLastName));
+
+        // Act
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Contact.Id, person.ContactId);
+        Assert.Equal(3, result.PreviousNames.Length);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/Usings.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/Usings.cs
@@ -1,4 +1,3 @@
-global using Moq;
 global using TeachingRecordSystem.Core.Dqt.Models;
 global using TeachingRecordSystem.Core.Dqt.Queries;
 global using TeachingRecordSystem.TestCommon;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.CreatePerson.cs
@@ -16,7 +16,7 @@ public partial class CrmTestData
 
     public class CreatePersonBuilder
     {
-        private const string TeacherStatusQualifiedTeacherAssessmentOnlyRoute = "100";
+        private const string TeacherStatusQualifiedTeacherTrained = "71";
         private const string EaryYearsStatusProfessionalStatus = "222";
 
         private DateOnly? _dateOfBirth;
@@ -147,7 +147,7 @@ public partial class CrmTestData
             return this;
         }
 
-        public CreatePersonBuilder WithQts(DateOnly qtsDate, string teacherStatus = TeacherStatusQualifiedTeacherAssessmentOnlyRoute)
+        public CreatePersonBuilder WithQts(DateOnly qtsDate, string teacherStatus = TeacherStatusQualifiedTeacherTrained)
         {
             if ((_qtsDate is not null && _qtsDate != qtsDate) || (_teacherStatus is not null && _teacherStatus != teacherStatus))
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.UpdatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmTestData.UpdatePerson.cs
@@ -15,7 +15,7 @@ public partial class CrmTestData
     public class UpdatePersonBuilder
     {
         private Guid? _personId = null;
-        private (string FirstName, string MiddleName, string LastName)? _updatedName = null;
+        private (string FirstName, string? MiddleName, string LastName)? _updatedName = null;
 
         public UpdatePersonBuilder WithPersonId(Guid personId)
         {
@@ -28,7 +28,7 @@ public partial class CrmTestData
             return this;
         }
 
-        public UpdatePersonBuilder WithUpdatedName(string firstName, string middleName, string lastName)
+        public UpdatePersonBuilder WithUpdatedName(string firstName, string? middleName, string lastName)
         {
             if (_updatedName is not null)
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/FakeXrmEasy/Plugins/QtsRegistrationUpdatedPlugin.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/FakeXrmEasy/Plugins/QtsRegistrationUpdatedPlugin.cs
@@ -1,0 +1,115 @@
+using FakeXrmEasy.Abstractions;
+using FakeXrmEasy.Abstractions.Plugins.Enums;
+using FakeXrmEasy.Pipeline;
+using FakeXrmEasy.Plugins.Definitions;
+using FakeXrmEasy.Plugins.PluginImages;
+using FakeXrmEasy.Plugins.PluginSteps;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt.Models;
+
+namespace TeachingRecordSystem.TestCommon.Infrastructure.FakeXrmEasy.Plugins;
+
+/// <summary>
+/// This plugin mirrors the poorly named QTSRegistrationDeletPlugin in CRM.
+/// </summary>
+public class QtsRegistrationUpdatedPlugin : IPlugin
+{
+    internal static void Register(IXrmFakedContext context)
+    {
+        var preImageDefinition = new PluginImageDefinition(
+            "preImage",
+            ProcessingStepImageType.PreImage,
+            new string[]
+            {
+                dfeta_qtsregistration.Fields.dfeta_PersonId,
+                dfeta_qtsregistration.Fields.dfeta_QTSDate,
+                dfeta_qtsregistration.Fields.dfeta_EYTSDate
+            });
+        context.RegisterPluginStep<QtsRegistrationUpdatedPlugin>(
+            new PluginStepDefinition()
+            {
+                EntityLogicalName = dfeta_qtsregistration.EntityLogicalName,
+                MessageName = "Delete",
+                Stage = ProcessingStepStage.Postoperation,
+                ImagesDefinitions = new List<IPluginImageDefinition>() { preImageDefinition }
+            });
+        context.RegisterPluginStep<QtsRegistrationUpdatedPlugin>(
+            new PluginStepDefinition()
+            {
+                EntityLogicalName = dfeta_qtsregistration.EntityLogicalName,
+                MessageName = "Update",
+                Stage = ProcessingStepStage.Postoperation,
+                ImagesDefinitions = new List<IPluginImageDefinition>() { preImageDefinition }
+            });
+    }
+
+    public void Execute(IServiceProvider serviceProvider)
+    {
+        var context = serviceProvider.GetRequiredService<IPluginExecutionContext>();
+        var orgService = serviceProvider.GetRequiredService<IOrganizationService>();
+
+        if (context.PreEntityImages.TryGetValue("preImage", out var preImage))
+        {
+            if (preImage.TryGetAttributeValue<EntityReference>(dfeta_qtsregistration.Fields.dfeta_PersonId, out var personIdEntityReference))
+            {
+                var personId = personIdEntityReference.Id;
+                if (context.MessageName == "Delete")
+                {
+                    UpdatePersonQtsDate(orgService, personId, null);
+                    UpdatePersonEytsDate(orgService, personId, null);
+                }
+                else
+                {
+                    var target = context.InputParameters["Target"] as Entity;
+                    var state = target!.GetAttributeValue<OptionSetValue>(dfeta_qtsregistration.Fields.StateCode);
+                    if (state?.Value == 1)
+                    {
+                        UpdatePersonQtsDate(orgService, personId, null);
+                        UpdatePersonEytsDate(orgService, personId, null);
+                    }
+                    else
+                    {
+                        var qtsDate = target.GetAttributeValue<DateTime?>(dfeta_qtsregistration.Fields.dfeta_QTSDate);
+                        var eytsDate = target.GetAttributeValue<DateTime?>(dfeta_qtsregistration.Fields.dfeta_EYTSDate);
+
+                        if (qtsDate.HasValue)
+                        {
+                            UpdatePersonQtsDate(orgService, personId, qtsDate);
+                        }
+
+                        if (eytsDate.HasValue)
+                        {
+                            UpdatePersonEytsDate(orgService, personId, eytsDate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void UpdatePersonQtsDate(IOrganizationService orgService, Guid personId, DateTime? qtsDate)
+    {
+        orgService.Execute(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = personId,
+                dfeta_QTSDate = qtsDate
+            }
+        });
+    }
+
+    private void UpdatePersonEytsDate(IOrganizationService orgService, Guid personId, DateTime? eytsDate)
+    {
+        orgService.Execute(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = personId,
+                dfeta_EYTSDate = eytsDate
+            }
+        });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
@@ -17,6 +17,8 @@ public class SeedCrmReferenceData : IStartupTask
     {
         AddSubjects();
         AddSanctionCodes();
+        AddTeacherStatuses();
+        AddEarlyYearsStatuses();
 
         return Task.CompletedTask;
     }
@@ -64,6 +66,58 @@ public class SeedCrmReferenceData : IStartupTask
         {
             dfeta_Value = "B1",
             dfeta_name = "B1 Description"
+        });
+    }
+
+    private void AddTeacherStatuses()
+    {
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "71",
+            dfeta_name = "Qualified Teacher (trained)",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "100",
+            dfeta_name = "Qualified Teacher: Assessment Only Route",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "90",
+            dfeta_name = "Qualified teacher: by virtue of achieving international qualified teacher status",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "213",
+            dfeta_name = "Qualified Teacher: QTS awarded in Wales",
+            dfeta_QTSDateRequired = true
+        });
+    }
+
+    private void AddEarlyYearsStatuses()
+    {
+        _xrmFakedContext.CreateEntity(new dfeta_earlyyearsstatus()
+        {
+            dfeta_Value = "220",
+            dfeta_name = "Early Years Trainee",
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_earlyyearsstatus()
+        {
+            dfeta_Value = "221",
+            dfeta_name = "Early Years Teacher Status"
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_earlyyearsstatus()
+        {
+            dfeta_Value = "222",
+            dfeta_name = "Early Years Professional Status"
         });
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
@@ -48,6 +48,7 @@ public static class ServiceCollectionExtensions
         AssignTicketNumberToIncidentPlugin.Register(fakedXrmContext);
         PersonNameChangedPlugin.Register(fakedXrmContext);
         CalculateActiveSanctionsPlugin.Register(fakedXrmContext);
+        QtsRegistrationUpdatedPlugin.Register(fakedXrmContext);
 
         services.AddSingleton<IXrmFakedContext>(fakedXrmContext);
         var organizationService = fakedXrmContext.GetAsyncOrganizationService();


### PR DESCRIPTION
### Context

Check want to show previous names so that it’s clear how they were found when they were found with a previous name.

### Changes proposed in this pull request

Amend the /v3/teachers/<trn> endpoint to add a new GetTeacherRequestIncludes entry - PreviousNames. When this is specified, populate a PreviousNames array at the root of the response that contains the previous names. Each entry in the array should have a FirstName, MiddleName and LastName property. Any null MiddleNames should be normalised to an empty string. Entries should be sorted such that the most recent name change is first.

We should apply the same logic when grouping dfeta_previousname records as we do for the TRS Support Console UI.

### Guidance to review

CRM + API + Tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
