### PR TITLE
Skeleton authentication scheme setup for Authorize project

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/AuthorizeAccessLinkGenerator.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.WebUtilities;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord;
+
+public class AuthorizeAccessLinkGenerator(LinkGenerator linkGenerator)
+{
+    public string Start(JourneyInstanceId journeyInstanceId) => Nino(journeyInstanceId);
+
+    public string Nino(JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/Nino", journeyInstanceId: journeyInstanceId);
+
+    private string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
+    {
+        var url = linkGenerator.GetPathByPage(page, handler, values: routeValues) ?? throw new InvalidOperationException("Page was not found.");
+
+        if (journeyInstanceId?.UniqueKey is string journeyInstanceUniqueKey)
+        {
+            url = QueryHelpers.AddQueryString(url, Constants.UniqueKeyQueryParameterName, journeyInstanceUniqueKey);
+        }
+
+        return url;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/FormFlow/DummyCurrentUserIdProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/FormFlow/DummyCurrentUserIdProvider.cs
@@ -1,0 +1,8 @@
+using TeachingRecordSystem.SupportUi.Infrastructure.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.FormFlow;
+
+public class DummyCurrentUserIdProvider : ICurrentUserIdProvider
+{
+    public string GetCurrentUserId() => Guid.Empty.ToString();
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/FormFlow/FormFlowHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/FormFlow/FormFlowHelper.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+using TeachingRecordSystem.FormFlow;
+using TeachingRecordSystem.FormFlow.State;
+
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.FormFlow;
+
+public class SignInJourneyHelper
+{
+    private readonly IUserInstanceStateProvider _userInstanceStateProvider;
+    private readonly JourneyDescriptor _journeyDescriptor;
+
+    public SignInJourneyHelper(IUserInstanceStateProvider userInstanceStateProvider, IOptions<FormFlowOptions> formFlowOptionsAccessor)
+    {
+        _userInstanceStateProvider = userInstanceStateProvider;
+
+        _journeyDescriptor = formFlowOptionsAccessor.Value.JourneyRegistry.GetJourneyByName(SignInJourneyState.JourneyName) ??
+            throw new InvalidOperationException($"Cannot find {SignInJourneyState.JourneyName} journey.");
+    }
+
+    public async Task<JourneyInstance<SignInJourneyState>?> GetInstanceAsync(HttpContext httpContext, JourneyInstanceId? instanceIdHint = null)
+    {
+        if (httpContext.Items.TryGetValue(typeof(JourneyInstance), out var journeyInstanceObj) &&
+            journeyInstanceObj is JourneyInstance<SignInJourneyState> instance)
+        {
+            return instance;
+        }
+
+        var valueProvider = CreateValueProvider(httpContext);
+
+        if (!JourneyInstanceId.TryResolve(_journeyDescriptor, valueProvider, out var instanceId) && instanceIdHint is null)
+        {
+            return null;
+        }
+
+        if (await _userInstanceStateProvider.GetInstanceAsync(instanceIdHint ?? instanceId, typeof(SignInJourneyState))
+            is not JourneyInstance<SignInJourneyState> persistedInstance)
+        {
+            return null;
+        }
+
+        httpContext.Items[typeof(JourneyInstance)] = persistedInstance;
+
+        return persistedInstance;
+    }
+
+    public async Task<JourneyInstance<SignInJourneyState>> GetOrCreateInstanceAsync(
+        HttpContext httpContext,
+        Func<SignInJourneyState> createState,
+        Action<SignInJourneyState> updateState)
+    {
+        var existingInstance = await GetInstanceAsync(httpContext);
+
+        if (existingInstance is not null)
+        {
+            await existingInstance.UpdateStateAsync(updateState);
+            return existingInstance;
+        }
+
+        var valueProvider = CreateValueProvider(httpContext);
+        var instanceId = JourneyInstanceId.Create(_journeyDescriptor, valueProvider);
+
+        var newState = createState();
+        var instance = (JourneyInstance<SignInJourneyState>)await _userInstanceStateProvider.CreateInstanceAsync(instanceId, typeof(SignInJourneyState), newState, properties: null);
+
+        httpContext.Items[typeof(JourneyInstance)] = instance;
+
+        return instance;
+    }
+
+    private static IValueProvider CreateValueProvider(HttpContext httpContext) =>
+        new QueryStringValueProvider(BindingSource.Query, httpContext.Request.Query, culture: null);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/Security/AuthenticationSchemes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/Security/AuthenticationSchemes.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.Security;
+
+public static class AuthenticationSchemes
+{
+    public const string FormFlowJourney = nameof(FormFlowJourney);
+
+    public const string MatchToTeachingRecord = nameof(MatchToTeachingRecord);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/Security/FormFlowJourneySignInHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/Security/FormFlowJourneySignInHandler.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.FormFlow;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.Security;
+
+/// <summary>
+/// An <see cref="IAuthenticationSignInHandler"/> that persists an <see cref="AuthenticationTicket"/> to
+/// the current FormFlow instance's state.
+/// </summary>
+public class FormFlowJourneySignInHandler(SignInJourneyHelper signInJourneyHelper) : IAuthenticationSignInHandler
+{
+    private AuthenticationScheme? _scheme;
+    private HttpContext? _context;
+
+    public async Task<AuthenticateResult> AuthenticateAsync()
+    {
+        EnsureInitialized();
+
+        var journeyInstance = await signInJourneyHelper.GetInstanceAsync(_context);
+
+        if (journeyInstance is null || journeyInstance.State.OneLoginAuthenticationTicket is null)
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        return AuthenticateResult.Success(journeyInstance.State.OneLoginAuthenticationTicket);
+    }
+
+    public Task ChallengeAsync(AuthenticationProperties? properties)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task ForbidAsync(AuthenticationProperties? properties)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context)
+    {
+        _scheme = scheme;
+        _context = context;
+        return Task.CompletedTask;
+    }
+
+    public async Task SignInAsync(ClaimsPrincipal user, AuthenticationProperties? properties)
+    {
+        EnsureInitialized();
+
+        if (properties is null || !properties.Items.TryGetValue(PropertyKeys.JourneyInstanceId, out var serializedInstanceId) ||
+            serializedInstanceId is null)
+        {
+            throw new InvalidOperationException($"{PropertyKeys.JourneyInstanceId} must be specified in {nameof(properties)}.");
+        }
+
+        var journeyInstanceId = JourneyInstanceId.Deserialize(serializedInstanceId);
+
+        var journeyInstance = await signInJourneyHelper.GetInstanceAsync(_context, journeyInstanceId) ??
+            throw new InvalidOperationException("No FormFlow journey.");
+
+        var ticket = new AuthenticationTicket(user, properties, _scheme.Name);
+
+        await journeyInstance.UpdateStateAsync(state => state.OnSignedInWithOneLogin(ticket));
+    }
+
+    public async Task SignOutAsync(AuthenticationProperties? properties)
+    {
+        EnsureInitialized();
+
+        var journeyInstance = await signInJourneyHelper.GetInstanceAsync(_context) ??
+            throw new InvalidOperationException("No FormFlow journey.");
+
+        await journeyInstance.UpdateStateAsync(state => state.Reset());
+    }
+
+    [MemberNotNull(nameof(_context), nameof(_scheme))]
+    private void EnsureInitialized()
+    {
+        if (_context is null || _scheme is null)
+        {
+            throw new InvalidOperationException("Not initialized.");
+        }
+    }
+
+    public static class PropertyKeys
+    {
+        public const string JourneyInstanceId = nameof(JourneyInstanceId);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/Security/MatchToTeachingRecordAuthenticationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Infrastructure/Security/MatchToTeachingRecordAuthenticationHandler.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics.CodeAnalysis;
+using GovUk.OneLogin.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.Security;
+
+public class MatchToTeachingRecordAuthenticationHandler(
+    SignInJourneyHelper signInJourneyHelper,
+    AuthorizeAccessLinkGenerator linkGenerator) : IAuthenticationHandler
+{
+    private AuthenticationScheme? _scheme;
+    private HttpContext? _context;
+
+    public async Task<AuthenticateResult> AuthenticateAsync()
+    {
+        EnsureInitialized();
+
+        var journeyInstance = await signInJourneyHelper.GetInstanceAsync(_context);
+
+        if (journeyInstance is null)
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var ticket = journeyInstance.State.AuthenticationTicket;
+
+        if (ticket is null)
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        return AuthenticateResult.Success(ticket);
+    }
+
+    public async Task ChallengeAsync(AuthenticationProperties? properties)
+    {
+        EnsureInitialized();
+
+        properties ??= new();
+        properties.RedirectUri ??= "/";
+
+        var journeyInstance = await signInJourneyHelper.GetOrCreateInstanceAsync(
+            _context,
+            createState: () => new SignInJourneyState(properties.RedirectUri!, OneLoginDefaults.AuthenticationScheme),
+            updateState: state => state.Reset());
+
+        properties.RedirectUri = linkGenerator.Start(journeyInstance.InstanceId);
+        properties.Items.Add(FormFlowJourneySignInHandler.PropertyKeys.JourneyInstanceId, journeyInstance.InstanceId.Serialize());
+        await _context!.ChallengeAsync(OneLoginDefaults.AuthenticationScheme, properties);
+    }
+
+    public Task ForbidAsync(AuthenticationProperties? properties)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context)
+    {
+        _scheme = scheme;
+        _context = context;
+        return Task.CompletedTask;
+    }
+
+    [MemberNotNull(nameof(_context), nameof(_scheme))]
+    private void EnsureInitialized()
+    {
+        if (_context is null || _scheme is null)
+        {
+            throw new InvalidOperationException("Not initialized.");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Pages/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Pages/Index.cshtml.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Infrastructure.Security;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Pages;
 
-[Authorize]
+[Journey(SignInJourneyState.JourneyName)]
+[Authorize(AuthenticationSchemes = AuthenticationSchemes.MatchToTeachingRecord)]
 public class IndexModel : PageModel
 {
     public void OnGet()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Pages/Nino.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Pages/Nino.cshtml
@@ -1,0 +1,6 @@
+@page "/nino"
+@model TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Pages.NinoModel
+@{
+}
+
+<h1>NINO</h1>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Pages/Nino.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/Pages/Nino.cshtml.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Pages;
+
+[Authorize]
+[Journey(SignInJourneyState.JourneyName), RequireJourneyInstance]
+public class NinoModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/SignInJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/SignInJourneyState.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Authentication;
+
+namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord;
+
+public class SignInJourneyState
+{
+    public const string JourneyName = "SignInJourney";
+
+    private readonly TicketSerializer _ticketSerializer = TicketSerializer.Default;
+
+    [JsonInclude]
+    private byte[]? _oneLoginAuthenticationTicket;
+
+    [JsonConstructor]
+    public SignInJourneyState(string redirectUri, string oneLoginAuthenticationScheme)
+    {
+        RedirectUri = redirectUri;
+        OneLoginAuthenticationScheme = oneLoginAuthenticationScheme;
+    }
+
+    public AuthenticationTicket? AuthenticationTicket { get; private set; }
+
+    [JsonIgnore]
+    public AuthenticationTicket? OneLoginAuthenticationTicket =>
+        _oneLoginAuthenticationTicket is not null ? _ticketSerializer.Deserialize(_oneLoginAuthenticationTicket) : null;
+
+    [JsonIgnore]
+    public bool AuthenticatedWithOneLogin => OneLoginAuthenticationTicket is not null;
+
+    public string RedirectUri { get; }
+
+    public string OneLoginAuthenticationScheme { get; }
+
+    public void OnSignedInWithOneLogin(AuthenticationTicket ticket)
+    {
+        _oneLoginAuthenticationTicket = _ticketSerializer.Serialize(ticket);
+        // TODO Should we reset all other state here?
+    }
+
+    public void Reset()
+    {
+        AuthenticationTicket = null;
+        _oneLoginAuthenticationTicket = null;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/TeachingRecordSystem.AuthorizeAccessToATeacherRecord.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccessToATeacherRecord/TeachingRecordSystem.AuthorizeAccessToATeacherRecord.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TeachingRecordSystem.Core\TeachingRecordSystem.Core.csproj" />
+    <ProjectReference Include="..\TeachingRecordSystem.FormFlow\TeachingRecordSystem.FormFlow.csproj" />
     <ProjectReference Include="..\TeachingRecordSystem.ServiceDefaults\TeachingRecordSystem.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.FormFlow.Tests/JourneyInstanceIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.FormFlow.Tests/JourneyInstanceIdTests.cs
@@ -34,7 +34,7 @@ public class JourneyInstanceIdTests
             keys: null,
             expectedInstanceKeyCount: 0,
             assertions: instanceId => { },
-            expectedSerializableId: () => $"key");
+            expectedSerializedValue: () => $"key");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class JourneyInstanceIdTests
                 randomKey = instanceId.Keys[Constants.UniqueKeyQueryParameterName];
                 Assert.NotNull(randomKey);
             },
-            expectedSerializableId: () => $"key?ffiid={randomKey}");
+            expectedSerializedValue: () => $"key?ffiid={randomKey}");
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class JourneyInstanceIdTests
             {
                 Assert.Equal(id, instanceId.Keys["id"]);
             },
-            expectedSerializableId: () => $"key?id={id}");
+            expectedSerializedValue: () => $"key?id={id}");
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class JourneyInstanceIdTests
                 randomKey = instanceId.Keys[Constants.UniqueKeyQueryParameterName];
                 Assert.Equal(id, instanceId.Keys["id"]);
             },
-            expectedSerializableId: () => $"key?id={id}&ffiid={randomKey}");
+            expectedSerializedValue: () => $"key?id={id}&ffiid={randomKey}");
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public class JourneyInstanceIdTests
                 Assert.NotNull(newRandomKey);
                 Assert.NotEqual(currentRandomKey, newRandomKey);
             },
-            expectedSerializableId: () => $"key?ffiid={newRandomKey}");
+            expectedSerializedValue: () => $"key?ffiid={newRandomKey}");
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class JourneyInstanceIdTests
             {
                 Assert.Equal(id, instanceId.Keys["id"]);
             },
