### PR TITLE
Fix lifetime of CrmQueryDispatcher and query handlers

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
@@ -10,9 +10,9 @@ public static partial class ServiceCollectionExtensions
             .FromAssembliesOf(typeof(ICrmQuery<>))
             .AddClasses(classes => classes.AssignableTo(typeof(ICrmQueryHandler<,>)))
                 .AsImplementedInterfaces()
-                .WithSingletonLifetime());
+                .WithTransientLifetime());
 
-        services.AddSingleton<ICrmQueryDispatcher, CrmQueryDispatcher>();
+        services.AddTransient<ICrmQueryDispatcher, CrmQueryDispatcher>();
 
         return services;
     }


### PR DESCRIPTION
The `CrmQueryDispatcher` and `ICrmQueryHandler<,>` registrations were all `Singleton`, but they rely on a transient `IOrganizationServiceAsync`. `IOrganizationServiceAsync` ends up coming from the root `IServiceProvider` and never gets disposed.