### PR TITLE
Add a model hierarchy for user types

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.CreateAdmin.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.CreateAdmin.cs
@@ -1,6 +1,5 @@
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.DataStore.Postgres;
-using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.Cli;
 
@@ -45,9 +44,8 @@ public static partial class Commands
                     Active = true,
                     Email = email,
                     Name = name,
-                    Roles = new[] { UserRoles.Administrator },
-                    UserId = Guid.NewGuid(),
-                    UserType = UserType.Person
+                    Roles = [UserRoles.Administrator],
+                    UserId = Guid.NewGuid()
                 });
 
                 await dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
@@ -4,31 +4,51 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
 
+public class UserBaseMapping : IEntityTypeConfiguration<UserBase>
+{
+    public void Configure(EntityTypeBuilder<UserBase> builder)
+    {
+        builder.ToTable("users");
+        builder.HasKey(e => e.UserId);
+        builder.HasDiscriminator(e => e.UserType)
+            .HasValue<User>(UserType.Person)
+            .HasValue<ApplicationUser>(UserType.Application)
+            .HasValue<Models.SystemUser>(UserType.System);
+        builder.Property(e => e.UserType).IsRequired();
+        builder.Property(e => e.Name).IsRequired().HasMaxLength(User.NameMaxLength);
+    }
+}
+
 public class UserMapping : IEntityTypeConfiguration<User>
 {
     public void Configure(EntityTypeBuilder<User> builder)
     {
-        builder.ToTable("users");
-        builder.HasKey(e => e.UserId);
-        builder.Property(e => e.UserType).IsRequired();
-        builder.Property(e => e.Name).IsRequired().HasMaxLength(User.NameMaxLength);
         builder.Property(e => e.Email).HasMaxLength(200).UseCollation("case_insensitive");
         builder.Property(e => e.AzureAdUserId).HasMaxLength(100);
         builder.Property(e => e.Roles).HasColumnType("varchar[]");
         builder.HasIndex(e => e.AzureAdUserId).IsUnique();
-
-        builder.HasData(GetDefaultUsers());
     }
+}
 
