### PR TITLE
Use new model types for MQs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateMandatoryQualificationQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateMandatoryQualificationQuery.cs
@@ -6,6 +6,6 @@ public record CreateMandatoryQualificationQuery : ICrmQuery<Guid>
     public required Guid MqEstablishmentId { get; init; }
     public required Guid SpecialismId { get; init; }
     public required DateOnly StartDate { get; init; }
-    public required dfeta_qualification_dfeta_MQ_Status Result { get; init; }
+    public required dfeta_qualification_dfeta_MQ_Status Status { get; init; }
     public required DateOnly? EndDate { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateMandatoryQualificationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateMandatoryQualificationHandler.cs
@@ -16,7 +16,7 @@ public class CreateMandatoryQualificationHandler : ICrmQueryHandler<CreateMandat
             dfeta_MQ_MQEstablishmentId = query.MqEstablishmentId.ToEntityReference(dfeta_mqestablishment.EntityLogicalName),
             dfeta_MQ_SpecialismId = query.SpecialismId.ToEntityReference(dfeta_specialism.EntityLogicalName),
             dfeta_MQStartDate = query.StartDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
-            dfeta_MQ_Status = query.Result,
+            dfeta_MQ_Status = query.Status,
             dfeta_MQ_Date = query.EndDate?.ToDateTimeWithDqtBstFix(isLocalTime: true),
         };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationStatus.cs
