### PR TITLE
Reduce production worker memory

### DIFF
--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -10,7 +10,6 @@
   "api_replicas": 2,
   "api_max_memory": "4Gi",
   "ui_replicas": 2,
-  "worker_max_memory": "4Gi",
   "worker_replicas": 2,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_enable_high_availability": true,


### PR DESCRIPTION
We made this so high believing that the `DqtReportingService` that lives here was the cause of memory issues. We've since found out that's not the case so we can drop this back down again.