### PR TITLE
Fix EventObserver.AssertEventsSaved to work with synced events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -74,6 +74,7 @@
     <PackageReference Include="PdfSharpCore" />
     <PackageReference Include="Scrutor" />
     <PackageReference Include="System.Net.Http.Json" />
+    <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
 </Project>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Infrastructure/CaptureEventObserver.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Infrastructure/CaptureEventObserver.cs
@@ -5,27 +5,19 @@ namespace TeachingRecordSystem.SupportUi.Tests.Infrastructure;
 
 public class CaptureEventObserver : IEventObserver
 {
-    private readonly AsyncLocal<List<EventBase>> _events = new();
+    private readonly List<EventBase> _events = new();
 
-    public void Clear() => _events.Value?.Clear();
-
-    public void Init() => _events.Value ??= new List<EventBase>();
+    public void Clear() => _events.Clear();
 
     public Task OnEventSaved(EventBase @event)
     {
-        if (_events.Value is null)
-        {
-            throw new InvalidOperationException("Not initialized.");
-        }
-
-        _events.Value.Add(@event);
-
+        _events.Add(@event);
         return Task.CompletedTask;
     }
 
     public void AssertEventsSaved(params Action<EventBase>[] eventInspectors)
     {
-        var events = (_events.Value ?? new()).AsReadOnly();
+        var events = _events.AsReadOnly();
         Assert.Collection(events, eventInspectors);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
+using TeachingRecordSystem.SupportUi.Tests.Infrastructure;
 
 namespace TeachingRecordSystem.SupportUi.Tests;
 
@@ -12,6 +13,7 @@ public class TestScopedServices
         Clock = new();
         DataverseAdapterMock = new();
         AzureActiveDirectoryUserServiceMock = new();
+        EventObserver = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -32,4 +34,6 @@ public class TestScopedServices
     public Mock<IDataverseAdapter> DataverseAdapterMock { get; }
 
     public Mock<IAadUserService> AzureActiveDirectoryUserServiceMock { get; }
+
+    public CaptureEventObserver EventObserver { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TeachingRecordSystem.TestCommon.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TeachingRecordSystem.TestCommon.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="Respawn" />
     <PackageReference Include="System.Linq.Async" />
-    <PackageReference Include="System.Reactive" />
     <PackageReference Include="xunit.assert" />
   </ItemGroup>
 


### PR DESCRIPTION
Normally events are created via EF and we use an interceptor to capture the events that were created during the running of a particular test to later assert on. The TrsDataSyncHelper doesn't use EF to sync events, however, so this interceptor doesn't ever see the events.

This change amends TrsDataSyncHelper to provide an IObservable that emits synced models. In our test base class we subscribe to that and push events onto the CaptureEventObserver for the corresponding test.