@@ -1,11 +1,59 @@
+using System.Reflection;
+
 namespace TeachingRecordSystem.Core.Models;
 
 public enum MandatoryQualificationStatus
 {
+    [MandatoryQualificationStatusInfo(name: "in progress", dfeta_qualification_dfeta_MQ_Status.InProgress)]
     InProgress = 0,
+    [MandatoryQualificationStatusInfo(name: "passed", dfeta_qualification_dfeta_MQ_Status.Passed)]
     Passed = 1,
+    [MandatoryQualificationStatusInfo(name: "deferred", dfeta_qualification_dfeta_MQ_Status.Deferred)]
     Deferred = 2,
+    [MandatoryQualificationStatusInfo(name: "extended", dfeta_qualification_dfeta_MQ_Status.Extended)]
     Extended = 3,
+    [MandatoryQualificationStatusInfo(name: "failed", dfeta_qualification_dfeta_MQ_Status.Failed)]
     Failed = 4,
+    [MandatoryQualificationStatusInfo(name: "withdrawn", dfeta_qualification_dfeta_MQ_Status.Withdrawn)]
     Withdrawn = 5,
+}
+
+public static class MandatoryQualificationStatusRegistry
+{
+    private static readonly IReadOnlyDictionary<MandatoryQualificationStatus, MandatoryQualificationStatusInfo> _info =
+        Enum.GetValues<MandatoryQualificationStatus>().ToDictionary(s => s, s => GetInfo(s));
+
+    public static IReadOnlyCollection<MandatoryQualificationStatusInfo> All => _info.Values.ToArray();
+
+    public static string GetName(this MandatoryQualificationStatus status) => _info[status].Name;
+
+    public static string GetTitle(this MandatoryQualificationStatus status) => _info[status].Title;
+
+    public static dfeta_qualification_dfeta_MQ_Status GetDqtStatus(this MandatoryQualificationStatus status) => _info[status].DqtStatus;
+
+    public static MandatoryQualificationStatus ToMandatoryQualificationStatus(this dfeta_qualification_dfeta_MQ_Status status) =>
+        _info.Values.Single(s => s.DqtStatus == status).Value;
+
+    private static MandatoryQualificationStatusInfo GetInfo(MandatoryQualificationStatus status)
+    {
+        var attr = status.GetType()
+            .GetMember(status.ToString())
+            .Single()
+            .GetCustomAttribute<MandatoryQualificationStatusInfoAttribute>() ??
+            throw new Exception($"{nameof(MandatoryQualificationStatus)}.{status} is missing the {nameof(MandatoryQualificationStatusInfoAttribute)} attribute.");
+
+        return new MandatoryQualificationStatusInfo(status, attr.Name, attr.DqtStatus);
+    }
+}
+
+public sealed record MandatoryQualificationStatusInfo(MandatoryQualificationStatus Value, string Name, dfeta_qualification_dfeta_MQ_Status DqtStatus)
+{
+    public string Title => Name[0..1].ToUpper() + Name[1..];
+}
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+file sealed class MandatoryQualificationStatusInfoAttribute(string name, dfeta_qualification_dfeta_MQ_Status dqtStatus) : Attribute
+{
+    public string Name => name;
+    public dfeta_qualification_dfeta_MQ_Status DqtStatus => dqtStatus;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqState.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using TeachingRecordSystem.Core.Dqt.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
@@ -8,19 +7,19 @@ public class AddMqState
 {
     public string? MqEstablishmentValue { get; set; }
 
-    public string? SpecialismValue { get; set; }
+    public MandatoryQualificationSpecialism? Specialism { get; set; }
 
     public DateOnly? StartDate { get; set; }
 
-    public dfeta_qualification_dfeta_MQ_Status? Result { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
 
     public DateOnly? EndDate { get; set; }
 
     [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(MqEstablishmentValue), nameof(SpecialismValue), nameof(StartDate), nameof(Result))]
+    [MemberNotNullWhen(true, nameof(MqEstablishmentValue), nameof(Specialism), nameof(StartDate), nameof(Status))]
     public bool IsComplete => !string.IsNullOrWhiteSpace(MqEstablishmentValue) &&
-        !string.IsNullOrEmpty(SpecialismValue) &&
+        Specialism.HasValue &&
         StartDate.HasValue &&
-        Result.HasValue &&
-        (Result!.Value != dfeta_qualification_dfeta_MQ_Status.Passed || (Result.Value == dfeta_qualification_dfeta_MQ_Status.Passed && EndDate.HasValue));
+        Status.HasValue &&
+        (Status != MandatoryQualificationStatus.Passed || (Status == MandatoryQualificationStatus.Passed && EndDate.HasValue));
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
@@ -25,7 +25,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Specialism</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="specialism">@Model.Specialism!.dfeta_name</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value data-testid="specialism">@Model.Specialism!.Value.GetTitle()</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.MqAddSpecialism(Model.PersonId, Model.JourneyInstance!.InstanceId)">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
@@ -39,7 +39,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Result</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="result">@Model.Result</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value data-testid="result">@Model.Status</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.MqAddResult(Model.PersonId, Model.JourneyInstance!.InstanceId)">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
@@ -32,25 +32,27 @@ public class CheckAnswersModel : PageModel
 
     public dfeta_mqestablishment? MqEstablishment { get; set; }
 
-    public dfeta_specialism? Specialism { get; set; }
+    public MandatoryQualificationSpecialism? Specialism { get; set; }
 
     public DateOnly? StartDate { get; set; }
 
-    public dfeta_qualification_dfeta_MQ_Status? Result { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
 
     public DateOnly? EndDate { get; set; }
 
     public async Task<IActionResult> OnPost()
     {
+        var mqSpecialism = await _referenceDataCache.GetMqSpecialismByValue(Specialism!.Value.GetDqtValue());
+
         await _crmQueryDispatcher.ExecuteQuery(
             new CreateMandatoryQualificationQuery()
             {
                 ContactId = PersonId,
                 MqEstablishmentId = MqEstablishment!.Id,
-                SpecialismId = Specialism!.Id,
+                SpecialismId = mqSpecialism.Id,
                 StartDate = StartDate!.Value,
-                Result = Result!.Value,
-                EndDate = Result == dfeta_qualification_dfeta_MQ_Status.Passed
+                Status = Status!.Value.GetDqtStatus(),
+                EndDate = Status == MandatoryQualificationStatus.Passed
                     ? EndDate!.Value
                     : null
             });
@@ -78,10 +80,10 @@ public class CheckAnswersModel : PageModel
 
         PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
         MqEstablishment = await _referenceDataCache.GetMqEstablishmentByValue(JourneyInstance!.State.MqEstablishmentValue!);
-        Specialism = await _referenceDataCache.GetMqSpecialismByValue(JourneyInstance!.State.SpecialismValue!);
-        StartDate = JourneyInstance!.State.StartDate;
-        Result = JourneyInstance!.State.Result;
-        EndDate = JourneyInstance!.State.EndDate;
+        Specialism = JourneyInstance.State.Specialism;
+        StartDate = JourneyInstance.State.StartDate;
+        Status = JourneyInstance.State.Status;
+        EndDate = JourneyInstance.State.EndDate;
 
         await next();
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Result.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Result.cshtml
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqAddResult(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
-            <govuk-radios asp-for="Result" data-testid="result-options">
+            <govuk-radios asp-for="Status" data-testid="result-options">
                 <govuk-radios-item value="@dfeta_qualification_dfeta_MQ_Status.Deferred" data-testid="result-deferred">
                     Deferred
                 </govuk-radios-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml
@@ -14,13 +14,13 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqAddSpecialism(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
-            <govuk-radios asp-for="SpecialismValue" data-testid="specialism-list">
+            <govuk-radios asp-for="Specialism" data-testid="specialism-list">
                 @if (Model.Specialisms is not null)
                 {
                     @foreach (var specialism in Model.Specialisms)
                     {
-                        <govuk-radios-item value="@specialism.dfeta_Value">
-                            @specialism.dfeta_name
+                        <govuk-radios-item value="@specialism.Value">
+                            @specialism.Title
                         </govuk-radios-item>
                     }
                 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
@@ -7,16 +7,8 @@ using TeachingRecordSystem.Core.Dqt.Models;
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
 [Journey(JourneyNames.AddMq), RequireJourneyInstance]
-public class StartDateModel : PageModel
+public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
 {
-    private readonly TrsLinkGenerator _linkGenerator;
-
-    public StartDateModel(
-        TrsLinkGenerator linkGenerator)
-    {
-        _linkGenerator = linkGenerator;
-    }
-
     public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
 
     [FromQuery]
@@ -42,13 +34,13 @@ public class StartDateModel : PageModel
 
         await JourneyInstance!.UpdateStateAsync(state => state.StartDate = StartDate);
 
-        return Redirect(_linkGenerator.MqAddResult(PersonId, JourneyInstance!.InstanceId));
+        return Redirect(linkGenerator.MqAddResult(PersonId, JourneyInstance!.InstanceId));
     }
 
     public async Task<IActionResult> OnPostCancel()
     {
         await JourneyInstance!.DeleteAsync();
-        return Redirect(_linkGenerator.PersonQualifications(PersonId));
+        return Redirect(linkGenerator.PersonQualifications(PersonId));
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml
@@ -29,7 +29,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Specialism</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="specialism">@(!string.IsNullOrEmpty(Model.Specialism) ? Model.Specialism : "None")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value data-testid="specialism">@(Model.Specialism?.GetTitle() ?? "None")</govuk-summary-list-row-value>
                 </govuk-summary-list-row>                
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
@@ -1,25 +1,15 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 [Journey(JourneyNames.DeleteMq), RequireJourneyInstance]
-public class ConfirmModel : PageModel
+public class ConfirmModel(
+    ICrmQueryDispatcher crmQueryDispatcher,
+    TrsLinkGenerator linkGenerator) : PageModel
 {
-    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
-    private readonly TrsLinkGenerator _linkGenerator;
-
-    public ConfirmModel(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        TrsLinkGenerator linkGenerator)
-    {
-        _crmQueryDispatcher = crmQueryDispatcher;
-        _linkGenerator = linkGenerator;
-    }
-
     public JourneyInstance<DeleteMqState>? JourneyInstance { get; set; }
 
     [FromRoute]
@@ -31,9 +21,9 @@ public class ConfirmModel : PageModel
 
     public string? TrainingProvider { get; set; }
 
-    public string? Specialism { get; set; }
+    public MandatoryQualificationSpecialism? Specialism { get; set; }
 
-    public dfeta_qualification_dfeta_MQ_Status? Status { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
 
     public DateOnly? StartDate { get; set; }
 
@@ -46,7 +36,7 @@ public class ConfirmModel : PageModel
     public async Task<IActionResult> OnPost()
     {
         // Currently adding empty JSON until the deleted event is defined in a future Trello card
-        await _crmQueryDispatcher.ExecuteQuery(
+        await crmQueryDispatcher.ExecuteQuery(
             new DeleteQualificationQuery(
                 QualificationId,
                 "{}"));
@@ -54,20 +44,20 @@ public class ConfirmModel : PageModel
         await JourneyInstance!.CompleteAsync();
         TempData.SetFlashSuccess("Mandatory qualification deleted");
 
-        return Redirect(_linkGenerator.PersonQualifications(PersonId!.Value));
+        return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }
 
     public async Task<IActionResult> OnPostCancel()
     {
         await JourneyInstance!.DeleteAsync();
-        return Redirect(_linkGenerator.PersonQualifications(PersonId!.Value));
+        return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         if (!JourneyInstance!.State.IsComplete)
         {
-            context.Result = Redirect(_linkGenerator.MqDelete(QualificationId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.MqDelete(QualificationId, JourneyInstance.InstanceId));
             return;
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
@@ -15,9 +15,9 @@ public class DeleteMqState
 
     public string? MqEstablishment { get; set; }
 
-    public string? Specialism { get; set; }
+    public MandatoryQualificationSpecialism? Specialism { get; set; }
 
-    public dfeta_qualification_dfeta_MQ_Status? Status { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
 
     public DateOnly? StartDate { get; set; }
 
@@ -57,9 +57,9 @@ public class DeleteMqState
         PersonId = personDetail!.Contact.Id;
         PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
         var mqEstablishment = qualification.dfeta_MQ_MQEstablishmentId is not null ? await referenceDataCache.GetMqEstablishmentById(qualification.dfeta_MQ_MQEstablishmentId.Id) : null;
-        MqEstablishment = mqEstablishment is not null ? mqEstablishment.dfeta_name : null;
+        MqEstablishment = mqEstablishment?.dfeta_name;
         var mqSpecialism = qualification.dfeta_MQ_SpecialismId is not null ? await referenceDataCache.GetMqSpecialismById(qualification.dfeta_MQ_SpecialismId.Id) : null;
-        Specialism = mqSpecialism is not null ? mqSpecialism.dfeta_name : null;
+        Specialism = mqSpecialism?.ToMandatoryQualificationSpecialism();
         StartDate = qualification.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);
         EndDate = qualification.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true);
         Initialized = true;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
@@ -9,7 +9,7 @@
 }
 
 <span class="govuk-caption-l">Delete qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">Mandatory qualification@(!string.IsNullOrEmpty(Model.Specialism) ? $" for {Model.Specialism!.ToLowerInvariant()}" : "")</h1>
+<h1 class="govuk-heading-l" data-testid="title">Mandatory qualification@(Model.Specialism is MandatoryQualificationSpecialism specialism ? $" for {specialism.GetName()}" : "")</h1>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
@@ -35,9 +35,9 @@ public class IndexModel : PageModel
 
     public string? TrainingProvider { get; set; }
 
-    public string? Specialism { get; set; }
+    public MandatoryQualificationSpecialism? Specialism { get; set; }
 
-    public dfeta_qualification_dfeta_MQ_Status? Status { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
 
     public DateOnly? StartDate { get; set; }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/Confirm.cshtml
@@ -25,8 +25,8 @@
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header" scope="row">Result</th>
-                        <td class="govuk-table__cell" data-testid="current-result">@(Model.CurrentResult.HasValue ? Model.CurrentResult.Value : "None")</td>
-                        <td class="govuk-table__cell" data-testid="new-result">@(Model.NewResult.HasValue ? Model.NewResult.Value : "None")</td>
+                        <td class="govuk-table__cell" data-testid="current-result">@(Model.CurrentStatus.HasValue ? Model.CurrentStatus.Value : "None")</td>
+                        <td class="govuk-table__cell" data-testid="new-result">@(Model.NewStatus.HasValue ? Model.NewStatus.Value : "None")</td>
                     </tr>
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header" scope="row">End date</th>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/EditMqResultState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/EditMqResultState.cs
@@ -12,17 +12,17 @@ public class EditMqResultState
 
     public string? PersonName { get; set; }
 
-    public dfeta_qualification_dfeta_MQ_Status? CurrentResult { get; set; }
+    public MandatoryQualificationStatus? CurrentStatus { get; set; }
 
-    public dfeta_qualification_dfeta_MQ_Status? Result { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
 
     public DateOnly? CurrentEndDate { get; set; }
 
     public DateOnly? EndDate { get; set; }
 
     [JsonIgnore]
-    public bool IsComplete => Result.HasValue &&
-        (Result!.Value != dfeta_qualification_dfeta_MQ_Status.Passed || (Result.Value == dfeta_qualification_dfeta_MQ_Status.Passed && EndDate.HasValue));
+    public bool IsComplete => Status.HasValue &&
+        (Status != MandatoryQualificationStatus.Passed || (Status == MandatoryQualificationStatus.Passed && EndDate.HasValue));
 
     public async Task EnsureInitialized(
         ICrmQueryDispatcher crmQueryDispatcher,
@@ -48,8 +48,8 @@ public class EditMqResultState
 
         EndDate = qualification.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true);
         CurrentEndDate = EndDate;
-        Result = qualification.dfeta_MQ_Status ?? (EndDate is not null ? dfeta_qualification_dfeta_MQ_Status.Passed : null);
-        CurrentResult = qualification.dfeta_MQ_Status;
+        Status = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus() ?? (EndDate is not null ? MandatoryQualificationStatus.Passed : null);
+        CurrentStatus = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus();
         PersonId = personDetail!.Contact.Id;
         PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
         Initialized = true;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/Index.cshtml
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditResult(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
-            <govuk-radios asp-for="Result" data-testid="result-options">
+            <govuk-radios asp-for="Status" data-testid="result-options">
                 <govuk-radios-item value="@dfeta_qualification_dfeta_MQ_Status.InProgress" data-testid="result-in-progress">
                     In Progress
                 </govuk-radios-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Result/Index.cshtml.cs
@@ -8,19 +8,10 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Result;
 
 [Journey(JourneyNames.EditMqResult), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel : PageModel
+public class IndexModel(
+    ICrmQueryDispatcher crmQueryDispatcher,
+    TrsLinkGenerator linkGenerator) : PageModel
 {
-    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
-    private readonly TrsLinkGenerator _linkGenerator;
-
-    public IndexModel(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        TrsLinkGenerator linkGenerator)
-    {
-        _crmQueryDispatcher = crmQueryDispatcher;
-        _linkGenerator = linkGenerator;
-    }
-
     public JourneyInstance<EditMqResultState>? JourneyInstance { get; set; }
 
     [FromRoute]
@@ -31,7 +22,7 @@ public class IndexModel : PageModel
     public string? PersonName { get; set; }
 
     [BindProperty]
-    public dfeta_qualification_dfeta_MQ_Status? Result { get; set; }
+    public MandatoryQualificationStatus? Status { get; set; }
 
     [BindProperty]
     [Display(Name = "End date")]
@@ -39,18 +30,18 @@ public class IndexModel : PageModel
 
     public void OnGet()
     {
-        Result ??= JourneyInstance!.State.Result;
+        Status ??= JourneyInstance!.State.Status;
         EndDate ??= JourneyInstance!.State.EndDate;
     }
 
     public async Task<IActionResult> OnPost()
     {
-        if (Result is null)
+        if (Status is null)
         {
-            ModelState.AddModelError(nameof(Result), "Select a result");
+            ModelState.AddModelError(nameof(Status), "Select a result");
         }
 
-        if (Result == dfeta_qualification_dfeta_MQ_Status.Passed && EndDate is null)
+        if (Status == MandatoryQualificationStatus.Passed && EndDate is null)
         {
             ModelState.AddModelError(nameof(EndDate), "Enter an end date");
         }
@@ -63,29 +54,29 @@ public class IndexModel : PageModel
         await JourneyInstance!.UpdateStateAsync(
             state =>
             {
-                state.Result = Result;
-                state.EndDate = Result == dfeta_qualification_dfeta_MQ_Status.Passed ? EndDate : null;
+                state.Status = Status;
+                state.EndDate = Status == MandatoryQualificationStatus.Passed ? EndDate : null;
             });
 
-        return Redirect(_linkGenerator.MqEditResultConfirm(QualificationId, JourneyInstance!.InstanceId));
+        return Redirect(linkGenerator.MqEditResultConfirm(QualificationId, JourneyInstance!.InstanceId));
     }
 
     public async Task<IActionResult> OnPostCancel()
     {
         await JourneyInstance!.DeleteAsync();
-        return Redirect(_linkGenerator.PersonQualifications(PersonId!.Value));
+        return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        var qualification = await _crmQueryDispatcher.ExecuteQuery(new GetQualificationByIdQuery(QualificationId));
+        var qualification = await crmQueryDispatcher.ExecuteQuery(new GetQualificationByIdQuery(QualificationId));
         if (qualification is null || qualification.dfeta_Type != dfeta_qualification_dfeta_Type.MandatoryQualification)
         {
             context.Result = NotFound();
             return;
         }
 
-        await JourneyInstance!.State.EnsureInitialized(_crmQueryDispatcher, qualification);
+        await JourneyInstance!.State.EnsureInitialized(crmQueryDispatcher, qualification);
 
         PersonId = JourneyInstance!.State.PersonId;
         PersonName = JourneyInstance!.State.PersonName;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml
@@ -25,8 +25,8 @@
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header" scope="row">Specialism</th>
-                        <td class="govuk-table__cell" data-testid="current-value">@Model.CurrentSpecialismName</td>
-                        <td class="govuk-table__cell" data-testid="new-value">@Model.NewSpecialism!.dfeta_name</td>
+                        <td class="govuk-table__cell" data-testid="current-value">@Model.CurrentSpecialism</td>
+                        <td class="govuk-table__cell" data-testid="new-value">@Model.NewSpecialism!.Value.GetTitle()</td>
                     </tr>
                 </tbody>
             </table>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
@@ -13,13 +13,13 @@ public class EditMqSpecialismState
 
     public string? PersonName { get; set; }
 
-    public string? CurrentSpecialismName { get; set; }
+    public MandatoryQualificationSpecialism? CurrentSpecialism { get; set; }
 
-    public string? SpecialismValue { get; set; }
+    public MandatoryQualificationSpecialism? Specialism { get; set; }
 
     [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(SpecialismValue))]
-    public bool IsComplete => !string.IsNullOrWhiteSpace(SpecialismValue);
+    [MemberNotNullWhen(true, nameof(Specialism))]
+    public bool IsComplete => Specialism is not null;
 
     public async Task EnsureInitialized(
         ICrmQueryDispatcher crmQueryDispatcher,
@@ -45,8 +45,8 @@ public class EditMqSpecialismState
                     Contact.Fields.dfeta_QTSDate)));
 
         var mqSpecialism = qualification.dfeta_MQ_SpecialismId is not null ? await referenceDataCache.GetMqSpecialismById(qualification.dfeta_MQ_SpecialismId.Id) : null;
-        SpecialismValue = mqSpecialism is not null ? mqSpecialism.dfeta_Value : null;
-        CurrentSpecialismName = mqSpecialism is not null ? mqSpecialism.dfeta_name : null;
+        Specialism = mqSpecialism?.ToMandatoryQualificationSpecialism();
+        CurrentSpecialism = mqSpecialism?.ToMandatoryQualificationSpecialism();
         PersonId = personDetail!.Contact.Id;
         PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
         Initialized = true;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml
@@ -14,13 +14,13 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditSpecialism(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
-            <govuk-radios asp-for="SpecialismValue" data-testid="specialism-list">
+            <govuk-radios asp-for="Specialism" data-testid="specialism-list">
                 @if (Model.Specialisms is not null)
                 {
                     @foreach (var specialism in Model.Specialisms)
                     {
-                        <govuk-radios-item value="@specialism.dfeta_Value">
-                            @specialism.dfeta_name
+                        <govuk-radios-item value="@specialism.Value">
+                            @specialism.Title
                         </govuk-radios-item>
                     }
                 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/_ViewImports.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/_ViewImports.cshtml
@@ -1,4 +1,5 @@
-﻿@using TeachingRecordSystem.SupportUi
+@using TeachingRecordSystem.Core.Models
+@using TeachingRecordSystem.SupportUi
 @namespace TeachingRecordSystem.SupportUi.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateMandatoryQualificationTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateMandatoryQualificationTests.cs
@@ -31,7 +31,7 @@ public class CreateMandatoryQualificationTests : IAsyncLifetime
             MqEstablishmentId = mqEstablishment.Id,
             SpecialismId = specialism.Id,
             StartDate = new DateOnly(2023, 01, 5),
-            Result = dfeta_qualification_dfeta_MQ_Status.Passed,
+            Status = dfeta_qualification_dfeta_MQ_Status.Passed,
             EndDate = new DateOnly(2023, 07, 10),
         };
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
@@ -35,7 +35,7 @@ public class GetQualificationsByContactIdTests : IAsyncLifetime
         var person = await _dataScope.TestData.CreatePerson(
             x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
                     .WithMandatoryQualification()
-                    .WithMandatoryQualification(providerValue: "959", specialismValue: "Visual"));
+                    .WithMandatoryQualification(providerValue: "959", specialism: MandatoryQualificationSpecialism.Visual));
 
         // Act
         var qualifications = await _crmQueryDispatcher.ExecuteQuery(new GetQualificationsByContactIdQuery(person.ContactId));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
@@ -19,12 +19,12 @@ public class UpdateMandatoryQualificationSpecialismTests : IAsyncLifetime
     public async Task QueryExecutesSuccessfully()
     {
         // Arrange
-        var originalSpecialismValue = "Visual";
-        var newSpecialism = await _dataScope.TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
+        var originalSpecialism = MandatoryQualificationSpecialism.Visual;
+        var newSpecialism = await _dataScope.TestData.ReferenceDataCache.GetMqSpecialismByValue(MandatoryQualificationSpecialism.Hearing.GetDqtValue());
 
         var person = await _dataScope.TestData.CreatePerson(
             x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
-                    .WithMandatoryQualification(specialismValue: originalSpecialismValue));
+                   .WithMandatoryQualification(specialism: originalSpecialism));
 
         var qualification = person.MandatoryQualifications.First();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/Usings.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/Usings.cs
@@ -1,5 +1,6 @@
 global using TeachingRecordSystem.Core.Dqt.Models;
 global using TeachingRecordSystem.Core.Dqt.Queries;
+global using TeachingRecordSystem.Core.Models;
 global using TeachingRecordSystem.TestCommon;
 global using Xunit;
 global using CrmTask = TeachingRecordSystem.Core.Dqt.Models.Task;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
@@ -104,8 +105,8 @@ public class MqTests : TestBase
     [Fact]
     public async Task EditMqSpecialism()
     {
-        var oldSpecialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
-        var newSpecialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Visual");
+        var oldSpecialism = MandatoryQualificationSpecialism.Hearing;
+        var newSpecialism = MandatoryQualificationSpecialism.Visual;
         var person = await TestData.CreatePerson(b => b.WithMandatoryQualification());
         var personId = person.PersonId;
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
@@ -121,9 +122,9 @@ public class MqTests : TestBase
 
         await page.AssertOnEditMqSpecialismPage(qualificationId);
 
-        await page.IsCheckedAsync($"label:text-is('{oldSpecialism.dfeta_name}')");
+        await page.IsCheckedAsync($"label:text-is('{oldSpecialism.GetTitle()}')");
 
-        await page.CheckAsync($"label:text-is('{newSpecialism.dfeta_name}')");
+        await page.CheckAsync($"label:text-is('{newSpecialism.GetTitle()}')");
 
         await page.ClickContinueButton();
 
@@ -172,10 +173,10 @@ public class MqTests : TestBase
     [Fact]
     public async Task EditMqResult()
     {
-        var oldResult = dfeta_qualification_dfeta_MQ_Status.Failed;
-        var newResult = dfeta_qualification_dfeta_MQ_Status.Passed;
+        var oldStatus = MandatoryQualificationStatus.Failed;
+        var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 11, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(result: oldResult));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
         var personId = person.PersonId;
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
 
@@ -190,9 +191,9 @@ public class MqTests : TestBase
 
         await page.AssertOnEditMqResultPage(qualificationId);
 
-        await page.IsCheckedAsync($"label:text-is('{oldResult}')");
+        await page.IsCheckedAsync($"label:text-is('{oldStatus}')");
 
-        await page.CheckAsync($"label:text-is('{newResult}')");
+        await page.CheckAsync($"label:text-is('{newStatus}')");
 
         await page.FillDateInput(newEndDate);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -1,5 +1,4 @@
 using FormFlow;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
@@ -33,18 +32,18 @@ public class CheckAnswersTests : TestBase
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
-        var specialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
-        var result = dfeta_qualification_dfeta_MQ_Status.Passed;
+        var status = MandatoryQualificationStatus.Passed;
         DateOnly? endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
             {
                 MqEstablishmentValue = mqEstablishment.dfeta_Value,
-                SpecialismValue = specialism.dfeta_Value,
+                Specialism = specialism,
                 StartDate = startDate,
-                Result = result,
+                Status = status,
                 EndDate = endDate
             });
 
@@ -58,25 +57,25 @@ public class CheckAnswersTests : TestBase
     }
 
     [Theory]
-    [InlineData(dfeta_qualification_dfeta_MQ_Status.InProgress)]
-    [InlineData(dfeta_qualification_dfeta_MQ_Status.Failed)]
-    [InlineData(dfeta_qualification_dfeta_MQ_Status.Passed)]
-    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState(dfeta_qualification_dfeta_MQ_Status result)
+    [InlineData(MandatoryQualificationStatus.InProgress)]
+    [InlineData(MandatoryQualificationStatus.Failed)]
+    [InlineData(MandatoryQualificationStatus.Passed)]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState(MandatoryQualificationStatus status)
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
-        var specialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
-        DateOnly? endDate = result == dfeta_qualification_dfeta_MQ_Status.Passed ? new DateOnly(2021, 11, 5) : null;
+        DateOnly? endDate = status == MandatoryQualificationStatus.Passed ? new DateOnly(2021, 11, 5) : null;
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
             {
                 MqEstablishmentValue = mqEstablishment.dfeta_Value,
-                SpecialismValue = specialism.dfeta_Value,
+                Specialism = specialism,
                 StartDate = startDate,
-                Result = result,
+                Status = status,
                 EndDate = endDate
             });
 
@@ -88,10 +87,10 @@ public class CheckAnswersTests : TestBase
         // Assert
         var doc = await response.GetDocument();
         Assert.Equal(mqEstablishment.dfeta_name, doc.GetElementByTestId("provider")!.TextContent);
-        Assert.Equal(specialism.dfeta_name, doc.GetElementByTestId("specialism")!.TextContent);
+        Assert.Equal(specialism.GetTitle(), doc.GetElementByTestId("specialism")!.TextContent);
         Assert.Equal(startDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("start-date")!.TextContent);
-        Assert.Equal(result.ToString(), doc.GetElementByTestId("result")!.TextContent);
-        if (result == dfeta_qualification_dfeta_MQ_Status.Passed)
+        Assert.Equal(status.ToString(), doc.GetElementByTestId("result")!.TextContent);
+        if (status == MandatoryQualificationStatus.Passed)
         {
             Assert.Equal(endDate!.Value.ToString("d MMMM yyyy"), doc.GetElementByTestId("end-date")!.TextContent);
         }
@@ -121,25 +120,25 @@ public class CheckAnswersTests : TestBase
     }
 
     [Theory]
-    [InlineData(dfeta_qualification_dfeta_MQ_Status.InProgress)]
-    [InlineData(dfeta_qualification_dfeta_MQ_Status.Failed)]
-    [InlineData(dfeta_qualification_dfeta_MQ_Status.Passed)]
-    public async Task Post_Confirm_CompletesJourneyAndRedirectsWithFlashMessage(dfeta_qualification_dfeta_MQ_Status result)
+    [InlineData(MandatoryQualificationStatus.InProgress)]
+    [InlineData(MandatoryQualificationStatus.Failed)]
+    [InlineData(MandatoryQualificationStatus.Passed)]
+    public async Task Post_Confirm_CompletesJourneyAndRedirectsWithFlashMessage(MandatoryQualificationStatus status)
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
-        var specialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
-        DateOnly? endDate = result == dfeta_qualification_dfeta_MQ_Status.Passed ? new DateOnly(2021, 11, 5) : null;
+        DateOnly? endDate = status == MandatoryQualificationStatus.Passed ? new DateOnly(2021, 11, 5) : null;
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
             {
                 MqEstablishmentValue = mqEstablishment.dfeta_Value,
-                SpecialismValue = specialism.dfeta_Value,
+                Specialism = specialism,
                 StartDate = startDate,
-                Result = result,
+                Status = status,
                 EndDate = endDate
             });
 
@@ -168,18 +167,18 @@ public class CheckAnswersTests : TestBase
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
-        var specialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
-        var result = dfeta_qualification_dfeta_MQ_Status.Passed;
+        var status = MandatoryQualificationStatus.Passed;
         DateOnly? endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
             {
                 MqEstablishmentValue = mqEstablishment.dfeta_Value,
-                SpecialismValue = specialism.dfeta_Value,
+                Specialism = specialism,
                 StartDate = startDate,
-                Result = result,
+                Status = status,
                 EndDate = endDate
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ResultTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ResultTests.cs
@@ -31,13 +31,13 @@ public class ResultTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
+        var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
             {
-                Result = result,
+                Status = status,
                 EndDate = endDate,
             });
 
@@ -52,7 +52,7 @@ public class ResultTests : TestBase
         var radioButtons = resultOptions!.GetElementsByTagName("input");
         var selectedResult = radioButtons.SingleOrDefault(r => r.HasAttribute("checked"));
         Assert.NotNull(selectedResult);
-        Assert.Equal(result.ToString(), selectedResult.GetAttribute("value"));
+        Assert.Equal(status.ToString(), selectedResult.GetAttribute("value"));
         Assert.Equal($"{endDate:%d}", doc.GetElementById("EndDate.Day")?.GetAttribute("value"));
         Assert.Equal($"{endDate:%M}", doc.GetElementById("EndDate.Month")?.GetAttribute("value"));
         Assert.Equal($"{endDate:yyyy}", doc.GetElementById("EndDate.Year")?.GetAttribute("value"));
@@ -79,7 +79,7 @@ public class ResultTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
-        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
+        var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(personId);
 
@@ -87,7 +87,7 @@ public class ResultTests : TestBase
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "Result", result.ToString() },
+                { "Status", status.ToString() },
                 { "EndDate.Day", $"{endDate:%d}" },
                 { "EndDate.Month", $"{endDate:%M}" },
                 { "EndDate.Year", $"{endDate:yyyy}" },
@@ -117,7 +117,7 @@ public class ResultTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "Result", "Select a result");
+        await AssertEx.HtmlResponseHasError(response, "Status", "Select a result");
     }
 
     [Fact]
@@ -125,14 +125,14 @@ public class ResultTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
+        var status = MandatoryQualificationStatus.Passed;
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/result?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "Result", result.ToString() },
+                { "Status", status.ToString() },
             }
         };
 
@@ -148,7 +148,7 @@ public class ResultTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var result = Core.Dqt.Models.dfeta_qualification_dfeta_MQ_Status.Passed;
+        var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
@@ -156,7 +156,7 @@ public class ResultTests : TestBase
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "Result", result.ToString() },
+                { "Status", status.ToString() },
                 { "EndDate.Day", $"{endDate:%d}" },
                 { "EndDate.Month", $"{endDate:%M}" },
                 { "EndDate.Year", $"{endDate:yyyy}" },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
@@ -31,12 +31,12 @@ public class SpecialismTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var specialismValue = "Hearing";
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()
             {
-                SpecialismValue = specialismValue
+                Specialism = specialism
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -50,7 +50,7 @@ public class SpecialismTests : TestBase
         var radioButtons = providerList!.GetElementsByTagName("input");
         var selectedSpecialism = radioButtons.SingleOrDefault(r => r.HasAttribute("checked"));
         Assert.NotNull(selectedSpecialism);
-        Assert.Equal(specialismValue, selectedSpecialism.GetAttribute("value"));
+        Assert.Equal(specialism.ToString(), selectedSpecialism.GetAttribute("value"));
     }
 
     [Fact]
@@ -58,14 +58,14 @@ public class SpecialismTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
-        var specialismValue = "Hearing";
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var journeyInstance = await CreateJourneyInstance(personId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "SpecialismValue", specialismValue }
+                { "Specialism", specialism }
             }
         };
 
@@ -92,7 +92,7 @@ public class SpecialismTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "SpecialismValue", "Select a specialism");
+        await AssertEx.HtmlResponseHasError(response, "Specialism", "Select a specialism");
     }
 
     [Fact]
