### PR TITLE
Activate Add MQ journey from Index page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Index.cshtml.cs
@@ -3,20 +3,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-public class IndexModel : PageModel
+[Journey(JourneyNames.AddMq), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
 {
-    private readonly TrsLinkGenerator _linkGenerator;
-
-    public IndexModel(TrsLinkGenerator linkGenerator)
-    {
-        _linkGenerator = linkGenerator;
-    }
+    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
 
     [FromQuery]
     public Guid PersonId { get; set; }
 
-    public IActionResult OnGet()
-    {
-        return Redirect(_linkGenerator.MqAddProvider(PersonId, null));
-    }
+    public IActionResult OnGet() => Redirect(linkGenerator.MqAddProvider(PersonId, JourneyInstance!.InstanceId));
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.Core.Dqt.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[Journey(JourneyNames.AddMq), ActivatesJourney, RequireJourneyInstance]
+[Journey(JourneyNames.AddMq), RequireJourneyInstance]
 public class ProviderModel : PageModel
 {
     private readonly ReferenceDataCache _referenceDataCache;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -41,7 +41,7 @@ public class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string MqAdd(Guid personId) =>
         GetRequiredPathByPage("/Mqs/AddMq/Index", routeValues: new { personId });
 
-    public string MqAddProvider(Guid personId, JourneyInstanceId? journeyInstanceId) =>
+    public string MqAddProvider(Guid personId, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/Mqs/AddMq/Provider", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
     public string MqAddProviderCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/IndexTests.cs
@@ -1,12 +1,7 @@
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class IndexTests : TestBase
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public IndexTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_RedirectsToMqAddProvider()
     {
@@ -16,10 +11,11 @@ public class IndexTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add?personId={person.PersonId}");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Initializes journey
+        response = await response.FollowRedirect(HttpClient);
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/provider?personId={person.PersonId}", response.Headers.Location?.OriginalString);
+        Assert.StartsWith($"/mqs/add/provider?personId={person.PersonId}", response.Headers.Location?.OriginalString);
     }
 }


### PR DESCRIPTION
We typically activate journeys on the Index page but for Add MQ we've done it on the provider page. This moves the activation to Index.