### PR TITLE
Rename test fixture and base class

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Endpoints/IdentityWebHooks/GetAnIdentityEndpointsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Endpoints/IdentityWebHooks/GetAnIdentityEndpointsTests.cs
@@ -8,20 +8,20 @@ using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 
 namespace TeachingRecordSystem.Api.Tests.Endpoints.IdentityWebHooks;
 
-public class GetAnIdentityEndpointsTests : ApiTestBase
+public class GetAnIdentityEndpointsTests : TestBase
 {
-    public GetAnIdentityEndpointsTests(ApiFixture apiFixture)
-       : base(apiFixture)
+    public GetAnIdentityEndpointsTests(HostFixture hostFixture)
+       : base(hostFixture)
     {
     }
 
-    private IOptions<GetAnIdentityOptions> GetAnIdentityOptions => ApiFixture.Services.GetRequiredService<IOptions<GetAnIdentityOptions>>();
+    private IOptions<GetAnIdentityOptions> GetAnIdentityOptions => HostFixture.Services.GetRequiredService<IOptions<GetAnIdentityOptions>>();
 
     [Fact]
     public async Task Post_WithNoSignatureInHeader_ReturnsUnauthorised()
     {
         // Arrange
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity");
 
@@ -37,7 +37,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
     {
         // Arrange
         var signature = "InvalidSignature";
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity");
@@ -60,7 +60,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")
@@ -89,7 +89,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")
@@ -115,7 +115,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")
@@ -144,7 +144,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")
@@ -189,7 +189,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")
@@ -236,7 +236,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")
@@ -283,7 +283,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")
@@ -336,7 +336,7 @@ public class GetAnIdentityEndpointsTests : ApiTestBase
 
         var jsonContent = JsonSerializer.Serialize(content, GetAnIdentityEndpoints.SerializerOptions);
         var signature = GenerateSignature(GetAnIdentityOptions.Value.WebHookClientSecret, jsonContent);
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
         httpClient.DefaultRequestHeaders.Add("X-Hub-Signature-256", signature);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/webhooks/identity")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Filters/CrmServiceProtectionFaultExceptionFilterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Filters/CrmServiceProtectionFaultExceptionFilterTests.cs
@@ -4,9 +4,9 @@ using Microsoft.Xrm.Sdk;
 
 namespace TeachingRecordSystem.Api.Tests.Filters;
 
-public class CrmServiceProtectionFaultExceptionFilterTests : ApiTestBase
+public class CrmServiceProtectionFaultExceptionFilterTests : TestBase
 {
-    public CrmServiceProtectionFaultExceptionFilterTests(ApiFixture apiFixture) : base(apiFixture)
+    public CrmServiceProtectionFaultExceptionFilterTests(HostFixture hostFixture) : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/HostFixture.cs
@@ -15,11 +15,11 @@ using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.Api.Tests;
 
-public class ApiFixture : WebApplicationFactory<Program>
+public class HostFixture : WebApplicationFactory<Program>
 {
     private readonly IConfiguration _configuration;
 
-    public ApiFixture(IConfiguration configuration)
+    public HostFixture(IConfiguration configuration)
     {
         _configuration = configuration;
         JwtSigningCredentials = new SigningCredentials(new RsaSecurityKey(RSA.Create()), SecurityAlgorithms.RsaSha256);
@@ -52,7 +52,7 @@ public class ApiFixture : WebApplicationFactory<Program>
             });
 
             // Add controllers defined in this test assembly
-            services.AddMvc().AddApplicationPart(typeof(ApiFixture).Assembly);
+            services.AddMvc().AddApplicationPart(typeof(HostFixture).Assembly);
 
             services.AddSingleton<CurrentApiClientProvider>();
             services.AddTestScoped<IClock>(tss => tss.Clock);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Startup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Startup.cs
@@ -5,10 +5,10 @@ public class Startup
     public void ConfigureHost(IHostBuilder hostBuilder) =>
         hostBuilder
             .ConfigureHostConfiguration(builder => builder
-                .AddUserSecrets<ApiFixture>(optional: true)
+                .AddUserSecrets<HostFixture>(optional: true)
                 .AddEnvironmentVariables())
             .ConfigureServices(services =>
             {
-                services.AddSingleton<ApiFixture>();
+                services.AddSingleton<HostFixture>();
             });
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V1/Operations/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V1/Operations/GetTeacherTests.cs
@@ -3,10 +3,10 @@ using TeachingRecordSystem.Api.Properties;
 
 namespace TeachingRecordSystem.Api.Tests.V1.Operations;
 
-public class GetTeacherTests : ApiTestBase
+public class GetTeacherTests : TestBase
 {
-    public GetTeacherTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetTeacherTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V1/SwaggerTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V1/SwaggerTests.cs
@@ -1,8 +1,8 @@
 namespace TeachingRecordSystem.Api.Tests.V1;
 
-public class SwaggerTests : ApiTestBase
+public class SwaggerTests : TestBase
 {
-    public SwaggerTests(ApiFixture apiFixture) : base(apiFixture)
+    public SwaggerTests(HostFixture hostFixture) : base(hostFixture)
     {
     }
 
@@ -11,7 +11,7 @@ public class SwaggerTests : ApiTestBase
     {
         // Arrange
         var request = new HttpRequestMessage(HttpMethod.Get, "swagger/v1.json");
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
 
         // Act
         var response = await httpClient.SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/FindTeachersTests.cs
@@ -4,9 +4,9 @@ using TeachingRecordSystem.Api.V2.Responses;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class FindTeachersTests : ApiTestBase
+public class FindTeachersTests : TestBase
 {
-    public FindTeachersTests(ApiFixture apiFixture) : base(apiFixture)
+    public FindTeachersTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.GetPerson });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetIttProvidersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetIttProvidersTests.cs
@@ -2,9 +2,9 @@
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class GetIttProvidersTests : ApiTestBase
+public class GetIttProvidersTests : TestBase
 {
-    public GetIttProvidersTests(ApiFixture apiFixture) : base(apiFixture)
+    public GetIttProvidersTests(HostFixture hostFixture) : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -8,9 +8,9 @@ using TeachingRecordSystem.Core.Services.GetAnIdentity.Api.Models;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class GetOrCreateTrnRequestTests : ApiTestBase
+public class GetOrCreateTrnRequestTests : TestBase
 {
-    public GetOrCreateTrnRequestTests(ApiFixture apiFixture) : base(apiFixture)
+    public GetOrCreateTrnRequestTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UpdatePerson });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTeacherTests.cs
@@ -6,10 +6,10 @@ using TeachingRecordSystem.Api.V2.ApiModels;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class GetTeacherTests : ApiTestBase
+public class GetTeacherTests : TestBase
 {
-    public GetTeacherTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetTeacherTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.GetPerson, ApiRoles.UpdatePerson });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTrnRequestTests.cs
@@ -6,9 +6,9 @@ using TeachingRecordSystem.Core.Dqt;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class GetTrnRequestTests : ApiTestBase
+public class GetTrnRequestTests : TestBase
 {
-    public GetTrnRequestTests(ApiFixture apiFixture) : base(apiFixture)
+    public GetTrnRequestTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UpdatePerson });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/SetIttOutcomeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/SetIttOutcomeTests.cs
@@ -7,9 +7,9 @@ using TeachingRecordSystem.Api.V2.Requests;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class SetIttOutcomeTests : ApiTestBase
+public class SetIttOutcomeTests : TestBase
 {
-    public SetIttOutcomeTests(ApiFixture apiFixture) : base(apiFixture)
+    public SetIttOutcomeTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UpdatePerson });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/SetNpqQualificationTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/SetNpqQualificationTests.cs
@@ -4,9 +4,9 @@ using TeachingRecordSystem.Api.V2.Requests;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class SetNpqQualificationTests : ApiTestBase
+public class SetNpqQualificationTests : TestBase
 {
-    public SetNpqQualificationTests(ApiFixture apiFixture) : base(apiFixture)
+    public SetNpqQualificationTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UpdateNpq });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/UnlockTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/UnlockTeacherTests.cs
@@ -4,9 +4,9 @@ using TeachingRecordSystem.Api.Tests.Attributes;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class UnlockTeacherTests : ApiTestBase
+public class UnlockTeacherTests : TestBase
 {
-    public UnlockTeacherTests(ApiFixture apiFixture) : base(apiFixture)
+    public UnlockTeacherTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UnlockPerson });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/UpdateTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/UpdateTeacherTests.cs
@@ -9,9 +9,9 @@ using TeachingRecordSystem.Api.Validation;
 
 namespace TeachingRecordSystem.Api.Tests.V2.Operations;
 
-public class UpdateTeacherTests : ApiTestBase
+public class UpdateTeacherTests : TestBase
 {
-    public UpdateTeacherTests(ApiFixture apiFixture) : base(apiFixture)
+    public UpdateTeacherTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UpdatePerson });
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/SwaggerTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/SwaggerTests.cs
@@ -1,8 +1,8 @@
 namespace TeachingRecordSystem.Api.Tests.V2;
 