@@ -100,14 +100,14 @@ public class SpecialismTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5)));
-        var specialismValue = "Hearing";
+        var specialism = MandatoryQualificationSpecialism.Hearing;
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "SpecialismValue", specialismValue }
+                { "Specialism", specialism }
             }
         };
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
@@ -37,31 +37,30 @@ public class ConfirmTests : TestBase
     }
 
     [Theory]
-    [InlineData("959", "Hearing", "2021-10-05", dfeta_qualification_dfeta_MQ_Status.Passed, "2021-11-05", MqDeletionReasonOption.ProviderRequest, "Some details about the deletion reason")]
-    [InlineData("959", "Hearing", "2021-10-05", dfeta_qualification_dfeta_MQ_Status.Deferred, null, MqDeletionReasonOption.ProviderRequest, null)]
+    [InlineData("959", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Passed, "2021-11-05", MqDeletionReasonOption.ProviderRequest, "Some details about the deletion reason")]
+    [InlineData("959", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Deferred, null, MqDeletionReasonOption.ProviderRequest, null)]
     [InlineData(null, null, null, null, null, MqDeletionReasonOption.AnotherReason, null)]
     public async Task Get_ValidRequest_DisplaysContentAsExpected(
         string? providerValue,
-        string? specialismValue,
+        MandatoryQualificationSpecialism? specialism,
         string? startDateString,
-        dfeta_qualification_dfeta_MQ_Status? status,
+        MandatoryQualificationStatus? status,
         string? endDateString,
         MqDeletionReasonOption deletionReason,
         string? deletionReasonDetail)
     {
         // Arrange
         var mqEstablishment = !string.IsNullOrEmpty(providerValue) ? await TestData.ReferenceDataCache.GetMqEstablishmentByValue(providerValue) : null;
-        var specialism = !string.IsNullOrEmpty(specialismValue) ? await TestData.ReferenceDataCache.GetMqSpecialismByValue(specialismValue) : null;
         DateOnly? startDate = !string.IsNullOrEmpty(startDateString) ? DateOnly.Parse(startDateString) : null;
         DateOnly? endDate = !string.IsNullOrEmpty(endDateString) ? DateOnly.Parse(endDateString) : null;
 
         var person = await TestData.CreatePerson(
             b => b.WithMandatoryQualification(
                 providerValue: providerValue,
-                specialismValue: specialismValue,
+                specialism: specialism,
                 startDate: startDate,
                 endDate: endDate,
-                result: status));
+                status: status));
         var qualification = person.MandatoryQualifications.Single();
         var journeyInstance = await CreateJourneyInstance(
             qualification.QualificationId,
@@ -70,8 +69,8 @@ public class ConfirmTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                MqEstablishment = mqEstablishment is not null ? mqEstablishment.dfeta_name : null,
-                Specialism = specialism is not null ? specialism.dfeta_name : null,
+                MqEstablishment = mqEstablishment?.dfeta_name,
+                Specialism = specialism,
                 Status = status,
                 StartDate = startDate,
                 EndDate = endDate,
@@ -93,7 +92,7 @@ public class ConfirmTests : TestBase
         Assert.Equal(deletionReason.GetDisplayName(), deletionSummary.GetElementByTestId("deletion-reason")!.TextContent);
         Assert.Equal(!string.IsNullOrEmpty(deletionReasonDetail) ? deletionReasonDetail : "None", deletionSummary.GetElementByTestId("deletion-reason-detail")!.TextContent);
         Assert.Equal(mqEstablishment is not null ? mqEstablishment.dfeta_name : "None", deletionSummary.GetElementByTestId("provider")!.TextContent);
-        Assert.Equal(specialism is not null ? specialism.dfeta_name : "None", deletionSummary.GetElementByTestId("specialism")!.TextContent);
+        Assert.Equal(specialism?.GetTitle() ?? "None", deletionSummary.GetElementByTestId("specialism")!.TextContent);
         Assert.Equal(status is not null ? status.Value.ToString() : "None", deletionSummary.GetElementByTestId("status")!.TextContent);
         Assert.Equal(startDate is not null ? startDate.Value.ToString("d MMMM yyyy") : "None", deletionSummary.GetElementByTestId("start-date")!.TextContent);
         Assert.Equal(endDate is not null ? endDate.Value.ToString("d MMMM yyyy") : "None", deletionSummary.GetElementByTestId("end-date")!.TextContent);
@@ -141,8 +140,8 @@ public class ConfirmTests : TestBase
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishment = "University of Leeds",
-                Specialism = "Hearing",
-                Status = dfeta_qualification_dfeta_MQ_Status.Passed,
+                Specialism = MandatoryQualificationSpecialism.Hearing,
+                Status = MandatoryQualificationStatus.Passed,
                 StartDate = new DateOnly(2023, 09, 01),
                 EndDate = new DateOnly(2023, 11, 05),
                 DeletionReason = MqDeletionReasonOption.ProviderRequest,
@@ -182,8 +181,8 @@ public class ConfirmTests : TestBase
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishment = "University of Leeds",
-                Specialism = "Hearing",
-                Status = dfeta_qualification_dfeta_MQ_Status.Passed,
+                Specialism = MandatoryQualificationSpecialism.Hearing,
+                Status = MandatoryQualificationStatus.Passed,
                 StartDate = new DateOnly(2023, 09, 01),
                 EndDate = new DateOnly(2023, 11, 05),
                 DeletionReason = MqDeletionReasonOption.ProviderRequest,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Result/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Result/ConfirmTests.cs
@@ -40,10 +40,10 @@ public class ConfirmTests : TestBase
     public async Task Get_ValidRequest_DisplaysContentAsExpected()
     {
         // Arrange
-        var oldResult = dfeta_qualification_dfeta_MQ_Status.Failed;
-        var newResult = dfeta_qualification_dfeta_MQ_Status.Passed;
+        var oldStatus = MandatoryQualificationStatus.Failed;
+        var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 12, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(result: oldResult));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -52,9 +52,9 @@ public class ConfirmTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                Result = newResult,
+                Status = newStatus,
                 EndDate = newEndDate,
-                CurrentResult = oldResult,
+                CurrentStatus = oldStatus,
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/result/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -68,8 +68,8 @@ public class ConfirmTests : TestBase
         var doc = await response.GetDocument();
         var changeDetails = doc.GetElementByTestId("change-details");
         Assert.NotNull(changeDetails);
-        Assert.Equal(oldResult.ToString(), changeDetails.GetElementByTestId("current-result")!.TextContent);
-        Assert.Equal(newResult.ToString(), changeDetails.GetElementByTestId("new-result")!.TextContent);
+        Assert.Equal(oldStatus.GetTitle(), changeDetails.GetElementByTestId("current-result")!.TextContent);
+        Assert.Equal(newStatus.GetTitle(), changeDetails.GetElementByTestId("new-result")!.TextContent);
         Assert.Equal("None", changeDetails.GetElementByTestId("current-end-date")!.TextContent);
         Assert.Equal(newEndDate.ToString("d MMMM yyyy"), changeDetails.GetElementByTestId("new-end-date")!.TextContent);
     }
