### PR TITLE
Remove : from pattern matching for qualified teacher

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -349,7 +349,7 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
         "213" => "Qualified",
         "214" => "Partial qualified teacher status",
         "223" => "Qualified",
-        _ when statusDescription.StartsWith("Qualified teacher:", StringComparison.InvariantCultureIgnoreCase) => "Qualified",
+        _ when statusDescription.StartsWith("Qualified teacher", StringComparison.InvariantCultureIgnoreCase) => "Qualified",
         _ => throw new ArgumentException("Invalid QTS Status")
     };
 


### PR DESCRIPTION
Not all statuses have : in, so the pattern matching fails for qts status description. This PR removes the ':' in the pattern matching for Qualified teacher.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
