### PR TITLE
Add a Migrated event for MQ records

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,6 @@ jobs:
         dotnet_test_args: >-
           --no-build
           -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-          --verbosity diag
       timeout-minutes: 5
 
     - name: API Tests

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -19,6 +19,6 @@ public class MandatoryQualification : Qualification
         var mqEstablishments = await referenceDataCache.GetMqEstablishments();
         var mqSpecialisms = await referenceDataCache.GetMqSpecialisms();
 
-        return TrsDataSyncHelper.MapMandatoryQualificationFromDqtQualification(qualification, mqEstablishments, mqSpecialisms);
+        return TrsDataSyncHelper.MapMandatoryQualificationFromDqtQualification(qualification, mqEstablishments, mqSpecialisms, applyMigrationMappings: true);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationMigratedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationMigratedEvent.cs
@@ -7,4 +7,11 @@ public record MandatoryQualificationMigratedEvent : EventBase, IEventWithPersonI
     public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required MandatoryQualification MandatoryQualification { get; init; }
+    public required MandatoryQualificationMigratedEventChanges Changes { get; init; }
+}
+
+public enum MandatoryQualificationMigratedEventChanges
+{
+    None = 0,
+    Provider = 1 << 0,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationMigratedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/MandatoryQualificationMigratedEvent.cs
@@ -1,0 +1,10 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record MandatoryQualificationMigratedEvent : EventBase, IEventWithPersonId, IEventWithMandatoryQualification, IEventWithKey
+{
+    public string? Key { get; init; }
+    public required Guid PersonId { get; init; }
+    public required MandatoryQualification MandatoryQualification { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
@@ -73,6 +73,7 @@ public class SyncAllMqsFromCrmJob
             await _trsDataSyncHelper.SyncMandatoryQualifications(
                 result.Entities.Select(e => e.ToEntity<dfeta_qualification>()).ToArray(),
                 ignoreInvalid: _syncOptionsAccessor.Value.IgnoreInvalidData,
+                createdMigratedEvent: true,
                 cancellationToken);
 
             if (result.MoreRecords)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
@@ -73,7 +73,7 @@ public class SyncAllMqsFromCrmJob
             await _trsDataSyncHelper.SyncMandatoryQualifications(
                 result.Entities.Select(e => e.ToEntity<dfeta_qualification>()).ToArray(),
                 ignoreInvalid: _syncOptionsAccessor.Value.IgnoreInvalidData,
-                createdMigratedEvent: true,
+                createdMigratedEvent: false,
                 cancellationToken);
 
             if (result.MoreRecords)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -53,15 +53,20 @@ public class TrsDataSyncHelper(
     public static MandatoryQualification MapMandatoryQualificationFromDqtQualification(
         dfeta_qualification qualification,
         IEnumerable<dfeta_mqestablishment> mqEstablishments,
-        IEnumerable<dfeta_specialism> mqSpecialisms)
+        IEnumerable<dfeta_specialism> mqSpecialisms,
+        bool applyMigrationMappings)
     {
         if (qualification.dfeta_Type != dfeta_qualification_dfeta_Type.MandatoryQualification)
         {
             throw new ArgumentException("Qualification is not a mandatory qualification.", nameof(qualification));
         }
 
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(
-            mqEstablishments.SingleOrDefault(e => e.Id == qualification.dfeta_MQ_MQEstablishmentId!?.Id), out var provider);
+        MandatoryQualificationProvider? provider = null;
+        if (applyMigrationMappings)
+        {
+            MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(
+                mqEstablishments.SingleOrDefault(e => e.Id == qualification.dfeta_MQ_MQEstablishmentId!?.Id), out provider);
+        }
 
         MandatoryQualificationSpecialism? specialism = qualification.dfeta_MQ_SpecialismId is not null ?
             mqSpecialisms.Single(s => s.Id == qualification.dfeta_MQ_SpecialismId.Id).ToMandatoryQualificationSpecialism() :
@@ -261,13 +266,13 @@ public class TrsDataSyncHelper(
             var mqEstablishments = await referenceDataCache.GetMqEstablishments();
             var mqSpecialisms = await referenceDataCache.GetMqSpecialisms();
 
-            var mqs = qualifications.Select(q => MapMandatoryQualificationFromDqtQualification(q, mqEstablishments, mqSpecialisms)).ToArray();
+            var mqs = qualifications.Select(q => MapMandatoryQualificationFromDqtQualification(q, mqEstablishments, mqSpecialisms, applyMigrationMappings: false)).ToArray();
 
             return await SyncMandatoryQualifications(mqs, events, ignoreInvalid: false, cancellationToken) == 1;
         }
         else
         {
-            return await SyncMandatoryQualifications(qualifications, ignoreInvalid: false, cancellationToken) == 1;
+            return await SyncMandatoryQualifications(qualifications, ignoreInvalid: false, createdMigratedEvent: false, cancellationToken) == 1;
         }
     }
 
@@ -275,6 +280,7 @@ public class TrsDataSyncHelper(
         dfeta_qualification entity,
         AuditDetailCollection auditDetails,
         bool ignoreInvalid,
+        bool createdMigratedEvent,
         CancellationToken cancellationToken = default)
     {
         var auditDetailsDict = new Dictionary<Guid, AuditDetailCollection>()
@@ -282,29 +288,31 @@ public class TrsDataSyncHelper(
             { entity.Id, auditDetails }
         };
 
-        return await SyncMandatoryQualifications(new[] { entity }, auditDetailsDict, ignoreInvalid, cancellationToken) == 1;
+        return await SyncMandatoryQualifications(new[] { entity }, auditDetailsDict, ignoreInvalid, createdMigratedEvent, cancellationToken) == 1;
     }
 
     public async Task<int> SyncMandatoryQualifications(
         IReadOnlyCollection<dfeta_qualification> entities,
         bool ignoreInvalid,
+        bool createdMigratedEvent,
         CancellationToken cancellationToken)
     {
         var auditDetails = await GetAuditRecords(dfeta_qualification.EntityLogicalName, entities.Select(q => q.Id), cancellationToken);
 
-        return await SyncMandatoryQualifications(entities, auditDetails, ignoreInvalid, cancellationToken);
+        return await SyncMandatoryQualifications(entities, auditDetails, ignoreInvalid, createdMigratedEvent, cancellationToken);
     }
 
     public async Task<int> SyncMandatoryQualifications(
         IReadOnlyCollection<dfeta_qualification> entities,
         IReadOnlyDictionary<Guid, AuditDetailCollection> auditDetails,
         bool ignoreInvalid,
+        bool createdMigratedEvent,
         CancellationToken cancellationToken = default)
     {
         // Not all dfeta_qualification records are MQs..
         var toSync = entities.Where(q => q.dfeta_Type == dfeta_qualification_dfeta_Type.MandatoryQualification);
 
-        var (mqs, events) = await MapMandatoryQualificationsAndAudits(toSync, auditDetails);
+        var (mqs, events) = await MapMandatoryQualificationsAndAudits(toSync, auditDetails, createdMigratedEvent);
 
         return await SyncMandatoryQualifications(mqs, events, ignoreInvalid, cancellationToken);
     }
@@ -816,7 +824,7 @@ public class TrsDataSyncHelper(
             EntityLogicalName = dfeta_qualification.EntityLogicalName,
             AttributeNames = attributeNames,
             GetSyncHandler = helper => (entities, ignoreInvalid, ct) =>
-                helper.SyncMandatoryQualifications(entities.Select(e => e.ToEntity<dfeta_qualification>()).ToArray(), ignoreInvalid, ct),
+                helper.SyncMandatoryQualifications(entities.Select(e => e.ToEntity<dfeta_qualification>()).ToArray(), ignoreInvalid, createdMigratedEvent: false, ct),
             WriteRecord = writeRecord
         };
     }
@@ -844,7 +852,8 @@ public class TrsDataSyncHelper(
 
     private async Task<(List<MandatoryQualification> MandatoryQualifications, List<EventBase> Events)> MapMandatoryQualificationsAndAudits(
         IEnumerable<dfeta_qualification> qualifications,
-        IReadOnlyDictionary<Guid, AuditDetailCollection> auditDetails)
+        IReadOnlyDictionary<Guid, AuditDetailCollection> auditDetails,
+        bool createMigratedEvent)
     {
         var mqEstablishments = await referenceDataCache.GetMqEstablishments();
         var mqSpecialisms = await referenceDataCache.GetMqSpecialisms();
@@ -854,7 +863,7 @@ public class TrsDataSyncHelper(
 
         foreach (var q in qualifications)
         {
-            var mapped = MapMandatoryQualificationFromDqtQualification(q, mqEstablishments, mqSpecialisms);
+            var mapped = MapMandatoryQualificationFromDqtQualification(q, mqEstablishments, mqSpecialisms, applyMigrationMappings: true);
 
             var audits = auditDetails[q.Id].AuditDetails;
             var versions = GetEntityVersions(q, audits, GetModelTypeSyncInfoForMandatoryQualification().AttributeNames);
@@ -892,6 +901,10 @@ public class TrsDataSyncHelper(
                         $" (qualification ID: '{q.Id}').");
                 }
             }
+            else if (createMigratedEvent)
+            {
+                events.Add(MapMigratedEvent(versions.Last()));
+            }
 
             mqs.Add(mapped);
         }
@@ -918,7 +931,7 @@ public class TrsDataSyncHelper(
                 CreatedUtc = snapshot.Timestamp,
                 RaisedBy = Events.Models.RaisedByUserInfo.FromDqtUser(snapshot.UserId, snapshot.UserName),
                 PersonId = snapshot.Entity.dfeta_PersonId.Id,
-                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity)
+                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: false)
             };
         }
 