@@ -106,10 +106,10 @@ public class ConfirmTests : TestBase
     public async Task Post_Confirm_CompletesJourneyAndRedirectsWithFlashMessage()
     {
         // Arrange
-        var oldResult = dfeta_qualification_dfeta_MQ_Status.Failed;
-        var newResult = dfeta_qualification_dfeta_MQ_Status.Passed;
+        var oldStatus = MandatoryQualificationStatus.Failed;
+        var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 12, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(result: oldResult));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -118,9 +118,9 @@ public class ConfirmTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                Result = newResult,
+                Status = newStatus,
                 EndDate = newEndDate,
-                CurrentResult = oldResult,
+                CurrentStatus = oldStatus,
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/result/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -146,10 +146,10 @@ public class ConfirmTests : TestBase
     public async Task Post_Cancel_DeletesJourneyAndRedirects()
     {
         // Arrange
-        var oldResult = dfeta_qualification_dfeta_MQ_Status.Failed;
-        var newResult = dfeta_qualification_dfeta_MQ_Status.Passed;
+        var oldStatus = MandatoryQualificationStatus.Failed;
+        var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 12, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(result: oldResult));
+        TestData.CreatePersonResult person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -158,9 +158,9 @@ public class ConfirmTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                Result = newResult,
+                Status = newStatus,
                 EndDate = newEndDate,
