### PR TITLE
Handle multiple updates for the same record in a change batch

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/ICrmEntityChangesService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Services/CrmEntityChanges/ICrmEntityChangesService.cs
@@ -12,5 +12,6 @@ public interface ICrmEntityChangesService
         ColumnSet columns,
         DateTime? modifiedSince,
         int pageSize = 1000,
+        bool rollUpChanges = true,
         CancellationToken cancellationToken = default);
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/Services/DqtReporting/DqtReportingFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/Services/DqtReporting/DqtReportingFixture.cs
@@ -20,16 +20,16 @@ public class DqtReportingFixture
         migrator.MigrateDb();
     }
 
-    public IClock Clock => _crmClientFixture.Clock;
+    public TestableClock Clock => _crmClientFixture.Clock;
 
     public string ReportingDbConnectionString { get; }
 
-    public Task PublishChangedItemAndConsume(IChangedItem changedItem) =>
+    public Task PublishChangedItemsAndConsume(params IChangedItem[] changedItems) =>
         WithService(async (service, changesObserver) =>
         {
             await service.LoadEntityMetadata();
 
-            changesObserver.OnNext(new IChangedItem[] { changedItem });
+            changesObserver.OnNext(changedItems);
             var processTask = service.ProcessChangesForEntityType(Contact.EntityLogicalName, CancellationToken.None);
             changesObserver.OnCompleted();
             await processTask;
@@ -40,7 +40,7 @@ public class DqtReportingFixture
         var options = Options.Create(new DqtReportingOptions()
         {
             CrmConnectionString = "dummy",
-            Entities = new[] { Contact.EntityLogicalName },
+            Entities = [Contact.EntityLogicalName],
             PollIntervalSeconds = 60,
             ProcessAllEntityTypesConcurrently = false,
             ReportingDbConnectionString = ReportingDbConnectionString,


### PR DESCRIPTION
Neither the `TrsDataSyncHelper` nor `DqtReportingService` can handle receiving multiple updates for the same record in a batch. Incredibly this hasn't happened yet but it's feasible that it could, especially with how chatty some of the old integration jobs are.

This change adds a `rollUpChanges` parameter to the `CrmEntityChangesService`. When this is set, it will only return the most recent update for given record to the consumer.

I've made this a parameter rather than having it happen all the time as it's possible we will have future consumers that want to see every change (e.g. if we're creating a log of changes). In such cases we don't want this roll up behaviour.