### PR TITLE
Only use journey state for mutable data

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -1,3 +1,6 @@
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Events;
+
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class MandatoryQualification : Qualification
@@ -10,4 +13,57 @@ public class MandatoryQualification : Qualification
 
     public Guid? DqtMqEstablishmentId { get; set; }
     public Guid? DqtSpecialismId { get; set; }
+
+    public static async Task<MandatoryQualification> MapFromDqtQualification(dfeta_qualification qualification, ReferenceDataCache referenceDataCache)
+    {
+        var mqEstablishments = await referenceDataCache.GetMqEstablishments();
+        var mqSpecialisms = await referenceDataCache.GetMqSpecialisms();
+
+        return MapFromDqtQualification(qualification, mqEstablishments, mqSpecialisms);
+    }
+
+    public static MandatoryQualification MapFromDqtQualification(
+        dfeta_qualification qualification,
+        IEnumerable<dfeta_mqestablishment> mqEstablishments,
+        IEnumerable<dfeta_specialism> mqSpecialisms)
+    {
+        if (qualification.dfeta_Type != dfeta_qualification_dfeta_Type.MandatoryQualification)
+        {
+            throw new ArgumentException("Qualification is not a mandatory qualification.", nameof(qualification));
+        }
+
+        var deletedEvent = qualification.dfeta_TrsDeletedEvent is not null and not "{}" ?
+            EventInfo.Deserialize<MandatoryQualificationDeletedEvent>(qualification.dfeta_TrsDeletedEvent).Event :
+            null;
+
+        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(
+            mqEstablishments.SingleOrDefault(e => e.Id == qualification.dfeta_MQ_MQEstablishmentId!?.Id), out var provider);
+
+        MandatoryQualificationSpecialism? specialism = qualification.dfeta_MQ_SpecialismId is not null ?
+            mqSpecialisms.Single(s => s.Id == qualification.dfeta_MQ_SpecialismId.Id).ToMandatoryQualificationSpecialism() :
+            null;
+
+        MandatoryQualificationStatus? status = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus() ??
+            (qualification.dfeta_MQ_Date.HasValue ? MandatoryQualificationStatus.Passed : null);
+
+        return new MandatoryQualification()
+        {
+            QualificationId = qualification.Id,
+            CreatedOn = qualification.CreatedOn!.Value,
+            UpdatedOn = qualification.ModifiedOn!.Value,
+            DeletedOn = deletedEvent?.CreatedUtc,
+            PersonId = qualification.dfeta_PersonId.Id,
+            DqtQualificationId = qualification.Id,
+            DqtState = (int)qualification.StateCode!,
+            DqtCreatedOn = qualification.CreatedOn!.Value,
+            DqtModifiedOn = qualification.ModifiedOn!.Value,
+            ProviderId = provider?.MandatoryQualificationProviderId,
+            Specialism = specialism,
+            Status = status,
+            StartDate = qualification.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+            EndDate = qualification.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+            DqtMqEstablishmentId = qualification.dfeta_MQ_MQEstablishmentId?.Id,
+            DqtSpecialismId = qualification.dfeta_MQ_SpecialismId?.Id
+        };
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetQualificationByIdHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetQualificationByIdHandler.cs
@@ -25,6 +25,8 @@ public class GetQualificationByIdHandler : ICrmQueryHandler<GetQualificationById
                 dfeta_qualification.Fields.dfeta_MQ_SpecialismId,
                 dfeta_qualification.Fields.dfeta_MQ_Date,
                 dfeta_qualification.Fields.dfeta_MQ_Status,
+                dfeta_qualification.Fields.CreatedOn,
+                dfeta_qualification.Fields.ModifiedOn,
                 dfeta_qualification.Fields.StateCode),
             Criteria = filter
         };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -566,35 +566,7 @@ public class TrsDataSyncHelper(
                 events.Add(deletedEvent);
             }
 
-            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(
-                mqEstablishments.SingleOrDefault(e => e.Id == q.dfeta_MQ_MQEstablishmentId!?.Id), out var provider);
-
-            MandatoryQualificationSpecialism? specialism = q.dfeta_MQ_SpecialismId is not null ?
-                mqSpecialisms.Single(s => s.Id == q.dfeta_MQ_SpecialismId.Id).ToMandatoryQualificationSpecialism() :
-                null;
-
-            MandatoryQualificationStatus? status = q.dfeta_MQ_Status?.ToMandatoryQualificationStatus() ??
-                (q.dfeta_MQ_Date.HasValue ? MandatoryQualificationStatus.Passed : null);
-
-            mqs.Add(new MandatoryQualification()
-            {
-                QualificationId = q.Id,
-                CreatedOn = q.CreatedOn!.Value,
-                UpdatedOn = q.ModifiedOn!.Value,
-                DeletedOn = deletedEvent?.CreatedUtc,
-                PersonId = q.dfeta_PersonId.Id,
-                DqtQualificationId = q.Id,
-                DqtState = (int)q.StateCode!,
-                DqtCreatedOn = q.CreatedOn!.Value,
-                DqtModifiedOn = q.ModifiedOn!.Value,
-                ProviderId = provider?.MandatoryQualificationProviderId,
-                Specialism = specialism,
-                Status = status,
-                StartDate = q.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
-                EndDate = q.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true),
-                DqtMqEstablishmentId = q.dfeta_MQ_MQEstablishmentId?.Id,
-                DqtSpecialismId = q.dfeta_MQ_SpecialismId?.Id
-            });
+            mqs.Add(MandatoryQualification.MapFromDqtQualification(q, mqEstablishments, mqSpecialisms));
         }
 
         return (mqs, events);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/AssignCurrentPersonInfoFilterBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/AssignCurrentPersonInfoFilterBase.cs
