### PR TITLE
[775] Reduce StatusCake sensitivity

### DIFF
--- a/terraform/aks/monitoring.tf
+++ b/terraform/aks/monitoring.tf
@@ -1,7 +1,7 @@
 module "statuscake" {
   count = var.enable_monitoring ? 1 : 0
 
-  source = "git::https://github.com/DFE-Digital/terraform-modules.git//monitoring/statuscake?ref=8c6c2e0dbb6a5e5a9c78db3a55910a8cdd9250d8"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//monitoring/statuscake?ref=stable"
 
   uptime_urls = concat(
     [
@@ -12,6 +12,4 @@ module "statuscake" {
   )
 
   contact_groups = [288912]
-
-  confirmation = 0
 }


### PR DESCRIPTION
### Context
This was changed during the front door errors investigation

### Changes proposed in this pull request

Revert to default StatusCake confirmations to eliminate false alarms

### Guidance to review
Check default

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