-    private static IEnumerable<User> GetDefaultUsers()
+public class ApplicationUserMapping : IEntityTypeConfiguration<ApplicationUser>
+{
+    public void Configure(EntityTypeBuilder<ApplicationUser> builder)
     {
-        yield return new()
-        {
-            UserId = User.SystemUserId,
-            UserType = UserType.Application,
-            Name = "System",
-            Active = true,
-            Roles = new[] { UserRoles.Administrator }
-        };
+        builder.Property(e => e.ApiRoles).HasColumnType("varchar[]");
     }
+}
+
+public class SystemUserMapping : IEntityTypeConfiguration<Models.SystemUser>
+{
+    public void Configure(EntityTypeBuilder<Models.SystemUser> builder)
+    {
+        builder.HasData(GetSystemUser());
+    }
+
+    private static Models.SystemUser GetSystemUser() => new()
+    {
+        UserId = UserBase.SystemUserId,
+        Name = "System",
+        Active = true
+    };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240115115428_SplitUserTypes.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240115115428_SplitUserTypes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240115115428_SplitUserTypes")]
+    partial class SplitUserTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240115115428_SplitUserTypes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240115115428_SplitUserTypes.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SplitUserTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string[]>(
+                name: "roles",
+                table: "users",
+                type: "varchar[]",
+                nullable: true,
+                oldClrType: typeof(string[]),
+                oldType: "varchar[]");
+
+            migrationBuilder.AddColumn<string[]>(
+                name: "api_roles",
+                table: "users",
+                type: "varchar[]",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "users",
+                keyColumn: "user_id",
+                keyValue: new Guid("a81394d1-a498-46d8-af3e-e077596ab303"),
+                column: "user_type",
+                value: 3);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "api_roles",
+                table: "users");
+
+            migrationBuilder.AlterColumn<string[]>(
+                name: "roles",
+                table: "users",
+                type: "varchar[]",
+                nullable: false,
+                defaultValue: new string[0],
+                oldClrType: typeof(string[]),
+                oldType: "varchar[]",
+                oldNullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "users",
+                keyColumn: "user_id",
+                keyValue: new Guid("a81394d1-a498-46d8-af3e-e077596ab303"),
+                columns: new[] { "azure_ad_user_id", "dqt_user_id", "email", "roles", "user_type" },
+                values: new object[] { null, null, null, new[] { "Administrator" }, 2 });
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -1,6 +1,6 @@
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
-public class User
+public abstract class UserBase
 {
     public const int NameMaxLength = 200;
 
@@ -8,10 +8,23 @@ public class User
 
     public required Guid UserId { get; init; }
     public required bool Active { get; set; }
-    public required UserType UserType { get; init; }
+    public UserType UserType { get; }
     public required string Name { get; set; }
-    public string? Email { get; set; }
+}
+
+public class User : UserBase
+{
+    public required string? Email { get; set; }
     public string? AzureAdUserId { get; set; }
     public required string[] Roles { get; set; }
     public Guid? DqtUserId { get; set; }
+}
+
+public class ApplicationUser : UserBase
+{
+    public required string[] ApiRoles { get; set; }
+}
+
+public class SystemUser : UserBase
+{
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -42,6 +42,8 @@ public class TrsDbContext : DbContext
 
     public DbSet<User> Users => Set<User>();
 
+    public DbSet<ApplicationUser> ApplicationUsers => Set<ApplicationUser>();
+
     public DbSet<Person> Persons => Set<Person>();
 
     public DbSet<Qualification> Qualifications => Set<Qualification>();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/UserType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/UserType.cs
@@ -3,5 +3,6 @@ namespace TeachingRecordSystem.Core.Models;
 public enum UserType
 {
     Person = 1,
-    Application = 2
+    Application = 2,
+    System = 3
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDeletedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDeletedEvent.cshtml
@@ -6,8 +6,6 @@
     var deletedEvent = Model.ItemModel.Event;
     var mandatoryQualification = deletedEvent.MandatoryQualification;
     var evidenceFileUrl = deletedEvent.EvidenceFile is not null ? await FileService.GetFileUrl(deletedEvent.EvidenceFile!.FileId, TimeSpan.FromMinutes(15)) : null;
-    var raisedByUser = Model.ItemModel.RaisedByUser;
-    var raisedBy = deletedEvent.RaisedBy.IsDqtUser ? (raisedByUser.DqtUser?.Name ?? "Unknown") : (raisedByUser.User?.Name) ?? "Unknown";
 }
 
 <div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item">
@@ -15,7 +13,7 @@
         <h2 class="moj-timeline__title">Mandatory qualification deleted</h2>
     </div>
     <p class="moj-timeline__date">
-        <span data-testid="raised-by">By @raisedBy on</span>
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
         <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">
             @Model.Timestamp.ToString("dd MMMMM yyyy 'at' h:mm tt")
         </time>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDqtDeactivatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDqtDeactivatedEvent.cshtml
@@ -3,8 +3,6 @@
 @{
     var deactivatedEvent = Model.ItemModel.Event;
     var mandatoryQualification = deactivatedEvent.MandatoryQualification;
-    var raisedByUser = Model.ItemModel.RaisedByUser;
-    var raisedBy = deactivatedEvent.RaisedBy.IsDqtUser ? (raisedByUser.DqtUser?.Name ?? "Unknown") : (raisedByUser.User?.Name) ?? "Unknown";
 }
 
 <div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item">
@@ -12,7 +10,7 @@
         <h2 class="moj-timeline__title">Mandatory qualification deactivated</h2>
     </div>
     <p class="moj-timeline__date">
-        <span data-testid="raised-by">By @raisedBy on</span>
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
         <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">
             @Model.Timestamp.ToString("dd MMMMM yyyy 'at' h:mm tt")
         </time>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RaisedByUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RaisedByUser.cs
@@ -1,9 +1,0 @@
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-
-namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.Timeline.Events;
-
-public record RaisedByUser
-{
-    public required User? User { get; set; }
-    public required DqtUser? DqtUser { get; set; }
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RaisedByUserInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RaisedByUserInfo.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.Timeline.Events;
+
+public record RaisedByUserInfo
+{
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/TimelineEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/TimelineEvent.cs
@@ -2,9 +2,9 @@ using TeachingRecordSystem.Core.Events;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.Timeline.Events;
 
-public record TimelineEvent(EventBase Event, RaisedByUser RaisedByUser);
+public record TimelineEvent(EventBase Event, RaisedByUserInfo RaisedByUser);
 
-public record TimelineEvent<TEvent>(TEvent Event, RaisedByUser RaisedByUser) : TimelineEvent(Event, RaisedByUser) where TEvent : EventBase
+public record TimelineEvent<TEvent>(TEvent Event, RaisedByUserInfo RaisedByUser) : TimelineEvent(Event, RaisedByUser) where TEvent : EventBase
 {
     public new TEvent Event => (TEvent)base.Event;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
@@ -79,7 +79,6 @@ public class ConfirmModel(
             Name = Name!,
             Roles = roles,
             UserId = Guid.NewGuid(),
-            UserType = UserType.Person,
             DqtUserId = dqtUser?.Id
         };
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestUsers.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestUsers.cs
@@ -1,7 +1,6 @@
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
@@ -11,25 +10,18 @@ public static class TestUsers
     {
         Active = true,
         Name = "Test administrator",
-        Roles = new[] { UserRoles.Administrator },
+        Roles = [UserRoles.Administrator],
         UserId = Guid.NewGuid(),
-        UserType = UserType.Person
+        Email = "test.admin@localhost"
     };
 
-    public class CreateUsersStartupTask : IStartupTask
+    public class CreateUsersStartupTask(TrsDbContext trsDbContext) : IStartupTask
     {
-        private readonly TrsDbContext _dbContext;
-
-        public CreateUsersStartupTask(TrsDbContext trsDbContext)
-        {
-            _dbContext = trsDbContext;
-        }
-
         public Task Execute()
         {
-            _dbContext.Users.Add(Administrator);
+            trsDbContext.Users.Add(Administrator);
 
-            return _dbContext.SaveChangesAsync();
+            return trsDbContext.SaveChangesAsync();
         }
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestUsers.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestUsers.cs
@@ -9,55 +9,48 @@ public static class TestUsers
     {
         Active = true,
         Name = "Test administrator",
-        Roles = new[] { UserRoles.Administrator },
+        Roles = [UserRoles.Administrator],
         UserId = Guid.NewGuid(),
-        UserType = UserType.Person
+        Email = "test.administrator@localhost"
     };
 
     public static User Helpdesk { get; } = new()
     {
         Active = true,
         Name = "Test helpdesk user",
-        Roles = new[] { UserRoles.Helpdesk },
+        Roles = [UserRoles.Helpdesk],
         UserId = Guid.NewGuid(),
-        UserType = UserType.Person
+        Email = "test.helpdesk@localhost"
     };
 
     public static User UnusedRole { get; } = new()
     {
         Active = true,
         Name = "Test other user",
-        Roles = new[] { "UnusedRole" },
+        Roles = ["UnusedRole"],
         UserId = Guid.NewGuid(),
-        UserType = UserType.Person
+        Email = "test.other@localhost"
     };
 
     public static User NoRoles { get; } = new()
     {
         Active = true,
         Name = "No roles",
-        Roles = Array.Empty<string>(),
+        Roles = [],
         UserId = Guid.NewGuid(),
-        UserType = UserType.Person
+        Email = "test.empty@localhost"
     };
 
-    public class CreateUsersStartupTask : IStartupTask
+    public class CreateUsersStartupTask(TrsDbContext trsDbContext) : IStartupTask
     {
-        private readonly TrsDbContext _dbContext;
-
-        public CreateUsersStartupTask(TrsDbContext trsDbContext)
-        {
-            _dbContext = trsDbContext;
-        }
-
         public Task Execute()
         {
-            _dbContext.Users.Add(Administrator);
-            _dbContext.Users.Add(Helpdesk);
-            _dbContext.Users.Add(UnusedRole);
-            _dbContext.Users.Add(NoRoles);
+            trsDbContext.Users.Add(Administrator);
+            trsDbContext.Users.Add(Helpdesk);
+            trsDbContext.Users.Add(UnusedRole);
+            trsDbContext.Users.Add(NoRoles);
 
-            return _dbContext.SaveChangesAsync();
+            return trsDbContext.SaveChangesAsync();
         }
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateUser.cs
@@ -1,6 +1,5 @@
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Models;
 
 namespace TeachingRecordSystem.TestCommon;
 
@@ -17,7 +16,7 @@ public partial class TestData
             active ??= true;
             name ??= GenerateName();
             email ??= GenerateUniqueEmail();
-            roles ??= new[] { UserRoles.Helpdesk };
+            roles ??= [UserRoles.Helpdesk];
 
             var user = new User()
             {
@@ -26,7 +25,6 @@ public partial class TestData
                 Email = email,
                 Roles = roles,
                 UserId = Guid.NewGuid(),
-                UserType = UserType.Person,
                 AzureAdUserId = null
             };
 


### PR DESCRIPTION
Currently we have a single `User` model for both `Application` users and `Person` users. This change introduces a hierarchy so that we have different types for both, with a common `UserBase` base type. API clients are going to become Application users, as are ID clients so it's neater to keep that away from person user-level roles etc. I've also added a third type - `System` - for the single special `System` user since it's not really either an `Application` user or `Person` user.

I went with `User` for the `Person` user type since `PersonUser` is similar to `Person`, and that's something else entirely.