### PR TITLE
Pre-warm the ReferenceDataCache

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt;
 
-public class ReferenceDataCache
+public class ReferenceDataCache : IStartupTask
 {
     private readonly ICrmQueryDispatcher _crmQueryDispatcher;
     private Task<dfeta_mqestablishment[]>? _mqEstablishmentsTask;
@@ -121,4 +121,14 @@ public class ReferenceDataCache
         LazyInitializer.EnsureInitialized(
             ref _mqEstablishmentsTask,
             () => _crmQueryDispatcher.ExecuteQuery(new GetAllMqEstablishmentsQuery()));
+
+    async Task IStartupTask.Execute()
+    {
+        await EnsureSanctionCodes();
+        await EnsureSubjects();
+        await EnsureTeacherStatuses();
+        await EnsureEarlyYearsStatuses();
+        await EnsureSpecialisms();
+        await EnsureMqEstablishments();
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
@@ -25,7 +25,8 @@ public static partial class ServiceCollectionExtensions
     {
         services.AddServiceClient(name: null, lifetime, createServiceClient);
 
-        services.TryAddSingleton<ReferenceDataCache>();
+        services.AddSingleton<ReferenceDataCache>();
+        services.AddStartupTask<ReferenceDataCache>();
 
         return services;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/StartupTasks.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/StartupTasks.cs
@@ -14,7 +14,7 @@ public static partial class ServiceCollectionExtensions
         AddStartupTask(services, _ => task);
 
     public static IServiceCollection AddStartupTask<T>(this IServiceCollection services) where T : class, IStartupTask =>
-        AddStartupTask(services, sp => sp.GetRequiredService<T>());
+        AddStartupTask(services, sp => sp.GetService<T>() ?? ActivatorUtilities.CreateInstance<T>(sp));
 
     public static IServiceCollection AddStartupTask(this IServiceCollection services, Func<IServiceProvider, IStartupTask> createTask)
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -72,7 +72,6 @@ public sealed class HostFixture : IAsyncDisposable, IStartupTask
                         .AddScheme<TestAuthenticationOptions, TestAuthenticationHandler>("Test", options => { });
 
                     services.AddSingleton<CurrentUserProvider>();
-                    services.AddTransient<TestUsers.CreateUsersStartupTask>();
                     services.AddStartupTask<TestUsers.CreateUsersStartupTask>();
                     services.AddSingleton<TestData>(
                         sp => ActivatorUtilities.CreateInstance<TestData>(sp, TestDataSyncConfiguration.Sync(sp.GetRequiredService<TrsDataSyncHelper>())));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -62,7 +62,6 @@ public class HostFixture : WebApplicationFactory<Program>
             });
 
             services.AddSingleton<CurrentUserProvider>();
-            services.AddTransient<TestUsers.CreateUsersStartupTask>();
             services.AddStartupTask<TestUsers.CreateUsersStartupTask>();
 
             services.AddSingleton<IEventObserver>(_ => new ForwardToTestScopedEventObserver());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
@@ -50,6 +50,10 @@ public static class ServiceCollectionExtensions
         CalculateActiveSanctionsPlugin.Register(fakedXrmContext);
         QtsRegistrationUpdatedPlugin.Register(fakedXrmContext);
 
+        // SeedCrmReferenceData must be registered before AddDefaultServiceClient is called
+        // to ensure this task runs before the cache pre-warming task
+        services.AddStartupTask<SeedCrmReferenceData>();
+
         services.AddSingleton<IXrmFakedContext>(fakedXrmContext);
         var organizationService = fakedXrmContext.GetAsyncOrganizationService2();
         services.AddDefaultServiceClient(ServiceLifetime.Singleton, _ => organizationService);
@@ -57,7 +61,6 @@ public static class ServiceCollectionExtensions
         fakedXrmContext.CallerProperties.CallerId = CreateTestUser();
 
         services.AddSingleton<SeedCrmReferenceData>();
-        services.AddStartupTask<SeedCrmReferenceData>();
 
         return services;
 


### PR DESCRIPTION
We see some timeouts from ID talking to this API after it's just been deployed. It's possible that the cold `ReferenceDataCache` is enough to slow down requests sufficiently for these timeouts to trip. This adds a start-up task to populate the entire `ReferenceDataCache`.