### PR TITLE
Add MQ deactivated event to change log

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtDeactivatedEvent.cs
@@ -1,0 +1,9 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record MandatoryQualificationDqtDeactivatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification
+{
+    public required Guid PersonId { get; init; }
+    public required MandatoryQualification MandatoryQualification { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeLog.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeLog.cshtml.cs
@@ -79,7 +79,7 @@ public class ChangeLogModel(ICrmQueryDispatcher crmQueryDispatcher, IDbContextFa
                             END = u.user_id
                 WHERE
                     e.payload ->> 'PersonId' = {personIdString}
-                    AND e.event_name = 'MandatoryQualificationDeletedEvent'
+                    AND e.event_name in ('MandatoryQualificationDeletedEvent', 'MandatoryQualificationDqtDeactivatedEvent')
                 """)
             .ToListAsync();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDqtDeactivatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDqtDeactivatedEvent.cshtml
@@ -1,0 +1,44 @@
+@using TeachingRecordSystem.Core.Events
+@model TimelineItem<TimelineEvent<MandatoryQualificationDqtDeactivatedEvent>>
+@{
+    var deactivatedEvent = Model.ItemModel.Event;
+    var mandatoryQualification = deactivatedEvent.MandatoryQualification;
+    var raisedByUser = Model.ItemModel.RaisedByUser;
+    var raisedBy = deactivatedEvent.RaisedBy.IsDqtUser ? (raisedByUser.DqtUser?.Name ?? "Unknown") : (raisedByUser.User?.Name) ?? "Unknown";
+}
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">Mandatory qualification deactivated</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span data-testid="raised-by">By @raisedBy on</span>
+        <time datetime="@deactivatedEvent.CreatedUtc.ToString("O")" data-testid="timeline-item-time">
+            @deactivatedEvent.CreatedUtc.ToString("dd MMMMM yyyy 'at' h:mm tt")
+        </time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="provider">@(mandatoryQualification.Provider is not null ? mandatoryQualification.Provider.Name : "None")</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Specialism</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="specialism">@(mandatoryQualification.Specialism.HasValue ? mandatoryQualification.Specialism.Value.GetTitle() : "None")</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="start-date">@(mandatoryQualification.StartDate.HasValue ? mandatoryQualification.StartDate.Value.ToString("d MMMM yyyy") : "None")</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="status">@(mandatoryQualification.Status.HasValue ? mandatoryQualification.Status.Value.GetTitle() : "None")</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="end-date">@(mandatoryQualification.EndDate.HasValue ? mandatoryQualification.EndDate.Value.ToString("d MMMM yyyy") : "None")</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+    </div>
+</div>


### PR DESCRIPTION
### Context

We’re not migrating deactivated MQs to TRS but we want to show MQs that were previously deactivated in DQT.

### Changes proposed in this pull request

Render an entry on the change log for every MandatoryQualificationDqtDeactivatedEvent as per the Figma designs.

### Guidance to review

New event + UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
