### PR TITLE
Amend TestData.CreatePerson to sync to TRS DB

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/HostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -36,7 +37,7 @@ public static class HostApplicationBuilderExtensions
 
             builder.Services.AddCrmEntityChangesService(name: TrsDataSyncService.CrmClientName);
 
-            builder.Services.AddSingleton<TrsDataSyncHelper>();
+            builder.Services.TryAddSingleton<TrsDataSyncHelper>();
         }
 
         return builder;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/ApiFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/ApiFixture.cs
@@ -12,6 +12,7 @@ using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.AccessYourQualifications;
 using TeachingRecordSystem.Core.Services.Certificates;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.Api.Tests;
 
@@ -60,9 +61,11 @@ public class ApiFixture : WebApplicationFactory<Program>
             services.AddTestScoped<IGetAnIdentityApiClient>(tss => tss.GetAnIdentityApiClientMock.Object);
             services.AddTestScoped<IOptions<AccessYourQualificationsOptions>>(tss => tss.AccessYourQualificationsOptions);
             services.AddTestScoped<ICertificateGenerator>(tss => tss.CertificateGeneratorMock.Object);
-            services.AddSingleton<TestData>();
+            services.AddSingleton<TestData>(
+                sp => ActivatorUtilities.CreateInstance<TestData>(sp, TestDataSyncConfiguration.Sync(sp.GetRequiredService<TrsDataSyncHelper>())));
             services.AddFakeXrm();
             services.AddSingleton<FakeTrnGenerator>();
+            services.AddSingleton<TrsDataSyncHelper>();
 
             services.Configure<GetAnIdentityOptions>(options =>
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -643,7 +643,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
                 .WithQts(qtsDate, qualifiedInWales ? QtsAwardedInWalesTeacherStatusValue : QualifiedTeacherTrainedTeacherStatusValue)
                 .WithEyts(eytsDate));
 
-        return person.ToContact();
+        return person.Contact;
     }
 
     private async Task ConfigureMocks(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
@@ -52,7 +52,12 @@ public sealed class CrmClientFixture : IDisposable
         _baseServiceClient,
         orgService => new DataverseAdapter(orgService, Clock, _memoryCache, _trnGenerationApiClient),
         orgService => new CrmQueryDispatcher(CreateQueryServiceProvider(orgService, _referenceDataCache), serviceClientName: null),
-        orgService => TestData.CreateWithCustomTrnGeneration(_dbFixture.GetDbContextFactory(), orgService, _referenceDataCache, () => _trnGenerationApiClient.GenerateTrn()),
+        orgService => TestData.CreateWithCustomTrnGeneration(
+            _dbFixture.GetDbContextFactory(),
+            orgService,
+            _referenceDataCache,
+            () => _trnGenerationApiClient.GenerateTrn(),
+            TestDataSyncConfiguration.NoSync()),
         _memoryCache);
 
     public void Dispose()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Playwright;
 using TeachingRecordSystem.Core;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.EndToEndTests.Infrastructure.Security;
 using TeachingRecordSystem.TestCommon;
 
@@ -71,9 +72,11 @@ public sealed class HostFixture : IAsyncDisposable, IStartupTask
                     services.AddSingleton<CurrentUserProvider>();
                     services.AddTransient<TestUsers.CreateUsersStartupTask>();
                     services.AddStartupTask<TestUsers.CreateUsersStartupTask>();
-                    services.AddSingleton<TestData>();
+                    services.AddSingleton<TestData>(
+                        sp => ActivatorUtilities.CreateInstance<TestData>(sp, TestDataSyncConfiguration.Sync(sp.GetRequiredService<TrsDataSyncHelper>())));
                     services.AddFakeXrm();
                     services.AddSingleton<FakeTrnGenerator>();
+                    services.AddSingleton<TrsDataSyncHelper>();
                 });
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Events.Processing;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.Infrastructure.FormFlow;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure;
@@ -69,10 +70,12 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddTestScoped<IClock>(tss => tss.Clock);
             services.AddTestScoped<IDataverseAdapter>(tss => tss.DataverseAdapterMock.Object);
             services.AddTestScoped<IAadUserService>(tss => tss.AzureActiveDirectoryUserServiceMock.Object);
