### PR TITLE
Add StatusDescription to api Endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
@@ -30,16 +30,18 @@ public record GetTeacherResponse
 
 public record GetTeacherResponseQts
 {
-    public required DateOnly Awarded { get; init; }
+    public required DateOnly? Awarded { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? CertificateUrl { get; init; }
+    public required string? StatusDescription { get; init; }
 }
 
 public record GetTeacherResponseEyts
 {
-    public required DateOnly Awarded { get; init; }
+    public required DateOnly? Awarded { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? CertificateUrl { get; init; }
+    public required string? StatusDescription { get; init; }
 }
 
 public record GetTeacherResponseInduction

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/GeneratedCode.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/GeneratedCode.cs
@@ -8553,7 +8553,8 @@ namespace TeachingRecordSystem.Core.Dqt.Models
 		/// </summary>
 		public static class Fields
 		{
-			public const string dfeta_EarlyYearsStatusId = "dfeta_earlyyearsstatusid";
+            public const string CreatedOn = "createdon";
+            public const string dfeta_EarlyYearsStatusId = "dfeta_earlyyearsstatusid";
 			public const string dfeta_EYTSDate = "dfeta_eytsdate";
 			public const string dfeta_InductionId = "dfeta_inductionid";
 			public const string dfeta_name = "dfeta_name";
@@ -8637,11 +8638,32 @@ namespace TeachingRecordSystem.Core.Dqt.Models
 				this.OnPropertyChanged("dfeta_EarlyYearsStatusId");
 			}
 		}
-		
-		/// <summary>
-		/// 
-		/// </summary>
-		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_eytsdate")]
+
+        /// <summary>
+        /// Date and time when the record was created.
+        /// </summary>
+        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+        public System.Nullable<System.DateTime> CreatedOn
+        {
+            [System.Diagnostics.DebuggerNonUserCode()]
+            get
+            {
+                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+            }
+            [System.Diagnostics.DebuggerNonUserCode()]
+            set
+            {
+                this.OnPropertyChanging("CreatedOn");
+                this.SetAttributeValue("createdon", value);
+                this.OnPropertyChanged("CreatedOn");
+            }
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dfeta_eytsdate")]
 		public System.Nullable<System.DateTime> dfeta_EYTSDate
 		{
 			[System.Diagnostics.DebuggerNonUserCode()]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
@@ -48,6 +48,18 @@ public class ReferenceDataCache : IStartupTask
         return teacherStatuses.Single(ts => ts.dfeta_Value == value, $"Could not find teacher status with value: '{value}'.");
     }
 
+    public async Task<dfeta_teacherstatus[]> GetTeacherStatuses()
+    {
+        var teacherStatuses = await EnsureTeacherStatuses();
+        return teacherStatuses;
+    }
+
+    public async Task<dfeta_earlyyearsstatus[]> GetEytsStatuses()
+    {
+        var earlyyearStatuses = await EnsureEarlyYearsStatuses();
+        return earlyyearStatuses;
+    }
+
     public async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatusByValue(string value)
     {
         var earlyYearsStatuses = await EnsureEarlyYearsStatuses();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
@@ -1,5 +1,5 @@
 using TeachingRecordSystem.Api.Tests.Attributes;
-using static TeachingRecordSystem.TestCommon.CrmTestData;
+using static TeachingRecordSystem.TestCommon.TestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.Api.Tests.Attributes;
+using static TeachingRecordSystem.TestCommon.CrmTestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 
@@ -59,19 +60,25 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
     [Fact]
     public async Task Get_ValidRequest_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact(qualifiedInWales: false);
+        var contact = await CreateContact();
         var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
+        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false, qtsRegistrations: null, expectedQts: null, expectedEyts: null);
     }
 
     [Fact]
     public async Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact(qualifiedInWales: true);
+        var qtsDate = new DateOnly(2021, 01, 01);
+        var qtsCreatedDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, QtsAwardedInWalesTeacherStatusValue, qtsCreatedDate, null, null)
+        };
+        var contact = await CreateContact(qts);
         var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false);
+        await ValidRequestForTeacher_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), "Qualified"), expectedEyts: null);
     }
 
     [Fact]
@@ -80,7 +87,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
         var contact = await CreateContact();
         var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectCertificateUrls: false);