@@ -1,0 +1,32 @@
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+public abstract class AssignCurrentPersonInfoFilterBase(ICrmQueryDispatcher crmQueryDispatcher)
+{
+    protected ICrmQueryDispatcher CrmQueryDispatcher { get; } = crmQueryDispatcher;
+
+    protected async Task<bool> TryAssignCurrentPersonInfo(Guid personId, HttpContext httpContext)
+    {
+        var contactDetail = await CrmQueryDispatcher.ExecuteQuery(
+            new GetContactDetailByIdQuery(
+                personId,
+                new ColumnSet(
+                    Contact.Fields.Id,
+                    Contact.Fields.FirstName,
+                    Contact.Fields.LastName)));
+
+        if (contactDetail is null)
+        {
+            return false;
+        }
+
+        httpContext.SetCurrentPersonFeature(
+            new CurrentPersonFeature(
+                contactDetail.Contact.Id,
+                contactDetail.Contact.FirstName,
+                contactDetail.Contact.LastName));
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckMandatoryQualificationExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckMandatoryQualificationExistsFilter.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+/// <summary>
+/// Checks that a Mandatory Qualification exists with the ID specified by the qualificationId route value.
+/// </summary>
+/// <remarks>
+/// <para>Returns a <see cref="StatusCodes.Status400BadRequest"/> response if the request is missing the qualicationId route value.</para>
+/// <para>Returns a <see cref="StatusCodes.Status404NotFound"/> response if no Mandatory Qualification with the specified ID exists.</para>
+/// <para>Assigns the <see cref="CurrentMandatoryQualificationFeature"/> and <see cref="CurrentPersonFeature"/> on success.</para>
+/// </remarks>
+public class CheckMandatoryQualificationExistsFilter(ICrmQueryDispatcher crmQueryDispatcher, ReferenceDataCache referenceDataCache) :
+    AssignCurrentPersonInfoFilterBase(crmQueryDispatcher), IAsyncResourceFilter
+{
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        if (context.RouteData.Values["qualificationId"] is not string qualificationIdParam ||
+            !Guid.TryParse(qualificationIdParam, out Guid qualificationId))
+        {
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        var qualification = await CrmQueryDispatcher.ExecuteQuery(new GetQualificationByIdQuery(qualificationId));
+
+        if (qualification is null ||
+            qualification.dfeta_Type != Core.Dqt.Models.dfeta_qualification_dfeta_Type.MandatoryQualification)
+        {
+            context.Result = new NotFoundResult();
+            return;
+        }
+
+        var mq = await MandatoryQualification.MapFromDqtQualification(qualification, referenceDataCache);
+
+        var provider = mq.ProviderId is Guid providerId ?
+            MandatoryQualificationProvider.All.Single(p => p.MandatoryQualificationProviderId == providerId) :
+            null;
+
+        var dqtEstablishment = qualification.dfeta_MQ_MQEstablishmentId?.Id is Guid establishmentId ?
+            await referenceDataCache.GetMqEstablishmentById(establishmentId) :
+            null;
+
+        context.HttpContext.SetCurrentMandatoryQualificationFeature(new(mq, provider, dqtEstablishment?.dfeta_name, dqtEstablishment?.dfeta_Value));
+
+        await TryAssignCurrentPersonInfo(qualification.dfeta_PersonId!.Id, context.HttpContext);
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -5,16 +5,20 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
-public class CheckPersonExistsFilter : IAsyncResourceFilter, IOrderedFilter
+/// <summary>
+/// Checks that a Person exists with the ID specified by the personId route value or query parameter.
+/// </summary>
+/// <remarks>
+/// <para>Returns a <see cref="StatusCodes.Status400BadRequest"/> response if the request is missing the personId route value.</para>
+/// <para>
+/// Returns a <see cref="StatusCodes.Status404NotFound"/> response if no person with the specified ID exists or if
+/// <paramref name="requireQts"/> is <c>true</c> and the person does not have QTS.
+/// </para>
+/// <para>Assigns the <see cref="CurrentPersonFeature"/> on success.</para>
+/// </remarks>
+public class CheckPersonExistsFilter(ICrmQueryDispatcher crmQueryDispatcher, bool requireQts = false) : IAsyncResourceFilter
 {
-    private readonly bool _requireQts;
-
-    public int Order => -200;
-
-    public CheckPersonExistsFilter(bool requireQts = false)
-    {
-        _requireQts = requireQts;
-    }
+    private readonly bool _requireQts = requireQts;
 
     public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
     {
@@ -25,7 +29,6 @@ public class CheckPersonExistsFilter : IAsyncResourceFilter, IOrderedFilter
             return;
         }
 
-        var crmQueryDispatcher = context.HttpContext.RequestServices.GetRequiredService<ICrmQueryDispatcher>();
         var person = await crmQueryDispatcher.ExecuteQuery(
             new GetContactDetailByIdQuery(
                 personId,
@@ -38,22 +41,30 @@ public class CheckPersonExistsFilter : IAsyncResourceFilter, IOrderedFilter
                     Contact.Fields.dfeta_StatedLastName,
                     Contact.Fields.dfeta_StatedMiddleName,
                     Contact.Fields.dfeta_QTSDate)));
+
         if (person is null)
         {
             context.Result = new NotFoundResult();
             return;
         }
-        else
+        else if (_requireQts && person.Contact.dfeta_QTSDate is null)
         {
-            if (_requireQts && person.Contact.dfeta_QTSDate is null)
-            {
-                context.Result = new BadRequestResult();
-                return;
-            }
+            context.Result = new BadRequestResult();
+            return;
         }
 
-        context.HttpContext.Items["CurrentPersonDetail"] = person;
+        context.HttpContext.SetCurrentPersonFeature(person);
 
         await next();
     }
+}
+
+public class CheckPersonExistsFilterFactory(bool requireQts = false) : IFilterFactory, IOrderedFilter
+{
+    public bool IsReusable => false;
+
+    public int Order => -200;
+
+    public IFilterMetadata CreateInstance(IServiceProvider serviceProvider) =>
+        ActivatorUtilities.CreateInstance<CheckPersonExistsFilter>(serviceProvider, requireQts);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Http.Features;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt.Models;
+
+namespace TeachingRecordSystem.SupportUi;
+
+public static class HttpContextExtensions
+{
+    public static CurrentPersonFeature GetCurrentPersonFeature(this HttpContext context) =>
+        context.Features.GetRequiredFeature<CurrentPersonFeature>();
+
+    public static void SetCurrentPersonFeature(this HttpContext context, CurrentPersonFeature currentPersonInfo) =>
+        context.Features.Set(currentPersonInfo);
+
+    public static void SetCurrentPersonFeature(this HttpContext context, ContactDetail contactDetail) =>
+        SetCurrentPersonFeature(
+            context,
+            new CurrentPersonFeature(
+                contactDetail.Contact.Id,
+                contactDetail.Contact.FirstName,
+                contactDetail.Contact.LastName));
+
+    public static CurrentMandatoryQualificationFeature GetCurrentMandatoryQualificationFeature(this HttpContext context) =>
+        context.Features.GetRequiredFeature<CurrentMandatoryQualificationFeature>();
+
+    public static void SetCurrentMandatoryQualificationFeature(this HttpContext context, CurrentMandatoryQualificationFeature currentMandatoryQualificationFeature) =>
+        context.Features.Set(currentMandatoryQualificationFeature);
+}
+
+public record CurrentPersonFeature(Guid PersonId, string FirstName, string LastName)
+{
+    public string Name => FirstName + " " + LastName;
+}
+
+public record CurrentMandatoryQualificationFeature(
+    MandatoryQualification MandatoryQualification,
+    MandatoryQualificationProvider? Provider,
+    string? DqtEstablishmentName,
+    string? DqtEstablishmentValue);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
@@ -65,14 +65,15 @@ public class CheckAnswersModel(
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        var personDetail = (ContactDetail?)context.HttpContext.Items["CurrentPersonDetail"];
-
         if (!JourneyInstance!.State.IsComplete)
         {
             context.Result = Redirect(linkGenerator.MqAddProvider(PersonId, JourneyInstance.InstanceId));
+            return;
         }
 
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonName = personInfo.Name;
         MqEstablishment = await referenceDataCache.GetMqEstablishmentByValue(JourneyInstance!.State.MqEstablishmentValue!);
         Specialism = JourneyInstance.State.Specialism;
         StartDate = JourneyInstance.State.StartDate;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.Dqt.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
@@ -40,17 +39,15 @@ public class SpecialismModel(TrsLinkGenerator linkGenerator) : PageModel
         return Redirect(linkGenerator.PersonQualifications(PersonId));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        var personDetail = (ContactDetail?)context.HttpContext.Items["CurrentPersonDetail"];
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         Specialisms = MandatoryQualificationSpecialismRegistry.All
             .OrderBy(t => t.Title)
             .ToArray();
 
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        PersonName = personInfo.Name;
         Specialism ??= JourneyInstance!.State.Specialism;
-
-        await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.Dqt.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
@@ -39,13 +38,11 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
         return Redirect(linkGenerator.PersonQualifications(PersonId));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        var personDetail = (ContactDetail?)context.HttpContext.Items["CurrentPersonDetail"];
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        PersonName = personInfo.Name;
         StartDate ??= JourneyInstance!.State.StartDate;
-
-        await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.Dqt.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
@@ -52,14 +51,12 @@ public class StatusModel(TrsLinkGenerator linkGenerator) : PageModel
         return Redirect(linkGenerator.PersonQualifications(PersonId));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        var personDetail = (ContactDetail?)context.HttpContext.Items["CurrentPersonDetail"];
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        PersonName = personInfo.Name;
         Status ??= JourneyInstance!.State.Status;
         EndDate ??= JourneyInstance!.State.EndDate;
-
-        await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
@@ -128,13 +128,16 @@ public class ConfirmModel(
             return;
         }
 
-        PersonId = JourneyInstance!.State.PersonId;
-        PersonName = JourneyInstance!.State.PersonName;
-        TrainingProvider = JourneyInstance!.State.ProviderName;
-        Specialism = JourneyInstance!.State.Specialism;
-        Status = JourneyInstance!.State.Status;
-        StartDate = JourneyInstance!.State.StartDate;
-        EndDate = JourneyInstance!.State.EndDate;
+        var qualificationInfo = context.HttpContext.GetCurrentMandatoryQualificationFeature();
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+        TrainingProvider = qualificationInfo.DqtEstablishmentName;
+        Specialism = qualificationInfo.MandatoryQualification.Specialism;
+        Status = qualificationInfo.MandatoryQualification.Status;
+        StartDate = qualificationInfo.MandatoryQualification.StartDate;
+        EndDate = qualificationInfo.MandatoryQualification.EndDate;
         DeletionReason = JourneyInstance!.State.DeletionReason;
         DeletionReasonDetail = JourneyInstance?.State.DeletionReasonDetail;
         EvidenceFileName = JourneyInstance!.State.EvidenceFileName;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
@@ -1,27 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 public class DeleteMqState
 {
     public bool Initialized { get; set; }
-
-    public Guid? PersonId { get; set; }
-
-    public string? PersonName { get; set; }
-
-    public string? ProviderName { get; set; }
-
-    public MandatoryQualificationSpecialism? Specialism { get; set; }
-
-    public MandatoryQualificationStatus? Status { get; set; }
-
-    public DateOnly? StartDate { get; set; }
-
-    public DateOnly? EndDate { get; set; }
 
     public MqDeletionReasonOption? DeletionReason { get; set; }
 
@@ -40,38 +24,4 @@ public class DeleteMqState
     public bool IsComplete => DeletionReason.HasValue &&
         UploadEvidence.HasValue &&
         (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
-
-    public async Task EnsureInitialized(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        ReferenceDataCache referenceDataCache,
-        dfeta_qualification qualification)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        var personDetail = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
-                qualification.dfeta_PersonId.Id,
-                new ColumnSet(
-                    Contact.Fields.Id,
-                    Contact.Fields.FirstName,
-                    Contact.Fields.MiddleName,
-                    Contact.Fields.LastName,
-                    Contact.Fields.dfeta_StatedFirstName,
-                    Contact.Fields.dfeta_StatedLastName,
-                    Contact.Fields.dfeta_StatedMiddleName,
-                    Contact.Fields.dfeta_QTSDate)));
-
-        PersonId = personDetail!.Contact.Id;
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
-        var mqEstablishment = qualification.dfeta_MQ_MQEstablishmentId is not null ? await referenceDataCache.GetMqEstablishmentById(qualification.dfeta_MQ_MQEstablishmentId.Id) : null;
-        ProviderName = mqEstablishment?.dfeta_name;
-        var mqSpecialism = qualification.dfeta_MQ_SpecialismId is not null ? await referenceDataCache.GetMqSpecialismById(qualification.dfeta_MQ_SpecialismId.Id) : null;
-        Specialism = mqSpecialism?.ToMandatoryQualificationSpecialism();
-        StartDate = qualification.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);
-        EndDate = qualification.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true);
-        Initialized = true;
-    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
@@ -57,8 +57,10 @@ public class ConfirmModel(
             return;
         }
 
-        PersonId = JourneyInstance!.State.PersonId;
-        PersonName = JourneyInstance!.State.PersonName;
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
         CurrentMqEstablishmentName = JourneyInstance!.State.CurrentMqEstablishmentName;
         NewMqEstablishment = await referenceDataCache.GetMqEstablishmentByValue(JourneyInstance!.State.MqEstablishmentValue!);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderState.cs
@@ -1,17 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
 public class EditMqProviderState
 {
     public bool Initialized { get; set; }
-
-    public Guid? PersonId { get; set; }
-
-    public string? PersonName { get; set; }
 
     public string? CurrentMqEstablishmentName { get; set; }
 
@@ -21,34 +15,15 @@ public class EditMqProviderState
     [MemberNotNullWhen(true, nameof(MqEstablishmentValue))]
     public bool IsComplete => !string.IsNullOrWhiteSpace(MqEstablishmentValue);
 
-    public async Task EnsureInitialized(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        ReferenceDataCache referenceDataCache,
-        dfeta_qualification qualification)
+    public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)
     {
         if (Initialized)
         {
             return;
         }
 
-        var personDetail = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
-                qualification.dfeta_PersonId.Id,
-                new ColumnSet(
-                    Contact.Fields.Id,
-                    Contact.Fields.FirstName,
-                    Contact.Fields.MiddleName,
-                    Contact.Fields.LastName,
-                    Contact.Fields.dfeta_StatedFirstName,
-                    Contact.Fields.dfeta_StatedLastName,
-                    Contact.Fields.dfeta_StatedMiddleName,
-                    Contact.Fields.dfeta_QTSDate)));
-
-        var mqEstablishment = qualification.dfeta_MQ_MQEstablishmentId is not null ? await referenceDataCache.GetMqEstablishmentById(qualification.dfeta_MQ_MQEstablishmentId.Id) : null;
-        MqEstablishmentValue = mqEstablishment is not null ? mqEstablishment.dfeta_Value : null;
-        CurrentMqEstablishmentName = mqEstablishment is not null ? mqEstablishment.dfeta_name : null;
-        PersonId = personDetail!.Contact.Id;
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        CurrentMqEstablishmentName = qualificationInfo.DqtEstablishmentName;
+        MqEstablishmentValue = qualificationInfo.DqtEstablishmentValue;
         Initialized = true;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
@@ -50,7 +50,7 @@ public class ConfirmModel(
         return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (!JourneyInstance!.State.IsComplete)
         {
@@ -58,11 +58,11 @@ public class ConfirmModel(
             return;
         }
 
-        PersonId = JourneyInstance!.State.PersonId;
-        PersonName = JourneyInstance!.State.PersonName;
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
         CurrentSpecialism = JourneyInstance!.State.CurrentSpecialism;
         NewSpecialism = JourneyInstance!.State.Specialism;
-
-        await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
@@ -1,17 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 public class EditMqSpecialismState
 {
     public bool Initialized { get; set; }
-
-    public Guid? PersonId { get; set; }
-
-    public string? PersonName { get; set; }
 
     public MandatoryQualificationSpecialism? CurrentSpecialism { get; set; }
 
@@ -21,34 +15,14 @@ public class EditMqSpecialismState
     [MemberNotNullWhen(true, nameof(Specialism))]
     public bool IsComplete => Specialism is not null;
 
-    public async Task EnsureInitialized(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        ReferenceDataCache referenceDataCache,
-        dfeta_qualification qualification)
+    public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)
     {
         if (Initialized)
         {
             return;
         }
 
-        var personDetail = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
-                qualification.dfeta_PersonId.Id,
-                new ColumnSet(
-                    Contact.Fields.Id,
-                    Contact.Fields.FirstName,
-                    Contact.Fields.MiddleName,
-                    Contact.Fields.LastName,
-                    Contact.Fields.dfeta_StatedFirstName,
-                    Contact.Fields.dfeta_StatedLastName,
-                    Contact.Fields.dfeta_StatedMiddleName,
-                    Contact.Fields.dfeta_QTSDate)));
-
-        var mqSpecialism = qualification.dfeta_MQ_SpecialismId is not null ? await referenceDataCache.GetMqSpecialismById(qualification.dfeta_MQ_SpecialismId.Id) : null;
-        Specialism = mqSpecialism?.ToMandatoryQualificationSpecialism();
-        CurrentSpecialism = mqSpecialism?.ToMandatoryQualificationSpecialism();
-        PersonId = personDetail!.Contact.Id;
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        Specialism = CurrentSpecialism = qualificationInfo.MandatoryQualification.Specialism;
         Initialized = true;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
@@ -47,7 +47,7 @@ public class ConfirmModel(
         return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (!JourneyInstance!.State.IsComplete)
         {
@@ -55,11 +55,11 @@ public class ConfirmModel(
             return;
         }
 
-        PersonId = JourneyInstance!.State.PersonId;
-        PersonName = JourneyInstance!.State.PersonName;
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
         CurrentStartDate = JourneyInstance!.State.CurrentStartDate;
         NewStartDate ??= JourneyInstance!.State.StartDate;
-
-        await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateState.cs
@@ -1,17 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
-using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 public class EditMqStartDateState
 {
     public bool Initialized { get; set; }
-
-    public Guid? PersonId { get; set; }
-
-    public string? PersonName { get; set; }
 
     public DateOnly? CurrentStartDate { get; set; }
 
@@ -21,32 +15,14 @@ public class EditMqStartDateState
     [MemberNotNullWhen(true, nameof(StartDate))]
     public bool IsComplete => StartDate is not null;
 
-    public async Task EnsureInitialized(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        dfeta_qualification qualification)
+    public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)
     {
         if (Initialized)
         {
             return;
         }
 
-        var personDetail = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
-                qualification.dfeta_PersonId.Id,
-                new ColumnSet(
-                    Contact.Fields.Id,
-                    Contact.Fields.FirstName,
-                    Contact.Fields.MiddleName,
-                    Contact.Fields.LastName,
-                    Contact.Fields.dfeta_StatedFirstName,
-                    Contact.Fields.dfeta_StatedLastName,
-                    Contact.Fields.dfeta_StatedMiddleName,
-                    Contact.Fields.dfeta_QTSDate)));
-
-        StartDate = qualification.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);
-        CurrentStartDate = StartDate;
-        PersonId = personDetail!.Contact.Id;
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        StartDate = CurrentStartDate = qualificationInfo.MandatoryQualification.StartDate;
         Initialized = true;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml.cs
@@ -2,25 +2,12 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 [Journey(JourneyNames.EditMqStartDate), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel : PageModel
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
 {
-    private readonly ICrmQueryDispatcher _crmQueryDispatcher;
-    private readonly TrsLinkGenerator _linkGenerator;
-
-    public IndexModel(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        TrsLinkGenerator linkGenerator)
-    {
-        _crmQueryDispatcher = crmQueryDispatcher;
-        _linkGenerator = linkGenerator;
-    }
-
     public JourneyInstance<EditMqStartDateState>? JourneyInstance { get; set; }
 
     [FromRoute]
@@ -53,29 +40,23 @@ public class IndexModel : PageModel
 
         await JourneyInstance!.UpdateStateAsync(state => state.StartDate = StartDate);
 
-        return Redirect(_linkGenerator.MqEditStartDateConfirm(QualificationId, JourneyInstance!.InstanceId));
+        return Redirect(linkGenerator.MqEditStartDateConfirm(QualificationId, JourneyInstance!.InstanceId));
     }
 
     public async Task<IActionResult> OnPostCancel()
     {
         await JourneyInstance!.DeleteAsync();
-        return Redirect(_linkGenerator.PersonQualifications(PersonId!.Value));
+        return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        var qualification = await _crmQueryDispatcher.ExecuteQuery(new GetQualificationByIdQuery(QualificationId));
-        if (qualification is null || qualification.dfeta_Type != dfeta_qualification_dfeta_Type.MandatoryQualification)
-        {
-            context.Result = NotFound();
-            return;
-        }
+        var qualificationInfo = context.HttpContext.GetCurrentMandatoryQualificationFeature();
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        await JourneyInstance!.State.EnsureInitialized(_crmQueryDispatcher, qualification);
+        JourneyInstance!.State.EnsureInitialized(qualificationInfo);
 
-        PersonId = JourneyInstance!.State.PersonId;
-        PersonName = JourneyInstance!.State.PersonName;
-
-        await next();
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
@@ -52,7 +52,7 @@ public class ConfirmModel(
         return Redirect(linkGenerator.PersonQualifications(PersonId!.Value));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (!JourneyInstance!.State.IsComplete)
         {
@@ -60,13 +60,13 @@ public class ConfirmModel(
             return;
         }
 
-        PersonId = JourneyInstance!.State.PersonId;
-        PersonName = JourneyInstance!.State.PersonName;
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
         CurrentStatus = JourneyInstance!.State.CurrentStatus;
         NewStatus ??= JourneyInstance!.State.Status;
         CurrentEndDate = JourneyInstance!.State.CurrentEndDate;
         NewEndDate ??= JourneyInstance!.State.EndDate;
-
-        await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqResultState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqResultState.cs
@@ -1,16 +1,10 @@
 using System.Text.Json.Serialization;
-using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Status;
 
 public class EditMqResultState
 {
     public bool Initialized { get; set; }
-
-    public Guid? PersonId { get; set; }
-
-    public string? PersonName { get; set; }
 
     public MandatoryQualificationStatus? CurrentStatus { get; set; }
 
@@ -24,34 +18,15 @@ public class EditMqResultState
     public bool IsComplete => Status.HasValue &&
         (Status != MandatoryQualificationStatus.Passed || Status == MandatoryQualificationStatus.Passed && EndDate.HasValue);
 
-    public async Task EnsureInitialized(
-        ICrmQueryDispatcher crmQueryDispatcher,
-        dfeta_qualification qualification)
+    public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)
     {
         if (Initialized)
         {
             return;
         }
 
-        var personDetail = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
-                qualification.dfeta_PersonId.Id,
-                new ColumnSet(
-                    Contact.Fields.Id,
-                    Contact.Fields.FirstName,
-                    Contact.Fields.MiddleName,
-                    Contact.Fields.LastName,
-                    Contact.Fields.dfeta_StatedFirstName,
-                    Contact.Fields.dfeta_StatedLastName,
-                    Contact.Fields.dfeta_StatedMiddleName,
-                    Contact.Fields.dfeta_QTSDate)));
-
-        EndDate = qualification.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true);
-        CurrentEndDate = EndDate;
-        Status = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus() ?? (EndDate is not null ? MandatoryQualificationStatus.Passed : null);
-        CurrentStatus = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus();
-        PersonId = personDetail!.Contact.Id;
-        PersonName = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
+        Status = CurrentStatus = qualificationInfo.MandatoryQualification.Status;
+        EndDate = CurrentEndDate = qualificationInfo.MandatoryQualification.EndDate;
         Initialized = true;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
@@ -67,13 +67,11 @@ public class QualificationsModel : PageModel
         return Task.WhenAll(mqs);
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        var personDetail = (ContactDetail?)context.HttpContext.Items["CurrentPersonDetail"];
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        Name = personDetail!.Contact.ResolveFullName(includeMiddleName: false);
-
-        await next();
+        Name = personInfo.Name;
     }
 
     public record MandatoryQualificationInfo

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -4,6 +4,7 @@ using Joonasw.AspNetCore.SecurityHeaders;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
@@ -89,13 +90,28 @@ builder.Services
             "/Persons/PersonDetail",
             model =>
             {
-                model.Filters.Add(new CheckPersonExistsFilter());
+                model.Filters.Add(new CheckPersonExistsFilterFactory());
             });
+
         options.Conventions.AddFolderApplicationModelConvention(
             "/Mqs/AddMq",
             model =>
             {
-                model.Filters.Add(new CheckPersonExistsFilter());
+                model.Filters.Add(new CheckPersonExistsFilterFactory());
+            });
+
+        options.Conventions.AddFolderApplicationModelConvention(
+            "/Mqs/DeleteMq",
+            model =>
+            {
+                model.Filters.Add(new ServiceFilterAttribute<CheckMandatoryQualificationExistsFilter>());
+            });
+
+        options.Conventions.AddFolderApplicationModelConvention(
+            "/Mqs/EditMq",
+            model =>
+            {
+                model.Filters.Add(new ServiceFilterAttribute<CheckMandatoryQualificationExistsFilter>() { Order = -200 });
             });
     })
     .AddMvcOptions(options =>
@@ -161,6 +177,7 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
 builder.Services
     .AddTransient<FormFlow.State.IUserInstanceStateProvider, DbUserInstanceStateProvider>()
     .AddTransient<ICurrentUserIdProvider, HttpContextCurrentUserIdProvider>()
+    .AddTransient<CheckMandatoryQualificationExistsFilter>()
     .AddFormFlow(options =>
     {
         options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
@@ -1,19 +1,13 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.DeleteMq;
 
-public class ConfirmTests : TestBase
+public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public ConfirmTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_MissingDataInJourneyState_Redirects()
     {
@@ -24,9 +18,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new DeleteMqState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -70,13 +62,6 @@ public class ConfirmTests : TestBase
             new DeleteMqState
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                ProviderName = mqEstablishment?.dfeta_name,
-                Specialism = specialism,
-                Status = status,
-                StartDate = startDate,
-                EndDate = endDate,
                 DeletionReason = deletionReason,
                 DeletionReasonDetail = deletionReasonDetail,
                 UploadEvidence = uploadEvidence,
@@ -124,9 +109,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new DeleteMqState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -173,13 +156,6 @@ public class ConfirmTests : TestBase
             new DeleteMqState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                ProviderName = mqEstablishment.dfeta_name,
-                Specialism = specialism,
-                Status = status,
-                StartDate = startDate,
-                EndDate = endDate,
                 DeletionReason = deletionReason,
                 DeletionReasonDetail = deletionReasonDetail,
                 UploadEvidence = true,
@@ -261,13 +237,6 @@ public class ConfirmTests : TestBase
             new DeleteMqState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
-                ProviderName = "University of Leeds",
-                Specialism = MandatoryQualificationSpecialism.Hearing,
-                Status = MandatoryQualificationStatus.Passed,
-                StartDate = new DateOnly(2023, 09, 01),
-                EndDate = new DateOnly(2023, 11, 05),
                 DeletionReason = MqDeletionReasonOption.ProviderRequest,
                 DeletionReasonDetail = "Some details about the deletion reason",
                 UploadEvidence = false

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
@@ -1,18 +1,12 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Provider;
 
-public class ConfirmTests : TestBase
+public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public ConfirmTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_MissingDataInJourneyState_Redirects()
     {
@@ -23,9 +17,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqProviderState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/provider/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -53,8 +45,6 @@ public class ConfirmTests : TestBase
             new EditMqProviderState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = newMqEstablishmentValue,
                 CurrentMqEstablishmentName = oldMqEstablishment.dfeta_name,
             });
@@ -84,9 +74,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqProviderState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -115,8 +103,6 @@ public class ConfirmTests : TestBase
             new EditMqProviderState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = newMqEstablishmentValue
             });
 
@@ -159,8 +145,6 @@ public class ConfirmTests : TestBase
             new EditMqProviderState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = newMqEstablishmentValue
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
@@ -1,17 +1,11 @@
 using AngleSharp.Html.Dom;
 using FormFlow;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Provider;
 
-public class IndexTests : TestBase
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public IndexTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
     {
@@ -64,8 +58,6 @@ public class IndexTests : TestBase
             new EditMqProviderState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = journeyMqEstablishmentValue
             });
 
