### PR TITLE
Don't raise error when shutting down sync services

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/DqtReportingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/DqtReportingService.cs
@@ -146,6 +146,10 @@ public partial class DqtReportingService : BackgroundService
                 {
                     await ProcessChangesForEntityType(entityType, ct);
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     throw new ProcessChangesException(entityType, ex);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -62,6 +62,10 @@ public class TrsDataSyncService(
                 {
                     await ProcessChangesForModelType(modelType, cancellationToken);
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     throw new ProcessChangesException(modelType, ex);


### PR DESCRIPTION
We have a few errors in Sentry caused by `OperationCanceledException`s in `TrsDataSyncService` when the app is shutting down. This change prevents wrapping those exceptions so that they are correctly handled (and not logged).

While the Sentry logs have only been for `TrsDataSyncService` I've made the same change to `DqtReportingService` too, since it's near-identical in its error handling and could see the same problem.