### PR TITLE
Check that MQs have actually been added/edited

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualificationProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualificationProvider.cs
@@ -17,7 +17,14 @@ public class MandatoryQualificationProvider
             return false;
         }
 
-        switch (mqestablishment.dfeta_Value)
+        return TryMapFromDqtMqEstablishmentValue(mqestablishment.dfeta_Value, out provider);
+    }
+
+    public static bool TryMapFromDqtMqEstablishmentValue(
+        string mqestablishmentValue,
+        [NotNullWhen(true)] out MandatoryQualificationProvider? provider)
+    {
+        switch (mqestablishmentValue)
         {
             case "963":  // University of Oxford/Oxford Polytechnic
                 provider = All.Single(p => p.Name == "University of Oxford/Oxford Polytechnic");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.Core.Jobs.Scheduling;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
@@ -9,7 +11,8 @@ namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 public class ConfirmModel(
     ICrmQueryDispatcher crmQueryDispatcher,
     ReferenceDataCache referenceDataCache,
-    TrsLinkGenerator linkGenerator) : PageModel
+    TrsLinkGenerator linkGenerator,
+    IBackgroundJobScheduler backgroundJobScheduler) : PageModel
 {
     public JourneyInstance<EditMqSpecialismState>? JourneyInstance { get; set; }
 
@@ -35,6 +38,8 @@ public class ConfirmModel(
 
         await JourneyInstance!.CompleteAsync();
         TempData.SetFlashSuccess("Mandatory qualification changed");
+
+        await backgroundJobScheduler.Enqueue<TrsDataSyncHelper>(helper => helper.SyncMandatoryQualification(QualificationId, CancellationToken.None));
 
         return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/MandatoryQualificationProviderTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/MandatoryQualificationProviderTests.cs
@@ -1,5 +1,4 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Dqt.Models;
 
 namespace TeachingRecordSystem.Core.Tests.DataStore.Postgres.Models;
 
@@ -49,13 +48,9 @@ public class MandatoryQualificationProviderTests
     public void TryMapFromDqtMqEstablishment_ReturnsExpectedResult(string mqestablishmentValue, bool expectedResult)
     {
         // Arrange
-        var mqestablishment = new dfeta_mqestablishment()
-        {
-            dfeta_Value = mqestablishmentValue
-        };
 
         // Act
-        var result = MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqestablishment, out var provider);
+        var result = MandatoryQualificationProvider.TryMapFromDqtMqEstablishmentValue(mqestablishmentValue, out var provider);
 
         // Assert
         Assert.Equal(expectedResult, result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -355,6 +355,13 @@ public partial class TestData
                 helper => helper.SyncPerson(contact, ignoreInvalid: false, CancellationToken.None),
                 _syncEnabledOverride);
 
+            foreach (var mq in _mqBuilders)
+            {
+                await testData.SyncConfiguration.SyncIfEnabled(
+                    helper => helper.SyncMandatoryQualification(mq.QualificationId, CancellationToken.None),
+                    _syncEnabledOverride);
+            }
+
             return new CreatePersonResult()
             {
                 PersonId = PersonId,
@@ -386,6 +393,8 @@ public partial class TestData
         private Option<MandatoryQualificationStatus?> _status;
         private Option<DateOnly?> _startDate;
         private Option<DateOnly?> _endDate;
+
+        public Guid QualificationId { get; } = Guid.NewGuid();
 
         public CreatePersonMandatoryQualificationBuilder WithDqtMqEstablishmentValue(string? value)
         {
@@ -421,7 +430,6 @@ public partial class TestData
         {
             var mqEstablishments = await testData.ReferenceDataCache.GetMqEstablishments();
 
-            var qualificationId = Guid.NewGuid();
             var personId = createPersonBuilder.PersonId;
 
             var dqtMqEstablishmentValue = _dqtMqEstablishmentValue.ValueOr(mqEstablishments.RandomOne().dfeta_Value);
@@ -440,7 +448,7 @@ public partial class TestData
 
             var qualification = new dfeta_qualification()
             {
-                Id = qualificationId,
+                Id = QualificationId,
                 dfeta_PersonId = personId.ToEntityReference(Contact.EntityLogicalName),
                 dfeta_Type = dfeta_qualification_dfeta_Type.MandatoryQualification,
                 dfeta_MQ_MQEstablishmentId = mqEstablishment?.Id.ToEntityReference(dfeta_mqestablishment.EntityLogicalName),
@@ -456,7 +464,7 @@ public partial class TestData
             });
 
             return new MandatoryQualificationInfo(
-                qualificationId,
+                QualificationId,
                 dqtMqEstablishmentValue,
                 specialism,
                 status,


### PR DESCRIPTION
Previously the tests for adding and editing MQs have not actually checked that the adds or edits have been done. This changes that by adding an on-demand sync as part of the POSTs and asserting against the TRS DB.