### PR TITLE
Amend Event schema to more easily track PersonId and source UserId

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
@@ -24,7 +24,7 @@ public class UserMapping : IEntityTypeConfiguration<User>
     {
         yield return new()
         {
-            UserId = Guid.Parse("a81394d1-a498-46d8-af3e-e077596ab303"),
+            UserId = User.SystemUserId,
             UserType = UserType.Application,
             Name = "System",
             Active = true,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231207135313_SourceUserIdEventSchema.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231207135313_SourceUserIdEventSchema.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231207135313_SourceUserIdEventSchema")]
+    partial class SourceUserIdEventSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231207135313_SourceUserIdEventSchema.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231207135313_SourceUserIdEventSchema.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SourceUserIdEventSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                update events set
+                payload = jsonb_set(payload, array['SourceUserId'], to_jsonb(payload->>'ActivatedByUserId'::text), true) - 'ActivatedByUserId'
+                where event_name = 'UserActivatedEvent'
+                and payload->>'SourceUserId' is null;
+
+                update events set
+                payload = jsonb_set(payload, array['SourceUserId'], to_jsonb(payload->>'AddedByUserId'::text), true) - 'AddedByUserId'
+                where event_name = 'UserAddedEvent'
+                and payload->>'SourceUserId' is null;
+
+                update events set
+                payload = jsonb_set(payload, array['SourceUserId'], to_jsonb(payload->>'DeactivatedByUserId'::text), true) - 'DeactivatedByUserId' - 'Changes'
+                where event_name = 'UserDeactivatedEvent'
+                and payload->>'SourceUserId' is null;
+                
+                update events set
+                payload = jsonb_set(payload, array['SourceUserId'], to_jsonb(payload->>'UpdatedByUserId'::text), true) - 'UpdatedByUserId'
+                where event_name = 'UserUpdatedEvent'
+                and payload->>'SourceUserId' is null;
+
+                update events set
+                payload = jsonb_set(payload, array['SourceUserId'], to_jsonb('a81394d1-a498-46d8-af3e-e077596ab303'::text), true)
+                where event_name in ('EytsAwardedEmailSentEvent', 'QtsAwardedEmailSentEvent', 'InductionCompletedEmailSentEvent', 'InternationalQtsAwardedEmailSentEvent')
+                and payload->>'SourceUserId' is null;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                update events set
+                payload = payload - 'SourceUserId'
+                where event_name in ('EytsAwardedEmailSentEvent', 'QtsAwardedEmailSentEvent', 'InductionCompletedEmailSentEvent', 'InternationalQtsAwardedEmailSentEvent')
+                and payload->>'SourceUserId' is not null;
+
+                update events set
+                payload = (payload || jsonb_build_object('UpdatedByUserId', payload->>'SourceUserId')) - 'SourceUserId'
+                where event_name = 'UserUpdatedEvent'
+                and payload->>'SourceUserId' is not null;
+
+                update events set
+                payload = (payload || jsonb_build_object('Changes', 0) || jsonb_build_object('DeactivatedByUserId', payload->>'SourceUserId')) - 'SourceUserId'
+                where event_name = 'UserDeactivatedEvent'
+                and payload->>'SourceUserId' is not null;
+                
+                update events set
+                payload = (payload || jsonb_build_object('AddedByUserId', payload->>'SourceUserId')) - 'SourceUserId'
+                where event_name = 'UserAddedEvent'
+                and payload->>'SourceUserId' is not null;
+
+                update events set
+                payload = (payload || jsonb_build_object('ActivatedByUserId', payload->>'SourceUserId')) - 'SourceUserId'
+                where event_name = 'UserActivatedEvent'
+                and payload->>'SourceUserId' is not null;
+                """);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -4,6 +4,8 @@ public class User
 {
     public const int NameMaxLength = 200;
 
+    public static Guid SystemUserId { get; } = new Guid("a81394d1-a498-46d8-af3e-e077596ab303");
+
     public required Guid UserId { get; init; }
     public required bool Active { get; set; }
     public required UserType UserType { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
@@ -3,4 +3,5 @@ namespace TeachingRecordSystem.Core.Events;
 public abstract record EventBase
 {
     public required DateTime CreatedUtc { get; init; }
+    public required Guid SourceUserId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EytsAwardedEmailSentEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EytsAwardedEmailSentEvent.cs
@@ -1,8 +1,8 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record EytsAwardedEmailSentEvent : EventBase
+public record EytsAwardedEmailSentEvent : EventBase, IEventWithPersonId
 {
-    public required Guid EytsAwardedEmailsJobId { get; set; }
-    public required Guid PersonId { get; set; }
-    public required string EmailAddress { get; set; }
+    public required Guid EytsAwardedEmailsJobId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string EmailAddress { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithPersonId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithPersonId.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public interface IEventWithPersonId
+{
+    Guid PersonId { get; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InductionCompletedEmailSentEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InductionCompletedEmailSentEvent.cs
@@ -1,8 +1,8 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record InductionCompletedEmailSentEvent : EventBase
+public record InductionCompletedEmailSentEvent : EventBase, IEventWithPersonId
 {
-    public required Guid InductionCompletedEmailsJobId { get; set; }
-    public required Guid PersonId { get; set; }
-    public required string EmailAddress { get; set; }
+    public required Guid InductionCompletedEmailsJobId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string EmailAddress { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InternationalQtsAwardedEmailSentEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InternationalQtsAwardedEmailSentEvent.cs
@@ -1,8 +1,8 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record InternationalQtsAwardedEmailSentEvent : EventBase
+public record InternationalQtsAwardedEmailSentEvent : EventBase, IEventWithPersonId
 {
-    public required Guid InternationalQtsAwardedEmailsJobId { get; set; }
-    public required Guid PersonId { get; set; }
-    public required string EmailAddress { get; set; }
+    public required Guid InternationalQtsAwardedEmailsJobId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string EmailAddress { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/QtsAwardedEmailSentEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/QtsAwardedEmailSentEvent.cs
@@ -1,8 +1,8 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record QtsAwardedEmailSentEvent : EventBase
+public record QtsAwardedEmailSentEvent : EventBase, IEventWithPersonId
 {
-    public required Guid QtsAwardedEmailsJobId { get; set; }
-    public required Guid PersonId { get; set; }
-    public required string EmailAddress { get; set; }
+    public required Guid QtsAwardedEmailsJobId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string EmailAddress { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserActivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserActivatedEvent.cs
@@ -2,8 +2,5 @@ namespace TeachingRecordSystem.Core.Events;
 
 public record UserActivatedEvent : EventBase
 {
-
     public required User User { get; init; }
-
-    public required Guid ActivatedByUserId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserAddedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserAddedEvent.cs
@@ -3,5 +3,4 @@ namespace TeachingRecordSystem.Core.Events;
 public record UserAddedEvent : EventBase
 {
     public required User User { get; init; }
-    public required Guid AddedByUserId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
@@ -3,14 +3,4 @@ namespace TeachingRecordSystem.Core.Events;
 public record UserDeactivatedEvent : EventBase
 {
     public required User User { get; init; }
-
-    public required Guid DeactivatedByUserId { get; init; }
-
-    public required UserDeactivatedEventChanges Changes { get; init; }
-}
-
-[Flags]
-public enum UserDeactivatedEventChanges
-{
-    Deactivated = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserUpdatedEvent.cs
@@ -3,7 +3,6 @@ namespace TeachingRecordSystem.Core.Events;
 public record UserUpdatedEvent : EventBase
 {
     public required User User { get; init; }
-    public required Guid UpdatedByUserId { get; init; }
     public required UserUpdatedEventChanges Changes { get; init; }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendEytsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendEytsAwardedEmailJob.cs
@@ -58,6 +58,7 @@ public class SendEytsAwardedEmailJob
             PersonId = personId,
             EmailAddress = item.EmailAddress,
             CreatedUtc = _clock.UtcNow,
+            SourceUserId = DataStore.Postgres.Models.User.SystemUserId
         });
 
         await _dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
@@ -58,6 +58,7 @@ public class SendInductionCompletedEmailJob
             PersonId = personId,
             EmailAddress = item.EmailAddress,
             CreatedUtc = _clock.UtcNow,
+            SourceUserId = DataStore.Postgres.Models.User.SystemUserId
         });
 
         await _dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInternationalQtsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInternationalQtsAwardedEmailJob.cs
@@ -58,6 +58,7 @@ public class SendInternationalQtsAwardedEmailJob
             PersonId = personId,
             EmailAddress = item.EmailAddress,
             CreatedUtc = _clock.UtcNow,
+            SourceUserId = DataStore.Postgres.Models.User.SystemUserId
         });
 
         await _dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendQtsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendQtsAwardedEmailJob.cs
@@ -58,6 +58,7 @@ public class SendQtsAwardedEmailJob
             PersonId = personId,
             EmailAddress = item.EmailAddress,
             CreatedUtc = _clock.UtcNow,
+            SourceUserId = DataStore.Postgres.Models.User.SystemUserId
         });
 
         await _dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
@@ -86,7 +86,7 @@ public class ConfirmModel : PageModel
         _dbContext.AddEvent(new UserAddedEvent()
         {
             User = Core.Events.User.FromModel(newUser),
-            AddedByUserId = User.GetUserId(),
+            SourceUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow
         });
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
@@ -103,7 +103,7 @@ public class EditUser : PageModel
         _dbContext.AddEvent(new UserUpdatedEvent
         {
             User = Core.Events.User.FromModel(user),
-            UpdatedByUserId = User.GetUserId(),
+            SourceUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow,
             Changes = changes
         });
@@ -129,9 +129,8 @@ public class EditUser : PageModel
         _dbContext.AddEvent(new UserDeactivatedEvent
         {
             User = Core.Events.User.FromModel(user),
-            DeactivatedByUserId = User.GetUserId(),
-            CreatedUtc = _clock.UtcNow,
-            Changes = UserDeactivatedEventChanges.Deactivated
+            SourceUserId = User.GetUserId(),
+            CreatedUtc = _clock.UtcNow
         });
 
         await _dbContext.SaveChangesAsync();
@@ -154,7 +153,7 @@ public class EditUser : PageModel
         _dbContext.AddEvent(new UserActivatedEvent
         {
             User = Core.Events.User.FromModel(user),
-            ActivatedByUserId = User.GetUserId(),
+            SourceUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow
         });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
@@ -99,7 +99,8 @@ public class PublishEventsBackgroundServiceTests : IAsyncLifetime
     private EventBase CreateDummyEvent() => new DummyEvent()
     {
         DummyProperty = Faker.Name.FullName(),
-        CreatedUtc = TestableClock.Initial.ToUniversalTime()
+        CreatedUtc = TestableClock.Initial.ToUniversalTime(),
+        SourceUserId = DataStore.Postgres.Models.User.SystemUserId
     };
 
     private class TestableEventObserver : IEventObserver

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
@@ -246,7 +246,7 @@ public class ConfirmTests : TestBase
         {
             var userCreatedEvent = Assert.IsType<UserAddedEvent>(e);
             Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
-            Assert.Equal(userCreatedEvent.AddedByUserId, GetCurrentUserId());
+            Assert.Equal(userCreatedEvent.SourceUserId, GetCurrentUserId());
             Assert.Equal(UserType.Person, userCreatedEvent.User.UserType);
             Assert.Equal(newName, userCreatedEvent.User.Name);
             Assert.Equal(email, userCreatedEvent.User.Email);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
@@ -194,7 +194,7 @@ public class EditUserTests : TestBase
             {
                 var userCreatedEvent = Assert.IsType<UserUpdatedEvent>(e);
                 Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
-                Assert.Equal(userCreatedEvent.UpdatedByUserId, GetCurrentUserId());
+                Assert.Equal(userCreatedEvent.SourceUserId, GetCurrentUserId());
                 Assert.Equal(UserType.Person, userCreatedEvent.User.UserType);
                 Assert.Equal(newName, userCreatedEvent.User.Name);
                 Assert.Equal(updatedUser.Email, userCreatedEvent.User.Email);
@@ -247,9 +247,8 @@ public class EditUserTests : TestBase
         {
             var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
             Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
-            Assert.Equal(userCreatedEvent.DeactivatedByUserId, GetCurrentUserId());
+            Assert.Equal(userCreatedEvent.SourceUserId, GetCurrentUserId());
             Assert.Equal(UserType.Person, userCreatedEvent.User.UserType);
-            Assert.Equal(UserDeactivatedEventChanges.Deactivated, userCreatedEvent.Changes);
         });
 
         var redirectResponse = await response.FollowRedirect(HttpClient);
@@ -295,7 +294,7 @@ public class EditUserTests : TestBase
         {
             var userCreatedEvent = Assert.IsType<UserActivatedEvent>(e);
             Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
-            Assert.Equal(userCreatedEvent.ActivatedByUserId, GetCurrentUserId());
+            Assert.Equal(userCreatedEvent.SourceUserId, GetCurrentUserId());
             Assert.Equal(UserType.Person, userCreatedEvent.User.UserType);
         });
 


### PR DESCRIPTION
We need to be able to efficiently query all events for a given `person ID`. This introduces an interface - `IEventWithPersonId` - to ensure that we consistently name the `person ID` property the same way so we can easily do that query.

In addition this adds a `SourceUserId` property to `EventBase` so we're always tracking the ID of the user who generated the event consistently. This is for the same reason as above; in our event queries we want to join to the `users` table so we can pull back the information of the user who caused the event and that's more-easily done if it's always named the same thing.