### PR TITLE
Use the primary key for ordering in SyncAll* jobs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
@@ -46,7 +46,7 @@ public class SyncAllMqsFromCrmJob
             Criteria = filter,
             Orders =
             {
-                new OrderExpression(dfeta_qualification.Fields.CreatedOn, OrderType.Ascending)
+                new OrderExpression(dfeta_qualification.PrimaryIdAttribute, OrderType.Ascending)
             },
             PageInfo = new PagingInfo()
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
@@ -41,7 +41,7 @@ public class SyncAllPersonsFromCrmJob
             Criteria = filter,
             Orders =
             {
-                new OrderExpression(Contact.Fields.CreatedOn, OrderType.Ascending)
+                new OrderExpression(Contact.PrimaryIdAttribute, OrderType.Ascending)
             },
             PageInfo = new PagingInfo()
             {


### PR DESCRIPTION
A full person sync in pre-prod has missed around 1/3 of records for some reason. The docs on paged queries say to use unique values for the 'order by' clause so I've changed our queries to use the primary key.