-                CurrentResult = oldResult,
+                CurrentStatus = oldStatus,
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/result/confirm/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
@@ -40,12 +40,9 @@ public class ConfirmTests : TestBase
     public async Task Get_ValidRequest_DisplaysContentAsExpected()
     {
         // Arrange
-        var oldMqSpecialismValue = "Hearing";
-        var oldMqSpecialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue(oldMqSpecialismValue);
-        var newMqSpecialismValue = "Visual";
-        var newMqSpecialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue(newMqSpecialismValue);
-        var person = await TestData.CreatePerson(
-                       b => b.WithMandatoryQualification(specialismValue: oldMqSpecialismValue));
+        var oldMqSpecialism = MandatoryQualificationSpecialism.Hearing;
+        var newMqSpecialism = MandatoryQualificationSpecialism.Visual;
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: oldMqSpecialism));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -54,8 +51,8 @@ public class ConfirmTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                SpecialismValue = newMqSpecialismValue,
-                CurrentSpecialismName = oldMqSpecialism.dfeta_name,
+                Specialism = newMqSpecialism,
+                CurrentSpecialism = oldMqSpecialism,
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -69,8 +66,8 @@ public class ConfirmTests : TestBase
         var doc = await response.GetDocument();
         var changeDetails = doc.GetElementByTestId("change-details");
         Assert.NotNull(changeDetails);