-            services.AddSingleton<TestData>();
+            services.AddSingleton<TestData>(
+                sp => ActivatorUtilities.CreateInstance<TestData>(sp, TestDataSyncConfiguration.Sync(sp.GetRequiredService<TrsDataSyncHelper>())));
             services.AddFakeXrm();
             services.AddTransient<ICurrentUserIdProvider, TestUserCurrentUserIdProvider>();
             services.AddSingleton<FakeTrnGenerator>();
+            services.AddSingleton<TrsDataSyncHelper>();
         });
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
@@ -23,7 +23,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -69,7 +69,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishment = mqEstablishment is not null ? mqEstablishment.dfeta_name : null,
                 Specialism = specialism is not null ? specialism.dfeta_name : null,
                 Status = status,
@@ -111,7 +111,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -139,7 +139,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishment = "University of Leeds",
                 Specialism = "Hearing",
                 Status = dfeta_qualification_dfeta_MQ_Status.Passed,
@@ -180,7 +180,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishment = "University of Leeds",
                 Specialism = "Hearing",
                 Status = dfeta_qualification_dfeta_MQ_Status.Passed,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
@@ -23,7 +23,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/provider/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -53,7 +53,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = newMqEstablishmentValue,
                 CurrentMqEstablishmentName = oldMqEstablishment.dfeta_name,
             });
@@ -85,7 +85,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -116,7 +116,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = newMqEstablishmentValue
             });
 
@@ -154,7 +154,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = newMqEstablishmentValue
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
@@ -67,7 +67,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = journeyMqEstablishmentValue
             });
 
@@ -144,7 +144,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = oldMqEstablishmentValue
             });
 
@@ -178,7 +178,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = mqEstablishmentValue
             });
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Result/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Result/ConfirmTests.cs
@@ -23,7 +23,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/result/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -51,7 +51,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Result = newResult,
                 EndDate = newEndDate,
                 CurrentResult = oldResult,
@@ -86,7 +86,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/result/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -117,7 +117,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Result = newResult,
                 EndDate = newEndDate,
                 CurrentResult = oldResult,
@@ -157,7 +157,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Result = newResult,
                 EndDate = newEndDate,
                 CurrentResult = oldResult,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Result/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Result/IndexTests.cs
@@ -71,7 +71,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Result = journeyResult,
                 EndDate = journeyEndDate
             });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
@@ -23,7 +23,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -53,7 +53,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 SpecialismValue = newMqSpecialismValue,
                 CurrentSpecialismName = oldMqSpecialism.dfeta_name,
             });
@@ -85,7 +85,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -115,7 +115,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 SpecialismValue = newMqSpecialismValue
             });
 
@@ -151,7 +151,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 SpecialismValue = specialismValue
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
@@ -66,7 +66,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 SpecialismValue = journeySpecialismValue
             });
 
@@ -143,7 +143,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 SpecialismValue = oldSpecialismValue
             });
 
@@ -176,7 +176,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 SpecialismValue = specialismValue
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
@@ -23,7 +23,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/start-date/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -50,7 +50,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -82,7 +82,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false)
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -112,7 +112,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -149,7 +149,7 @@ public class ConfirmTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = oldStartDate
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
@@ -64,7 +64,7 @@ public class IndexTests : TestBase
             {
                 Initialized = true,
                 PersonId = person.PersonId,
-                PersonName = person.ToContact().ResolveFullName(includeMiddleName: false),
+                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = journeyStartDate
             });
 


### PR DESCRIPTION
A pre-requisite for syncing MQs to TRS is syncing persons. This amends `TestData` to support syncing generally and updates the `CreatePerson` method to sync the created `contact` record.

For CRM integration tests we don't need syncing and enabling it will slow down already very slow tests. As such, whether we sync by default is configurable by passing in a parameter to `TestData`'s constructor. This can also be overridden on a per call basis - `TestData.CreatePerson(b => b.WithSyncOverride(false))`.