-            expectedSerializableId: () => $"key?id={id}");
+            expectedSerializedValue: () => $"key?id={id}");
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class JourneyInstanceIdTests
             keys: null,
             expectedInstanceKeyCount: 0,
             assertions: instanceId => { },
-            expectedSerializableId: () => $"key");
+            expectedSerializedValue: () => $"key");
     }
 
     [Fact]
@@ -309,7 +309,7 @@ public class JourneyInstanceIdTests
         IDictionary<string, string>? keys,
         int expectedInstanceKeyCount,
         Action<JourneyInstanceId> assertions,
-        Func<string> expectedSerializableId)
+        Func<string> expectedSerializedValue)
     {
         // Arrange
         var journeyDescriptor = new JourneyDescriptor(
@@ -327,7 +327,7 @@ public class JourneyInstanceIdTests
         Assert.Equal("key", instanceId.JourneyName);
         Assert.Equal(expectedInstanceKeyCount, instanceId.Keys.Count);
         assertions(instanceId);
-        Assert.Equal(expectedSerializableId(), instanceId.SerializableId);
+        Assert.Equal(expectedSerializedValue(), instanceId.Serialize());
     }
 
     private void TryResolveReturnsExpectedInstance(


### PR DESCRIPTION
This sets up most of the structure for the two-phase authentication for Authorize access.

The OneLogin handler takes a fixed set of credentials but we will have a different set per client. Accordingly, we will have a OneLogin scheme for every one of our clients. (A future PR will wire this up.)

The OneLogin handler needs a 'sign in scheme' that can persist the AuthenticationTicket over multiple requests. Typically this is Cookies but here we're using FormFlow state instead. The thinking behind is that we want to support multiple concurrent sign ins for different clients and each of those needs its own state. If we used cookies it would mean a cookie-per-client, which could be a lot of cookies (and a messy Cookies page). This is the `FormFlowJourneySignInHandler` type and there only needs to be one of these.

The third handler type is the
`MatchToTeachingRecordAuthenticationHandler`. This is the scheme that actually gets called by code that wants to authenticate the user. It delegates to the appropriate OneLogin scheme to sign the user in to One Login, then redirects the user to the NINO page, which will begin the matching process. Eventually a teaching record may be found and authentication will be considered complete.