### PR TITLE
Include Inactive teacher statuses

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllTeacherStatusesHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllTeacherStatusesHandler.cs
@@ -17,7 +17,6 @@ public class GetAllTeacherStatusesHandler : ICrmQueryHandler<GetAllTeacherStatus
                 dfeta_teacherstatus.Fields.dfeta_QTSDateRequired,
                 dfeta_teacherstatus.Fields.dfeta_Value)
         };
-        queryExpression.Criteria.AddCondition(dfeta_teacherstatus.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_teacherStatusState.Active);
 
         var request = new RetrieveMultipleRequest()
         {


### PR DESCRIPTION
The previous PR that added status description to the v3 teachers endpoint gets status descriptions and caches them. It was noticed that a teacher has a qts with an inactive teacherstatusid - therefore Single() errors because the query was filtering out inactive ones. This PR allows the inactive teacher statuses to be returned.

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