-public class SwaggerTests : ApiTestBase
+public class SwaggerTests : TestBase
 {
-    public SwaggerTests(ApiFixture apiFixture) : base(apiFixture)
+    public SwaggerTests(HostFixture hostFixture) : base(hostFixture)
     {
     }
 
@@ -11,7 +11,7 @@ public class SwaggerTests : ApiTestBase
     {
         // Arrange
         var request = new HttpRequestMessage(HttpMethod.Get, "swagger/v2.json");
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
 
         // Act
         var response = await httpClient.SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/CreateDateOfBirthChangeTests.cs
@@ -7,10 +7,10 @@ using TeachingRecordSystem.Api.Tests.Attributes;
 namespace TeachingRecordSystem.Api.Tests.V3;
 
 [Collection(nameof(DisableParallelization))]  // Configures EvidenceFilesHttpClient
-public class CreateDateOfBirthChangeTests : ApiTestBase
+public class CreateDateOfBirthChangeTests : TestBase
 {
-    public CreateDateOfBirthChangeTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public CreateDateOfBirthChangeTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UpdatePerson });
     }
@@ -26,7 +26,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         var evidenceFileUrl = Faker.Internet.SecureUrl();
         var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
 
-        ApiFixture.ConfigureEvidenceFilesHttpClient(options =>
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
         {
             var builder = new HttpRequestInterceptionBuilder();
 
@@ -107,7 +107,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         var evidenceFileUrl = Faker.Internet.SecureUrl();
         var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
 
-        ApiFixture.ConfigureEvidenceFilesHttpClient(options =>
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
         {
             var builder = new HttpRequestInterceptionBuilder();
 
@@ -181,7 +181,7 @@ public class CreateDateOfBirthChangeTests : ApiTestBase
         var evidenceFileUrl = Faker.Internet.SecureUrl();
         var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
 
-        ApiFixture.ConfigureEvidenceFilesHttpClient(options =>
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
         {
             var builder = new HttpRequestInterceptionBuilder();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/CreateNameChangeTests.cs
@@ -7,10 +7,10 @@ using TeachingRecordSystem.Api.Tests.Attributes;
 namespace TeachingRecordSystem.Api.Tests.V3;
 
 [Collection(nameof(DisableParallelization))]  // Configures EvidenceFilesHttpClient
-public class CreateNameChangeTests : ApiTestBase
+public class CreateNameChangeTests : TestBase
 {
-    public CreateNameChangeTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public CreateNameChangeTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.UpdatePerson });
     }
@@ -66,7 +66,7 @@ public class CreateNameChangeTests : ApiTestBase
         var evidenceFileUrl = Faker.Internet.SecureUrl();
         var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
 
-        ApiFixture.ConfigureEvidenceFilesHttpClient(options =>
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
         {
             var builder = new HttpRequestInterceptionBuilder();
 
@@ -116,7 +116,7 @@ public class CreateNameChangeTests : ApiTestBase
         var evidenceFileUrl = Faker.Internet.SecureUrl();
         var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
 
-        ApiFixture.ConfigureEvidenceFilesHttpClient(options =>
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
         {
             var builder = new HttpRequestInterceptionBuilder();
 
@@ -198,7 +198,7 @@ public class CreateNameChangeTests : ApiTestBase
         var evidenceFileUrl = Faker.Internet.SecureUrl();
         var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
 
-        ApiFixture.ConfigureEvidenceFilesHttpClient(options =>
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
         {
             var builder = new HttpRequestInterceptionBuilder();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/FindTeachersTests.cs
@@ -4,10 +4,10 @@ using TeachingRecordSystem.Api.Tests.Attributes;
 namespace TeachingRecordSystem.Api.Tests.V3;
 
 [Collection(nameof(DisableParallelization))]
-public class FindTeachersTests : ApiTestBase
+public class FindTeachersTests : TestBase
 {
-    public FindTeachersTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public FindTeachersTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
         XrmFakedContext.DeleteAllEntities<Contact>();
         SetCurrentApiClient(new[] { ApiRoles.GetPerson });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetEytsCertificateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetEytsCertificateTests.cs
@@ -1,9 +1,9 @@
 namespace TeachingRecordSystem.Api.Tests.V3;
 
-public class GetEytsCertificateTests : ApiTestBase
+public class GetEytsCertificateTests : TestBase
 {
-    public GetEytsCertificateTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetEytsCertificateTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetInductionCertificateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetInductionCertificateTests.cs
@@ -2,10 +2,10 @@ using Microsoft.Xrm.Sdk;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 
-public class GetInductionCertificateTests : ApiTestBase
+public class GetInductionCertificateTests : TestBase
 {
-    public GetInductionCertificateTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetInductionCertificateTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetNpqCertificateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetNpqCertificateTests.cs
@@ -2,10 +2,10 @@ using Microsoft.Xrm.Sdk;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 
-public class GetNpqCertificateTests : ApiTestBase
+public class GetNpqCertificateTests : TestBase
 {
-    public GetNpqCertificateTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetNpqCertificateTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetQtsCertificateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetQtsCertificateTests.cs
@@ -2,13 +2,13 @@ using TeachingRecordSystem.Core.Dqt;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 
-public class GetQtsCertificateTests : ApiTestBase
+public class GetQtsCertificateTests : TestBase
 {
     private const string QtsAwardedInWalesTeacherStatusValue = "213";
     private readonly Guid _qtsAwardedInWalesTeacherStatusId = Guid.NewGuid();
 
-    public GetQtsCertificateTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetQtsCertificateTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherByTrnTests.cs
@@ -5,8 +5,8 @@ namespace TeachingRecordSystem.Api.Tests.V3;
 
 public class GetTeacherByTrnTests : GetTeacherTestBase
 {
-    public GetTeacherByTrnTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetTeacherByTrnTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
         SetCurrentApiClient(new[] { ApiRoles.GetPerson });
     }
@@ -20,7 +20,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{trn}");
 
         // Act
-        var response = await ApiFixture.CreateClient().SendAsync(request);
+        var response = await HostFixture.CreateClient().SendAsync(request);
 
         // Assert
         Assert.Equal(StatusCodes.Status401Unauthorized, (int)response.StatusCode);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTestBase.cs
@@ -7,7 +7,7 @@ using static TeachingRecordSystem.TestCommon.TestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3;
 
-public abstract class GetTeacherTestBase : ApiTestBase
+public abstract class GetTeacherTestBase : TestBase
 {
     internal const string QualifiedTeacherTrainedTeacherStatusValue = "71";
     internal const string QtsAwardedInWalesTeacherStatusValue = "213";
@@ -18,7 +18,7 @@ public abstract class GetTeacherTestBase : ApiTestBase
     private readonly DateOnly defaultqtsDate = new DateOnly(1997, 4, 23);
     private readonly DateOnly defaulteytsDate = new DateOnly(1995, 5, 14);
 
-    protected GetTeacherTestBase(ApiFixture apiFixture) : base(apiFixture)
+    protected GetTeacherTestBase(HostFixture hostFixture) : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/GetTeacherTests.cs
@@ -4,8 +4,8 @@ namespace TeachingRecordSystem.Api.Tests.V3;
 
 public class GetTeacherTests : GetTeacherTestBase
 {
-    public GetTeacherTests(ApiFixture apiFixture)
-        : base(apiFixture)
+    public GetTeacherTests(HostFixture hostFixture)
+        : base(hostFixture)
     {
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/SwaggerTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/SwaggerTests.cs
@@ -1,8 +1,8 @@
 namespace TeachingRecordSystem.Api.Tests.V3;
 
-public class SwaggerTests : ApiTestBase
+public class SwaggerTests : TestBase
 {
-    public SwaggerTests(ApiFixture apiFixture) : base(apiFixture)
+    public SwaggerTests(HostFixture hostFixture) : base(hostFixture)
     {
     }
 
@@ -11,7 +11,7 @@ public class SwaggerTests : ApiTestBase
     {
         // Arrange
         var request = new HttpRequestMessage(HttpMethod.Get, "swagger/v3.json");
-        var httpClient = ApiFixture.CreateClient();
+        var httpClient = HostFixture.CreateClient();
 
         // Act
         var response = await httpClient.SendAsync(request);


### PR DESCRIPTION
Other test projects have `HostFixture` and `TestBase`; the API test project has `ApiFixture` and `ApiTestBase` instead. This fixes the inconsistency.