+        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(HttpClientWithApiKey, baseUrl, contact, expectCertificateUrls: false, qtsRegistrations: null, expectedQts: null, expectedEyts: null);
     }
 
     [Fact]
@@ -89,7 +96,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
         var contact = await CreateContact();
         var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
 
-        await ValidRequestWithInduction_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, contact, expectCertificateUrls: false);
+        await ValidRequestWithInduction_ReturnsExpectedInductionContent(HttpClientWithApiKey, baseUrl, contact);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 using Microsoft.Xrm.Sdk;
 using TeachingRecordSystem.Api.V3.ApiModels;
 using TeachingRecordSystem.Core.Dqt;
-using static TeachingRecordSystem.TestCommon.CrmTestData;
+using static TeachingRecordSystem.TestCommon.TestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -747,7 +747,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             .Returns(async (string s, RequestBuilder b) => await TestData.ReferenceDataCache.GetTeacherStatusByValue(s));
 
         using var ctx = new DqtCrmServiceContext(TestData.OrganizationService);
-        var qtsRegistrationss = ctx.dfeta_qtsregistrationSet
+        var qtsRegs = ctx.dfeta_qtsregistrationSet
             .Where(c => c.GetAttributeValue<Guid>(dfeta_qtsregistration.Fields.dfeta_PersonId) == contact.Id)
             .ToArray();
 
@@ -755,7 +755,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
             .Setup(mock => mock.GetQtsRegistrationsByTeacher(
                 contact.Id,
                 It.IsAny<string[]>()))
-            .ReturnsAsync(qtsRegistrationss ?? Array.Empty<dfeta_qtsregistration>());
+            .ReturnsAsync(qtsRegs ?? Array.Empty<dfeta_qtsregistration>());
 
         var allEytsStatuses = await TestData.ReferenceDataCache.GetEytsStatuses();
         var distinctEyts = qtsRegistrations?.Where(x => !string.IsNullOrEmpty(x.EytsStatusValue)).Select(x => x.EytsStatusValue).Distinct().ToArray();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
@@ -1,3 +1,5 @@
+using static TeachingRecordSystem.TestCommon.CrmTestData;
+
 namespace TeachingRecordSystem.Api.Tests.V3;
 
 public class GetTeacherTests : GetTeacherTestBase
@@ -23,34 +25,149 @@ public class GetTeacherTests : GetTeacherTestBase
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_ValidRequest_ReturnsExpectedResponse()
+    [Theory]
+    [InlineData("28", "Qualified")]
+    [InlineData("50", "Qualified")]
+    [InlineData("67", "Qualified")]
+    [InlineData("68", "Qualified")]
+    [InlineData("69", "Qualified")]
+    [InlineData("71", "Qualified")]
+    [InlineData("87", "Qualified")]
+    [InlineData("90", "Qualified")]
+    [InlineData("100", "Qualified")]
+    [InlineData("103", "Qualified")]
+    [InlineData("104", "Qualified")]
+    [InlineData("206", "Qualified")]
+    [InlineData("211", "Trainee teacher")]
+    [InlineData("212", "Assessment only route candidate")]
+    [InlineData("214", "Partial qualified teacher status")]
+    public async Task Get_ValidRequestWithSingleQts_ReturnsExpectedResponse(string qtsStatusValue, string qtsStatusDescription)
     {
-        var contact = await CreateContact(qualifiedInWales: false);
+        var qtsDate = new DateOnly(2021, 01, 01);
+        var qtsCreatedDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, qtsStatusValue, qtsCreatedDate, null, null)
+        };
+        var contact = await CreateContact(qts);
         var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: true, expectEysCertificateUrl: false, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), qtsStatusDescription), expectedEyts: null);
+    }
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: true, expectEysCertificateUrl: true);
+    [Theory]
+    [InlineData("213", "Qualified")]
+    public async Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse(string qtsStatusValue, string qtsStatusDescription)
+    {
+        var qtsDate = new DateOnly(2021, 01, 01);
+        var qtsCreatedDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, qtsStatusValue, qtsCreatedDate, null, null)
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/teacher";
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), qtsStatusDescription), expectedEyts: null);
+    }
+
+    [Theory]
+    [InlineData("220", "Early years trainee")]
+    [InlineData("221", "Qualified")]
+    [InlineData("222", "Early years professional status")]
+    public async Task Get_ValidRequestWithSingleEYTS_ReturnsExpectedResponse(string eytsStatusValue, string eytsStatusDescription)
+    {
+        var eytsDate = new DateOnly(2021, 01, 01);
+        var createdDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(null, null, createdDate, eytsDate, eytsStatusValue)
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/teacher";
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: true, qtsRegistrations: qts, expectedQts: null, expectedEyts: (eytsDate.ToDateTime(), eytsStatusDescription));
     }
 
     [Fact]
