### PR TITLE
Create populated MQ by default in tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllSpecialismsHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllSpecialismsHandler.cs
@@ -10,8 +10,6 @@ public class GetAllSpecialismsHandler : ICrmQueryHandler<GetAllSpecialismsQuery,
     public async Task<dfeta_specialism[]> Execute(GetAllSpecialismsQuery query, IOrganizationServiceAsync organizationService)
     {
         var filter = new FilterExpression(LogicalOperator.And);
-        filter.AddCondition(dfeta_specialism.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_specialismState.Active);
-        filter.AddCondition(dfeta_specialism.Fields.dfeta_Value, ConditionOperator.In, "Hearing", "Multi-Sensory", "Visual");
 
         var queryExpression = new QueryExpression
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
@@ -32,10 +32,10 @@ public class GetQualificationsByContactIdTests : IAsyncLifetime
     public async Task WhenCalled_ForContactWithQualifications_ReturnsQualificationsAsExpected()
     {
         // Arrange
-        var person = await _dataScope.TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
-                    .WithMandatoryQualification()
-                    .WithMandatoryQualification(providerValue: "959", specialism: MandatoryQualificationSpecialism.Visual));
+        var person = await _dataScope.TestData.CreatePerson(x => x
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithMandatoryQualification()
+            .WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue("959").WithSpecialism(MandatoryQualificationSpecialism.Visual)));
 
         // Act
         var qualifications = await _crmQueryDispatcher.ExecuteQuery(new GetQualificationsByContactIdQuery(person.ContactId));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationEstablishmentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationEstablishmentTests.cs
@@ -22,9 +22,9 @@ public class UpdateMandatoryQualificationEstablishmentTests : IAsyncLifetime
         var originalMqEstablishmentValue = "955";
         var newMqEstablishment = await _dataScope.TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
 
-        var person = await _dataScope.TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
-                    .WithMandatoryQualification(providerValue: originalMqEstablishmentValue));
+        var person = await _dataScope.TestData.CreatePerson(x => x
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(originalMqEstablishmentValue)));
 
         var qualification = person.MandatoryQualifications.First();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
@@ -22,9 +22,9 @@ public class UpdateMandatoryQualificationSpecialismTests : IAsyncLifetime
         var originalSpecialism = MandatoryQualificationSpecialism.Visual;
         var newSpecialism = await _dataScope.TestData.ReferenceDataCache.GetMqSpecialismByValue(MandatoryQualificationSpecialism.Hearing.GetDqtValue());
 
-        var person = await _dataScope.TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
-                   .WithMandatoryQualification(specialism: originalSpecialism));
+        var person = await _dataScope.TestData.CreatePerson(x => x
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithMandatoryQualification(q => q.WithSpecialism(originalSpecialism)));
 
         var qualification = person.MandatoryQualifications.First();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStartDateTests.cs
@@ -22,9 +22,9 @@ public class UpdateMandatoryQualificationStartDateTests : IAsyncLifetime
         var originalStartDate = new DateOnly(2021, 10, 5);
         var newStartDate = new DateOnly(2020, 11, 7);
 
-        var person = await _dataScope.TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
-                .WithMandatoryQualification(startDate: originalStartDate));
+        var person = await _dataScope.TestData.CreatePerson(x => x
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithMandatoryQualification(q => q.WithStartDate(originalStartDate)));
 
         var qualification = person.MandatoryQualifications.First();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStatusTests.cs
@@ -28,9 +28,9 @@ public class UpdateMandatoryQualificationStatusTests : IAsyncLifetime
         DateOnly? originalEndDate = !string.IsNullOrEmpty(originalEndDateString) ? DateOnly.Parse(originalEndDateString) : null;
         DateOnly? newEndDate = !string.IsNullOrEmpty(newEndDateString) ? DateOnly.Parse(newEndDateString) : null;
 
-        var person = await _dataScope.TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5))
-                .WithMandatoryQualification(status: originalMqStatus, endDate: originalEndDate));
+        var person = await _dataScope.TestData.CreatePerson(x => x
+            .WithQts(qtsDate: new DateOnly(2021, 10, 5))
+            .WithMandatoryQualification(q => q.WithStatus(originalMqStatus).WithEndDate(originalEndDate)));
 
         var qualification = person.MandatoryQualifications.First();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
