### PR TITLE
Fix sign out when user has no roles

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckUserExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckUserExistsFilter.cs
@@ -11,7 +11,7 @@ public class CheckUserExistsFilter : IAsyncResourceFilter, IOrderedFilter
     {
         var user = context.HttpContext.User;
 
-        if (user.Identity?.IsAuthenticated == true && !user.IsActiveTrsUser())
+        if (user.Identity?.IsAuthenticated == true && !user.IsActiveTrsUser() && context.HttpContext.Request.Path != "/sign-out")
         {
             var viewResult = new ViewResult()
             {


### PR DESCRIPTION
The filter that shows the 'You have no roles' message is preventing people from signing out.