### PR TITLE
Person sync tweaks

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240124104333_PersonCreatedUpdated.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240124104333_PersonCreatedUpdated.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240124104333_PersonCreatedUpdated")]
+    partial class PersonCreatedUpdated
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240124104333_PersonCreatedUpdated.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240124104333_PersonCreatedUpdated.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersonCreatedUpdated : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_on",
+                table: "persons",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_on",
+                table: "persons",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_on",
+                table: "persons",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "created_on",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_on",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "updated_on",
+                table: "persons");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -3,6 +3,9 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 public class Person
 {
     public required Guid PersonId { get; init; }
+    public required DateTime? CreatedOn { get; init; }
+    public required DateTime? UpdatedOn { get; set; }
+    public DateTime? DeletedOn { get; set; }
     public required string Trn { get; set; }
     public required string FirstName { get; set; }
     public required string MiddleName { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
@@ -31,14 +31,7 @@ public class SyncAllPersonsFromCrmJob
         var columns = new ColumnSet(TrsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person).AttributeNames);
 
         // Ensure this is kept in sync with the predicate in TrsDataSyncHelper.SyncContacts
-        var filter = new FilterExpression(LogicalOperator.And)
-        {
-            Conditions =
-            {
-                new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.NotNull),
-                new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.NotEqual, ""),
-            }
-        };
+        var filter = new FilterExpression(LogicalOperator.And);
 
         var query = new QueryExpression(Contact.EntityLogicalName)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -640,6 +640,8 @@ public class TrsDataSyncHelper(
         var columnNames = new[]
         {
             "person_id",
+            "created_on",
+            "updated_on",
             "trn",
             "first_name",
             "middle_name",
@@ -698,6 +700,8 @@ public class TrsDataSyncHelper(
         Action<NpgsqlBinaryImporter, Person> writeRecord = (writer, person) =>
         {
             writer.WriteValueOrNull(person.PersonId, NpgsqlDbType.Uuid);
+            writer.WriteNullableValueOrNull(person.CreatedOn, NpgsqlDbType.TimestampTz);
+            writer.WriteNullableValueOrNull(person.UpdatedOn, NpgsqlDbType.TimestampTz);
             writer.WriteValueOrNull(person.Trn, NpgsqlDbType.Char);
             writer.WriteValueOrNull(person.FirstName, NpgsqlDbType.Varchar);
             writer.WriteValueOrNull(person.MiddleName, NpgsqlDbType.Varchar);
@@ -833,6 +837,8 @@ public class TrsDataSyncHelper(
         .Select(c => new Person()
         {
             PersonId = c.ContactId!.Value,
+            CreatedOn = c.CreatedOn!.Value,
+            UpdatedOn = c.ModifiedOn!.Value,
             Trn = c.dfeta_TRN,
             FirstName = (c.HasStatedNames() ? c.dfeta_StatedFirstName : c.FirstName) ?? string.Empty,
             MiddleName = (c.HasStatedNames() ? c.dfeta_StatedMiddleName : c.MiddleName) ?? string.Empty,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -161,9 +161,9 @@ public class TrsDataSyncHelper(
 
     public async Task<int> SyncPersons(IReadOnlyCollection<Contact> entities, bool ignoreInvalid, CancellationToken cancellationToken = default)
     {
-        // For now, only sync records that have TRNs.
+        // We're syncing all contacts for now.
         // Keep this in sync with the filter in the SyncAllContactsFromCrmJob job.
-        var toSync = entities.Where(e => !string.IsNullOrEmpty(e.dfeta_TRN));
+        IEnumerable<Contact> toSync = entities;
 
         if (ignoreInvalid)
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Person.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Person.cs
@@ -93,6 +93,8 @@ public partial class TrsDataSyncHelperTests
             var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.DqtContactId == entity.Id);
             Assert.NotNull(person);
             Assert.Equal(entity.Id, person.PersonId);
+            Assert.Equal(entity.CreatedOn, person.CreatedOn);
+            Assert.Equal(entity.ModifiedOn, person.UpdatedOn);
             Assert.Equal(entity.Id, person.DqtContactId);
             Assert.Equal(entity.dfeta_TRN, person.Trn);
             Assert.Equal(entity.FirstName, person.FirstName);


### PR DESCRIPTION
Until now we've not synced contact records without a TRN but we have some MQs linked to a contact record that doesn't have a TRN. This removes the filter to sync all contacts; we can always remove excess data later on.

I've also added {Created|Updated|Deleted}On fields to Person to be consistent with what we're doing elsewhere. Once we've done a full sync a subsequent change will make the former two non-nullable.