-        Assert.Equal(oldMqSpecialism.dfeta_name, changeDetails.GetElementByTestId("current-value")!.TextContent);
-        Assert.Equal(newMqSpecialism.dfeta_name, changeDetails.GetElementByTestId("new-value")!.TextContent);
+        Assert.Equal(oldMqSpecialism.GetTitle(), changeDetails.GetElementByTestId("current-value")!.TextContent);
+        Assert.Equal(newMqSpecialism.GetTitle(), changeDetails.GetElementByTestId("new-value")!.TextContent);
     }
 
     [Fact]
@@ -105,9 +102,9 @@ public class ConfirmTests : TestBase
     public async Task Post_Confirm_CompletesJourneyAndRedirectsWithFlashMessage()
     {
         // Arrange
-        var oldMqSpecialismValue = "Hearing";
-        var newMqSpecialismValue = "Visual";
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialismValue: oldMqSpecialismValue));
+        var oldMqSpecialism = MandatoryQualificationSpecialism.Hearing;
+        var newMqSpecialism = MandatoryQualificationSpecialism.Visual;
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: oldMqSpecialism));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -116,7 +113,7 @@ public class ConfirmTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                SpecialismValue = newMqSpecialismValue
+                Specialism = newMqSpecialism
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -142,8 +139,8 @@ public class ConfirmTests : TestBase
     public async Task Post_Cancel_DeletesJourneyAndRedirects()
     {
         // Arrange
-        var specialismValue = "Hearing";
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialismValue: specialismValue));
+        var specialism = MandatoryQualificationSpecialism.Hearing;
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: specialism));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -152,7 +149,7 @@ public class ConfirmTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                SpecialismValue = specialismValue
+                Specialism = specialism
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/confirm/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
@@ -31,8 +31,8 @@ public class IndexTests : TestBase
     public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
     {
         // Arrange
-        var databaseSpecialismValue = "Hearing";
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialismValue: databaseSpecialismValue));
+        var databaseSpecialism = MandatoryQualificationSpecialism.Hearing;
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: databaseSpecialism));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 
@@ -49,16 +49,16 @@ public class IndexTests : TestBase
         var radioButtons = specialismList!.GetElementsByTagName("input");
         var selectedSpecialism = radioButtons.SingleOrDefault(r => r.HasAttribute("checked"));
         Assert.NotNull(selectedSpecialism);