-    public async Task Get_ValidRequestForTeacherQualifiedInWales_ReturnsExpectedResponse()
+    public async Task Get_ValidRequestWithoutEYTSorQTS_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact(qualifiedInWales: true);
+        var contact = await CreateContact(null);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/teacher";
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: false, qtsRegistrations: null, expectedQts: null, expectedEyts: null);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithEYTSandQTS_ReturnsExpectedResponse()
+    {
+        var qtsDate = new DateOnly(2021, 05, 15);
+        var eytsDate = new DateOnly(2021, 01, 01);
+        var createdDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, "212", createdDate, eytsDate, "220")
+        };
+        var contact = await CreateContact(qts);
         var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: true);
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: true, expectEysCertificateUrl: true, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), "Assessment only route candidate"), expectedEyts: (eytsDate.ToDateTime(), "Early years trainee"));
+    }
+
+    [Fact]
+    public async Task Get_MultipleQTSRecords_ReturnsMostRecent()
+    {
+        var qtsDate1 = new DateOnly(2021, 05, 15);
+        var qtsDate2 = new DateOnly(2021, 06, 15);
+        var createdDate1 = new DateTime(2021, 05, 15);
+        var createdDate2 = new DateTime(2021, 06, 15);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate1, "212", createdDate1, null, null),
+            new QtsRegistration(qtsDate2, "212", createdDate2, null, null)
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/teacher";
+
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: true, expectEysCertificateUrl: false, qtsRegistrations: qts, expectedQts: (qtsDate2.ToDateTime(), "Assessment only route candidate"), expectedEyts: null);
+    }
+
+    [Fact]
+    public async Task Get_MultipleEYTSRecords_ReturnsMostRecent()
+    {
+        var eytsDate1 = new DateOnly(2021, 05, 15);
+        var eytsDate2 = new DateOnly(2021, 06, 15);
+        var createdDate1 = new DateTime(2021, 05, 15);
+        var createdDate2 = new DateTime(2021, 06, 15);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(null, null, createdDate1, eytsDate1, "220"),
+            new QtsRegistration(null, null, createdDate2, eytsDate2, "220")
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/teacher";
+
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, expectQtsCertificateUrl: false, expectEysCertificateUrl: true, qtsRegistrations: qts, expectedQts: null, expectedEyts: (eytsDate2.ToDateTime(), "Early years trainee"));
     }
 
     [Fact]
     public async Task Get_ValidRequestForContactWithMultiWordFirstName_ReturnsExpectedResponse()
     {
-        var contact = await CreateContact(hasMultiWordFirstName: true);
+        var qtsDate = new DateOnly(2021, 05, 15);
+        var eytsDate = new DateOnly(2021, 01, 01);
+        var createdDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, "212", createdDate, eytsDate, "220")
+        };
+        var contact = await CreateContact(hasMultiWordFirstName: true, qtsQualifications: qts);
         var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(httpClient, baseUrl, contact, expectCertificateUrls: true);
+        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(httpClient, baseUrl, contact, expectCertificateUrls: true, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), "Assessment only route candidate"), expectedEyts: (eytsDate.ToDateTime(), "Early years trainee"));
     }
 
     [Fact]
@@ -60,7 +177,7 @@ public class GetTeacherTests : GetTeacherTestBase
         var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
         var baseUrl = "/v3/teacher";
 
-        await ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, contact, expectCertificateUrls: true);
+        await ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, contact, true);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
@@ -1,4 +1,4 @@
-using static TeachingRecordSystem.TestCommon.CrmTestData;
+using static TeachingRecordSystem.TestCommon.TestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateMandatoryQualificationTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateMandatoryQualificationTests.cs
@@ -19,7 +19,7 @@ public class CreateMandatoryQualificationTests : IAsyncLifetime
     public async Task QueryExecutesSuccessfully()
     {
         // Arrange
-        var person = await _dataScope.TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await _dataScope.TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), teacherStatusValue: "213", createdDate: new DateTime(2021, 10, 5)));
         var mqEstablishment = await _dataScope.TestData.ReferenceDataCache.GetMqEstablishmentByValue("955"); // University of Birmingham
         var specialism = await _dataScope.TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
         var startDate = new DateOnly(2023, 01, 5);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationByIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationByIdTests.cs
