### PR TITLE
Prefer IReadOnlyCollection<T>

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
@@ -1,10 +1,8 @@
-using System.Collections.Immutable;
-
 namespace TeachingRecordSystem.Api.V3;
 
 public static class Constants
 {
-    public static ImmutableArray<string> ExposableSanctionCodes { get; } = new[]
+    public static IReadOnlyCollection<string> ExposableSanctionCodes { get; } = new[]
     {
         "G1",
         "A18",
@@ -37,9 +35,9 @@ public static class Constants
         "A2",
         "A24",
         "A23",
-    }.ToImmutableArray();
+    };
 
-    public static ImmutableArray<string> ProhibitionSanctionCodes { get; } = new[]
+    public static IReadOnlyCollection<string> ProhibitionSanctionCodes { get; } = new[]
     {
         "G1",
         "B1",
@@ -60,5 +58,5 @@ public static class Constants
         "A5A",
         "A1B",
         "A1A",
-    }.ToImmutableArray();
+    };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/FindTeachersHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/FindTeachersHandler.cs
@@ -62,7 +62,7 @@ public class FindTeachersHandler(ICrmQueryDispatcher crmQueryDispatcher, IConfig
                         Code = s.SanctionCode,
                         StartDate = s.Sanction.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true)
                     })
-                    .ToImmutableArray(),
+                    .AsReadOnly(),
                 PreviousNames = previousNames[r.Id]
                     .Select(name => new NameInfo()
                     {
@@ -70,10 +70,10 @@ public class FindTeachersHandler(ICrmQueryDispatcher crmQueryDispatcher, IConfig
                         MiddleName = name.MiddleName,
                         LastName = name.LastName
                     })
-                    .ToImmutableArray()
+                    .AsReadOnly()
             })
             .OrderBy(c => c.Trn)
-            .ToImmutableArray()
+            .AsReadOnly()
         };
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/FindTeachersResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/FindTeachersResponse.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using TeachingRecordSystem.Api.V3.ApiModels;
 using TeachingRecordSystem.Api.V3.Requests;
 
@@ -8,7 +7,7 @@ public record FindTeachersResponse
 {
     public required int Total { get; init; }
     public required FindTeachersRequest Query { get; init; }
-    public required ImmutableArray<FindTeachersResponseResult> Results { get; init; }
+    public required IReadOnlyCollection<FindTeachersResponseResult> Results { get; init; }
 }
 
 public record FindTeachersResponseResult
@@ -18,6 +17,6 @@ public record FindTeachersResponseResult
     public required string FirstName { get; init; }
     public required string MiddleName { get; init; }
     public required string LastName { get; init; }