-        Assert.Equal(databaseSpecialismValue, selectedSpecialism.GetAttribute("value"));
+        Assert.Equal(databaseSpecialism.ToString(), selectedSpecialism.GetAttribute("value"));
     }
 
     [Fact]
     public async Task Get_ValidRequestWithInitializedJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var databaseSpecialismValue = "Hearing";
-        var journeySpecialismValue = "Visual";
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialismValue: databaseSpecialismValue));
+        var databaseSpecialism = MandatoryQualificationSpecialism.Hearing;
+        var journeySpecialism = MandatoryQualificationSpecialism.Visual;
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: databaseSpecialism));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -67,7 +67,7 @@ public class IndexTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                SpecialismValue = journeySpecialismValue
+                Specialism = journeySpecialism
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -83,7 +83,7 @@ public class IndexTests : TestBase
         var radioButtons = specialismList!.GetElementsByTagName("input");
         var selectedSpecialism = radioButtons.SingleOrDefault(r => r.HasAttribute("checked"));
         Assert.NotNull(selectedSpecialism);
-        Assert.Equal(journeySpecialismValue, selectedSpecialism.GetAttribute("value"));
+        Assert.Equal(journeySpecialism.ToString(), selectedSpecialism.GetAttribute("value"));
     }
 
     [Fact]