@@ -143,7 +143,7 @@ public class MqTests : TestBase
     {
         var oldStartDate = new DateOnly(2021, 10, 5);
         var newStartDate = new DateOnly(2021, 10, 6);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: oldStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(oldStartDate)));
         var personId = person.PersonId;
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
 
@@ -177,7 +177,7 @@ public class MqTests : TestBase
         var oldStatus = MandatoryQualificationStatus.Failed;
         var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 11, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStatus(oldStatus)));
         var personId = person.PersonId;
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
@@ -58,13 +58,12 @@ public class ConfirmTests : TestBase
         DateOnly? startDate = !string.IsNullOrEmpty(startDateString) ? DateOnly.Parse(startDateString) : null;
         DateOnly? endDate = !string.IsNullOrEmpty(endDateString) ? DateOnly.Parse(endDateString) : null;
 
-        var person = await TestData.CreatePerson(
-            b => b.WithMandatoryQualification(
-                providerValue: providerValue,
-                specialism: specialism,
-                startDate: startDate,
-                endDate: endDate,
-                status: status));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q
+            .WithDqtMqEstablishmentValue(providerValue)
+            .WithSpecialism(specialism)
+            .WithStartDate(startDate)
+            .WithEndDate(endDate)
+            .WithStatus(status)));
         var qualification = person.MandatoryQualifications.Single();
         var journeyInstance = await CreateJourneyInstance(
             qualification.QualificationId,
@@ -157,12 +156,12 @@ public class ConfirmTests : TestBase
         var evidenceFileId = Guid.NewGuid();
         var evidenceFileName = "test.pdf";
 
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(
-            providerValue: mqEstablishmentDqtValue,
-            specialism: specialism,
-            status: status,
-            startDate: startDate,
-            endDate: endDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q
+            .WithDqtMqEstablishmentValue(mqEstablishmentDqtValue)
+            .WithSpecialism(specialism)
+            .WithStatus(status)
+            .WithStartDate(startDate)
+            .WithEndDate(endDate)));
 
         var qualificationId = person.MandatoryQualifications!.Single().QualificationId;
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(mqEstablishmentDqtValue);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
@@ -44,8 +44,7 @@ public class ConfirmTests : TestBase
         var oldMqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(oldMqEstablishmentValue);
         var newMqEstablishmentValue = "959"; // University of Leeds
         var newMqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(newMqEstablishmentValue);
-        var person = await TestData.CreatePerson(
-            b => b.WithMandatoryQualification(providerValue: oldMqEstablishmentValue));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(oldMqEstablishmentValue)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -107,8 +106,7 @@ public class ConfirmTests : TestBase
         // Arrange
         var oldMqEstablishmentValue = "955"; // University of Birmingham
         var newMqEstablishmentValue = "959"; // University of Leeds
-        var person = await TestData.CreatePerson(
-                       b => b.WithMandatoryQualification(providerValue: oldMqEstablishmentValue));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(oldMqEstablishmentValue)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -145,8 +143,7 @@ public class ConfirmTests : TestBase
         // Arrange
         var oldMqEstablishmentValue = "955"; // University of Birmingham
         var newMqEstablishmentValue = "959"; // University of Leeds
