### PR TITLE
Fix event processing for synced events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -11,6 +11,7 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.ToTable("events");
         builder.Property(e => e.EventName).IsRequired().HasMaxLength(200);
         builder.Property(e => e.Created).IsRequired();
+        builder.Property(e => e.Inserted).IsRequired();
         builder.Property(e => e.Payload).IsRequired().HasColumnType("jsonb");
         builder.Property(e => e.Published);
         builder.HasKey(e => e.EventId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231221141110_EventInserted.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231221141110_EventInserted.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231221141110_EventInserted")]
+    partial class EventInserted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -79,7 +82,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("character varying(200)")
                         .HasColumnName("event_name");
 
-                    b.Property<DateTime>("Inserted")
+                    b.Property<DateTime?>("Inserted")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("inserted");
@@ -337,97 +340,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasName("pk_journey_states");
 
                     b.ToTable("journey_states", (string)null);
-                });
-
-            modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.MandatoryQualificationProvider", b =>
-                {
-                    b.Property<Guid>("MandatoryQualificationProviderId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("mandatory_qualification_provider_id");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("name");
-
-                    b.HasKey("MandatoryQualificationProviderId")
-                        .HasName("pk_mandatory_qualification_providers");
-
-                    b.ToTable("mandatory_qualification_providers", (string)null);
-
-                    b.HasData(
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("e28ea41d-408d-4c89-90cc-8b9b04ac68f5"),
-                            Name = "University of Birmingham"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("89f9a1aa-3d68-4985-a4ce-403b6044c18c"),
-                            Name = "University of Leeds"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("aa5c300e-3b7c-456c-8183-3520b3d55dca"),
-                            Name = "University of Manchester"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("f417e73e-e2ad-40eb-85e3-55865be7f6be"),
-                            Name = "Mary Hare School / University of Hertfordshire"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("fbf22e04-b274-4c80-aba8-79fb6a7a32ce"),
-                            Name = "University of Edinburgh"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("26204149-349c-4ad6-9466-bb9b83723eae"),
-                            Name = "Liverpool John Moores University"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("0c30f666-647c-4ea8-8883-0fc6010b56be"),
-                            Name = "University of Oxford/Oxford Polytechnic"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("d0e6d54c-5e90-438a-945d-f97388c2b352"),
-                            Name = "University of Cambridge"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("aec32252-ef25-452e-a358-34a04e03369c"),
-                            Name = "University of Newcastle-upon-Tyne"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("d9ee7054-7fde-4cfd-9a5e-4b99511d1b3d"),
-                            Name = "University of Plymouth"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("707d58ca-1953-413b-9a46-41e9b0be885e"),
-                            Name = "University of Hertfordshire"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("3fc648a7-18e4-49e7-8a4b-1612616b72d5"),
-                            Name = "University of London"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("374dceb8-8224-45b8-b7dc-a6b0282b1065"),
-                            Name = "Bristol Polytechnic"
-                        },
-                        new
-                        {
-                            MandatoryQualificationProviderId = new Guid("d4fc958b-21de-47ec-9f03-36ae237a1b11"),
-                            Name = "University College, Swansea"
-                        });
                 });
 
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.Person", b =>
@@ -800,10 +712,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("date")
                         .HasColumnName("end_date");
 
-                    b.Property<Guid?>("ProviderId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("mq_provider_id");
-
                     b.Property<int?>("Specialism")
                         .HasColumnType("integer")
                         .HasColumnName("mq_specialism");
@@ -875,14 +783,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
                         .HasConstraintName("fk_qualifications_person");
-                });
-
-            modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.MandatoryQualification", b =>
-                {
-                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.MandatoryQualificationProvider", null)
-                        .WithMany()
-                        .HasForeignKey("ProviderId")
-                        .HasConstraintName("fk_qualifications_mandatory_qualification_provider");
                 });
 
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.EytsAwardedEmailsJob", b =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231221141110_EventInserted.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20231221141110_EventInserted.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EventInserted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "inserted",
+                table: "events",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.Sql("update events set inserted = created where inserted is null");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "inserted",
+                table: "events",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "inserted",
+                table: "events");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
@@ -8,10 +8,11 @@ public class Event
     public required Guid EventId { get; init; }
     public required string EventName { get; init; }
     public required DateTime Created { get; init; }
+    public required DateTime Inserted { get; init; }
     public required string Payload { get; init; }
     public bool Published { get; set; }
 
