### PR TITLE
Add DB schema for MQs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Requests/SetNpqQualificationRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Requests/SetNpqQualificationRequest.cs
@@ -3,7 +3,6 @@ using System.ComponentModel.DataAnnotations;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
-using TeachingRecordSystem.Api.V2.ApiModels;
 
 namespace TeachingRecordSystem.Api.V2.Requests;
 
@@ -17,5 +16,5 @@ public class SetNpqQualificationRequest : IRequest
     public string Trn { get; set; }
 
     [Required]
-    public QualificationType? QualificationType { get; set; }
+    public ApiModels.QualificationType? QualificationType { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.CreateAdmin.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.CreateAdmin.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.Cli;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationMapping.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class MandatoryQualificationMapping : IEntityTypeConfiguration<MandatoryQualification>
+{
+    public void Configure(EntityTypeBuilder<MandatoryQualification> builder)
+    {
+        builder.Property(q => q.Specialism).HasColumnName("mq_specialism");
+        builder.Property(q => q.Status).HasColumnName("mq_status");
+        builder.Property(q => q.StartDate).HasColumnName("start_date");
+        builder.Property(q => q.EndDate).HasColumnName("end_date");
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class QualificationMapping : IEntityTypeConfiguration<Qualification>
+{
+    public void Configure(EntityTypeBuilder<Qualification> builder)
+    {
+        builder.ToTable("qualifications");
+        builder.HasKey(q => q.QualificationId);
+        builder.HasQueryFilter(q => EF.Property<DateTime?>(q, nameof(Qualification.DeletedOn)) != null);
+        builder.HasDiscriminator(q => q.QualificationType)
+            .HasValue<MandatoryQualification>(QualificationType.MandatoryQualification);
+        builder.HasOne<Person>().WithMany().HasForeignKey(q => q.PersonId).HasConstraintName("fk_qualifications_person");
+        builder.HasOne<User>().WithMany().HasForeignKey(q => q.CreatedByUserId).HasConstraintName("fk_qualifications_created_by");
+        builder.HasOne<User>().WithMany().HasForeignKey(q => q.UpdatedByUserId).HasConstraintName("fk_qualifications_updated_by");
+        builder.HasOne<User>().WithMany().HasForeignKey(q => q.DeletedByUserId).HasConstraintName("fk_qualifications_deleted_by");
+        builder.HasIndex(q => q.PersonId);
+        builder.HasIndex(q => q.DqtQualificationId).HasFilter("dqt_qualification_id is not null").IsUnique();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231208121135_MqQualifications.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231208121135_MqQualifications.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231208121135_MqQualifications")]
+    partial class MqQualifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231208121135_MqQualifications.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231208121135_MqQualifications.cs
@@ -1,0 +1,87 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class MqQualifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "qualifications",
+                columns: table => new
+                {
+                    qualification_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_by_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_by_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    updated_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    deleted_by_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    deleted_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    qualification_type = table.Column<int>(type: "integer", nullable: false),
+                    person_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    dqt_qualification_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    dqt_first_sync = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    dqt_last_sync = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    dqt_state = table.Column<int>(type: "integer", nullable: true),
+                    dqt_created_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    dqt_modified_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    mq_specialism = table.Column<int>(type: "integer", nullable: true),
+                    mq_status = table.Column<int>(type: "integer", nullable: true),
+                    start_date = table.Column<DateOnly>(type: "date", nullable: true),
+                    end_date = table.Column<DateOnly>(type: "date", nullable: true),
+                    dqt_mq_establishment_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    dqt_specialism_id = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_qualifications", x => x.qualification_id);
+                    table.ForeignKey(
+                        name: "fk_qualifications_created_by",
+                        column: x => x.created_by_user_id,
+                        principalTable: "users",
+                        principalColumn: "user_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_qualifications_deleted_by",
+                        column: x => x.deleted_by_user_id,
+                        principalTable: "users",
+                        principalColumn: "user_id");
+                    table.ForeignKey(
+                        name: "fk_qualifications_person",
+                        column: x => x.person_id,
+                        principalTable: "persons",
+                        principalColumn: "person_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_qualifications_updated_by",
+                        column: x => x.updated_by_user_id,
+                        principalTable: "users",
+                        principalColumn: "user_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_qualifications_dqt_qualification_id",
+                table: "qualifications",
+                column: "dqt_qualification_id",
+                unique: true,
+                filter: "dqt_qualification_id is not null");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_qualifications_person_id",
+                table: "qualifications",
+                column: "person_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "qualifications");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -1,0 +1,13 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class MandatoryQualification : Qualification
+{
+    // TODO Add Provider here when we've figured out how to model MQ Providers
+    public MandatoryQualificationSpecialism? Specialism { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
+    public DateOnly? StartDate { get; set; }
+    public DateOnly? EndDate { get; set; }
+
+    public Guid? DqtMqEstablishmentId { get; set; }
+    public Guid? DqtSpecialismId { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
@@ -1,0 +1,21 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public abstract class Qualification
+{
+    public required Guid QualificationId { get; init; }
+    public required Guid CreatedByUserId { get; init; }
+    public required DateTime CreatedOn { get; init; }
+    public required Guid UpdatedByUserId { get; set; }
+    public required DateTime UpdatedOn { get; set; }
+    public Guid? DeletedByUserId { get; set; }
+    public DateTime? DeletedOn { get; set; }
+    public QualificationType QualificationType { get; }
+    public required Guid PersonId { get; init; }
+
+    public Guid? DqtQualificationId { get; set; }
+    public DateTime? DqtFirstSync { get; set; }
+    public DateTime? DqtLastSync { get; set; }
+    public int? DqtState { get; set; }
+    public DateTime? DqtCreatedOn { get; set; }
+    public DateTime? DqtModifiedOn { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 using User = TeachingRecordSystem.Core.DataStore.Postgres.Models.User;
@@ -43,6 +44,10 @@ public class TrsDbContext : DbContext
 
     public DbSet<Person> Persons => Set<Person>();
 
+    public DbSet<Qualification> Qualifications => Set<Qualification>();
+
+    public DbSet<MandatoryQualification> MandatoryQualifications => Set<MandatoryQualification>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString)
     {
         if (connectionString != null)
@@ -61,6 +66,11 @@ public class TrsDbContext : DbContext
     public void AddEvent(EventBase @event)
     {
         Events.Add(Event.FromEventBase(@event));
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder.Conventions.Remove<ForeignKeyIndexConvention>();
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumExtensions.cs
@@ -9,7 +9,7 @@ public static class EnumExtensions
     {
         var displayAttribute = enumValue.GetType()
           .GetMember(enumValue.ToString())
-          .First()
+          .Single()
           .GetCustomAttribute<DisplayAttribute>();
 
         return displayAttribute is null ? enumValue.ToString() : displayAttribute.GetName();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationSpecialism.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationSpecialism.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace TeachingRecordSystem.Core.Models;
+
+public enum MandatoryQualificationSpecialism
+{
+    [MandatoryQualificationInfo(isValidForNewRecord: false), Display(Name = "Auditory")]
+    Auditory = 0,
+
+    [MandatoryQualificationInfo, Display(Name = "Deaf education")]
+    DeafEducation = 1,
+
+    [MandatoryQualificationInfo, Display(Name = "Hearing")]
+    Hearing = 2,
+
+    [MandatoryQualificationInfo, Display(Name = "Multi-Sensory")]
+    MultiSensory = 3,
+
+    [MandatoryQualificationInfo, Display(Name = "N/A")]
+    NotApplicable = 4,
+
+    [MandatoryQualificationInfo, Display(Name = "Visual")]
+    Visual = 5,
+}
+
+public static class MandatoryQualificationSpecialismExtensions
+{
+    public static bool IsValidForNewRecord(this MandatoryQualificationSpecialism specialism) =>
+        specialism.GetType()
+            .GetMember(specialism.ToString())
+            .Single()
+            .GetCustomAttribute<MandatoryQualificationInfoAttribute>()?
+            .IsValidForNewRecord == true;
+}
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+file sealed class MandatoryQualificationInfoAttribute(bool isValidForNewRecord = true) : Attribute
+{
+    public bool IsValidForNewRecord => isValidForNewRecord;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationStatus.cs
@@ -1,0 +1,11 @@
+namespace TeachingRecordSystem.Core.Models;
+
+public enum MandatoryQualificationStatus
+{
+    InProgress = 0,
+    Passed = 1,
+    Deferred = 2,
+    Extended = 3,
+    Failed = 4,
+    Withdrawn = 5,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/QualificationType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/QualificationType.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Models;
+
+public enum QualificationType
+{
+    MandatoryQualification = 0
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/UserType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/UserType.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Core;
+namespace TeachingRecordSystem.Core.Models;
 
 public enum UserType
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Usings.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Usings.cs
@@ -1,2 +1,3 @@
 global using TeachingRecordSystem.Core.Dqt.Models;
+global using TeachingRecordSystem.Core.Models;
 global using CrmTask = TeachingRecordSystem.Core.Dqt.Models.Task;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Usings.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Usings.cs
@@ -1,5 +1,6 @@
 global using FormFlow;
 global using TeachingRecordSystem.Core;
 global using TeachingRecordSystem.Core.Dqt;
+global using TeachingRecordSystem.Core.Models;
 global using ColumnSet = Microsoft.Xrm.Sdk.Query.ColumnSet;
 global using CrmTask = TeachingRecordSystem.Core.Dqt.Models.Task;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/SetNpqQualificationTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/SetNpqQualificationTests.cs
@@ -1,7 +1,6 @@
 #nullable disable
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.Tests.Attributes;
-using TeachingRecordSystem.Api.V2.ApiModels;
 using TeachingRecordSystem.Api.V2.Requests;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
@@ -154,7 +153,7 @@ public class SetNpqQualificationTests : ApiTestBase
         // Act
         var response = await HttpClientWithApiKey.PutAsync(
             $"v2/npq-qualifications?trn={trn}",
-            CreateRequest(req => req.QualificationType = (QualificationType)(-1)));
+            CreateRequest(req => req.QualificationType = (TeachingRecordSystem.Api.V2.ApiModels.QualificationType)(-1)));
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/EventInfoTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/EventInfoTests.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.Core.Events;
+using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.Core.Tests;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestUsers.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestUsers.cs
@@ -1,6 +1,7 @@
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Usings.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Usings.cs
@@ -1,4 +1,5 @@
 global using Moq;
 global using TeachingRecordSystem.Core;
+global using TeachingRecordSystem.Core.Models;
 global using TeachingRecordSystem.TestCommon;
 global using Xunit;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateUser.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.TestCommon;
 


### PR DESCRIPTION
This adds a base `Qualification` entity plus a derived `MandatoryQualification` entity. Properties for both are mapped to a single `qualifications` table in Postgres. I've omitted the MQ Provider property for now until we know more about how it will be modelled.

As part of this I've introduced a top-level `Models` namespace within the `Core` project for enums to live. From there we can re-use them in EF Models, Events, API responses etc.

I've also removed the EF convention that automatically creates indexes for FKs; that results in too many un-needed indexes particularly on the `{Created|Updated|Deleted}ByUserId` columns.