### PR TITLE
Add One Login config to Edit Application User UI + tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
@@ -35,6 +35,8 @@ public class ApplicationUserMapping : IEntityTypeConfiguration<ApplicationUser>
     public void Configure(EntityTypeBuilder<ApplicationUser> builder)
     {
         builder.Property(e => e.ApiRoles).HasColumnType("varchar[]");
+        builder.Property(e => e.OneLoginClientId).HasMaxLength(50);
+        builder.Property(e => e.OneLoginPrivateKeyPem).HasMaxLength(2000);
     }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240129115405_ApplicationUserOneLoginClientIdAndPem.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240129115405_ApplicationUserOneLoginClientIdAndPem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240129115405_ApplicationUserOneLoginClientIdAndPem")]
+    partial class ApplicationUserOneLoginClientIdAndPem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240129115405_ApplicationUserOneLoginClientIdAndPem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240129115405_ApplicationUserOneLoginClientIdAndPem.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class ApplicationUserOneLoginClientIdAndPem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "one_login_client_id",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "one_login_private_key_pem",
+                table: "users",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "one_login_client_id",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "one_login_private_key_pem",
+                table: "users");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -20,10 +20,13 @@ public class User : UserBase
 
 public class ApplicationUser : UserBase
 {
+    public const int OneLoginClientIdMaxLength = 50;
     public const string NameUniqueIndexName = "ix_users_application_user_name";
 
     public required string[] ApiRoles { get; set; }
     public ICollection<ApiKey> ApiKeys { get; } = null!;
+    public string? OneLoginClientId { get; set; }
+    public string? OneLoginPrivateKeyPem { get; set; }
 }
 
 public class SystemUser : UserBase

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ApplicationUserUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ApplicationUserUpdatedEvent.cs
@@ -14,4 +14,6 @@ public enum ApplicationUserUpdatedEventChanges
     None = 0,
     Name = 1 << 0,
     ApiRoles = 1 << 1,
+    OneLoginClientId = 1 << 2,
+    OneLoginPrivateKeyPem = 1 << 3
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
@@ -5,11 +5,15 @@ public record ApplicationUser
     public required Guid UserId { get; init; }
     public required string Name { get; init; }
     public required string[] ApiRoles { get; set; }