-        var person = await TestData.CreatePerson(
-                       b => b.WithMandatoryQualification(providerValue: oldMqEstablishmentValue));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(oldMqEstablishmentValue)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
@@ -33,8 +33,7 @@ public class IndexTests : TestBase
     {
         // Arrange        
         var databaseMqEstablishmentValue = "955"; // University of Birmingham
-        var person = await TestData.CreatePerson(
-            b => b.WithMandatoryQualification(providerValue: databaseMqEstablishmentValue));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(databaseMqEstablishmentValue)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 
@@ -58,8 +57,7 @@ public class IndexTests : TestBase
         // Arrange        
         var databaseMqEstablishmentValue = "955"; // University of Birmingham
         var journeyMqEstablishmentValue = "959"; // University of Leeds
-        var person = await TestData.CreatePerson(
-            b => b.WithMandatoryQualification(providerValue: databaseMqEstablishmentValue));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(databaseMqEstablishmentValue)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -135,8 +133,7 @@ public class IndexTests : TestBase
         // Arrange
         var oldMqEstablishmentValue = "955"; // University of Birmingham
         var newMqEstablishmentValue = "959"; // University of Leeds
-        var person = await TestData.CreatePerson(
-            b => b.WithMandatoryQualification(providerValue: oldMqEstablishmentValue));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(oldMqEstablishmentValue)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
@@ -42,7 +42,7 @@ public class ConfirmTests : TestBase
         // Arrange
         var oldMqSpecialism = MandatoryQualificationSpecialism.Hearing;
         var newMqSpecialism = MandatoryQualificationSpecialism.Visual;
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: oldMqSpecialism));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithSpecialism(oldMqSpecialism)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -104,7 +104,7 @@ public class ConfirmTests : TestBase
         // Arrange
         var oldMqSpecialism = MandatoryQualificationSpecialism.Hearing;
         var newMqSpecialism = MandatoryQualificationSpecialism.Visual;
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: oldMqSpecialism));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithSpecialism(oldMqSpecialism)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -140,7 +140,7 @@ public class ConfirmTests : TestBase
     {
         // Arrange
         var specialism = MandatoryQualificationSpecialism.Hearing;
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: specialism));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithSpecialism(specialism)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
@@ -32,7 +32,7 @@ public class IndexTests : TestBase
     {
         // Arrange
         var databaseSpecialism = MandatoryQualificationSpecialism.Hearing;
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: databaseSpecialism));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithSpecialism(databaseSpecialism)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 
@@ -58,7 +58,7 @@ public class IndexTests : TestBase
         // Arrange
         var databaseSpecialism = MandatoryQualificationSpecialism.Hearing;
         var journeySpecialism = MandatoryQualificationSpecialism.Visual;
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: databaseSpecialism));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithSpecialism(databaseSpecialism)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -135,7 +135,7 @@ public class IndexTests : TestBase
         // Arrange
         var oldSpecialism = MandatoryQualificationSpecialism.Hearing;
         var newSpecialism = MandatoryQualificationSpecialism.Visual;
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: oldSpecialism));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithSpecialism(oldSpecialism)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -168,7 +168,7 @@ public class IndexTests : TestBase
     {
         // Arrange
         var specialism = MandatoryQualificationSpecialism.Hearing;
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(specialism: specialism));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithSpecialism(specialism)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
@@ -42,7 +42,7 @@ public class ConfirmTests : TestBase
         // Arrange
         var oldStartDate = new DateOnly(2021, 10, 5);
         var newStartDate = new DateOnly(2021, 10, 6);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: oldStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(oldStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -104,7 +104,7 @@ public class ConfirmTests : TestBase
         // Arrange
         var oldStartDate = new DateOnly(2021, 10, 5);
         var newStartDate = new DateOnly(2021, 10, 6);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: oldStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(oldStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -141,7 +141,7 @@ public class ConfirmTests : TestBase
     {
         // Arrange
         var oldStartDate = new DateOnly(2021, 10, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: oldStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(oldStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
@@ -32,7 +32,7 @@ public class IndexTests : TestBase
     {
         // Arrange
         var databaseStartDate = new DateOnly(2021, 10, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: databaseStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(databaseStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 
@@ -56,7 +56,7 @@ public class IndexTests : TestBase
         // Arrange
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var journeyStartDate = new DateOnly(2021, 10, 6);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: databaseStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(databaseStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -110,7 +110,7 @@ public class IndexTests : TestBase
     {
         // Arrange
         var databaseStartDate = new DateOnly(2021, 10, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: databaseStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(databaseStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 
@@ -132,7 +132,7 @@ public class IndexTests : TestBase
         // Arrange
         var oldStartDate = new DateOnly(2021, 10, 5);
         var newStartDate = new DateOnly(2021, 10, 6);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: oldStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(oldStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 
@@ -159,7 +159,7 @@ public class IndexTests : TestBase
     {
         // Arrange
         var oldStartDate = new DateOnly(2021, 10, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(startDate: oldStartDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStartDate(oldStartDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
@@ -43,7 +43,7 @@ public class ConfirmTests : TestBase
         var oldStatus = MandatoryQualificationStatus.Failed;
         var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 12, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStatus(oldStatus)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -109,7 +109,7 @@ public class ConfirmTests : TestBase
         var oldStatus = MandatoryQualificationStatus.Failed;
         var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 12, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStatus(oldStatus)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -149,7 +149,7 @@ public class ConfirmTests : TestBase
         var oldStatus = MandatoryQualificationStatus.Failed;
         var newStatus = MandatoryQualificationStatus.Passed;
         var newEndDate = new DateOnly(2021, 12, 5);
-        TestData.CreatePersonResult person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStatus(oldStatus)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/IndexTests.cs
@@ -33,7 +33,7 @@ public class IndexTests : TestBase
         // Arrange
         var databaseStatus = MandatoryQualificationStatus.Passed;
         var databaseEndDate = new DateOnly(2021, 11, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: databaseStatus, endDate: databaseEndDate));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStatus(databaseStatus).WithEndDate(databaseEndDate)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 
@@ -63,7 +63,7 @@ public class IndexTests : TestBase
         var databaseStatus = MandatoryQualificationStatus.Failed;
         var journeyStatus = MandatoryQualificationStatus.Passed;
         var journeyEndDate = new DateOnly(2021, 12, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: databaseStatus));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStatus(databaseStatus)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -164,7 +164,7 @@ public class IndexTests : TestBase
         var oldStatus = MandatoryQualificationStatus.Failed;
         var newStatus = dfeta_qualification_dfeta_MQ_Status.Passed;
         var newEndDate = new DateOnly(2021, 12, 5);
-        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(status: oldStatus));
+        var person = await TestData.CreatePerson(b => b.WithMandatoryQualification(q => q.WithStatus(oldStatus)));
         var qualificationId = person.MandatoryQualifications!.First().QualificationId;
         var journeyInstance = await CreateJourneyInstance(qualificationId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
@@ -58,7 +58,12 @@ public class QualificationsTests : TestBase
         DateOnly? endDate = !string.IsNullOrEmpty(endDateString) ? DateOnly.Parse(endDateString) : null;
         var person = await TestData.CreatePerson(x => x
             .WithQts(qtsDate: new DateOnly(2021, 10, 5))
-            .WithMandatoryQualification(providerValue, specialism, status, startDate, endDate));
+            .WithMandatoryQualification(q => q
+                .WithDqtMqEstablishmentValue(providerValue)
+                .WithSpecialism(specialism)
+                .WithStatus(status)
+                .WithStartDate(startDate)
+                .WithEndDate(endDate)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.ContactId}/qualifications");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
@@ -1,6 +1,7 @@
 using FakeXrmEasy.Abstractions;
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.TestCommon;
 
@@ -152,22 +153,14 @@ public class SeedCrmReferenceData : IStartupTask
 
     private void AddSpecialisms()
     {
-        _xrmFakedContext.CreateEntity(new dfeta_specialism()
+        foreach (var specialism in MandatoryQualificationSpecialismRegistry.All)
         {
-            dfeta_Value = "Hearing",
-            dfeta_name = "Hearing"
-        });
-
-        _xrmFakedContext.CreateEntity(new dfeta_specialism()
-        {
-            dfeta_Value = "Multi-Sensory",
-            dfeta_name = "Multi_Sensory Impairment"
-        });
-
-        _xrmFakedContext.CreateEntity(new dfeta_specialism()
-        {
-            dfeta_Value = "Visual",
-            dfeta_name = "Visual Impairment"
-        });
+            _xrmFakedContext.CreateEntity(new dfeta_specialism()
+            {
+                dfeta_Value = specialism.DqtValue,
+                dfeta_name = specialism.Title,
+                StateCode = specialism.IsValidForNewRecord ? dfeta_specialismState.Active : dfeta_specialismState.Inactive
+            });
+        }
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
@@ -202,6 +202,19 @@ public partial class TestData
 
     public Contact_GenderCode GenerateGender() => Faker.Enum.Random<Contact_GenderCode>();
 
+    public DateOnly GenerateDate(DateOnly min, DateOnly? max = null)
+    {
+        if (max is not null && max <= min)
+        {
+            throw new ArgumentOutOfRangeException("max", "max must be after min.");
+        }
+
+        max ??= min.AddYears(1);
+
+        var daysDiff = Math.Min(1, (int)(max.Value.ToDateTime(TimeOnly.MinValue) - min.ToDateTime(TimeOnly.MinValue)).TotalDays);
+        return min.AddDays(Random.Shared.Next(minValue: 1, maxValue: daysDiff));
+    }
+
     public string GenerateNationalInsuranceNumber() => Faker.Identification.UkNationalInsuranceNumber();
 
     protected async Task<T> WithDbContext<T>(Func<TrsDbContext, Task<T>> action)


### PR DESCRIPTION
Our `TestData` methods are intended to create fully-populated, sane-looking data by default with options to override specific attributes, where required. Our current method for MQs creates an empty MQ however.

This change moves to a builder-style approach for adding MQs and will create a fully-populated MQ by default. Fields can be removed by calling the appropriate `With*` method and passing a `null` argument.