### PR TITLE
Delete MQ CRM query changes, UI and tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/DeleteQualificationQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/DeleteQualificationQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record DeleteQualificationQuery(Guid QualificationId, string SerializedEvent) : ICrmQuery<bool>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/DeleteQualificationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/DeleteQualificationHandler.cs
@@ -1,0 +1,23 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class DeleteQualificationHandler : ICrmQueryHandler<DeleteQualificationQuery, bool>
+{
+    public async Task<bool> Execute(DeleteQualificationQuery query, IOrganizationServiceAsync organizationService)
+    {
+        await organizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new dfeta_qualification()
+            {
+                Id = query.QualificationId,
+                StateCode = dfeta_qualificationState.Inactive,
+                dfeta_TrsDeletedEvent = query.SerializedEvent
+            }
+        });
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -11,4 +11,5 @@ public static class JourneyNames
     public const string EditMqSpecialism = nameof(EditMqSpecialism);
     public const string EditMqStartDate = nameof(EditMqStartDate);
     public const string EditMqResult = nameof(EditMqResult);
+    public const string DeleteMq = nameof(DeleteMq);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml
@@ -1,0 +1,54 @@
+@page "/mqs/{qualificationId}/delete/confirm/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq.ConfirmModel
+@{
+    ViewBag.Title = "Delete qualification";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.MqDelete(Model.QualificationId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+}
+
+<span class="govuk-caption-l">Delete qualification - @Model.PersonName</span>
+<h1 class="govuk-heading-l" data-testid="title">Confirm deletion of mandatory qualification</h1>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.MqDeleteConfirm(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-summary-list data-testid="deletion-summary">
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Reason for deleting</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="deletion-reason">@Model.DeletionReason!.GetDisplayName()</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>More detail about the reason for deleting</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="deletion-reason-detail">@(!string.IsNullOrEmpty(Model.DeletionReasonDetail) ? Model.DeletionReasonDetail : "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="provider">@(!string.IsNullOrEmpty(Model.TrainingProvider) ? Model.TrainingProvider : "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Specialism</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="specialism">@(!string.IsNullOrEmpty(Model.Specialism) ? Model.Specialism : "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>                
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="status">@(Model.Status.HasValue ? Model.Status : "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>                
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="start-date">@(Model.StartDate.HasValue ? Model.StartDate.Value.ToString("d MMMM yyyy") : "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="end-date">@(Model.EndDate.HasValue ? Model.EndDate.Value.ToString("d MMMM yyyy") : "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <div class="govuk-button-group">
+                <govuk-button class="govuk-button--warning" type="submit">Delete qualification</govuk-button>
+                <govuk-button formaction="@LinkGenerator.MqDeleteConfirmCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+[Journey(JourneyNames.DeleteMq), RequireJourneyInstance]
+public class ConfirmModel : PageModel
+{
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+    private readonly TrsLinkGenerator _linkGenerator;
+
+    public ConfirmModel(
+        ICrmQueryDispatcher crmQueryDispatcher,
+        TrsLinkGenerator linkGenerator)
+    {
+        _crmQueryDispatcher = crmQueryDispatcher;
+        _linkGenerator = linkGenerator;
+    }
+
+    public JourneyInstance<DeleteMqState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid QualificationId { get; set; }
+
+    public Guid? PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public string? TrainingProvider { get; set; }
+
+    public string? Specialism { get; set; }
+
+    public dfeta_qualification_dfeta_MQ_Status? Status { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+
+    public MqDeletionReasonOption? DeletionReason { get; set; }
+
+    public string? DeletionReasonDetail { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        // Currently adding empty JSON until the deleted event is defined in a future Trello card
+        await _crmQueryDispatcher.ExecuteQuery(
+            new DeleteQualificationQuery(
+                QualificationId,
+                "{}"));
+
+        await JourneyInstance!.CompleteAsync();
+        TempData.SetFlashSuccess("Mandatory qualification deleted");
+
+        return Redirect(_linkGenerator.PersonQualifications(PersonId!.Value));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(_linkGenerator.PersonQualifications(PersonId!.Value));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (!JourneyInstance!.State.IsComplete)
+        {
+            context.Result = Redirect(_linkGenerator.MqDelete(QualificationId, JourneyInstance.InstanceId));
+            return;
+        }
+
+        PersonId = JourneyInstance!.State.PersonId;
+        PersonName = JourneyInstance!.State.PersonName;
+        TrainingProvider = JourneyInstance!.State.MqEstablishment;
+        Specialism = JourneyInstance!.State.Specialism;
+        Status = JourneyInstance!.State.Status;
+        StartDate = JourneyInstance!.State.StartDate;
+        EndDate = JourneyInstance!.State.EndDate;
+        DeletionReason = JourneyInstance!.State.DeletionReason;
+        DeletionReasonDetail = JourneyInstance?.State.DeletionReasonDetail;
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+public class DeleteMqState
+{
+    public bool Initialized { get; set; }
+
+    public Guid? PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public string? MqEstablishment { get; set; }
+
+    public string? Specialism { get; set; }
+
+    public dfeta_qualification_dfeta_MQ_Status? Status { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+
+    public MqDeletionReasonOption? DeletionReason { get; set; }
+
+    public string? DeletionReasonDetail { get; set; }
+
+    [JsonIgnore]
+    [MemberNotNullWhen(true, nameof(DeletionReason))]
+    public bool IsComplete => DeletionReason.HasValue;
+
+    public async Task EnsureInitialized(
+        ICrmQueryDispatcher crmQueryDispatcher,
+        ReferenceDataCache referenceDataCache,
+        dfeta_qualification qualification)
+    {
+        if (Initialized)
+        {
+            return;
+        }
+
+        var personDetail = await crmQueryDispatcher.ExecuteQuery(
+            new GetContactDetailByIdQuery(
+                qualification.dfeta_PersonId.Id,
+                new ColumnSet(
+                    Contact.Fields.Id,
+                    Contact.Fields.FirstName,
+                    Contact.Fields.MiddleName,
+                    Contact.Fields.LastName,
+                    Contact.Fields.dfeta_StatedFirstName,
+                    Contact.Fields.dfeta_StatedLastName,
+                    Contact.Fields.dfeta_StatedMiddleName,
+                    Contact.Fields.dfeta_QTSDate)));
+
+        PersonId = personDetail!.Contact.Id;
+        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        var mqEstablishment = qualification.dfeta_MQ_MQEstablishmentId is not null ? await referenceDataCache.GetMqEstablishmentById(qualification.dfeta_MQ_MQEstablishmentId.Id) : null;
+        MqEstablishment = mqEstablishment is not null ? mqEstablishment.dfeta_name : null;
+        var mqSpecialism = qualification.dfeta_MQ_SpecialismId is not null ? await referenceDataCache.GetMqSpecialismById(qualification.dfeta_MQ_SpecialismId.Id) : null;
+        Specialism = mqSpecialism is not null ? mqSpecialism.dfeta_name : null;
+        StartDate = qualification.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);
+        EndDate = qualification.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true);
+        Initialized = true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
@@ -1,0 +1,45 @@
+@page "/mqs/{qualificationId}/delete/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq.IndexModel
+@{
+    ViewBag.Title = "Delete qualification";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.PersonQualifications(Model.PersonId!.Value)">Back</govuk-back-link>
+}
+
+<span class="govuk-caption-l">Delete qualification - @Model.PersonName</span>
+<h1 class="govuk-heading-l" data-testid="title">Mandatory qualification@(!string.IsNullOrEmpty(Model.Specialism) ? $" for {Model.Specialism!.ToLowerInvariant()}" : "")</h1>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.MqDelete(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-radios asp-for="DeletionReason" data-testid="deletion-reason-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend>
+                        <h3 class="govuk-heading-m">Reason for deleting</h3>
+                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-item value="@MqDeletionReasonOption.AddedInError">
+                        @MqDeletionReasonOption.AddedInError.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MqDeletionReasonOption.ProviderRequest">
+                        @MqDeletionReasonOption.ProviderRequest.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MqDeletionReasonOption.UnableToConfirmIfTheDataIsCorrect">
+                        @MqDeletionReasonOption.UnableToConfirmIfTheDataIsCorrect.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MqDeletionReasonOption.AnotherReason">
+                        @MqDeletionReasonOption.AnotherReason.GetDisplayName()
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>                
+            </govuk-radios>
+
+            <govuk-character-count asp-for="DeletionReasonDetail" label-class="govuk-label--m" max-length="3000" />
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.MqDeleteCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+[Journey(JourneyNames.DeleteMq), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel : PageModel
+{
+    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
+    private readonly ReferenceDataCache _referenceDataCache;
+    private readonly TrsLinkGenerator _linkGenerator;
+
+    public IndexModel(
+        ICrmQueryDispatcher crmQueryDispatcher,
+        ReferenceDataCache referenceDataCache,
+        TrsLinkGenerator linkGenerator)
+    {
+        _crmQueryDispatcher = crmQueryDispatcher;
+        _referenceDataCache = referenceDataCache;
+        _linkGenerator = linkGenerator;
+    }
+
+    public JourneyInstance<DeleteMqState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid QualificationId { get; set; }
+
+    public Guid? PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public string? TrainingProvider { get; set; }
+
+    public string? Specialism { get; set; }
+
+    public dfeta_qualification_dfeta_MQ_Status? Status { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Reason for deleting")]
+    public MqDeletionReasonOption? DeletionReason { get; set; }
+
+    [BindProperty]
+    [Display(Name = "More detail about the reason for deleting")]
+    public string? DeletionReasonDetail { get; set; }
+
+    public void OnGet()
+    {
+        DeletionReason ??= JourneyInstance!.State.DeletionReason;
+        DeletionReasonDetail ??= JourneyInstance?.State.DeletionReasonDetail;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (DeletionReason is null)
+        {
+            ModelState.AddModelError(nameof(DeletionReason), "Select a reason for deleting");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.DeletionReason = DeletionReason;
+            state.DeletionReasonDetail = DeletionReasonDetail;
+        });
+
+        return Redirect(_linkGenerator.MqDeleteConfirm(QualificationId, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(_linkGenerator.PersonQualifications(PersonId!.Value));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var qualification = await _crmQueryDispatcher.ExecuteQuery(new GetQualificationByIdQuery(QualificationId));
+        if (qualification is null || qualification.dfeta_Type != dfeta_qualification_dfeta_Type.MandatoryQualification)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        await JourneyInstance!.State.EnsureInitialized(_crmQueryDispatcher, _referenceDataCache, qualification);
+
+        PersonId = JourneyInstance!.State.PersonId;
+        PersonName = JourneyInstance!.State.PersonName;
+        TrainingProvider = JourneyInstance!.State.MqEstablishment;
+        Specialism = JourneyInstance!.State.Specialism;
+        Status = JourneyInstance!.State.Status;
+        StartDate = JourneyInstance!.State.StartDate;
+        EndDate = JourneyInstance!.State.EndDate;
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/MqDeletionReasonOption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/MqDeletionReasonOption.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+public enum MqDeletionReasonOption
+{
+    [Display(Name = "Added in error")]
+    AddedInError,
+    [Display(Name = "Provider request")]
+    ProviderRequest,
+    [Display(Name = "Unable to confirm if the data is correct")]
+    UnableToConfirmIfTheDataIsCorrect,
+    [Display(Name = "Another reason")]
+    AnotherReason
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -22,7 +22,7 @@ else
         <govuk-summary-card data-testid="mq-@mq.QualificationId">
             <govuk-summary-card-title>Mandatory qualification@(!string.IsNullOrEmpty(mq.Specialism) ? $" for {mq.Specialism!.ToLowerInvariant()}" : "")</govuk-summary-card-title>
             <govuk-summary-card-actions>
-                <govuk-summary-card-action href="#" visually-hidden-text="remove qualification" data-testid="remove-mq-@mq.QualificationId">Remove qualification</govuk-summary-card-action>
+                <govuk-summary-card-action href="@LinkGenerator.MqDelete(mq.QualificationId, null)" visually-hidden-text="delete qualification" data-testid="delete-link-@mq.QualificationId">Delete qualification</govuk-summary-card-action>
             </govuk-summary-card-actions>
             <govuk-summary-list>                
                 <govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -249,6 +249,12 @@ builder.Services
             typeof(TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Result.EditMqResultState),
             requestDataKeys: new[] { "qualificationId" },
             appendUniqueKey: true));
+
+        options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
+            JourneyNames.DeleteMq,
+            typeof(TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq.DeleteMqState),
+            requestDataKeys: new[] { "qualificationId" },
+            appendUniqueKey: true));
     });
 
 builder.Services

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -126,6 +126,18 @@ public class TrsLinkGenerator
     public string MqEditResultConfirmCancel(Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/Mqs/EditMq/Result/Confirm", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
 
+    public string MqDelete(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/Mqs/DeleteMq/Index", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+
+    public string MqDeleteCancel(Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Mqs/DeleteMq/Index", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+
+    public string MqDeleteConfirm(Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Mqs/DeleteMq/Confirm", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+
+    public string MqDeleteConfirmCancel(Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Mqs/DeleteMq/Confirm", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+
     public string Persons(string? search = null, ContactSearchSortByOption? sortBy = null, int? pageNumber = null) =>
         GetRequiredPathByPage("/Persons/Index", routeValues: new { search, sortBy, pageNumber });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/DeleteQualificationTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.Tests/QueryTests/DeleteQualificationTests.cs
@@ -1,0 +1,35 @@
+namespace TeachingRecordSystem.Core.Dqt.Tests.QueryTests;
+
+public class DeleteQualificationTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public DeleteQualificationTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = crmClientFixture.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange
+        var person = await _dataScope.TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualification = person.MandatoryQualifications.Single();
+
+        // Act
+        await _crmQueryDispatcher.ExecuteQuery(new DeleteQualificationQuery(qualification.QualificationId, "{}"));
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+        var updatedQualification = ctx.dfeta_qualificationSet.SingleOrDefault(q => q.GetAttributeValue<Guid>(dfeta_qualification.PrimaryIdAttribute) == qualification.QualificationId);
+        Assert.NotNull(updatedQualification);
+        Assert.Equal(dfeta_qualificationState.Inactive, updatedQualification.StateCode);
+        Assert.Equal("{}", updatedQualification.dfeta_TrsDeletedEvent);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
@@ -1,4 +1,6 @@
+using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
@@ -203,5 +205,40 @@ public class MqTests : TestBase
         await page.AssertOnPersonQualificationsPage(personId);
 
         await page.AssertFlashMessage("Mandatory qualification changed");
+    }
+
+    [Fact]
+    public async Task DeleteMq()
+    {
+        var deletionReason = MqDeletionReasonOption.ProviderRequest;
+        var deletionReasonDetail = "My deletion reason detail";
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var personId = person.PersonId;
+        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonQualificationsPage(person.PersonId);
+
+        await page.AssertOnPersonQualificationsPage(person.PersonId);
+
+        await page.ClickLinkForElementWithTestId($"delete-link-{qualificationId}");
+
+        await page.AssertOnDeleteMqPage(qualificationId);
+
+        await page.CheckAsync($"label:text-is('{deletionReason.GetDisplayName()}')");
+
+        await page.FillAsync("label:text-is('More detail about the reason for deleting')", deletionReasonDetail);
+
+        await page.ClickContinueButton();
+
+        await page.AssertOnDeleteMqConfirmPage(qualificationId);
+
+        await page.ClickButton("Delete qualification");
+
+        await page.AssertOnPersonQualificationsPage(personId);
+
+        await page.AssertFlashMessage("Mandatory qualification deleted");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -209,6 +209,16 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/mqs/{qualificationId}/result/confirm");
     }
 
+    public static async Task AssertOnDeleteMqPage(this IPage page, Guid qualificationId)
+    {
+        await page.WaitForUrlPathAsync($"/mqs/{qualificationId}/delete");
+    }
+
+    public static async Task AssertOnDeleteMqConfirmPage(this IPage page, Guid qualificationId)
+    {
+        await page.WaitForUrlPathAsync($"/mqs/{qualificationId}/delete/confirm");
+    }
+
     public static async Task AssertFlashMessage(this IPage page, string expectedHeader)
     {
         Assert.Equal(expectedHeader, await page.InnerTextAsync($".govuk-notification-banner__heading:text-is('{expectedHeader}')"));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
@@ -1,0 +1,214 @@
+using FormFlow;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.DeleteMq;
+
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_MissingDataInJourneyState_Redirects()
+    {
+        // Arrange        
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualificationId = person.MandatoryQualifications!.First().QualificationId;
+        var journeyInstance = await CreateJourneyInstance(
+            qualificationId,
+            new DeleteMqState()
+            {
+                Initialized = true,
+                PersonId = person.PersonId,
+                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/mqs/{qualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData("959", "Hearing", "2021-10-05", dfeta_qualification_dfeta_MQ_Status.Passed, "2021-11-05", MqDeletionReasonOption.ProviderRequest, "Some details about the deletion reason")]
+    [InlineData("959", "Hearing", "2021-10-05", dfeta_qualification_dfeta_MQ_Status.Deferred, null, MqDeletionReasonOption.ProviderRequest, null)]
+    [InlineData(null, null, null, null, null, MqDeletionReasonOption.AnotherReason, null)]
+    public async Task Get_ValidRequest_DisplaysContentAsExpected(
+        string? providerValue,
+        string? specialismValue,
+        string? startDateString,
+        dfeta_qualification_dfeta_MQ_Status? status,
+        string? endDateString,
+        MqDeletionReasonOption deletionReason,
+        string? deletionReasonDetail)
+    {
+        // Arrange
+        var mqEstablishment = !string.IsNullOrEmpty(providerValue) ? await TestData.ReferenceDataCache.GetMqEstablishmentByValue(providerValue) : null;
+        var specialism = !string.IsNullOrEmpty(specialismValue) ? await TestData.ReferenceDataCache.GetMqSpecialismByValue(specialismValue) : null;
+        DateOnly? startDate = !string.IsNullOrEmpty(startDateString) ? DateOnly.Parse(startDateString) : null;
+        DateOnly? endDate = !string.IsNullOrEmpty(endDateString) ? DateOnly.Parse(endDateString) : null;
+
+        var person = await TestData.CreatePerson(
+            b => b.WithMandatoryQualification(
+                providerValue: providerValue,
+                specialismValue: specialismValue,
+                startDate: startDate,
+                endDate: endDate,
+                result: status));
+        var qualification = person.MandatoryQualifications.Single();
+        var journeyInstance = await CreateJourneyInstance(
+            qualification.QualificationId,
+            new DeleteMqState
+            {
+                Initialized = true,
+                PersonId = person.PersonId,
+                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                MqEstablishment = mqEstablishment is not null ? mqEstablishment.dfeta_name : null,
+                Specialism = specialism is not null ? specialism.dfeta_name : null,
+                Status = status,
+                StartDate = startDate,
+                EndDate = endDate,
+                DeletionReason = deletionReason,
+                DeletionReasonDetail = deletionReasonDetail
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualification.QualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        var deletionSummary = doc.GetElementByTestId("deletion-summary");
+        Assert.NotNull(deletionSummary);
+        Assert.Equal(deletionReason.GetDisplayName(), deletionSummary.GetElementByTestId("deletion-reason")!.TextContent);
+        Assert.Equal(!string.IsNullOrEmpty(deletionReasonDetail) ? deletionReasonDetail : "None", deletionSummary.GetElementByTestId("deletion-reason-detail")!.TextContent);
+        Assert.Equal(mqEstablishment is not null ? mqEstablishment.dfeta_name : "None", deletionSummary.GetElementByTestId("provider")!.TextContent);
+        Assert.Equal(specialism is not null ? specialism.dfeta_name : "None", deletionSummary.GetElementByTestId("specialism")!.TextContent);
+        Assert.Equal(status is not null ? status.Value.ToString() : "None", deletionSummary.GetElementByTestId("status")!.TextContent);
+        Assert.Equal(startDate is not null ? startDate.Value.ToString("d MMMM yyyy") : "None", deletionSummary.GetElementByTestId("start-date")!.TextContent);
+        Assert.Equal(endDate is not null ? endDate.Value.ToString("d MMMM yyyy") : "None", deletionSummary.GetElementByTestId("end-date")!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_MissingDataInJourneyState_Redirects()
+    {
+        // Arrange        
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualificationId = person.MandatoryQualifications!.First().QualificationId;
+        var journeyInstance = await CreateJourneyInstance(
+            qualificationId,
+            new DeleteMqState()
+            {
+                Initialized = true,
+                PersonId = person.PersonId,
+                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/mqs/{qualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_Confirm_CompletesJourneyAndRedirectsWithFlashMessage()
+    {
+        // Arrange        
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualificationId = person.MandatoryQualifications!.First().QualificationId;
+        var journeyInstance = await CreateJourneyInstance(
+            qualificationId,
+            new DeleteMqState()
+            {
+                Initialized = true,
+                PersonId = person.PersonId,
+                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                MqEstablishment = "University of Leeds",
+                Specialism = "Hearing",
+                Status = dfeta_qualification_dfeta_MQ_Status.Passed,
+                StartDate = new DateOnly(2023, 09, 01),
+                EndDate = new DateOnly(2023, 11, 05),
+                DeletionReason = MqDeletionReasonOption.ProviderRequest,
+                DeletionReasonDetail = "Some details about the deletion reason",
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "Mandatory qualification deleted");
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.True(journeyInstance.Completed);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualificationId = person.MandatoryQualifications!.First().QualificationId;
+        var journeyInstance = await CreateJourneyInstance(
+            qualificationId,
+            new DeleteMqState()
+            {
+                Initialized = true,
+                PersonId = person.PersonId,
+                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                MqEstablishment = "University of Leeds",
+                Specialism = "Hearing",
+                Status = dfeta_qualification_dfeta_MQ_Status.Passed,
+                StartDate = new DateOnly(2023, 09, 01),
+                EndDate = new DateOnly(2023, 11, 05),
+                DeletionReason = MqDeletionReasonOption.ProviderRequest,
+                DeletionReasonDetail = "Some details about the deletion reason",
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/confirm/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+
+    private async Task<JourneyInstance<DeleteMqState>> CreateJourneyInstance(Guid qualificationId, DeleteMqState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.DeleteMq,
+            state ?? new DeleteMqState(),
+            new KeyValuePair<string, object>("qualificationId", qualificationId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/IndexTests.cs
@@ -1,0 +1,164 @@
+using FormFlow;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.DeleteMq;
+
+public class IndexTests : TestBase
+{
+    public IndexTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
+    {
+        // Arrange
+        var qualificationId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(qualificationId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithQualificationIdForValidQualification_ReturnsOk()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualification = person.MandatoryQualifications.Single();
+        var journeyInstance = await CreateJourneyInstance(qualification.QualificationId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualification.QualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualification = person.MandatoryQualifications.Single();
+        var deletionReason = MqDeletionReasonOption.ProviderRequest;
+        var journeyInstance = await CreateJourneyInstance(
+            qualification.QualificationId,
+            new DeleteMqState()
+            {
+                DeletionReason = deletionReason,
+                DeletionReasonDetail = "My deletion reason detail"
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualification.QualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        var deletionReasonOptions = doc.GetElementByTestId("deletion-reason-options");
+        var radioButtons = deletionReasonOptions!.GetElementsByTagName("input");
+        var selectedDeletionReason = radioButtons.SingleOrDefault(r => r.HasAttribute("checked"));
+        Assert.NotNull(selectedDeletionReason);
+        Assert.Equal(deletionReason.ToString(), selectedDeletionReason.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
+    {
+        // Arrange
+        var qualificationId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(qualificationId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoDeletionReasonIsSelected_ReturnsError()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualification = person.MandatoryQualifications.Single();
+        var journeyInstance = await CreateJourneyInstance(qualification.QualificationId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualification.QualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "DeletionReason", "Select a reason for deleting");
+    }
+
+    [Fact]
+    public async Task Post_WhenDeletionReasonIsSelected_RedirectsToConfirmPage()
+    {
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualification = person.MandatoryQualifications.Single();
+        var journeyInstance = await CreateJourneyInstance(qualification.QualificationId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualification.QualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "DeletionReason", MqDeletionReasonOption.ProviderRequest.ToString() },
+                { "DeletionReasonDetail", "My deletion reason detail" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/mqs/{qualification.QualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
+        var qualification = person.MandatoryQualifications.Single();
+        var journeyInstance = await CreateJourneyInstance(qualification.QualificationId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualification.QualificationId}/delete/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private async Task<JourneyInstance<DeleteMqState>> CreateJourneyInstance(Guid qualificationId, DeleteMqState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.DeleteMq,
+            state ?? new DeleteMqState(),
+            new KeyValuePair<string, object>("qualificationId", qualificationId));
+}


### PR DESCRIPTION
### Context

We need a way for users to remove an MQ from a person’s record.

### Changes proposed in this pull request

Following the designs in Figma to implement the Delete MQ journey.

The page URL should be /mqs/{qualificationId}/delete

If no reason is selected, show an error ‘Select a reason for deleting’.

The Upload evidence file upload is out of scope of this ticket. Adding the audit trail entry is also out of scope.

The Delete button should deactivate the CRM record and populate the dfeta_trsdeletedevent with a JSON-serialized event (contents TBC) - to be implemented as a single transaction.

### Guidance to review

CRM query + UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
