### PR TITLE
Show timestamps in local time on Change log

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DateTimeExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DateTimeExtensions.cs
@@ -19,6 +19,15 @@ public static class DateTimeExtensions
     public static DateOnly? ToDateOnlyWithDqtBstFix(this DateTime? dateTime, bool isLocalTime) =>
         dateTime.HasValue ? ToDateOnlyWithDqtBstFix(dateTime.Value, isLocalTime) : null;
 
-    public static DateTime? WithDqtBstFix(this DateTime? dateTime, bool isLocalTime) =>
-        dateTime.HasValue ? (isLocalTime ? TimeZoneInfo.ConvertTimeFromUtc(dateTime.Value, _gmt) : dateTime.Value) : null;
+    public static DateTime? ToUtc(this DateTime dateTime) =>
+        TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified), _gmt);
+
+    public static DateTime? ToUtc(this DateTime? dateTime) =>
+        dateTime.HasValue ? ToUtc(dateTime.Value) : null;
+
+    public static DateTime ToLocal(this DateTime dateTime) =>
+        TimeZoneInfo.ConvertTimeFromUtc(dateTime, _gmt);
+
+    public static DateTime? ToLocal(this DateTime? dateTime) =>
+        dateTime.HasValue ? ToLocal(dateTime.Value) : null;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeLog.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeLog.cshtml.cs
@@ -86,15 +86,15 @@ public class ChangeLogModel(ICrmQueryDispatcher crmQueryDispatcher, IDbContextFa
         TimelineItems = notesResult
             .Annotations.Select(n => (TimelineItem)new TimelineItem<Annotation>(
                 TimelineItemType.Annotation,
-                n.ModifiedOn.WithDqtBstFix(isLocalTime: true)!.Value,
+                n.ModifiedOn!.Value.ToLocal(),
                 n))
             .Concat(notesResult.IncidentResolutions.Select(r => new TimelineItem<(IncidentResolution, Incident)>(
                 TimelineItemType.IncidentResolution,
-                r.Resolution.ModifiedOn.WithDqtBstFix(isLocalTime: true)!.Value,
+                r.Resolution.ModifiedOn!.Value.ToLocal(),
                 r)))
             .Concat(notesResult.Tasks.Select(t => new TimelineItem<CrmTask>(
                 TimelineItemType.Task,
-                t.ModifiedOn.WithDqtBstFix(isLocalTime: true)!.Value,
+                t.ModifiedOn!.Value.ToLocal(),
                 t)))
             .Concat(eventsWithUser.Select(MapTimelineEvent))
             .OrderByDescending(i => i.Timestamp)
@@ -141,7 +141,7 @@ public class ChangeLogModel(ICrmQueryDispatcher crmQueryDispatcher, IDbContextFa
         var timelineEventType = typeof(TimelineEvent<>).MakeGenericType(@event.GetType()!);
         var timelineEvent = (TimelineEvent)Activator.CreateInstance(timelineEventType, @event, raiseByUser)!;
         var timelineItemType = typeof(TimelineItem<>).MakeGenericType(timelineEventType);
-        return (TimelineItem)Activator.CreateInstance(timelineItemType, TimelineItemType.Event, timelineEvent.Event.CreatedUtc, timelineEvent)!;
+        return (TimelineItem)Activator.CreateInstance(timelineItemType, TimelineItemType.Event, timelineEvent.Event.CreatedUtc.ToLocal(), timelineEvent)!;
     }
 
     /// <summary>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDeletedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDeletedEvent.cshtml
@@ -16,8 +16,8 @@
     </div>
     <p class="moj-timeline__date">
         <span data-testid="raised-by">By @raisedBy on</span>
-        <time datetime="@deletedEvent.CreatedUtc.ToString("O")" data-testid="timeline-item-time">
-            @deletedEvent.CreatedUtc.ToString("dd MMMMM yyyy 'at' h:mm tt")
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">
+            @Model.Timestamp.ToString("dd MMMMM yyyy 'at' h:mm tt")
         </time>
     </p>
     <div class="moj-timeline__description">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDqtDeactivatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDqtDeactivatedEvent.cshtml
@@ -13,8 +13,8 @@
     </div>
     <p class="moj-timeline__date">
         <span data-testid="raised-by">By @raisedBy on</span>
-        <time datetime="@deactivatedEvent.CreatedUtc.ToString("O")" data-testid="timeline-item-time">
-            @deactivatedEvent.CreatedUtc.ToString("dd MMMMM yyyy 'at' h:mm tt")
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">
+            @Model.Timestamp.ToString("dd MMMMM yyyy 'at' h:mm tt")
         </time>
     </p>
     <div class="moj-timeline__description">

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
@@ -249,10 +249,12 @@ public class ChangeLogTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson(b => b.WithMandatoryQualification().WithMandatoryQualification());
+        var dateTimeOutsideBst = new DateTime(2021, 1, 1, 10, 30, 0, DateTimeKind.Utc);
+        var dateTimeInsideBst = new DateTime(2021, 6, 1, 10, 30, 0, DateTimeKind.Utc);
         var mqs = new (bool RaisedByDqtUser, TestData.MandatoryQualificationInfo Mq, DateTime CreatedUtc)[]
         {
-            (true, person.MandatoryQualifications[0], Clock.UtcNow.AddSeconds(-2)),
-            (false, person.MandatoryQualifications[1], Clock.UtcNow)
+            (true, person.MandatoryQualifications[0], dateTimeOutsideBst),
+            (false, person.MandatoryQualifications[1], dateTimeInsideBst)
         };
 
         var dqtUserId = await TestData.GetCurrentCrmUserId();
@@ -314,7 +316,7 @@ public class ChangeLogTests : TestBase
         Assert.Equal(2, changes.Count);
         Assert.Null(changes[0].GetElementByTestId("timeline-item-status"));
         Assert.Equal($"By {user.Name} on", changes[0].GetElementByTestId("raised-by")!.TextContent.Trim());
-        Assert.NotNull(changes[0].GetElementByTestId("timeline-item-time"));
+        Assert.Equal("01 June 2021 at 11:30 AM", changes[0].GetElementByTestId("timeline-item-time")!.TextContent.Trim());
         Assert.Equal(deactivatedEvents[1].MandatoryQualification.Provider!.Name, changes[0].GetElementByTestId("provider")!.TextContent.Trim());
         Assert.Equal(deactivatedEvents[1].MandatoryQualification.Specialism!.Value.GetTitle(), changes[0].GetElementByTestId("specialism")!.TextContent.Trim());
         Assert.Equal(deactivatedEvents[1].MandatoryQualification.StartDate!.Value.ToString("d MMMM yyyy"), changes[0].GetElementByTestId("start-date")!.TextContent.Trim());
@@ -323,7 +325,7 @@ public class ChangeLogTests : TestBase
 
         Assert.Null(changes[1].GetElementByTestId("timeline-item-status"));
         Assert.Equal($"By Test User on", changes[1].GetElementByTestId("raised-by")!.TextContent.Trim());
-        Assert.NotNull(changes[0].GetElementByTestId("timeline-item-time"));
+        Assert.Equal("01 January 2021 at 10:30 AM", changes[1].GetElementByTestId("timeline-item-time")!.TextContent.Trim());
         Assert.Equal(deactivatedEvents[0].MandatoryQualification.Provider!.Name, changes[1].GetElementByTestId("provider")!.TextContent.Trim());
         Assert.Equal(deactivatedEvents[0].MandatoryQualification.Specialism!.Value.GetTitle(), changes[1].GetElementByTestId("specialism")!.TextContent.Trim());
         Assert.Equal(deactivatedEvents[0].MandatoryQualification.StartDate!.Value.ToString("d MMMM yyyy"), changes[1].GetElementByTestId("start-date")!.TextContent.Trim());


### PR DESCRIPTION
### Context

TRS stores timestamps in UTC but for display purposes we should show them in GMT/BST.

### Changes proposed in this pull request

Amend the Change log to display timestamps in GMT/BST.

### Guidance to review

UI change + tests

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
