### PR TITLE
Add MQ Provider to DB

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationMapping.cs
@@ -8,6 +8,8 @@ public class MandatoryQualificationMapping : IEntityTypeConfiguration<MandatoryQ
 {
     public void Configure(EntityTypeBuilder<MandatoryQualification> builder)
     {
+        builder.HasOne<MandatoryQualificationProvider>().WithMany().HasForeignKey(p => p.ProviderId).HasConstraintName("fk_qualifications_mandatory_qualification_provider");
+        builder.Property(q => q.ProviderId).HasColumnName("mq_provider_id");
         builder.Property(q => q.Specialism).HasColumnName("mq_specialism");
         builder.Property(q => q.Status).HasColumnName("mq_status");
         builder.Property(q => q.StartDate).HasColumnName("start_date");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationProviderMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationProviderMapping.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class MandatoryQualificationProviderMapping : IEntityTypeConfiguration<MandatoryQualificationProvider>
+{
+    public void Configure(EntityTypeBuilder<MandatoryQualificationProvider> builder)
+    {
+        builder.ToTable("mandatory_qualification_providers");
+        builder.HasKey(p => p.MandatoryQualificationProviderId);
+        builder.Property(p => p.Name).HasMaxLength(200);
+
+        builder.HasData(MandatoryQualificationProvider.All);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231219171728_MqProviders.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231219171728_MqProviders.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231219171728_MqProviders")]
+    partial class MqProviders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231219171728_MqProviders.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231219171728_MqProviders.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class MqProviders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "mq_provider_id",
+                table: "qualifications",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "mandatory_qualification_providers",
+                columns: table => new
+                {
+                    mandatory_qualification_provider_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_mandatory_qualification_providers", x => x.mandatory_qualification_provider_id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "mandatory_qualification_providers",
+                columns: new[] { "mandatory_qualification_provider_id", "name" },
+                values: new object[,]
+                {
+                    { new Guid("0c30f666-647c-4ea8-8883-0fc6010b56be"), "University of Oxford/Oxford Polytechnic" },
+                    { new Guid("26204149-349c-4ad6-9466-bb9b83723eae"), "Liverpool John Moores University" },
+                    { new Guid("374dceb8-8224-45b8-b7dc-a6b0282b1065"), "Bristol Polytechnic" },
+                    { new Guid("3fc648a7-18e4-49e7-8a4b-1612616b72d5"), "University of London" },
+                    { new Guid("707d58ca-1953-413b-9a46-41e9b0be885e"), "University of Hertfordshire" },
+                    { new Guid("89f9a1aa-3d68-4985-a4ce-403b6044c18c"), "University of Leeds" },
+                    { new Guid("aa5c300e-3b7c-456c-8183-3520b3d55dca"), "University of Manchester" },
+                    { new Guid("aec32252-ef25-452e-a358-34a04e03369c"), "University of Newcastle-upon-Tyne" },
+                    { new Guid("d0e6d54c-5e90-438a-945d-f97388c2b352"), "University of Cambridge" },
+                    { new Guid("d4fc958b-21de-47ec-9f03-36ae237a1b11"), "University College, Swansea" },
+                    { new Guid("d9ee7054-7fde-4cfd-9a5e-4b99511d1b3d"), "University of Plymouth" },
+                    { new Guid("e28ea41d-408d-4c89-90cc-8b9b04ac68f5"), "University of Birmingham" },
+                    { new Guid("f417e73e-e2ad-40eb-85e3-55865be7f6be"), "Mary Hare School / University of Hertfordshire" },
+                    { new Guid("fbf22e04-b274-4c80-aba8-79fb6a7a32ce"), "University of Edinburgh" }
+                });
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_qualifications_mandatory_qualification_provider",
+                table: "qualifications",
+                column: "mq_provider_id",
+                principalTable: "mandatory_qualification_providers",
+                principalColumn: "mandatory_qualification_provider_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_qualifications_mandatory_qualification_provider",
+                table: "qualifications");
+
+            migrationBuilder.DropTable(
+                name: "mandatory_qualification_providers");
+
+            migrationBuilder.DropColumn(
+                name: "mq_provider_id",
+                table: "qualifications");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -2,7 +2,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class MandatoryQualification : Qualification
 {
-    // TODO Add Provider here when we've figured out how to model MQ Providers
+    public Guid? ProviderId { get; set; }
     public MandatoryQualificationSpecialism? Specialism { get; set; }
     public MandatoryQualificationStatus? Status { get; set; }
     public DateOnly? StartDate { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualificationProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualificationProvider.cs
@@ -1,0 +1,150 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class MandatoryQualificationProvider
+{
+    public required Guid MandatoryQualificationProviderId { get; init; }
+    public required string Name { get; set; }
+
+    public static bool TryMapFromDqtMqEstablishment(
+        dfeta_mqestablishment? mqestablishment,
+        [NotNullWhen(true)] out MandatoryQualificationProvider? provider)
+    {
+        if (mqestablishment is null)
+        {
+            provider = null;
+            return false;
+        }
+
+        switch (mqestablishment.dfeta_Value)
+        {
+            case "963":  // University of Oxford/Oxford Polytechnic
+                provider = All.Single(p => p.Name == "University of Oxford/Oxford Polytechnic");
+                return true;
+            case "957":  // University of Edinburgh
+                provider = All.Single(p => p.Name == "University of Edinburgh");
+                return true;
+            case "150":  // Postgraduate Diploma in Deaf Education, University of Manchester, School of Psychological Sciences
+            case "961":  // University of Manchester
+                provider = All.Single(p => p.Name == "University of Manchester");
+                return true;
+            case "210":  // Postgraduate Diploma in Multi-Sensory Impairment and Deafblindness, University of Birmingham, School of Education
+            case "180":  // BPhil in Multi-Sensory Impairment and Deafblindness, University of Birmingham, School of Education
+            case "160":  // BPhil in Education (Special Education: Hearing Impairment), University of Birmingham, School of Education
+            case "120":  // Postgraduate Diploma in Education (Special Education: Hearing Impairment), University of Birmingham, School of Education
+            case "20":  // BPhil for Teachers of Children with a Visual Impairment, University of Birmingham, School of Education
+            case "30":  // Postgraduate Diploma for Teachers of Children with Visual Impairment, University of Birmingham, School of Education
+            case "955":  // University of Birmingham
+                provider = All.Single(p => p.Name == "University of Birmingham");
+                return true;
+            case "956":  // University of Cambridge
+                provider = All.Single(p => p.Name == "University of Cambridge");
+                return true;
+            case "964":  // Liverpool John Moores University
+                provider = All.Single(p => p.Name == "Liverpool John Moores University");
+                return true;
+            case "959":  // University of Leeds
+                provider = All.Single(p => p.Name == "University of Leeds");
+                return true;
+            case "962":  // University of Newcastle-upon-Tyne
+                provider = All.Single(p => p.Name == "University of Newcastle-upon-Tyne");
+                return true;
+            case "90":  // Masters Level: Mandatory Qualification for Teachers of Children with Visual Impairment, University of Plymouth, Faculty of Education, in partnership with the Sensory Consortium
+            case "965":  // Plymouth University
+                provider = All.Single(p => p.Name == "University of Plymouth");
+                return true;
+            case "140":  // Postgraduate Diploma (Education of Deaf Children), University of Hertfordshire
+            case "958":  // University of Hertfordshire
+                provider = All.Single(p => p.Name == "University of Hertfordshire");
+                return true;
+            case "960":  // University of London
+            case "50":  // Graduate Diploma in Special and Inclusive Education: Disabilities of Sight, University of London Institute of Education
+                provider = All.Single(p => p.Name == "University of London");
+                return true;
+            case "951":  // Bristol Polytechnic
+                provider = All.Single(p => p.Name == "Bristol Polytechnic");
+                return true;
+            case "954":  // University College, Swansea
+                provider = All.Single(p => p.Name == "University College, Swansea");
+                return true;
+            default:
+                provider = null;
+                return false;
+        }
+    }
+
+    public static MandatoryQualificationProvider[] All { get; } =
+    [
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("e28ea41d-408d-4c89-90cc-8b9b04ac68f5"),
+            Name = "University of Birmingham"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("89f9a1aa-3d68-4985-a4ce-403b6044c18c"),
+            Name = "University of Leeds"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("aa5c300e-3b7c-456c-8183-3520b3d55dca"),
+            Name = "University of Manchester"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("f417e73e-e2ad-40eb-85e3-55865be7f6be"),
+            Name = "Mary Hare School / University of Hertfordshire"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("fbf22e04-b274-4c80-aba8-79fb6a7a32ce"),
+            Name = "University of Edinburgh"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("26204149-349c-4ad6-9466-bb9b83723eae"),
+            Name = "Liverpool John Moores University"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("0c30f666-647c-4ea8-8883-0fc6010b56be"),
+            Name = "University of Oxford/Oxford Polytechnic"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("d0e6d54c-5e90-438a-945d-f97388c2b352"),
+            Name = "University of Cambridge"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("aec32252-ef25-452e-a358-34a04e03369c"),
+            Name = "University of Newcastle-upon-Tyne"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("d9ee7054-7fde-4cfd-9a5e-4b99511d1b3d"),
+            Name = "University of Plymouth"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("707d58ca-1953-413b-9a46-41e9b0be885e"),
+            Name = "University of Hertfordshire"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("3fc648a7-18e4-49e7-8a4b-1612616b72d5"),
+            Name = "University of London"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("374dceb8-8224-45b8-b7dc-a6b0282b1065"),
+            Name = "Bristol Polytechnic"
+        },
+        new MandatoryQualificationProvider()
+        {
+            MandatoryQualificationProviderId = new Guid("d4fc958b-21de-47ec-9f03-36ae237a1b11"),
+            Name = "University College, Swansea"
+        },
+    ];
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/MandatoryQualification.cs
@@ -3,8 +3,17 @@ namespace TeachingRecordSystem.Core.Events.Models;
 public record MandatoryQualification
 {
     public required Guid QualificationId { get; init; }
+    public required MandatoryQualificationProvider? Provider { get; init; }
     public required MandatoryQualificationSpecialism? Specialism { get; init; }
     public required MandatoryQualificationStatus? Status { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
+}
+
+public record MandatoryQualificationProvider
+{
+    public required Guid? MandatoryQualificationProviderId { get; init; }
+    public required string? Name { get; init; }
+    public Guid? DqtMqEstablishmentId { get; init; }
+    public string? DqtMqEstablishmentName { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
@@ -13,7 +13,7 @@ public class DeleteMqState
 
     public string? PersonName { get; set; }
 
-    public string? MqEstablishment { get; set; }
+    public string? ProviderName { get; set; }
 
     public MandatoryQualificationSpecialism? Specialism { get; set; }
 
@@ -67,7 +67,7 @@ public class DeleteMqState
         PersonId = personDetail!.Contact.Id;
         PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
         var mqEstablishment = qualification.dfeta_MQ_MQEstablishmentId is not null ? await referenceDataCache.GetMqEstablishmentById(qualification.dfeta_MQ_MQEstablishmentId.Id) : null;
-        MqEstablishment = mqEstablishment?.dfeta_name;
+        ProviderName = mqEstablishment?.dfeta_name;
         var mqSpecialism = qualification.dfeta_MQ_SpecialismId is not null ? await referenceDataCache.GetMqSpecialismById(qualification.dfeta_MQ_SpecialismId.Id) : null;
         Specialism = mqSpecialism?.ToMandatoryQualificationSpecialism();
         StartDate = qualification.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
@@ -153,7 +153,7 @@ public class IndexModel(
 
         PersonId = JourneyInstance!.State.PersonId;
         PersonName = JourneyInstance!.State.PersonName;
-        TrainingProvider = JourneyInstance!.State.MqEstablishment;
+        TrainingProvider = JourneyInstance!.State.ProviderName;
         Specialism = JourneyInstance!.State.Specialism;
         Status = JourneyInstance!.State.Status;
         StartDate = JourneyInstance!.State.StartDate;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/MandatoryQualificationProviderTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/MandatoryQualificationProviderTests.cs
@@ -1,0 +1,63 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt.Models;
+
+namespace TeachingRecordSystem.Core.Tests.DataStore.Postgres.Models;
+
+public class MandatoryQualificationProviderTests
+{
+    [Theory]
+    [InlineData("963", true)]
+    [InlineData("957", true)]
+    [InlineData("150", true)]
+    [InlineData("961", true)]
+    [InlineData("210", true)]
+    [InlineData("180", true)]
+    [InlineData("160", true)]
+    [InlineData("120", true)]
+    [InlineData("20", true)]
+    [InlineData("30", true)]
+    [InlineData("955", true)]
+    [InlineData("956", true)]
+    [InlineData("964", true)]
+    [InlineData("959", true)]
+    [InlineData("962", true)]
+    [InlineData("90", true)]
+    [InlineData("965", true)]
+    [InlineData("140", true)]
+    [InlineData("958", true)]
+    [InlineData("960", true)]
+    [InlineData("50", true)]
+    [InlineData("951", true)]
+    [InlineData("954", true)]
+    [InlineData("952", false)]
+    [InlineData("100", false)]
+    [InlineData("110", false)]
+    [InlineData("60", false)]
+    [InlineData("10", false)]
+    [InlineData("130", false)]
+    [InlineData("70", false)]
+    [InlineData("170", false)]
+    [InlineData("80", false)]
+    [InlineData("200", false)]
+    [InlineData("190", false)]
+    [InlineData("40", false)]
+    [InlineData("220", false)]
+    [InlineData("953", false)]
+    [InlineData("240", false)]
+    [InlineData("230", false)]
+    [InlineData("950", false)]
+    public void TryMapFromDqtMqEstablishment_ReturnsExpectedResult(string mqestablishmentValue, bool expectedResult)
+    {
+        // Arrange
+        var mqestablishment = new dfeta_mqestablishment()
+        {
+            dfeta_Value = mqestablishmentValue
+        };
+
+        // Act
+        var result = MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqestablishment, out var provider);
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/EventInfoTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/EventInfoTests.cs
@@ -14,7 +14,7 @@ public class EventInfoTests
         {
             EventId = Guid.NewGuid(),
             CreatedUtc = DateTime.UtcNow,
-            RaisedBy = DataStore.Postgres.Models.User.SystemUserId,
+            RaisedBy = Core.DataStore.Postgres.Models.User.SystemUserId,
             User = new()
             {
                 AzureAdUserId = "ad-user-id",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
@@ -9,18 +9,13 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.TestCommon;
 
-public class DbHelper
+public class DbHelper(string connectionString)
 {
     private Respawner? _respawner;
     private readonly SemaphoreSlim _schemaLock = new(1, 1);
     private bool _haveResetSchema = false;
 
-    public DbHelper(string connectionString)
-    {
-        ConnectionString = connectionString;
-    }
-
-    public string ConnectionString { get; }
+    public string ConnectionString { get; } = connectionString;
 
     public static void ConfigureDbServices(IServiceCollection services, string connectionString)
     {
@@ -107,6 +102,7 @@ public class DbHelper
             connection,
             new RespawnerOptions()
             {
-                DbAdapter = DbAdapter.Postgres
+                DbAdapter = DbAdapter.Postgres,
+                TablesToIgnore = ["mandatory_qualification_providers"]
             });
 }


### PR DESCRIPTION
Also updates the MQ model for events to capture provider. We allow for specifying a DQT provider name in these events as the conversion from DQT MQ establishments to TRS MQ providers is lossy.