### PR TITLE
Add EventId property to EventBase

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
@@ -6,6 +6,7 @@ public abstract record EventBase
 {
     public static JsonSerializerOptions JsonSerializerOptions { get; } = new();
 
+    public required Guid EventId { get; init; }
     public required DateTime CreatedUtc { get; init; }
     public required Guid SourceUserId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendEytsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendEytsAwardedEmailJob.cs
@@ -54,6 +54,7 @@ public class SendEytsAwardedEmailJob
 
         _dbContext.AddEvent(new EytsAwardedEmailSentEvent
         {
+            EventId = Guid.NewGuid(),
             EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,
             PersonId = personId,
             EmailAddress = item.EmailAddress,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
@@ -54,6 +54,7 @@ public class SendInductionCompletedEmailJob
 
         _dbContext.AddEvent(new InductionCompletedEmailSentEvent
         {
+            EventId = Guid.NewGuid(),
             InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
             PersonId = personId,
             EmailAddress = item.EmailAddress,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInternationalQtsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInternationalQtsAwardedEmailJob.cs
@@ -54,6 +54,7 @@ public class SendInternationalQtsAwardedEmailJob
 
         _dbContext.AddEvent(new InternationalQtsAwardedEmailSentEvent
         {
+            EventId = Guid.NewGuid(),
             InternationalQtsAwardedEmailsJobId = internationalQtsAwardedEmailsJobId,
             PersonId = personId,
             EmailAddress = item.EmailAddress,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendQtsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendQtsAwardedEmailJob.cs
@@ -54,6 +54,7 @@ public class SendQtsAwardedEmailJob
 
         _dbContext.AddEvent(new QtsAwardedEmailSentEvent
         {
+            EventId = Guid.NewGuid(),
             QtsAwardedEmailsJobId = qtsAwardedEmailsJobId,
             PersonId = personId,
             EmailAddress = item.EmailAddress,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
@@ -87,6 +87,7 @@ public class ConfirmModel(
 
         _dbContext.AddEvent(new UserAddedEvent()
         {
+            EventId = Guid.NewGuid(),
             User = Core.Events.User.FromModel(newUser),
             SourceUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
@@ -102,6 +102,7 @@ public class EditUser : PageModel
 
         _dbContext.AddEvent(new UserUpdatedEvent
         {
+            EventId = Guid.NewGuid(),
             User = Core.Events.User.FromModel(user),
             SourceUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow,
@@ -128,6 +129,7 @@ public class EditUser : PageModel
 
         _dbContext.AddEvent(new UserDeactivatedEvent
         {
+            EventId = Guid.NewGuid(),
             User = Core.Events.User.FromModel(user),
             SourceUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow
@@ -152,6 +154,7 @@ public class EditUser : PageModel
 
         _dbContext.AddEvent(new UserActivatedEvent
         {
+            EventId = Guid.NewGuid(),
             User = Core.Events.User.FromModel(user),
             SourceUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/EventInfoTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/EventInfoTests.cs
@@ -11,6 +11,7 @@ public class EventInfoTests
         // Arrange
         var @e = new UserActivatedEvent()
         {
+            EventId = Guid.NewGuid(),
             CreatedUtc = DateTime.UtcNow,
             SourceUserId = DataStore.Postgres.Models.User.SystemUserId,
             User = new()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
@@ -98,6 +98,7 @@ public class PublishEventsBackgroundServiceTests : IAsyncLifetime
 
     private EventBase CreateDummyEvent() => new DummyEvent()
     {
+        EventId = Guid.NewGuid(),
         DummyProperty = Faker.Name.FullName(),
         CreatedUtc = TestableClock.Initial.ToUniversalTime(),
         SourceUserId = DataStore.Postgres.Models.User.SystemUserId


### PR DESCRIPTION
Part 1 of N of adding an `EventId` property to `EventBase` (so the serialized event always has an ID in it and that ID can be generated outside of the DB).

Adding a `required` property here is safe as we don't read back events anywhere yet.