### PR TITLE
Fix flaky API tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/GetAnIdentity/GetAnIdentityOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/GetAnIdentity/GetAnIdentityOptions.cs
@@ -8,14 +8,14 @@ public class GetAnIdentityOptions
     public required string TokenEndpoint { get; set; }
 
     [Required]
-    public required string ClientId { get; init; }
+    public required string ClientId { get; set; }
 
     [Required]
-    public required string ClientSecret { get; init; }
+    public required string ClientSecret { get; set; }
 
     [Required]
-    public required string BaseAddress { get; init; }
+    public required string BaseAddress { get; set; }
 
     [Required]
-    public required string WebHookClientSecret { get; init; }
+    public required string WebHookClientSecret { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/ApiFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/ApiFixture.cs
@@ -23,6 +23,7 @@ public class ApiFixture : WebApplicationFactory<Program>
     {
         _configuration = configuration;
         JwtSigningCredentials = new SigningCredentials(new RsaSecurityKey(RSA.Create()), SecurityAlgorithms.RsaSha256);
+        _ = Services;  // Start the host
     }
 
     public HttpClientInterceptorOptions EvidenceFilesHttpClientInterceptorOptions { get; } = new();
@@ -58,11 +59,19 @@ public class ApiFixture : WebApplicationFactory<Program>
             services.AddTestScoped<IDataverseAdapter>(tss => tss.DataverseAdapterMock.Object);
             services.AddTestScoped<IGetAnIdentityApiClient>(tss => tss.GetAnIdentityApiClientMock.Object);
             services.AddTestScoped<IOptions<AccessYourQualificationsOptions>>(tss => tss.AccessYourQualificationsOptions);
-            services.AddTestScoped<IOptions<GetAnIdentityOptions>>(tss => tss.GetAnIdentityOptions);
             services.AddTestScoped<ICertificateGenerator>(tss => tss.CertificateGeneratorMock.Object);
             services.AddSingleton<TestData>();
             services.AddFakeXrm();
             services.AddSingleton<FakeTrnGenerator>();
+
+            services.Configure<GetAnIdentityOptions>(options =>
+            {
+                options.TokenEndpoint = "dummy";
+                options.ClientId = "dummy";
+                options.ClientSecret = "dummy";
+                options.BaseAddress = "dummy";
+                options.WebHookClientSecret = "dummy";
+            });
 
             services.AddHttpClient("EvidenceFiles")
                 .AddHttpMessageHandler(_ => EvidenceFilesHttpClientInterceptorOptions.CreateHttpMessageHandler())

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/ApiTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/ApiTestBase.cs
@@ -2,7 +2,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using FakeXrmEasy.Abstractions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using TeachingRecordSystem.Api.Infrastructure.Json;
 using TeachingRecordSystem.Api.Tests.Infrastructure.Security;
@@ -40,8 +39,6 @@ public abstract class ApiTestBase
     public TestableClock Clock => _testServices.Clock;
 
     public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock => _testServices.GetAnIdentityApiClientMock;
-
-    public IOptions<GetAnIdentityOptions> GetAnIdentityOptions => _testServices.GetAnIdentityOptions;
 
     public HttpClient HttpClientWithApiKey { get; }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Endpoints/IdentityWebHooks/GetAnIdentityEndpointsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Endpoints/IdentityWebHooks/GetAnIdentityEndpointsTests.cs
@@ -1,8 +1,10 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 using TeachingRecordSystem.Api.Endpoints.IdentityWebHooks;
 using TeachingRecordSystem.Api.Endpoints.IdentityWebHooks.Messages;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 
 namespace TeachingRecordSystem.Api.Tests.Endpoints.IdentityWebHooks;
 
@@ -12,6 +14,8 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
        : base(apiFixture)
     {
     }
+
+    private IOptions<GetAnIdentityOptions> GetAnIdentityOptions => ApiFixture.Services.GetRequiredService<IOptions<GetAnIdentityOptions>>();
 
     [Fact]
     public async Task Post_WithNoSignatureInHeader_ReturnsUnauthorised()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestScopedServices.cs
@@ -17,15 +17,6 @@ public class TestScopedServices
         DataverseAdapterMock = new();
         GetAnIdentityApiClientMock = new();
 
-        GetAnIdentityOptions = Options.Create(new GetAnIdentityOptions()
-        {
-            TokenEndpoint = "dummy",
-            ClientId = "dummy",
-            ClientSecret = "dummy",
-            BaseAddress = "dummy",
-            WebHookClientSecret = "dummy"
-        });
-
         AccessYourQualificationsOptions = Options.Create(new AccessYourQualificationsOptions()
         {
             BaseAddress = "https://aytq.com",
@@ -52,8 +43,6 @@ public class TestScopedServices
     public Mock<IDataverseAdapter> DataverseAdapterMock { get; }
 
     public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock { get; }
-
-    public IOptions<GetAnIdentityOptions> GetAnIdentityOptions { get; }
 
     public IOptions<AccessYourQualificationsOptions> AccessYourQualificationsOptions { get; }
 


### PR DESCRIPTION
The endpoint used to process webhooks effectively had a non-scoped reference to `IOptions<GetAnIdentityOptions>` which was causing the host to startup and configure itself multiple times. This in turn was causing the DB schema to be regenerated multiple times (clearing out data too) and leading to flakiness.