@@ -931,7 +944,7 @@ public class TrsDataSyncHelper(
                 CreatedUtc = snapshot.Timestamp,
                 RaisedBy = Events.Models.RaisedByUserInfo.FromDqtUser(snapshot.UserId, snapshot.UserName),
                 PersonId = snapshot.Entity.dfeta_PersonId.Id,
-                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity),
+                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: false),
                 DqtState = (int)snapshot.Entity.StateCode!
             };
         }
@@ -975,7 +988,7 @@ public class TrsDataSyncHelper(
                         CreatedUtc = snapshot.Timestamp,
                         RaisedBy = Events.Models.RaisedByUserInfo.FromDqtUser(snapshot.UserId, snapshot.UserName),
                         PersonId = snapshot.Entity.dfeta_PersonId.Id,
-                        MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity)
+                        MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: false)
                     };
                 }
                 else
@@ -987,7 +1000,7 @@ public class TrsDataSyncHelper(
                         CreatedUtc = snapshot.Timestamp,
                         RaisedBy = Events.Models.RaisedByUserInfo.FromDqtUser(snapshot.UserId, snapshot.UserName),
                         PersonId = snapshot.Entity.dfeta_PersonId.Id,
-                        MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity)
+                        MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: false)
                     };
                 }
             }
