### PR TITLE
Amended MQ UI to treat MQ with end date as Passed

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -62,18 +62,20 @@ public class TrsDataSyncHelper(
         }
 
         MandatoryQualificationProvider? provider = null;
+        var dqtMqStatus = qualification.dfeta_MQ_Status;
         if (applyMigrationMappings)
         {
             MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(
                 mqEstablishments.SingleOrDefault(e => e.Id == qualification.dfeta_MQ_MQEstablishmentId!?.Id), out provider);
+
+            dqtMqStatus ??= (qualification.dfeta_MQ_Date.HasValue ? dfeta_qualification_dfeta_MQ_Status.Passed : null);
         }
 
         MandatoryQualificationSpecialism? specialism = qualification.dfeta_MQ_SpecialismId is not null ?
             mqSpecialisms.Single(s => s.Id == qualification.dfeta_MQ_SpecialismId.Id).ToMandatoryQualificationSpecialism() :
             null;
 
-        MandatoryQualificationStatus? status = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus() ??
-            (qualification.dfeta_MQ_Date.HasValue ? MandatoryQualificationStatus.Passed : null);
+        MandatoryQualificationStatus? status = dqtMqStatus?.ToMandatoryQualificationStatus();
 
         return new MandatoryQualification()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
@@ -51,6 +52,7 @@ public class ConfirmModel(
     {
         var qualification = (await crmQueryDispatcher.ExecuteQuery(new GetQualificationByIdQuery(QualificationId)))!;
 
+        var dqtMqStatus = qualification.dfeta_MQ_Status ?? (qualification.dfeta_MQ_Date.HasValue ? dfeta_qualification_dfeta_MQ_Status.Passed : null);
         var establishment = qualification.dfeta_MQ_MQEstablishmentId?.Id is Guid establishmentId ?
             await referenceDataCache.GetMqEstablishmentById(establishmentId) :
             null;
@@ -78,7 +80,7 @@ public class ConfirmModel(
                     } :
                     null,
                 Specialism = specialism?.ToMandatoryQualificationSpecialism(),
-                Status = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus(),
+                Status = dqtMqStatus?.ToMandatoryQualificationStatus(),
                 StartDate = qualification.dfeta_MQStartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                 EndDate = qualification.dfeta_MQ_Date?.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             },

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Events;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
@@ -57,8 +58,9 @@ public class ConfirmModel(
     {
         var qualification = (await crmQueryDispatcher.ExecuteQuery(new GetQualificationByIdQuery(QualificationId)))!;
 
+        var dqtMqStatus = qualification.dfeta_MQ_Status ?? (qualification.dfeta_MQ_Date.HasValue ? dfeta_qualification_dfeta_MQ_Status.Passed : null);
         var changes = MandatoryQualificationUpdatedEventChanges.None |
-            (NewStatus != qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus() ? MandatoryQualificationUpdatedEventChanges.Status : 0) |
+            (NewStatus != dqtMqStatus?.ToMandatoryQualificationStatus() ? MandatoryQualificationUpdatedEventChanges.Status : 0) |
             (NewEndDate != qualification.dfeta_MQ_Date?.ToDateOnlyWithDqtBstFix(isLocalTime: true) ? MandatoryQualificationUpdatedEventChanges.EndDate : 0);
 
         if (changes != MandatoryQualificationUpdatedEventChanges.None)
@@ -84,7 +86,7 @@ public class ConfirmModel(
                     } :
                     null,
                 Specialism = specialism?.ToMandatoryQualificationSpecialism(),
-                Status = qualification.dfeta_MQ_Status?.ToMandatoryQualificationStatus(),
+                Status = dqtMqStatus?.ToMandatoryQualificationStatus(),
                 StartDate = qualification.dfeta_MQStartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                 EndDate = qualification.dfeta_MQ_Date?.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqStatusState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqStatusState.cs
@@ -48,7 +48,7 @@ public class EditMqStatusState
             return;
         }
 
-        Status = CurrentStatus = qualificationInfo.MandatoryQualification.Status;
+        Status = CurrentStatus = qualificationInfo.MandatoryQualification.Status ?? (qualificationInfo.MandatoryQualification.EndDate.HasValue ? MandatoryQualificationStatus.Passed : null);
         EndDate = CurrentEndDate = qualificationInfo.MandatoryQualification.EndDate;
         Initialized = true;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqStatusState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqStatusState.cs
@@ -48,7 +48,7 @@ public class EditMqStatusState
             return;
         }
 
-        Status = CurrentStatus = qualificationInfo.MandatoryQualification.Status ?? (qualificationInfo.MandatoryQualification.EndDate.HasValue ? MandatoryQualificationStatus.Passed : null);
+        Status = CurrentStatus = qualificationInfo.MandatoryQualification.Status;
         EndDate = CurrentEndDate = qualificationInfo.MandatoryQualification.EndDate;
         Initialized = true;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
@@ -52,6 +52,7 @@ public class QualificationsModel : PageModel
             {
                 var mqEstablishment = q.dfeta_MQ_MQEstablishmentId is not null ? await _referenceDataCache.GetMqEstablishmentById(q.dfeta_MQ_MQEstablishmentId.Id) : null;
                 var specialism = q.dfeta_MQ_SpecialismId is not null ? await _referenceDataCache.GetMqSpecialismById(q.dfeta_MQ_SpecialismId.Id) : null;
+                var status = q.dfeta_MQ_Status ?? (q.dfeta_MQ_Date.HasValue ? dfeta_qualification_dfeta_MQ_Status.Passed : null);
 
                 return new MandatoryQualificationInfo
                 {
@@ -60,7 +61,7 @@ public class QualificationsModel : PageModel
                     Specialism = specialism?.ToMandatoryQualificationSpecialism(),
                     StartDate = q.dfeta_MQStartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
                     EndDate = q.dfeta_MQ_Date.ToDateOnlyWithDqtBstFix(isLocalTime: true),
-                    Status = q.dfeta_MQ_Status?.ToMandatoryQualificationStatus()
+                    Status = status?.ToMandatoryQualificationStatus()
                 };
             });
 


### PR DESCRIPTION
### Context

Existing Mandatory Qualifications in CRM will not have a status set so when trying to Edit them in TRS there would not be an existing status.

However if an MQ has an end date then it implicitly indicates that it is Passed.

### Changes proposed in this pull request

Amend the view MQ and edit MQ status UI to show an MQ as Passed if dfeta_MQ_Status is null and dfeta_MQ_Date is not null.

### Guidance to review

Simplish change

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