+    public string? OneLoginClientId { get; set; }
+    public string? OneLoginPrivateKeyPem { get; set; }
 
     public static ApplicationUser FromModel(DataStore.Postgres.Models.ApplicationUser user) => new()
     {
         UserId = user.UserId,
         Name = user.Name,
-        ApiRoles = user.ApiRoles
+        ApiRoles = user.ApiRoles,
+        OneLoginClientId = user.OneLoginClientId,
+        OneLoginPrivateKeyPem = user.OneLoginPrivateKeyPem
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml
@@ -41,7 +41,7 @@
                         {
                             <tr class="govuk-table__row">
                                 <td class="govuk-table__cell">
-                                    <a href="@LinkGenerator.EditApiKey(key.ApiKeyId)" class="govuk-link">@key.ApiKeyId</a>
+                                    <a href="@LinkGenerator.EditApiKey(key.ApiKeyId)" class="govuk-link" data-testid="EditApiKey-@key.ApiKeyId">@key.ApiKeyId</a>
                                 </td>
                                 <td class="govuk-table__cell" data-testid="Expiry">
                                     @if (key.Expires is DateTime expires)
@@ -72,8 +72,12 @@
             </table>
 
             <div class="govuk-!-margin-bottom-1">
-                <govuk-button-link href="@LinkGenerator.AddApiKey(Model.UserId)" class="govuk-button--secondary">Add API key</govuk-button-link>
+                <govuk-button-link href="@LinkGenerator.AddApiKey(Model.UserId)" class="govuk-button--secondary" data-testid="AddApiKey">Add API key</govuk-button-link>
             </div>
+
+            <h2 class="govuk-heading-m">One Login</h2>
+            <govuk-input asp-for="OneLoginClientId" label-class="govuk-label--s" autocomplete="off" />
+            <govuk-textarea asp-for="OneLoginPrivateKeyPem" label-class="govuk-label--s" />
 
             <govuk-button type="submit">Save changes</govuk-button>
         </form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/Index.cshtml
@@ -19,7 +19,7 @@
             {
                 <tr class="govuk-table__row" data-testid="user-@user.UserId">
                     <td class="govuk-table__cell">
-                        <a href="@LinkGenerator.EditApplicationUser(user.UserId)" class="govuk-link" data-testid="edit-user-@user.UserId">@user.Name</a>
+                        <a href="@LinkGenerator.EditApplicationUser(user.UserId)" class="govuk-link" data-testid="edit-application-user-@user.UserId">@user.Name</a>
                     </td>
                 </tr>
             }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/ApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/ApplicationUserTests.cs
@@ -1,0 +1,132 @@
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using TeachingRecordSystem.Core;
+
+namespace TeachingRecordSystem.SupportUi.EndToEndTests;
+
+public class ApplicationUserTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task AddApplicationUser()
+    {
+        var applicationUserName = TestData.GenerateApplicationUserName();
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToApplicationUsersPage();
+
+        await page.AssertOnApplicationUsersPage();
+
+        await page.ClickLinkForElementWithTestId("add-application-user");
+
+        await page.AssertOnAddApplicationUserPage();
+
+        await page.FillAsync("text=Name", applicationUserName);
+
+        await page.ClickButton("Save");
+
+        var applicationUserId = await WithDbContext(async dbContext =>
+        {
+            var applicationUser = await dbContext.ApplicationUsers.Where(u => u.Name == applicationUserName).SingleOrDefaultAsync();
+            return applicationUser!.UserId;
+        });
+
+        await page.AssertOnEditApplicationUserPage(applicationUserId);
+
+        await page.AssertFlashMessage("Application user added");
+    }
+
+    [Fact]
+    public async Task EditApplicationUser()
+    {
+        var applicationUser = await TestData.CreateApplicationUser();
+        var applicationUserId = applicationUser.UserId;
+        var newApplicationUserName = TestData.GenerateChangedApplicationUserName(applicationUser.Name);
+        var newOneLoginClientId = Guid.NewGuid().ToString();
+        var newOneLoginPrivateKeyPem = TestCommon.TestData.GeneratePrivateKeyPem();
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToApplicationUsersPage();
+
+        await page.AssertOnApplicationUsersPage();
+
+        await page.ClickLinkForElementWithTestId($"edit-application-user-{applicationUserId}");
+
+        await page.AssertOnEditApplicationUserPage(applicationUserId);
+
+        await page.FillAsync("text=Name", newApplicationUserName);
+        await page.SetCheckedAsync($"label:text-is('{ApiRoles.GetPerson}')", true);
+        await page.SetCheckedAsync($"label:text-is('{ApiRoles.UpdatePerson}')", true);
+        await page.FillAsync("text=Client ID", newOneLoginClientId);
+        await page.FillAsync("text=Private Key PEM", newOneLoginPrivateKeyPem);
+
+        await page.ClickButton("Save changes");
+
+        await page.AssertOnApplicationUsersPage();
+
+        await page.AssertFlashMessage("Application user updated");
+    }
+
+    [Fact]
+    public async Task AddApiKey()
+    {
+        var applicationUser = await TestData.CreateApplicationUser();
+        var applicationUserId = applicationUser.UserId;
+        var apiKey = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToApplicationUsersPage();
+
+        await page.AssertOnApplicationUsersPage();
+
+        await page.ClickLinkForElementWithTestId($"edit-application-user-{applicationUserId}");
+
+        await page.AssertOnEditApplicationUserPage(applicationUserId);
+
+        await page.ClickLinkForElementWithTestId("AddApiKey");
+
+        await page.AssertOnAddApiKeyPage();
+
+        await page.FillAsync("label:text-is('Key')", apiKey);
+
+        await page.ClickButton("Save");
+
+        await page.AssertOnEditApplicationUserPage(applicationUserId);
+
+        await page.AssertFlashMessage("API key added");
+    }
+
+    [Fact]
+    public async Task EditApiKey()
+    {
+        var applicationUser = await TestData.CreateApplicationUser();
+        var applicationUserId = applicationUser.UserId;
+        var apiKey = await TestData.CreateApiKey(applicationUser.UserId);
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToApplicationUsersPage();
+
+        await page.AssertOnApplicationUsersPage();
+
+        await page.ClickLinkForElementWithTestId($"edit-application-user-{applicationUserId}");
+
+        await page.AssertOnEditApplicationUserPage(applicationUserId);
+
+        await page.ClickLinkForElementWithTestId($"EditApiKey-{apiKey.ApiKeyId}");
+
+        await page.AssertOnEditApiKeyPage(apiKey.ApiKeyId);
+
+        await page.ClickButton("Expire");
+
+        await page.AssertOnEditApplicationUserPage(applicationUserId);
+
+        await page.AssertFlashMessage("API key expired");
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -41,6 +41,11 @@ public static class PageExtensions
         await page.GotoAsync($"/users");
     }
 
+    public static async Task GoToApplicationUsersPage(this IPage page)
+    {
+        await page.GotoAsync($"/application-users");
+    }
+
     public static Task ClickLinkForElementWithTestId(this IPage page, string testId) =>
         page.GetByTestId(testId).ClickAsync();
 
@@ -263,6 +268,31 @@ public static class PageExtensions
     public static async Task AssertOnEditUserPage(this IPage page, Guid userId)
     {
         await page.WaitForUrlPathAsync($"/users/{userId}");
+    }
+
+    public static async Task AssertOnApplicationUsersPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync($"/application-users");
+    }
+
+    public static async Task AssertOnAddApplicationUserPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync($"/application-users/add");
+    }
+
+    public static async Task AssertOnEditApplicationUserPage(this IPage page, Guid applicationUserId)
+    {
+        await page.WaitForUrlPathAsync($"/application-users/{applicationUserId}");
+    }
+
+    public static async Task AssertOnAddApiKeyPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync($"/api-keys/add");
+    }
+
+    public static async Task AssertOnEditApiKeyPage(this IPage page, Guid apiKeyId)
+    {
+        await page.WaitForUrlPathAsync($"/api-keys/{apiKeyId}");
     }
 
     public static async Task AssertFlashMessage(this IPage page, string expectedHeader)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestBase.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.EndToEndTests.Infrastructure.Security;
 using TeachingRecordSystem.TestCommon;