@@ -1011,8 +1024,8 @@ public class TrsDataSyncHelper(
                 CreatedUtc = snapshot.Timestamp,
                 RaisedBy = Events.Models.RaisedByUserInfo.FromDqtUser(snapshot.UserId, snapshot.UserName),
                 PersonId = snapshot.Entity.dfeta_PersonId.Id,
-                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity),
-                OldMandatoryQualification = GetEventMandatoryQualification(previous.Entity),
+                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: false),
+                OldMandatoryQualification = GetEventMandatoryQualification(previous.Entity, applyMigrationMappings: false),
                 ChangeReason = null,
                 ChangeReasonDetail = null,
                 EvidenceFile = null,
@@ -1020,13 +1033,28 @@ public class TrsDataSyncHelper(
             };
         }
 
-        Events.Models.MandatoryQualification GetEventMandatoryQualification(dfeta_qualification snapshot)
+        EventBase MapMigratedEvent(EntityVersionInfo<dfeta_qualification> snapshot)
         {
-            var mapped = MapMandatoryQualificationFromDqtQualification(snapshot, mqEstablishments, mqSpecialisms);
+            return new MandatoryQualificationMigratedEvent()
+            {
+                EventId = Guid.NewGuid(),
+                Key = $"{snapshot.Entity.Id}-Migrated",
+                CreatedUtc = clock.UtcNow,
+                RaisedBy = Events.Models.RaisedByUserInfo.FromUserId(Core.DataStore.Postgres.Models.SystemUser.SystemUserId),
+                PersonId = snapshot.Entity.dfeta_PersonId.Id,
+                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: true)
+            };
+        }
+
+        Events.Models.MandatoryQualification GetEventMandatoryQualification(dfeta_qualification snapshot, bool applyMigrationMappings)
+        {
+            var mapped = MapMandatoryQualificationFromDqtQualification(snapshot, mqEstablishments, mqSpecialisms, applyMigrationMappings);
 
             var establishment = snapshot.dfeta_MQ_MQEstablishmentId?.Id is Guid establishmentId ?
                 mqEstablishments.Single(e => e.Id == establishmentId) :
                 null;
+
+            var provider = MandatoryQualificationProvider.All.SingleOrDefault(p => p.MandatoryQualificationProviderId == mapped.ProviderId);
 
             return new()
             {
@@ -1034,8 +1062,8 @@ public class TrsDataSyncHelper(
                 Provider = establishment is not null ?
                     new()
                     {
-                        MandatoryQualificationProviderId = null,
-                        Name = null,
+                        MandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId,
+                        Name = provider?.Name,
                         DqtMqEstablishmentId = establishment?.Id,
                         DqtMqEstablishmentName = establishment?.dfeta_name
                     } :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -1035,6 +1035,11 @@ public class TrsDataSyncHelper(
 
         EventBase MapMigratedEvent(EntityVersionInfo<dfeta_qualification> snapshot)
         {
+            var eventMandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: true);
+
+            var changes = MandatoryQualificationMigratedEventChanges.None |
+                (eventMandatoryQualification.Provider?.Name != eventMandatoryQualification.Provider?.DqtMqEstablishmentName ? MandatoryQualificationMigratedEventChanges.Provider : 0);
+
             return new MandatoryQualificationMigratedEvent()
             {
                 EventId = Guid.NewGuid(),
@@ -1042,7 +1047,8 @@ public class TrsDataSyncHelper(
                 CreatedUtc = clock.UtcNow,
                 RaisedBy = Events.Models.RaisedByUserInfo.FromUserId(Core.DataStore.Postgres.Models.SystemUser.SystemUserId),
                 PersonId = snapshot.Entity.dfeta_PersonId.Id,
-                MandatoryQualification = GetEventMandatoryQualification(snapshot.Entity, applyMigrationMappings: true)
+                MandatoryQualification = eventMandatoryQualification,
+                Changes = changes
             };
         }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -1,6 +1,5 @@
 using FormFlow;
 using Microsoft.EntityFrameworkCore;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
@@ -136,8 +135,6 @@ public class CheckAnswersTests : TestBase
         var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
 
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
-        MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
-        Assert.NotNull(provider);
 
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
@@ -177,7 +174,6 @@ public class CheckAnswersTests : TestBase
         {
             var qualification = await dbContext.MandatoryQualifications.SingleOrDefaultAsync(q => q.PersonId == person.PersonId);
             Assert.NotNull(qualification);
-            Assert.Equal(provider!.MandatoryQualificationProviderId, qualification.ProviderId);
             Assert.Equal(specialism, qualification.Specialism);
             Assert.Equal(status, qualification.Status);
             Assert.Equal(startDate, qualification.StartDate);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
@@ -222,7 +222,7 @@ public partial class TestData
     {
         if (max is not null && max <= min)
         {
-            throw new ArgumentOutOfRangeException("max", "max must be after min.");
+            throw new ArgumentOutOfRangeException(nameof(max), "max must be after min.");
         }
 
         max ??= min.AddYears(1);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -226,8 +227,9 @@ public partial class TestData
 
         max ??= min.AddYears(1);
 
-        var daysDiff = Math.Min(1, (int)(max.Value.ToDateTime(TimeOnly.MinValue) - min.ToDateTime(TimeOnly.MinValue)).TotalDays);
-        return min.AddDays(Random.Shared.Next(minValue: 1, maxValue: daysDiff));
+        var daysDiff = (int)(max.Value.ToDateTime(TimeOnly.MinValue) - min.ToDateTime(TimeOnly.MinValue)).TotalDays;
+        Debug.Assert(daysDiff > 0);
+        return min.AddDays(Random.Shared.Next(minValue: 1, maxValue: daysDiff + 1));
     }
 
     public DateOnly GenerateChangedDate(DateOnly currentDate, DateOnly min, DateOnly? max = null)


### PR DESCRIPTION
We're adding an additional event at migration time for MQs so we have a place to record data changes (e.g. provider mappings). This adds the relevant logic for creating that event.