-    public required ImmutableArray<SanctionInfo> Sanctions { get; init; }
-    public required ImmutableArray<NameInfo> PreviousNames { get; init; }
+    public required IReadOnlyCollection<SanctionInfo> Sanctions { get; init; }
+    public required IReadOnlyCollection<NameInfo> PreviousNames { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Responses/GetTeacherResponse.cs
@@ -18,13 +18,13 @@ public record GetTeacherResponse
     public required GetTeacherResponseQts? Qts { get; init; }
     public required GetTeacherResponseEyts? Eyts { get; init; }
     public required Option<GetTeacherResponseInduction?> Induction { get; init; }
-    public required Option<IEnumerable<GetTeacherResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
-    public required Option<IEnumerable<GetTeacherResponseNpqQualification>> NpqQualifications { get; init; }
-    public required Option<IEnumerable<GetTeacherResponseMandatoryQualification>> MandatoryQualifications { get; init; }
-    public required Option<IEnumerable<GetTeacherResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
-    public required Option<IEnumerable<SanctionInfo>> Sanctions { get; init; }
-    public required Option<IEnumerable<AlertInfo>> Alerts { get; init; }
-    public required Option<IEnumerable<NameInfo>> PreviousNames { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseNpqQualification>> NpqQualifications { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseMandatoryQualification>> MandatoryQualifications { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
+    public required Option<IReadOnlyCollection<SanctionInfo>> Sanctions { get; init; }
+    public required Option<IReadOnlyCollection<AlertInfo>> Alerts { get; init; }
+    public required Option<IReadOnlyCollection<NameInfo>> PreviousNames { get; init; }
     public required Option<bool> AllowIdSignInWithProhibitions { get; init; }
 }
 
@@ -52,7 +52,7 @@ public record GetTeacherResponseInduction
     public required string? StatusDescription { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? CertificateUrl { get; init; }
-    public required IEnumerable<GetTeacherResponseInductionPeriod> Periods { get; init; }
+    public required IReadOnlyCollection<GetTeacherResponseInductionPeriod> Periods { get; init; }
 }
 
 public record GetTeacherResponseInductionPeriod
@@ -78,7 +78,7 @@ public record GetTeacherResponseInitialTeacherTraining
     public required IttOutcome? Result { get; init; }
     public required GetTeacherResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
     public required GetTeacherResponseInitialTeacherTrainingProvider? Provider { get; init; }
-    public required IEnumerable<GetTeacherResponseInitialTeacherTrainingSubject> Subjects { get; init; }
+    public required IReadOnlyCollection<GetTeacherResponseInitialTeacherTrainingSubject> Subjects { get; init; }
 }
 
 public record GetTeacherResponseInitialTeacherTrainingQualification
@@ -127,7 +127,7 @@ public record GetTeacherResponseHigherEducationQualification
 {
     public required string Name { get; init; }
     public required DateOnly? Awarded { get; init; }
-    public required IEnumerable<GetTeacherResponseHigherEducationQualificationSubject> Subjects { get; init; }
+    public required IReadOnlyCollection<GetTeacherResponseHigherEducationQualificationSubject> Subjects { get; init; }
 }
 
 public record GetTeacherResponseHigherEducationQualificationSubject

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumerableExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumerableExtensions.cs
@@ -2,6 +2,9 @@ namespace TeachingRecordSystem.Core;
 
 public static class EnumerableExtensions
 {
+    public static IReadOnlyCollection<T> AsReadOnly<T>(this IEnumerable<T> enumerable) =>
+        enumerable is IReadOnlyCollection<T> roc ? roc : enumerable.ToArray();
+
     public static T First<T>(this IEnumerable<T> source, Func<T, bool> predicate, string failedErrorMessage) =>
         source.FirstOrDefault(predicate) ?? throw new InvalidOperationException(failedErrorMessage);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/FindTeachersTests.cs
@@ -121,8 +121,8 @@ public class FindTeachersTests : ApiTestBase
                         {
                             new
                             {
-                                code = person1.Sanctions[0].SanctionCode,
-                                startDate = person1.Sanctions[0].StartDate
+                                code = person1.Sanctions.First().SanctionCode,
+                                startDate = person1.Sanctions.First().StartDate
                             }
                         },
                         previousNames = Array.Empty<object>()
@@ -138,8 +138,8 @@ public class FindTeachersTests : ApiTestBase
                         {
                             new
                             {
-                                code = person2.Sanctions[0].SanctionCode,
-                                startDate = person2.Sanctions[0].StartDate
+                                code = person2.Sanctions.First().SanctionCode,
+                                startDate = person2.Sanctions.First().StartDate
                             }
                         },
                         previousNames = Array.Empty<object>()
@@ -194,8 +194,8 @@ public class FindTeachersTests : ApiTestBase
                         {
                             new
                             {
-                                code = person1.Sanctions[0].SanctionCode,
-                                startDate = person1.Sanctions[0].StartDate
+                                code = person1.Sanctions.First().SanctionCode,
+                                startDate = person1.Sanctions.First().StartDate
                             }
                         },
                         previousNames = Array.Empty<object>()
@@ -211,8 +211,8 @@ public class FindTeachersTests : ApiTestBase
                         {
                             new
                             {
-                                code = person2.Sanctions[0].SanctionCode,
-                                startDate = person2.Sanctions[0].StartDate
+                                code = person2.Sanctions.First().SanctionCode,
+                                startDate = person2.Sanctions.First().StartDate
                             }
                         },
                         previousNames = new object[]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
@@ -66,12 +66,12 @@ public class AlertsTests : TestBase
         var previousAlerts = doc.GetElementByTestId("previous-alerts");
         Assert.NotNull(previousAlerts);
 
-        var previousAlert = previousAlerts.GetElementByTestId($"previous-alert-{person.Sanctions[0].SanctionId}");
+        var previousAlert = previousAlerts.GetElementByTestId($"previous-alert-{person.Sanctions.First().SanctionId}");
         Assert.NotNull(previousAlert);
-        Assert.Equal(sanctionCodeName, previousAlert.GetElementByTestId($"previous-alert-description-{person.Sanctions[0].SanctionId}")!.TextContent);
-        Assert.Equal(sanctionStartDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-start-date-{person.Sanctions[0].SanctionId}")!.TextContent);
-        Assert.Equal(sanctionEndDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-end-date-{person.Sanctions[0].SanctionId}")!.TextContent);
-        Assert.Equal("Closed", previousAlert.GetElementByTestId($"previous-alert-status-{person.Sanctions[0].SanctionId}")!.TextContent);
+        Assert.Equal(sanctionCodeName, previousAlert.GetElementByTestId($"previous-alert-description-{person.Sanctions.First().SanctionId}")!.TextContent);
+        Assert.Equal(sanctionStartDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-start-date-{person.Sanctions.First().SanctionId}")!.TextContent);
+        Assert.Equal(sanctionEndDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-end-date-{person.Sanctions.First().SanctionId}")!.TextContent);
+        Assert.Equal("Closed", previousAlert.GetElementByTestId($"previous-alert-status-{person.Sanctions.First().SanctionId}")!.TextContent);
     }
 
     [Fact]
@@ -92,10 +92,10 @@ public class AlertsTests : TestBase
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
         var doc = await response.GetDocument();
-        var currentAlert = doc.GetElementByTestId($"current-alert-{person.Sanctions[0].SanctionId}");
+        var currentAlert = doc.GetElementByTestId($"current-alert-{person.Sanctions.First().SanctionId}");
         Assert.NotNull(currentAlert);
-        Assert.Equal(sanctionStartDate.ToString("dd/MM/yyyy"), currentAlert.GetElementByTestId($"current-alert-start-date-{person.Sanctions[0].SanctionId}")!.TextContent);
-        var details = currentAlert.GetElementByTestId($"current-alert-details-{person.Sanctions[0].SanctionId}");
+        Assert.Equal(sanctionStartDate.ToString("dd/MM/yyyy"), currentAlert.GetElementByTestId($"current-alert-start-date-{person.Sanctions.First().SanctionId}")!.TextContent);
+        var details = currentAlert.GetElementByTestId($"current-alert-details-{person.Sanctions.First().SanctionId}");
         Assert.NotNull(details);
 
         var previousAlerts = doc.GetElementByTestId("previous-alerts");
@@ -126,20 +126,20 @@ public class AlertsTests : TestBase
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
         var doc = await response.GetDocument();
-        var currentAlert = doc.GetElementByTestId($"current-alert-{person.Sanctions[0].SanctionId}");
+        var currentAlert = doc.GetElementByTestId($"current-alert-{person.Sanctions.First().SanctionId}");
         Assert.NotNull(currentAlert);
-        Assert.Equal(sanction1StartDate.ToString("dd/MM/yyyy"), currentAlert.GetElementByTestId($"current-alert-start-date-{person.Sanctions[0].SanctionId}")!.TextContent);
-        var details = currentAlert.GetElementByTestId($"current-alert-details-{person.Sanctions[0].SanctionId}");
+        Assert.Equal(sanction1StartDate.ToString("dd/MM/yyyy"), currentAlert.GetElementByTestId($"current-alert-start-date-{person.Sanctions.First().SanctionId}")!.TextContent);
+        var details = currentAlert.GetElementByTestId($"current-alert-details-{person.Sanctions.First().SanctionId}");
         Assert.NotNull(details);
 
         var previousAlerts = doc.GetElementByTestId("previous-alerts");
         Assert.NotNull(previousAlerts);
 
-        var previousAlert = previousAlerts.GetElementByTestId($"previous-alert-{person.Sanctions[1].SanctionId}");
+        var previousAlert = previousAlerts.GetElementByTestId($"previous-alert-{person.Sanctions.Last().SanctionId}");
         Assert.NotNull(previousAlert);
-        Assert.Equal(sanction2CodeName, previousAlert.GetElementByTestId($"previous-alert-description-{person.Sanctions[1].SanctionId}")!.TextContent);
-        Assert.Equal(sanction2StartDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-start-date-{person.Sanctions[1].SanctionId}")!.TextContent);
-        Assert.Equal(sanction2EndDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-end-date-{person.Sanctions[1].SanctionId}")!.TextContent);
-        Assert.Equal("Closed", previousAlert.GetElementByTestId($"previous-alert-status-{person.Sanctions[1].SanctionId}")!.TextContent);
+        Assert.Equal(sanction2CodeName, previousAlert.GetElementByTestId($"previous-alert-description-{person.Sanctions.Last().SanctionId}")!.TextContent);
+        Assert.Equal(sanction2StartDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-start-date-{person.Sanctions.Last().SanctionId}")!.TextContent);
+        Assert.Equal(sanction2EndDate.ToString("dd/MM/yyyy"), previousAlert.GetElementByTestId($"previous-alert-end-date-{person.Sanctions.Last().SanctionId}")!.TextContent);
+        Assert.Equal("Closed", previousAlert.GetElementByTestId($"previous-alert-status-{person.Sanctions.Last().SanctionId}")!.TextContent);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
@@ -158,8 +158,8 @@ public class ChangeLogTests : TestBase
         var person = await TestData.CreatePerson(b => b.WithMandatoryQualification().WithMandatoryQualification());
         var mqs = new (bool RaisedByDqtUser, TestData.MandatoryQualificationInfo Mq, DateTime CreatedUtc)[]
         {
-            (true, person.MandatoryQualifications[0], Clock.UtcNow.AddSeconds(-2)),
-            (false, person.MandatoryQualifications[1], Clock.UtcNow)
+            (true, person.MandatoryQualifications.First(), Clock.UtcNow.AddSeconds(-2)),
+            (false, person.MandatoryQualifications.Last(), Clock.UtcNow)
         };
 
         var dqtUserId = await TestData.GetCurrentCrmUserId();
@@ -253,8 +253,8 @@ public class ChangeLogTests : TestBase
         var dateTimeInsideBst = new DateTime(2021, 6, 1, 10, 30, 0, DateTimeKind.Utc);
         var mqs = new (bool RaisedByDqtUser, TestData.MandatoryQualificationInfo Mq, DateTime CreatedUtc)[]
         {
-            (true, person.MandatoryQualifications[0], dateTimeOutsideBst),
-            (false, person.MandatoryQualifications[1], dateTimeInsideBst)
+            (true, person.MandatoryQualifications.First(), dateTimeOutsideBst),
+            (false, person.MandatoryQualifications.Last(), dateTimeInsideBst)
         };
 
         var dqtUserId = await TestData.GetCurrentCrmUserId();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.Xrm.Sdk.Messages;
 using Optional;
 using Optional.Unsafe;
@@ -551,8 +550,8 @@ public partial class TestData
         public required string? NationalInsuranceNumber { get; init; }
         public required DateOnly? QtsDate { get; init; }
         public required DateOnly? EytsDate { get; init; }
-        public required ImmutableArray<Sanction> Sanctions { get; init; }
-        public required ImmutableArray<MandatoryQualificationInfo> MandatoryQualifications { get; init; }
+        public required IReadOnlyCollection<Sanction> Sanctions { get; init; }
+        public required IReadOnlyCollection<MandatoryQualificationInfo> MandatoryQualifications { get; init; }
     }
 
     public record Sanction(Guid SanctionId, string SanctionCode, DateOnly? StartDate, DateOnly? EndDate, DateOnly? ReviewDate, bool Spent, string? Details, string? DetailsLink, bool IsActive);


### PR DESCRIPTION
We've previously (partially) moved to `ImmutableArray<>` as our preferred collection type, largely because it's immutable but you can concisely add or remove elements (and get a new collection back). With C# 12's collection expressions and spread operator it's now easy to do the same thing with all collection types.

This change moves to `IReadOnlyCollection<T>` on the API request & response types.