### PR TITLE
Use a scope per query in CrmQueryDispatcher

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmQueryDispatcher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmQueryDispatcher.cs
@@ -14,10 +14,12 @@ public class CrmQueryDispatcher : ICrmQueryDispatcher
 
     public async Task<TResult> ExecuteQuery<TResult>(ICrmQuery<TResult> query)
     {
-        var organizationService = _serviceProvider.GetRequiredService<IOrganizationServiceAsync>();
+        using var scope = _serviceProvider.CreateScope();
+
+        var organizationService = scope.ServiceProvider.GetRequiredService<IOrganizationServiceAsync>();
 
         var handlerType = typeof(ICrmQueryHandler<,>).MakeGenericType(query.GetType(), typeof(TResult));
-        var handler = _serviceProvider.GetRequiredService(handlerType);
+        var handler = scope.ServiceProvider.GetRequiredService(handlerType);
 
         var wrapperHandlerType = typeof(QueryHandler<,>).MakeGenericType(query.GetType(), typeof(TResult));
         var wrappedHandler = (QueryHandler<TResult>)Activator.CreateInstance(wrapperHandlerType, handler)!;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static partial class ServiceCollectionExtensions
                 .AsImplementedInterfaces()
                 .WithTransientLifetime());
 
-        services.AddTransient<ICrmQueryDispatcher, CrmQueryDispatcher>();
+        services.AddSingleton<ICrmQueryDispatcher, CrmQueryDispatcher>();
 
         return services;
     }


### PR DESCRIPTION
The previous change made `CrmQueryDispatcher` transient, assuming that it will be resolved from an `IServiceScope`'s `IServiceProvider` and `Dispose()`ed shortly afterwards, along with the `IOrganizationServiceAsync`. However, we have some background services like `DqtReportingService` that are long-running and so effectively still end up with a singleton `IOrganizationServiceAsync`.

This change flips `CrmQueryDispatcher` back to be `Singleton` but amends its implementation to create a new `IServiceScope` for every `ExecuteQuery()` call. This effectively guarantees that the `IOrganizationServiceAsync` will be short-lived and will be `Dispose()`ed.