### PR TITLE
Handle rate limit error in inner fault

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ExceptionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ExceptionExtensions.cs
@@ -8,7 +8,18 @@ public static class ExceptionExtensions
     public static bool IsCrmRateLimitException(this Exception exception, out TimeSpan retryAfter)
     {
         if (exception is FaultException<OrganizationServiceFault> fault &&
-            fault.Detail.ErrorDetails.TryGetValue("Retry-After", out var retryAfterObj) &&
+            IsCrmRateLimitFault(fault.Detail, out retryAfter))
+        {
+            return true;
+        }
+
+        retryAfter = default;
+        return false;
+    }
+
+    public static bool IsCrmRateLimitFault(this OrganizationServiceFault fault, out TimeSpan retryAfter)
+    {
+        if (fault.ErrorDetails.TryGetValue("Retry-After", out var retryAfterObj) &&
             retryAfterObj is TimeSpan retryAfterTs)
         {
             retryAfter = retryAfterTs;


### PR DESCRIPTION
When sending a batch request we can get a rate limit error within an inner response. 