### PR TITLE
Don't map MQ Provider until we've migrated data

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -1003,16 +1003,14 @@ public class TrsDataSyncHelper(
                 mqEstablishments.Single(e => e.Id == establishmentId) :
                 null;
 
-            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-
             return new()
             {
                 QualificationId = mapped.QualificationId,
-                Provider = provider is not null || establishment is not null ?
+                Provider = establishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                        Name = provider?.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = establishment?.Id,
                         DqtMqEstablishmentName = establishment?.dfeta_name
                     } :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
@@ -41,8 +40,6 @@ public class CheckAnswersModel(
 
         var mqSpecialism = await referenceDataCache.GetMqSpecialismByValue(Specialism!.Value.GetDqtValue());
 
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(MqEstablishment, out var provider);
-
         var createdEvent = new MandatoryQualificationCreatedEvent()
         {
             EventId = Guid.NewGuid(),
@@ -52,11 +49,11 @@ public class CheckAnswersModel(
             MandatoryQualification = new()
             {
                 QualificationId = qualificationId,
-                Provider = provider is not null || MqEstablishment is not null ?
+                Provider = MqEstablishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                        Name = provider?.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = MqEstablishment?.Id,
                         DqtMqEstablishmentName = MqEstablishment?.dfeta_name
                     } :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
@@ -56,8 +55,6 @@ public class ConfirmModel(
             await referenceDataCache.GetMqEstablishmentById(establishmentId) :
             null;
 
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-
         var specialism = qualification.dfeta_MQ_SpecialismId?.Id is Guid specialismId ?
             await referenceDataCache.GetMqSpecialismById(specialismId) :
             null;
@@ -71,11 +68,11 @@ public class ConfirmModel(
             MandatoryQualification = new()
             {
                 QualificationId = QualificationId,
-                Provider = provider is not null || establishment is not null ?
+                Provider = establishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                        Name = provider?.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = establishment?.Id,
                         DqtMqEstablishmentName = establishment?.dfeta_name
                     } :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
@@ -45,9 +44,6 @@ public class ConfirmModel(
                 await referenceDataCache.GetMqEstablishmentById(oldEstablishmentId) :
                 null;
 
-            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(oldEstablishment, out var oldProvider);
-            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(NewMqEstablishment, out var newProvider);
-
             var specialism = qualification.dfeta_MQ_SpecialismId?.Id is Guid specialismId ?
                 await referenceDataCache.GetMqSpecialismById(specialismId) :
                 null;
@@ -55,11 +51,11 @@ public class ConfirmModel(
             var oldMqEventModel = new Core.Events.Models.MandatoryQualification()
             {
                 QualificationId = QualificationId,
-                Provider = oldProvider is not null || oldEstablishment is not null ?
+                Provider = oldEstablishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = oldProvider?.MandatoryQualificationProviderId,
-                        Name = oldProvider?.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = oldEstablishment?.Id,
                         DqtMqEstablishmentName = oldEstablishment?.dfeta_name
                     } :
@@ -80,8 +76,8 @@ public class ConfirmModel(
                 {
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = newProvider!.MandatoryQualificationProviderId,
-                        Name = newProvider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = NewMqEstablishment!.Id,
                         DqtMqEstablishmentName = NewMqEstablishment.dfeta_name
                     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
@@ -45,8 +44,6 @@ public class ConfirmModel(
                 await referenceDataCache.GetMqEstablishmentById(establishmentId) :
                 null;
 
-            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-
             var specialism = qualification.dfeta_MQ_SpecialismId?.Id is Guid specialismId ?
                 await referenceDataCache.GetMqSpecialismById(specialismId) :
                 null;
@@ -54,11 +51,11 @@ public class ConfirmModel(
             var oldMqEventModel = new Core.Events.Models.MandatoryQualification()
             {
                 QualificationId = QualificationId,
-                Provider = provider is not null || establishment is not null ?
+                Provider = establishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                        Name = provider?.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = establishment?.Id,
                         DqtMqEstablishmentName = establishment?.dfeta_name
                     } :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
@@ -44,8 +43,6 @@ public class ConfirmModel(
                 await referenceDataCache.GetMqEstablishmentById(establishmentId) :
                 null;
 
-            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-
             var specialism = qualification.dfeta_MQ_SpecialismId?.Id is Guid specialismId ?
                 await referenceDataCache.GetMqSpecialismById(specialismId) :
                 null;
@@ -53,11 +50,11 @@ public class ConfirmModel(
             var oldMqEventModel = new Core.Events.Models.MandatoryQualification()
             {
                 QualificationId = QualificationId,
-                Provider = provider is not null || establishment is not null ?
+                Provider = establishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                        Name = provider?.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = establishment?.Id,
                         DqtMqEstablishmentName = establishment?.dfeta_name
                     } :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
@@ -48,8 +47,6 @@ public class ConfirmModel(
                 await referenceDataCache.GetMqEstablishmentById(establishmentId) :
                 null;
 
-            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-
             var specialism = qualification.dfeta_MQ_SpecialismId?.Id is Guid specialismId ?
                 await referenceDataCache.GetMqSpecialismById(specialismId) :
                 null;
@@ -57,11 +54,11 @@ public class ConfirmModel(
             var oldMqEventModel = new Core.Events.Models.MandatoryQualification()
             {
                 QualificationId = QualificationId,
-                Provider = provider is not null || establishment is not null ?
+                Provider = establishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                        Name = provider?.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = establishment?.Id,
                         DqtMqEstablishmentName = establishment?.dfeta_name
                     } :

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.MandatoryQualification.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.MandatoryQualification.cs
@@ -444,8 +444,6 @@ public partial class TrsDataSyncHelperTests
             await TestData.ReferenceDataCache.GetMqEstablishmentById(establishmentId) :
             null;
 
-        Core.DataStore.Postgres.Models.MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
-
         var specialism = entity.dfeta_MQ_SpecialismId?.Id is Guid dqtSpecialismId ?
             (await TestData.ReferenceDataCache.GetMqSpecialismById(dqtSpecialismId)).ToMandatoryQualificationSpecialism() :
             (MandatoryQualificationSpecialism?)null;
@@ -455,8 +453,8 @@ public partial class TrsDataSyncHelperTests
             (MandatoryQualificationStatus?)null;
 
         Assert.Equal(entity.Id, eventModel.QualificationId);
-        Assert.Equal(provider?.MandatoryQualificationProviderId, eventModel.Provider?.MandatoryQualificationProviderId);
-        Assert.Equal(provider?.Name, eventModel.Provider?.Name);
+        Assert.False(eventModel.Provider?.MandatoryQualificationProviderId.HasValue);
+        Assert.Null(eventModel.Provider?.Name);
         Assert.Equal(mqEstablishment?.Id, eventModel.Provider?.DqtMqEstablishmentId);
         Assert.Equal(mqEstablishment?.dfeta_name, eventModel.Provider?.DqtMqEstablishmentName);
         Assert.Equal(specialism, eventModel.Specialism);
@@ -512,8 +510,6 @@ public partial class TrsDataSyncHelperTests
 
         if (trsAuditEventId is Guid eventId)
         {
-            Core.DataStore.Postgres.Models.MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-
             var updatedEvent = new MandatoryQualificationCreatedEvent()
             {
                 EventId = eventId,
@@ -523,11 +519,11 @@ public partial class TrsDataSyncHelperTests
                 MandatoryQualification = new()
                 {
                     QualificationId = newQualification.Id,
-                    Provider = provider is not null || establishment is not null ?
+                    Provider = establishment is not null ?
                         new()
                         {
-                            MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                            Name = provider?.Name,
+                            MandatoryQualificationProviderId = null,
+                            Name = null,
                             DqtMqEstablishmentId = establishment?.Id,
                             DqtMqEstablishmentName = establishment?.dfeta_name
                         } :
@@ -641,9 +637,6 @@ public partial class TrsDataSyncHelperTests
 
         if (trsAuditEventId is Guid eventId)
         {
-            Core.DataStore.Postgres.Models.MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-            Core.DataStore.Postgres.Models.MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(existingEstablishment, out var existingProvider);
-
             var updatedEvent = new MandatoryQualificationUpdatedEvent()
             {
                 EventId = eventId,
@@ -653,11 +646,11 @@ public partial class TrsDataSyncHelperTests
                 MandatoryQualification = new()
                 {
                     QualificationId = updatedQualification.Id,
-                    Provider = provider is not null || establishment is not null ?
+                    Provider = establishment is not null ?
                         new()
                         {
-                            MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
-                            Name = provider?.Name,
+                            MandatoryQualificationProviderId = null,
+                            Name = null,
                             DqtMqEstablishmentId = establishment?.Id,
                             DqtMqEstablishmentName = establishment?.dfeta_name
                         } :
@@ -670,11 +663,11 @@ public partial class TrsDataSyncHelperTests
                 OldMandatoryQualification = new()
                 {
                     QualificationId = existingQualification.Id,
-                    Provider = provider is not null || establishment is not null ?
+                    Provider = establishment is not null ?
                         new()
                         {
-                            MandatoryQualificationProviderId = existingProvider?.MandatoryQualificationProviderId,
-                            Name = existingProvider?.Name,
+                            MandatoryQualificationProviderId = null,
+                            Name = null,
                             DqtMqEstablishmentId = existingEstablishment?.Id,
                             DqtMqEstablishmentName = existingEstablishment?.dfeta_name
                         } :
@@ -724,8 +717,6 @@ public partial class TrsDataSyncHelperTests
         var currentDqtUser = await TestData.GetCurrentCrmUser();
 
         var establishment = await TestData.ReferenceDataCache.GetMqEstablishmentById(existingQualification.dfeta_MQ_MQEstablishmentId.Id);
-        Core.DataStore.Postgres.Models.MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(establishment, out var provider);
-        Assert.NotNull(provider);
 
         var specialism = (await TestData.ReferenceDataCache.GetMqSpecialismById(existingQualification.dfeta_MQ_SpecialismId.Id))
             .ToMandatoryQualificationSpecialism();
@@ -744,8 +735,8 @@ public partial class TrsDataSyncHelperTests
                 QualificationId = existingQualification.Id,
                 Provider = new()
                 {
-                    MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                    Name = provider.Name,
+                    MandatoryQualificationProviderId = null,
+                    Name = null,
                     DqtMqEstablishmentId = establishment.Id,
                     DqtMqEstablishmentName = establishment.dfeta_name
                 },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -199,8 +199,8 @@ public class CheckAnswersTests : TestBase
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
@@ -1,5 +1,4 @@
 using FormFlow;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
@@ -149,8 +148,6 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var qualificationId = person.MandatoryQualifications!.Single().QualificationId;
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(mqEstablishmentDqtValue);
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
-        Assert.NotNull(provider);
 
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -193,8 +190,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
@@ -98,8 +98,6 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oldMqEstablishmentValue = "955"; // University of Birmingham
         var newMqEstablishmentValue = "959"; // University of Leeds
         var oldEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(oldMqEstablishmentValue);
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(oldEstablishment, out var oldProvider);
-        Assert.NotNull(oldProvider);
         var newEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(newMqEstablishmentValue);
         MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(newEstablishment, out var newProvider);
         Assert.NotNull(newProvider);
@@ -155,8 +153,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = newProvider.MandatoryQualificationProviderId,
-                        Name = newProvider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = newEstablishment.Id,
                         DqtMqEstablishmentName = newEstablishment.dfeta_name
                     },
@@ -170,8 +168,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = oldProvider.MandatoryQualificationProviderId,
-                        Name = oldProvider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = oldEstablishment.Id,
                         DqtMqEstablishmentName = oldEstablishment.dfeta_name
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
@@ -1,6 +1,5 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
@@ -100,8 +99,6 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualification = person.MandatoryQualifications.First();
         var qualificationId = qualification.QualificationId;
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(qualification.DqtMqEstablishmentValue!);
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
-        Assert.NotNull(provider);
 
         EventObserver.Clear();
 
@@ -150,8 +147,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },
@@ -165,8 +162,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
@@ -1,6 +1,5 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
@@ -100,8 +99,6 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualification = person.MandatoryQualifications.First();
         var qualificationId = qualification.QualificationId;
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(qualification.DqtMqEstablishmentValue!);
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
-        Assert.NotNull(provider);
 
         EventObserver.Clear();
 
@@ -151,8 +148,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },
@@ -166,8 +163,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
@@ -1,6 +1,5 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Status;
 
@@ -106,8 +105,6 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualification = person.MandatoryQualifications.First();
         var qualificationId = qualification.QualificationId;
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue(qualification.DqtMqEstablishmentValue!);
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
-        Assert.NotNull(provider);
 
         EventObserver.Clear();
 
@@ -159,8 +156,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },
@@ -174,8 +171,8 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                     QualificationId = qualificationId,
                     Provider = new()
                     {
-                        MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
-                        Name = provider.Name,
+                        MandatoryQualificationProviderId = null,
+                        Name = null,
                         DqtMqEstablishmentId = mqEstablishment.Id,
                         DqtMqEstablishmentName = mqEstablishment.dfeta_name
                     },


### PR DESCRIPTION
Events that pre-date MQ migration to TRS should not have any migration-time mappings applied, otherwise a misleading audit trail is created.