### PR TITLE
Dynamic API client for tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
@@ -46,7 +46,7 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthentic
             return Task.FromResult(AuthenticateResult.Fail($"No client found with specified API key."));
         }
 
-        var principal = CreatePrincipal(client);
+        var principal = CreatePrincipal(client.ClientId);
         var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
         LogContext.PushProperty("ClientId", client.ClientId);
@@ -54,11 +54,11 @@ public class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthentic
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 
-    private static ClaimsPrincipal CreatePrincipal(ApiClient client)
+    public static ClaimsPrincipal CreatePrincipal(string clientId)
     {
         var identity = new ClaimsIdentity(new[]
         {
-            new Claim(ClaimTypes.Name, client.ClientId)
+            new Claim(ClaimTypes.Name, clientId)
         });
 
         return new ClaimsPrincipal(identity);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
@@ -1,10 +1,5 @@
 {
   "Platform": "Local",
-  "ApiClients": {
-    "tests": {
-      "ApiKey": [ "tests" ]
-    }
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Error",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Infrastructure/Security/TestAuthentication.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Infrastructure/Security/TestAuthentication.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+
+namespace TeachingRecordSystem.Api.Tests.Infrastructure.Security;
+
+public class TestAuthenticationHandler : AuthenticationHandler<TestAuthenticationOptions>
+{
+    private readonly CurrentApiClientProvider _currentApiClientProvider;
+
+    public TestAuthenticationHandler(
+        CurrentApiClientProvider currentApiClientProvider,
+        IOptionsMonitor<TestAuthenticationOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock) :
+        base(options, logger, encoder, clock)
+    {
+        _currentApiClientProvider = currentApiClientProvider;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("X-Use-CurrentClientIdProvider", out var useCurrentClientIdProvider) ||
+            useCurrentClientIdProvider != "true")
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var currentApiClientId = _currentApiClientProvider.CurrentApiClientId;
+
+        if (currentApiClientId is not null)
+        {
+            var principal = ApiKeyAuthenticationHandler.CreatePrincipal(currentApiClientId);
+
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+        else
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+    }
+}
+
+public class TestAuthenticationOptions : AuthenticationSchemeOptions { }
+
+public class CurrentApiClientProvider
+{
+    private readonly AsyncLocal<string> _currentApiClientId = new();
+
+    [DisallowNull]
+    public string? CurrentApiClientId
+    {
+        get => _currentApiClientId.Value;
+        set => _currentApiClientId.Value = value;
+    }
+}


### PR DESCRIPTION
Until now we've used a single fixed API client ID (and key) in our API tests. Now we're adding roles (and want to use various role combinations in tests) we need a more dynamic mechanism.

This introduces a `TestAuthenticationHandler` similar to what we use in other test projects. There's a singleton `CurrentApiClientProvider` that's shared by the server and tests that allows setting the current user ID. (It's an `AsyncLocal` to allow concurrent tests to set their own user independently.) 

Given we have two authentication schemes in the API - the API key plus an ID access token - we have to know when our test handler should run vs when it shouldn't (we don't want this `TestAuthenticationHandler` kicking in when we're testing endpoints that require an ID access token). To do that, I've added a header to the `HttpClient` used for API key-based calls; the authentication handler looks for that before it runs.