@@ -126,16 +126,16 @@ public class IndexTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "SpecialismValue", "Select a specialism");
+        await AssertEx.HtmlResponseHasError(response, "Specialism", "Select a specialism");
     }
 
     [Fact]
     public async Task Post_WhenSpecialismIsSelected_RedirectsToConfirmPage()
     {
         // Arrange
-        var oldSpecialismValue = "Hearing";
-        var newSpecialismValue = "Visual";
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialismValue: oldSpecialismValue));
+        var oldSpecialism = MandatoryQualificationSpecialism.Hearing;
+        var newSpecialism = MandatoryQualificationSpecialism.Visual;
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: oldSpecialism));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -144,14 +144,14 @@ public class IndexTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                SpecialismValue = oldSpecialismValue
+                Specialism = oldSpecialism
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "SpecialismValue", newSpecialismValue }
+                { "Specialism", newSpecialism }
             }
         };
 
@@ -167,8 +167,8 @@ public class IndexTests : TestBase
     public async Task Post_Cancel_DeletesJourneyAndRedirects()
     {
         // Arrange
-        var specialismValue = "Hearing";
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialismValue: specialismValue));
+        var specialism = MandatoryQualificationSpecialism.Hearing;
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: specialism));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -177,7 +177,7 @@ public class IndexTests : TestBase
                 Initialized = true,
                 PersonId = person.PersonId,
                 PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                SpecialismValue = specialismValue
+                Specialism = specialism
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
@@ -1,5 +1,3 @@
-using TeachingRecordSystem.Core.Dqt.Models;
-
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
 
 public class QualificationsTests : TestBase
@@ -44,24 +42,23 @@ public class QualificationsTests : TestBase
     }
 
     [Theory]
-    [InlineData("959", "Hearing", "2022-01-05", dfeta_qualification_dfeta_MQ_Status.Passed, "2022-07-13")]
-    [InlineData("959", "Hearing", "2022-01-05", dfeta_qualification_dfeta_MQ_Status.Deferred, null)]
+    [InlineData("959", MandatoryQualificationSpecialism.Hearing, "2022-01-05", MandatoryQualificationStatus.Passed, "2022-07-13")]
+    [InlineData("959", MandatoryQualificationSpecialism.Hearing, "2022-01-05", MandatoryQualificationStatus.Deferred, null)]
     [InlineData(null, null, null, null, null)]
     public async Task Get_WithPersonIdForPersonWithMandatoryQualifications_DisplaysExpectedContent(
         string? providerValue,
-        string? specialismValue,
+        MandatoryQualificationSpecialism? specialism,
         string? startDateString,
-        dfeta_qualification_dfeta_MQ_Status? result,
+        MandatoryQualificationStatus? status,
         string? endDateString)
     {
         // Arrange
         var mqEstablishment = !string.IsNullOrEmpty(providerValue) ? await TestData.ReferenceDataCache.GetMqEstablishmentByValue(providerValue) : null;
-        var specialism = !string.IsNullOrEmpty(specialismValue) ? await TestData.ReferenceDataCache.GetMqSpecialismByValue(specialismValue) : null;
         DateOnly? startDate = !string.IsNullOrEmpty(startDateString) ? DateOnly.Parse(startDateString) : null;
         DateOnly? endDate = !string.IsNullOrEmpty(endDateString) ? DateOnly.Parse(endDateString) : null;
-        var person = await TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
-                    .WithMandatoryQualification(providerValue, specialismValue, startDate, endDate, result));
+        var person = await TestData.CreatePerson(x => x
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithMandatoryQualification(providerValue, specialism, status, startDate, endDate));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.ContactId}/qualifications");
@@ -79,9 +76,9 @@ public class QualificationsTests : TestBase
         var mandatoryQualificationSummary = doc.GetElementByTestId($"mq-{qualificationId}");
         Assert.NotNull(mandatoryQualificationSummary);
         Assert.Equal(mqEstablishment is not null ? mqEstablishment.dfeta_name : "None", mandatoryQualificationSummary.GetElementByTestId($"mq-provider-{qualificationId}")!.TextContent);
-        Assert.Equal(specialism is not null ? specialism.dfeta_name : "None", mandatoryQualificationSummary.GetElementByTestId($"mq-specialism-{qualificationId}")!.TextContent);
+        Assert.Equal(specialism?.GetTitle() ?? "None", mandatoryQualificationSummary.GetElementByTestId($"mq-specialism-{qualificationId}")!.TextContent);
         Assert.Equal(startDate is not null ? startDate.Value.ToString("d MMMM yyyy") : "None", mandatoryQualificationSummary.GetElementByTestId($"mq-start-date-{qualificationId}")!.TextContent);
-        Assert.Equal(result is not null ? result.Value.ToString() : "None", mandatoryQualificationSummary.GetElementByTestId($"mq-result-{qualificationId}")!.TextContent);
+        Assert.Equal(status is not null ? status.Value.ToString() : "None", mandatoryQualificationSummary.GetElementByTestId($"mq-result-{qualificationId}")!.TextContent);
         Assert.Equal(endDate is not null ? endDate.Value.ToString("d MMMM yyyy") : "None", mandatoryQualificationSummary.GetElementByTestId($"mq-end-date-{qualificationId}")!.TextContent);
     }
 }


### PR DESCRIPTION
Amends the MQ UI to use the new model types instead of CRM model types.

I've also extended the information around reference data (`MandatoryQualificationStatus` and `MandatoryQualficationSpecialism`). Of note is that we're now storing both a 'name' and a 'title'; the former is for use mid-sentence and the latter is for use in a title or start of a sentence.

There are a few places still referring to 'Result' instead of 'Status'. I've updated property names etc. as I've changed the types but for the most part I've kept renaming to a minimum here.