### PR TITLE
Add retries to TrsDataSyncService and DqtReportingService

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -63,6 +63,7 @@
     <PackageVersion Include="NSwag.Examples" Version="1.0.11" />
     <PackageVersion Include="Optional" Version="4.0.0" />
     <PackageVersion Include="PdfSharpCore" Version="1.3.62" />
+    <PackageVersion Include="Polly.Core" Version="8.2.1" />
     <PackageVersion Include="RedisRateLimiting.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="Respawn" Version="6.1.0" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -74,6 +74,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Optional" />
     <PackageReference Include="PdfSharpCore" />
+    <PackageReference Include="Polly.Core" />
     <PackageReference Include="Scrutor" />
     <PackageReference Include="System.Net.Http.Json" />
     <PackageReference Include="System.Reactive" />


### PR DESCRIPTION
We see intermittent errors talking to CRM and our 'fail fast' policy for sync-related services means these services are shutting down. This adds simple retries with an exponential backoff that should hopefully be enough to weather CRM flakiness.