@@ -33,7 +33,7 @@ public class GetQualificationByIdTests : IAsyncLifetime
     {
         // Arrange
         var person = await _dataScope.TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
                     .WithMandatoryQualification());
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
@@ -33,7 +33,7 @@ public class GetQualificationsByContactIdTests : IAsyncLifetime
     {
         // Arrange
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification()
             .WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue("959").WithSpecialism(MandatoryQualificationSpecialism.Visual)));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationEstablishmentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationEstablishmentTests.cs
@@ -23,7 +23,7 @@ public class UpdateMandatoryQualificationEstablishmentTests : IAsyncLifetime
         var newMqEstablishment = await _dataScope.TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5), teacherStatusValue: "213", createdDate: new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(originalMqEstablishmentValue)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
@@ -23,7 +23,7 @@ public class UpdateMandatoryQualificationSpecialismTests : IAsyncLifetime
         var newSpecialism = await _dataScope.TestData.ReferenceDataCache.GetMqSpecialismByValue(MandatoryQualificationSpecialism.Hearing.GetDqtValue());
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithSpecialism(originalSpecialism)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStartDateTests.cs
@@ -23,7 +23,7 @@ public class UpdateMandatoryQualificationStartDateTests : IAsyncLifetime
         var newStartDate = new DateOnly(2020, 11, 7);
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithStartDate(originalStartDate)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStatusTests.cs
@@ -29,7 +29,7 @@ public class UpdateMandatoryQualificationStatusTests : IAsyncLifetime
         DateOnly? newEndDate = !string.IsNullOrEmpty(newEndDateString) ? DateOnly.Parse(newEndDateString) : null;
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithStatus(originalMqStatus).WithEndDate(originalEndDate)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
@@ -16,7 +16,7 @@ public class MqTests : TestBase
     [Fact]
     public async Task AddMq()
     {
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
         var startDate = new DateOnly(2021, 3, 1);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -32,7 +32,7 @@ public class CheckAnswersTests : TestBase
     public async Task Get_WithPersonIdForValidPersonReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
@@ -65,7 +65,7 @@ public class CheckAnswersTests : TestBase
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState(MandatoryQualificationStatus status)
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
@@ -128,7 +128,7 @@ public class CheckAnswersTests : TestBase
     public async Task Post_Confirm_CompletesJourneyRedirectsWithFlashMessageAndCreatesMq(MandatoryQualificationStatus status)
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
         var specialism = MandatoryQualificationSpecialism.Hearing;
@@ -179,7 +179,7 @@ public class CheckAnswersTests : TestBase
     public async Task Post_Cancel_DeletesJourneyRedirectsAndDoesNotCreateMq()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ProviderTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ProviderTests.cs
@@ -31,7 +31,7 @@ public class ProviderTests : TestBase
     public async Task Get_WithPersonIdForValidPerson_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/provider?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -47,7 +47,7 @@ public class ProviderTests : TestBase
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var mqEstablishmentValue = "959"; // University of Leeds
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
@@ -95,7 +95,7 @@ public class ProviderTests : TestBase
     public async Task Post_WhenNoProviderIsSelected_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/provider?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -114,7 +114,7 @@ public class ProviderTests : TestBase
     public async Task Post_WhenProviderIsSelected_RedirectsToSpecialismPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var mqEstablishmentValue = "959"; // University of Leeds
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
@@ -31,7 +31,7 @@ public class SpecialismTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
-        var specialismValue = "Hearing";
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
@@ -99,8 +99,8 @@ public class SpecialismTests : TestBase
     public async Task Post_WhenSpecialismIsSelected_RedirectsToStartDatePage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var specialismValue = "Hearing";
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
@@ -30,8 +30,8 @@ public class SpecialismTests : TestBase
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var specialism = MandatoryQualificationSpecialism.Hearing;
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var specialismValue = "Hearing";
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
@@ -80,7 +80,7 @@ public class SpecialismTests : TestBase
     public async Task Post_WhenNoSpecialismIsSelected_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -100,7 +100,7 @@ public class SpecialismTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var specialism = MandatoryQualificationSpecialism.Hearing;
+        var specialismValue = "Hearing";
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StartDateTests.cs
@@ -30,7 +30,7 @@ public class StartDateTests : TestBase
     public async Task Get_WithPersonIdForValidPerson_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -46,7 +46,7 @@ public class StartDateTests : TestBase
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var startDate = new DateOnly(2021, 10, 5);
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
@@ -96,7 +96,7 @@ public class StartDateTests : TestBase
     public async Task Post_WhenNoStartDateIsEntered_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -115,7 +115,7 @@ public class StartDateTests : TestBase
     public async Task Post_WhenStartDateIsEntered_RedirectsToResultPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var startDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
@@ -30,7 +30,7 @@ public class StatusTests : TestBase
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(
@@ -62,7 +62,7 @@ public class StatusTests : TestBase
     public async Task Get_WithPersonIdForValidPerson_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -105,7 +105,7 @@ public class StatusTests : TestBase
     public async Task Post_WhenResultIsNotSelected_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -125,7 +125,7 @@ public class StatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var status = MandatoryQualificationStatus.Passed;
+        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -148,7 +148,7 @@ public class StatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var status = MandatoryQualificationStatus.Passed;
+        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
         var endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
@@ -124,8 +124,8 @@ public class StatusTests : TestBase
     public async Task Post_WhenResultIsPassedAndEndDateHasNotBeenEntered_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var status = MandatoryQualificationStatus.Passed;
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -147,8 +147,8 @@ public class StatusTests : TestBase
     public async Task Post_ValidRequest_RedirectsToResultPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
+        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
@@ -57,7 +57,7 @@ public class QualificationsTests : TestBase
         DateOnly? startDate = !string.IsNullOrEmpty(startDateString) ? DateOnly.Parse(startDateString) : null;
         DateOnly? endDate = !string.IsNullOrEmpty(endDateString) ? DateOnly.Parse(endDateString) : null;
         var person = await TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q
                 .WithDqtMqEstablishmentValue(providerValue)
                 .WithSpecialism(specialism)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
@@ -101,6 +101,97 @@ public class SeedCrmReferenceData : IStartupTask
             dfeta_name = "Qualified Teacher: QTS awarded in Wales",
             dfeta_QTSDateRequired = true
         });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "212",