-    public static Event FromEventBase(EventBase @event)
+    public static Event FromEventBase(EventBase @event, DateTime? inserted)
     {
         var eventName = @event.GetEventName();
         var payload = JsonSerializer.Serialize(@event, inputType: @event.GetType(), EventBase.JsonSerializerOptions);
@@ -19,8 +20,9 @@ public class Event
         return new Event()
         {
             EventId = @event.EventId,
-            Created = @event.CreatedUtc,
             EventName = eventName,
+            Created = @event.CreatedUtc,
+            Inserted = inserted ?? @event.CreatedUtc,
             Payload = payload
         };
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -63,9 +63,9 @@ public class TrsDbContext : DbContext
             .UseSnakeCaseNamingConvention();
     }
 
-    public void AddEvent(EventBase @event)
+    public void AddEvent(EventBase @event, DateTime? inserted = null)
     {
-        Events.Add(Event.FromEventBase(@event));
+        Events.Add(Event.FromEventBase(@event, inserted));
     }
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/PublishEventsBackgroundService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/PublishEventsBackgroundService.cs
@@ -60,9 +60,11 @@ public class PublishEventsBackgroundService : BackgroundService
                 .FromSql($"""
                     select * from events
                     where published is false
-                    and created > {lastProcessedEventTimestamp}
+                    and inserted > {lastProcessedEventTimestamp}
                     and event_id != {lastProcessedEventId}
-                    for update skip locked limit {BatchSize}
+                    order by inserted, created
+                    for update skip locked
+                    limit {BatchSize}
                     """)
                 .ToListAsync(cancellationToken: cancellationToken);
 
@@ -88,7 +90,7 @@ public class PublishEventsBackgroundService : BackgroundService
                 }
                 finally
                 {
-                    lastProcessedEventTimestamp = e.Created;
+                    lastProcessedEventTimestamp = e.Inserted;
                     lastProcessedEventId = e.EventId;
                 }
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -582,6 +582,7 @@ public class TrsDataSyncHelper(
             "event_id",
             "event_name",
             "created",
+            "inserted",
             "payload"
         };
 
@@ -592,6 +593,7 @@ public class TrsDataSyncHelper(
                 event_id UUID NOT NULL,
                 event_name VARCHAR(200) NOT NULL,
                 created TIMESTAMP WITH TIME ZONE NOT NULL,
+                inserted TIMESTAMP WITH TIME ZONE NOT NULL,
                 payload JSONB NOT NULL
             )
             """;
@@ -622,6 +624,7 @@ public class TrsDataSyncHelper(
             writer.WriteValueOrNull(e.EventId, NpgsqlDbType.Uuid);
             writer.WriteValueOrNull(e.GetEventName(), NpgsqlDbType.Varchar);
             writer.WriteValueOrNull(e.CreatedUtc, NpgsqlDbType.TimestampTz);
+            writer.WriteValueOrNull(clock.UtcNow, NpgsqlDbType.TimestampTz);
             writer.WriteValueOrNull(payload, NpgsqlDbType.Jsonb);
         }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Events/Processing/PublishEventsBackgroundServiceTests.cs
@@ -8,14 +8,9 @@ using TeachingRecordSystem.Core.Events.Processing;
 namespace TeachingRecordSystem.Core.Tests.Events.Processing;
 
 [Collection(nameof(DisableParallelization))]
-public class PublishEventsBackgroundServiceTests : IAsyncLifetime
+public class PublishEventsBackgroundServiceTests(DbFixture dbFixture) : IAsyncLifetime
 {
-    private readonly DbFixture _dbFixture;
-
-    public PublishEventsBackgroundServiceTests(DbFixture dbFixture)
-    {
-        _dbFixture = dbFixture;
-    }
+    private readonly DbFixture _dbFixture = dbFixture;
 
     public Task InitializeAsync() =>
         _dbFixture.WithDbContext(dbContext => dbContext.Database.ExecuteSqlAsync($"delete from events"));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbFixture.cs
@@ -4,17 +4,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.TestCommon;
 
-public class DbFixture
+public class DbFixture(DbHelper dbHelper, IServiceProvider serviceProvider)
 {
-    public DbFixture(DbHelper dbHelper, IServiceProvider serviceProvider)
-    {
-        DbHelper = dbHelper;
-        Services = serviceProvider;
-    }
+    public DbHelper DbHelper { get; } = dbHelper;
 
-    public DbHelper DbHelper { get; }
-
-    public IServiceProvider Services { get; }
+    public IServiceProvider Services { get; } = serviceProvider;
 
     public TrsDbContext GetDbContext() => Services.GetRequiredService<TrsDbContext>();
 


### PR DESCRIPTION
With syncing events from DQT it's possible to see events out-of-order (w.r.t. their Created time) when publishing. This adds an Inserted time and amends the publishing service to use that when looking for new events.