@@ -16,6 +18,13 @@ public abstract class TestBase
     public HostFixture HostFixture { get; }
 
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
+
+    public virtual async Task<T> WithDbContext<T>(Func<TrsDbContext, Task<T>> action)
+    {
+        var dbContextFactory = HostFixture.Services.GetRequiredService<IDbContextFactory<TrsDbContext>>();
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync();
+        return await action(dbContext);
+    }
 
     protected void SetCurrentUser(User user)
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events;
 
@@ -7,18 +8,28 @@ public partial class TestData
 {
     public async Task<ApplicationUser> CreateApplicationUser(
         string? name = null,
-        string[]? apiRoles = null)
+        string[]? apiRoles = null,
+        bool? hasOneLoginSettings = false)
     {
         var user = await WithDbContext(async dbContext =>
         {
             name ??= GenerateApplicationUserName();
             apiRoles ??= [];
+            string? oneLoginClientId = null;
+            string? oneLoginPrivateKeyPem = null;
+            if (hasOneLoginSettings == true)
+            {
+                oneLoginClientId = Guid.NewGuid().ToString();
+                oneLoginPrivateKeyPem = GeneratePrivateKeyPem();
+            }
 
             var user = new ApplicationUser()
             {
                 Name = name,
                 UserId = Guid.NewGuid(),
-                ApiRoles = apiRoles
+                ApiRoles = apiRoles,
+                OneLoginClientId = oneLoginClientId,
+                OneLoginPrivateKeyPem = oneLoginPrivateKeyPem
             };
 
             dbContext.ApplicationUsers.Add(user);
@@ -38,5 +49,10 @@ public partial class TestData
         });
 
         return user;
+    }
+
+    public static string GeneratePrivateKeyPem()
+    {
+        return RSA.Create().ExportRSAPrivateKeyPem();
     }
 }


### PR DESCRIPTION
### Context

We need to store a separate set of credentials for One Login for every TRS Application User.

### Changes proposed in this pull request

Add OneLoginClientId and OneLoginPrivateKeyPem properties to the ApplicationUser model.

Add a One Login section to the Edit Application User page with optional fields for each of the new fields (use a textarea for the OneLoginPrivateKeyPem field and validate it using ImportFromPem on RSA).

### Guidance to review

UI + tests + end to end tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