+            dfeta_name = "Assessment only route candidate",
+            dfeta_QTSDateRequired = false
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "214",
+            dfeta_name = "Partial qualified teacher status",
+            dfeta_QTSDateRequired = false
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "211",
+            dfeta_name = "Trainee teacher",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "103",
+            dfeta_name = "Qualified Teacher: By virtue of overseas qualifications",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "104",
+            dfeta_name = "Qualified Teacher (by virtue of non-UK teaching qualifications)",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "206",
+            dfeta_name = "Qualified Teacher: Under temporary provision 2005/36/EC",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "223",
+            dfeta_name = "Qualified Teacher (by virtue of European teaching qualifications)",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "50",
+            dfeta_name = "Person not qualified for employment as a regular teacher whose employment as an Instructor is allowed under Regulation 18 of the Schools Regulations 1959",
+            dfeta_QTSDateRequired = false
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "67",
+            dfeta_name = "Qualified Teacher: Under the EC Directive",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "68",
+            dfeta_name = "Qualified Teacher: Teachers trained/registered in Scotland",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "69",
+            dfeta_name = "Qualified Teacher: Teachers trained/registered in Scotland",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "87",
+            dfeta_name = "Qualified teacher (under the EC Directive) further qualified to teach the deaf or partially hearing under Regulation 15(2) of the Special Schools and Handicapped Pupils Regulations 1959",
+            dfeta_QTSDateRequired = true
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_teacherstatus()
+        {
+            dfeta_Value = "28",
+            dfeta_name = "Qualified Teacher: Teacher trained/registered in Scotland, further qualified to teach the deaf or partially hearing impaired under Regulation 15(2) of the Special Schools and Handicapped Pupils Regulations 1959.",
+            dfeta_QTSDateRequired = true
+        });
     }
 
     private void AddEarlyYearsStatuses()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -35,7 +35,6 @@ public partial class TestData
         private bool? _hasNationalInsuranceNumber;
         private readonly List<MandatoryQualification> _mandatoryQualifications = new();
         private readonly List<QtsRegistration> _qtsRegistrations = new();
