### PR TITLE
Add a Key to Event for deduplication

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -14,7 +14,9 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.Property(e => e.Inserted).IsRequired();
         builder.Property(e => e.Payload).IsRequired().HasColumnType("jsonb");
         builder.Property(e => e.Published);
+        builder.Property(e => e.Key).HasMaxLength(200);
         builder.HasKey(e => e.EventId);
         builder.HasIndex(e => e.Payload).HasMethod("gin");
+        builder.HasIndex(e => e.Key).IsUnique().HasFilter("key is not null").HasDatabaseName(Event.KeyUniqueIndexName);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240116112546_EventKey.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240116112546_EventKey.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240116112546_EventKey")]
+    partial class EventKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240116112546_EventKey.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240116112546_EventKey.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EventKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "key",
+                table: "events",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_events_key",
+                table: "events",
+                column: "key",
+                unique: true,
+                filter: "key is not null");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_events_key",
+                table: "events");
+
+            migrationBuilder.DropColumn(
+                name: "key",
+                table: "events");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
@@ -4,11 +4,14 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class Event
 {
+    public const string KeyUniqueIndexName = "ix_events_key";
+
     public required Guid EventId { get; init; }
     public required string EventName { get; init; }
     public required DateTime Created { get; init; }
     public required DateTime Inserted { get; init; }
     public required string Payload { get; init; }
+    public string? Key { get; init; }
     public bool Published { get; set; }
 
     public static Event FromEventBase(EventBase @event, DateTime? inserted)
@@ -22,7 +25,8 @@ public class Event
             EventName = eventName,
             Created = @event.CreatedUtc,
             Inserted = inserted ?? @event.CreatedUtc,
-            Payload = payload
+            Payload = payload,
+            Key = @event is IEventWithKey eventWithKey ? eventWithKey.Key : null
         };
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithKey.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithKey.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public interface IEventWithKey
+{
+    string? Key { get; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationCreatedEvent.cs
@@ -2,8 +2,9 @@ using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record MandatoryQualificationCreatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification
+public record MandatoryQualificationCreatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification, IEventWithKey
 {
+    public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required MandatoryQualification MandatoryQualification { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtDeactivatedEvent.cs
@@ -2,8 +2,9 @@ using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record MandatoryQualificationDqtDeactivatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification
+public record MandatoryQualificationDqtDeactivatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification, IEventWithKey
 {
+    public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required MandatoryQualification MandatoryQualification { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtImportedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtImportedEvent.cs
@@ -2,8 +2,9 @@ using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record MandatoryQualificationDqtImportedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification
+public record MandatoryQualificationDqtImportedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification, IEventWithKey
 {
+    public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required MandatoryQualification MandatoryQualification { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtReactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationDqtReactivatedEvent.cs
@@ -2,8 +2,9 @@ using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record MandatoryQualificationDqtReactivatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification
+public record MandatoryQualificationDqtReactivatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification, IEventWithKey
 {
+    public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required MandatoryQualification MandatoryQualification { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationUpdatedEvent.cs
@@ -2,8 +2,9 @@ using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record MandatoryQualificationUpdatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification
+public record MandatoryQualificationUpdatedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification, IEventWithKey
 {
+    public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required MandatoryQualification MandatoryQualification { get; init; }
     public required MandatoryQualification OldMandatoryQualification { get; init; }


### PR DESCRIPTION
Until now we've borrowed the GUIDs from CRM's audit events to use as an `EventId` so that we can safely sync multiple times without creating duplicate events. However, for the forthcoming 'migrated' events, we won't have an external ID to use nor will we have a way to create a deterministic ID ourselves. Also, we should really be in control of our own ID generation.

This change adds an optional `key` column to the `events` table. If specified, it must be unique. The sync process is updated to handle collisions on keys. An interface - `IEventWithKey` - is used for specifying a key on a given event.