### PR TITLE
Handle MQs with a deactivated provider

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllMqEstablishmentsHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllMqEstablishmentsHandler.cs
@@ -10,7 +10,6 @@ public class GetAllMqEstablishmentsHandler : ICrmQueryHandler<GetAllMqEstablishm
     public async Task<dfeta_mqestablishment[]> Execute(GetAllMqEstablishmentsQuery query, IOrganizationServiceAsync organizationService)
     {
         var filter = new FilterExpression(LogicalOperator.And);
-        filter.AddCondition(dfeta_mqestablishment.Fields.StateCode, ConditionOperator.Equal, (int)dfeta_mqestablishmentState.Active);
 
         var queryExpression = new QueryExpression
         {


### PR DESCRIPTION
We have some existing active MQs linked to an inactive provider. This amends our query that gets all providers to return inactive too.

This will give us a larger than ideal list of providers for creating a new MQ too; the data move to TRS and provider rationalisation will sort that out.