-        private string? _teacherStatus;
         private string? _earlyYearsStatus;
         private readonly List<Sanction> _sanctions = [];
         private readonly List<CreatePersonMandatoryQualificationBuilder> _mqBuilders = [];

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -35,7 +35,6 @@ public partial class TestData
         private bool? _hasNationalInsuranceNumber;
         private readonly List<MandatoryQualification> _mandatoryQualifications = new();
         private readonly List<QtsRegistration> _qtsRegistrations = new();
-        private string? _earlyYearsStatus;
         private readonly List<Sanction> _sanctions = [];
         private readonly List<CreatePersonMandatoryQualificationBuilder> _mqBuilders = [];
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -234,7 +234,7 @@ public partial class TestData
             txnRequestBuilder.AddRequest(new CreateRequest() { Target = contact });
 
             IInnerRequestHandle<RetrieveResponse>? getQtsRegistationTask = null;
-            var qts = _qtsRegistrations.Where(x => x.TeacherStatusValue != null);
+            var qts = _qtsRegistrations.Where(x => x.TeacherStatusValue != null && x.QtsDate != null);
             foreach (var item in qts)
             {
                 var teacherStatus = await testData.ReferenceDataCache.GetTeacherStatusByValue(item.TeacherStatusValue!);
@@ -266,6 +266,7 @@ public partial class TestData
                         Id = qtsRegistrationId,
                         dfeta_QTSDate = item.QtsDate!.Value.FromDateOnlyWithDqtBstFix(isLocalTime: true),
                         dfeta_TeacherStatusId = teacherStatus.Id.ToEntityReference(dfeta_teacherstatus.EntityLogicalName),
+                        CreatedOn = item.CreatedOn
                     }
                 });
 
@@ -276,7 +277,7 @@ public partial class TestData
                 });
             }
 
-            var eyts = _qtsRegistrations.Where(x => x.EytsStatusValue != null);
+            var eyts = _qtsRegistrations.Where(x => x.EytsStatusValue != null && x.EytsDate != null);
             IInnerRequestHandle<RetrieveResponse>? getEytsRegistationTask = null;
             foreach (var item in eyts)
             {
@@ -300,6 +301,7 @@ public partial class TestData
                         Id = eytsRegistrationId,
                         dfeta_EYTSDate = item.EytsDate!.Value.FromDateOnlyWithDqtBstFix(isLocalTime: true),
                         dfeta_EarlyYearsStatusId = earlyYearsStatus.Id.ToEntityReference(dfeta_earlyyearsstatus.EntityLogicalName),
+                        CreatedOn = item.CreatedOn
                     }
                 });
 
@@ -472,8 +474,7 @@ public partial class TestData
                 dfeta_MQ_Status = status?.GetDqtStatus()
                 QtsDate = getQtsRegistationTask != null ? getQtsRegistationTask.GetResponse().Entity.ToEntity<dfeta_qtsregistration>().dfeta_QTSDate.ToDateOnlyWithDqtBstFix(true) : null,
                 EytsDate = getEytsRegistationTask != null ? getEytsRegistationTask.GetResponse().Entity.ToEntity<dfeta_qtsregistration>().dfeta_EYTSDate.ToDateOnlyWithDqtBstFix(true) : null,
-                Sanctions = _sanctions.ToImmutableArray()
-
+                Sanctions = _sanctions.ToImmutableArray(),
                 MandatoryQualifications = _mandatoryQualifications.ToImmutableArray()
             };
 

--- a/crm_attributes.json
+++ b/crm_attributes.json
@@ -166,6 +166,7 @@
     "statecode"
   ],
   "dfeta_qtsregistration": [
+    "createdon",
     "dfeta_earlyyearsstatusid",
     "dfeta_eytsdate",
     "dfeta_inductionid",


### PR DESCRIPTION
Add a StatusDescription property to both the Qts and Eyts blocks on the API.

https://trello.com/c/WbNK62Jp/342-add-teacher-status-and-eyts-status-to-api

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
