### PR TITLE
Move event serializer options onto EventBase

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
@@ -5,8 +5,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class Event
 {
-    public static JsonSerializerOptions JsonSerializerOptions { get; } = new();
-
     public long EventId { get; }
     public required string EventName { get; init; }
     public required DateTime Created { get; init; }
@@ -16,7 +14,7 @@ public class Event
     public static Event FromEventBase(EventBase @event)
     {
         var eventName = @event.GetType().Name;
-        var payload = JsonSerializer.Serialize(@event, inputType: @event.GetType(), JsonSerializerOptions);
+        var payload = JsonSerializer.Serialize(@event, inputType: @event.GetType(), EventBase.JsonSerializerOptions);
 
         return new Event()
         {
@@ -32,6 +30,6 @@ public class Event
         var eventType = Type.GetType(eventTypeName) ??
             throw new Exception($"Could not find event type '{eventTypeName}'.");
 
-        return (EventBase)JsonSerializer.Deserialize(Payload, eventType, JsonSerializerOptions)!;
+        return (EventBase)JsonSerializer.Deserialize(Payload, eventType, EventBase.JsonSerializerOptions)!;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EventInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EventInfo.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 
 namespace TeachingRecordSystem.Core;
@@ -97,7 +96,7 @@ file class EventInfoJsonConverter : JsonConverter<EventInfo>
                     throw new JsonException();
                 }
 
-                var @event = JsonSerializer.Deserialize(ref reader, eventType, Event.JsonSerializerOptions);
+                var @event = JsonSerializer.Deserialize(ref reader, eventType, EventBase.JsonSerializerOptions);
 
                 reader.Read();
 
@@ -118,7 +117,7 @@ file class EventInfoJsonConverter : JsonConverter<EventInfo>
         writer.WritePropertyName("EventTypeName");
         writer.WriteStringValue(eventTypeName);
         writer.WritePropertyName("Event");
-        JsonSerializer.Serialize(writer, value.Event, eventType, Event.JsonSerializerOptions);
+        JsonSerializer.Serialize(writer, value.Event, eventType, EventBase.JsonSerializerOptions);
         writer.WriteEndObject();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
@@ -1,7 +1,11 @@
+using System.Text.Json;
+
 namespace TeachingRecordSystem.Core.Events;
 
 public abstract record EventBase
 {
+    public static JsonSerializerOptions JsonSerializerOptions { get; } = new();
+
     public required DateTime CreatedUtc { get; init; }
     public required Guid SourceUserId { get; init; }
 }


### PR DESCRIPTION
Serializer options make more sense on `EventBase` than on the EF model.