### PR TITLE
Enable azure RBAC deployments on all services

### DIFF
--- a/.github/workflows/actions/deploy-aks-environment/action.yml
+++ b/.github/workflows/actions/deploy-aks-environment/action.yml
@@ -20,7 +20,7 @@ runs:
         terraform_version: 1.5.0
         terraform_wrapper: false
 
-    - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+    - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
       with:
         azure-credentials: ${{ inputs.azure_credentials }}
 

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -34,7 +34,7 @@ jobs:
         uses: azure/setup-kubectl@v3
 
       - name: Get k8s credentials
-        run: az aks get-credentials -g ${{ env.CLUSTER_RESOURCE_GROUP }} -n ${{ env.CLUSTER_NAME }}
+        run: make production_aks get-cluster-credentials
 
       - name: Install konduit
         run: make install-konduit
@@ -42,7 +42,7 @@ jobs:
       - name: Dump database
         run: bin/konduit.sh -k ${{ env.KEYVAULT_NAME }} -d trs trs-production-worker -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose -f backup.sql.gz
 
-      - uses: DFE-Digital/github-actions/set-arm-environment-variables@master
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ production: paas
 	$(eval AZURE_BACKUP_STORAGE_CONTAINER_NAME=dqt-api)
 
 .PHONY: dev_aks
-dev_aks: aks
+dev_aks: aks test-cluster
 	$(eval DEPLOY_ENV=dev)
 	$(eval AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test)
 	$(eval RESOURCE_NAME_PREFIX=s189t01)
@@ -68,7 +68,7 @@ dev_aks: aks
 	$(eval ENV_TAG=dev)
 
 .PHONY: test_aks
-test_aks: aks
+test_aks: aks test-cluster
 	$(eval DEPLOY_ENV=test)
 	$(eval AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test)
 	$(eval RESOURCE_NAME_PREFIX=s189t01)
@@ -76,7 +76,7 @@ test_aks: aks
 	$(eval ENV_TAG=test)
 
 .PHONY: pre-production_aks
-pre-production_aks: aks
+pre-production_aks: aks test-cluster
 	$(eval DEPLOY_ENV=pre-production)
 	$(eval AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test)
 	$(eval RESOURCE_NAME_PREFIX=s189t01)
@@ -84,7 +84,7 @@ pre-production_aks: aks
 	$(eval ENV_TAG=pre-prod)
 
 .PHONY: production_aks
-production_aks: aks
+production_aks: aks production-cluster
 	$(eval DEPLOY_ENV=production)
 	$(eval AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production)
 	$(eval RESOURCE_NAME_PREFIX=s189p01)
@@ -255,3 +255,16 @@ install-konduit: ## Install the konduit script, for accessing backend services
 		&& curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o bin/konduit.sh \
 		&& chmod +x bin/konduit.sh \
 		|| true
+
+test-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189t01-tsc-ts-rg)
+	$(eval CLUSTER_NAME=s189t01-tsc-test-aks)
+
+production-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189p01-tsc-pd-rg)
+	$(eval CLUSTER_NAME=s189p01-tsc-production-aks)
+
+get-cluster-credentials: set-azure-account
+	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}
+	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)
+

--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/eppo/environment" {
+  version     = "1.3.5"
+  constraints = "1.3.5"
+  hashes = [
+    "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
+    "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
+    "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
+    "zh:12ca5162286b80b7f46bd013ae2007641132d201af12bc6adb872f9a0ff85b7a",
+    "zh:2991085432bd4dc718aadfb37b2cdb6201ef73a8a0e5661411f46d9ec782e678",
+    "zh:2a8f6801266f89b816ebfdb441411e53f4cf1e0278e853715fb561946ad5a575",
+    "zh:8783a8dc846d3e71b38ca470066f506dde8040f149402f0d348e5dca7f012909",
+    "zh:8bc8f61e496e96c81c46e1aa59bf2155b6acc80db1ea462f2ddd665748fcda7f",
+    "zh:95fb102fecceb3a5b44dbe9fbe262494a0abdb6805addf1286c5d92cd4b0f779",
+    "zh:a158837ec561c161d3c47068e30bca341e5e4c7abff7fa72b9522438b85af4ac",
+    "zh:a738a7b2e953ee8059f9e68d48ae954175d001a5480f29e22d717bee9fd93f7f",
+    "zh:bac4b3a38eed35c91269cd008ad88862f47be99474de85e9a2efcce6564e0c24",
+    "zh:cd56a12eef3515fa5a5845d550be2f67989c8e65563e8fa9f5060666c0728a7c",
+    "zh:e3e895bc8b557b36bfa03f251df429aa0fba068f4c7ef0ed6ac551b7cba9ff86",
+    "zh:e959a9e826e3c33242bf4492ee12e5f8be023cf2461702c43d1833c4a8516232",
+    "zh:f41d9d60b205e6d536881e4af7bb9fc85ae90858bfddf695f95fbd68e01e0ad3",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.57.0"
   constraints = "3.57.0"

--- a/terraform/aks/provider.tf
+++ b/terraform/aks/provider.tf
@@ -17,6 +17,15 @@ provider "kubernetes" {
   client_certificate     = module.cluster_data.kubernetes_client_certificate
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
 }
 
 provider "statuscake" {


### PR DESCRIPTION
### Context

Enable azure RBAC deployments on all services

### Changes proposed in this pull request

- Replace get-credentials with make get-cluster-credentials

- Add get-cluster-credentials: kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli) to get-cluster-credentials
- Update kubernetes Provider

### Guidance to review

Access https://dev.teacher-qualifications-api.education.gov.uk/health, ensure status returns "OK"

### Before merging

Merge after https://github.com/DFE-Digital/terraform-modules/releases/tag/v0.23.0 is releases

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