@@ -140,8 +132,6 @@ public class IndexTests : TestBase
             new EditMqProviderState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = oldMqEstablishmentValue
             });
 
@@ -174,8 +164,6 @@ public class IndexTests : TestBase
             new EditMqProviderState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 MqEstablishmentValue = mqEstablishmentValue
             });
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
@@ -1,17 +1,11 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Specialism;
 
-public class ConfirmTests : TestBase
+public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public ConfirmTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_MissingDataInJourneyState_Redirects()
     {
@@ -22,9 +16,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqSpecialismState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -50,8 +42,6 @@ public class ConfirmTests : TestBase
             new EditMqSpecialismState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Specialism = newMqSpecialism,
                 CurrentSpecialism = oldMqSpecialism,
             });
@@ -81,9 +71,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqSpecialismState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -112,8 +100,6 @@ public class ConfirmTests : TestBase
             new EditMqSpecialismState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Specialism = newMqSpecialism
             });
 
@@ -155,8 +141,6 @@ public class ConfirmTests : TestBase
             new EditMqSpecialismState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Specialism = newMqSpecialism
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
@@ -1,16 +1,10 @@
 using FormFlow;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Specialism;
 
-public class IndexTests : TestBase
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public IndexTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
     {
@@ -65,8 +59,6 @@ public class IndexTests : TestBase
             new EditMqSpecialismState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Specialism = journeySpecialism
             });
 
