### PR TITLE
Add a script and just recipe to clear schema cache

### DIFF
--- a/justfile
+++ b/justfile
@@ -95,3 +95,7 @@ make *ARGS:
 # Generates CRM model types
 generate-crm-models *ARGS:
   @scripts/Generate-CrmModels.ps1 {{ARGS}}
+
+# Removes the cached DB schema version file for tests
+remove-tests-schema-cache:
+  @scripts/Remove-TestsSchemaCache.ps1

--- a/scripts/Remove-TestsSchemaCache.ps1
+++ b/scripts/Remove-TestsSchemaCache.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = "Stop"
+
+$appDataDir = Join-Path -Path ([Environment]::GetFolderPath("ApplicationData")) "TeachingRecordSystem.Tests"
+Get-ChildItem $appDataDir -Filter "*-dbversion.txt" | ForEach-Object { Remove-Item -Force $_ }


### PR DESCRIPTION
When a test project deploys the DB, it stashes away a hash of the current schema definition in an AppData folder. The next time the tests are run, the hash is re-calculated and if it matches what's in the AppData file we know the schema hasn't changed and we can skip re-deploying the DB.

Occasionally something goes wrong and we want to force re-deploying the DB. This script is a helpful shortcut for doing that.