### PR TITLE
Remove the {Created|Updated|Deleted}ByUserId columns from Qualification

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
@@ -14,9 +14,6 @@ public class QualificationMapping : IEntityTypeConfiguration<Qualification>
         builder.HasDiscriminator(q => q.QualificationType)
             .HasValue<MandatoryQualification>(QualificationType.MandatoryQualification);
         builder.HasOne<Person>().WithMany().HasForeignKey(q => q.PersonId).HasConstraintName("fk_qualifications_person");
-        builder.HasOne<User>().WithMany().HasForeignKey(q => q.CreatedByUserId).HasConstraintName("fk_qualifications_created_by");
-        builder.HasOne<User>().WithMany().HasForeignKey(q => q.UpdatedByUserId).HasConstraintName("fk_qualifications_updated_by");
-        builder.HasOne<User>().WithMany().HasForeignKey(q => q.DeletedByUserId).HasConstraintName("fk_qualifications_deleted_by");
         builder.HasIndex(q => q.PersonId);
         builder.HasIndex(q => q.DqtQualificationId).HasFilter("dqt_qualification_id is not null").IsUnique();
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231212184014_RemoveUserFksOnQualification.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231212184014_RemoveUserFksOnQualification.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231212184014_RemoveUserFksOnQualification")]
+    partial class RemoveUserFksOnQualification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231212184014_RemoveUserFksOnQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231212184014_RemoveUserFksOnQualification.cs
@@ -1,0 +1,86 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveUserFksOnQualification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_qualifications_created_by",
+                table: "qualifications");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_qualifications_deleted_by",
+                table: "qualifications");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_qualifications_updated_by",
+                table: "qualifications");
+
+            migrationBuilder.DropColumn(
+                name: "created_by_user_id",
+                table: "qualifications");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by_user_id",
+                table: "qualifications");
+
+            migrationBuilder.DropColumn(
+                name: "updated_by_user_id",
+                table: "qualifications");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "created_by_user_id",
+                table: "qualifications",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "deleted_by_user_id",
+                table: "qualifications",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "updated_by_user_id",
+                table: "qualifications",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_qualifications_created_by",
+                table: "qualifications",
+                column: "created_by_user_id",
+                principalTable: "users",
+                principalColumn: "user_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_qualifications_deleted_by",
+                table: "qualifications",
+                column: "deleted_by_user_id",
+                principalTable: "users",
+                principalColumn: "user_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_qualifications_updated_by",
+                table: "qualifications",
+                column: "updated_by_user_id",
+                principalTable: "users",
+                principalColumn: "user_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
@@ -3,11 +3,8 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 public abstract class Qualification
 {
     public required Guid QualificationId { get; init; }
-    public required Guid CreatedByUserId { get; init; }
     public required DateTime CreatedOn { get; init; }
-    public required Guid UpdatedByUserId { get; set; }
     public required DateTime UpdatedOn { get; set; }
-    public Guid? DeletedByUserId { get; set; }
     public DateTime? DeletedOn { get; set; }
     public QualificationType QualificationType { get; }
     public required Guid PersonId { get; init; }


### PR DESCRIPTION
Migrated data can't have {Created|Updated|Deleted}ByUserId columns populated unless we also migrate all user accounts from CRM (because foreign keys). We'll use audit records instead if we need to look up the user who performed a particular action.