@@ -142,8 +134,6 @@ public class IndexTests : TestBase
             new EditMqSpecialismState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Specialism = oldSpecialism
             });
 
@@ -175,8 +165,6 @@ public class IndexTests : TestBase
             new EditMqSpecialismState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Specialism = specialism
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
@@ -1,17 +1,11 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.StartDate;
 
-public class ConfirmTests : TestBase
+public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public ConfirmTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_MissingDataInJourneyState_Redirects()
     {
@@ -22,9 +16,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqStartDateState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/start-date/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -50,8 +42,6 @@ public class ConfirmTests : TestBase
             new EditMqStartDateState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -81,9 +71,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqStartDateState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -112,8 +100,6 @@ public class ConfirmTests : TestBase
             new EditMqStartDateState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -156,8 +142,6 @@ public class ConfirmTests : TestBase
             new EditMqStartDateState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = newStartDate
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
@@ -1,16 +1,10 @@
 using FormFlow;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.StartDate;
 
-public class IndexTests : TestBase
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public IndexTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
     {
@@ -63,8 +57,6 @@ public class IndexTests : TestBase
             new EditMqStartDateState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 StartDate = journeyStartDate
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
@@ -1,17 +1,11 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Status;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Status;
 
-public class ConfirmTests : TestBase
+public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public ConfirmTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_MissingDataInJourneyState_Redirects()
     {
@@ -22,9 +16,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqResultState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/status/confirm?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -51,8 +43,6 @@ public class ConfirmTests : TestBase
             new EditMqResultState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Status = newStatus,
                 EndDate = newEndDate,
                 CurrentStatus = oldStatus,
@@ -85,9 +75,7 @@ public class ConfirmTests : TestBase
             qualificationId,
             new EditMqResultState()
             {
-                Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false)
+                Initialized = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/status/confirm?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -117,8 +105,6 @@ public class ConfirmTests : TestBase
             new EditMqResultState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Status = newStatus,
                 EndDate = newEndDate,
                 CurrentStatus = oldStatus,
@@ -165,8 +151,6 @@ public class ConfirmTests : TestBase
             new EditMqResultState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Status = newStatus,
                 EndDate = newEndDate,
                 CurrentStatus = oldStatus,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/IndexTests.cs
@@ -4,13 +4,8 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Status;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Status;
 
-public class IndexTests : TestBase
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public IndexTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
     {
@@ -70,8 +65,6 @@ public class IndexTests : TestBase
             new EditMqResultState()
             {
                 Initialized = true,
-                PersonId = person.PersonId,
-                PersonName = person.Contact.ResolveFullName(includeMiddleName: false),
                 Status = journeyStatus,
                 EndDate = journeyEndDate
             });


### PR DESCRIPTION
Until now we've used journey state as a kind of cache for any data that the journey needs. I've changed this around so that only mutable data is stored.

The filter approach we started for 'personId' is now extended to cover MQs and this moves to using strongly-typed features and extension methods instead of `HttpContext.Items`.