### PR TITLE
Add a debug page for overriding user information

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -1,11 +1,16 @@
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
 using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess;
 
-public class AuthorizeAccessLinkGenerator(LinkGenerator linkGenerator)
+public class AuthorizeAccessLinkGenerator(LinkGenerator linkGenerator, IOptions<AuthorizeAccessOptions> optionsAccessor)
 {
-    public string Start(JourneyInstanceId journeyInstanceId) => Nino(journeyInstanceId);
+    public string Start(JourneyInstanceId journeyInstanceId, bool skipDebugPage = false) => optionsAccessor.Value.ShowDebugPages && !skipDebugPage ?
+        DebugIdentity(journeyInstanceId) :
+        Nino(journeyInstanceId);
+
+    public string DebugIdentity(JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/DebugIdentity", journeyInstanceId: journeyInstanceId);
 
     public string Nino(JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/Nino", journeyInstanceId: journeyInstanceId);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessOptions.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.AuthorizeAccess;
+
+public class AuthorizeAccessOptions
+{
+    public required bool ShowDebugPages { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Conventions/BindJourneyInstancePropertiesConvention.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Conventions/BindJourneyInstancePropertiesConvention.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Infrastructure.Conventions;
+
+public class BindJourneyInstancePropertiesConvention : IPageApplicationModelConvention
+{
+    public void Apply(PageApplicationModel model)
+    {
+        var journeyInstanceProperties = model.HandlerProperties.Where(p =>
+            p.ParameterType == typeof(JourneyInstance) ||
+                p.ParameterType.IsGenericType && p.ParameterType.GetGenericTypeDefinition() == typeof(JourneyInstance<>));
+
+        foreach (var journeyInstanceProperty in journeyInstanceProperties)
+        {
+            journeyInstanceProperty.BindingInfo ??= new BindingInfo();
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/PageModelExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/PageModelExtensions.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess;
+
+public static class PageModelExtensions
+{
+    public static PageResult PageWithErrors(this PageModel pageModel) => new PageResult() { StatusCode = StatusCodes.Status400BadRequest };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml
@@ -1,0 +1,66 @@
+@page "/debug"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.DebugIdentityModel
+@{
+    ViewBag.Title = "Identity information";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.DebugIdentity(Model.JourneyInstance!.InstanceId)" method="post">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="Subject" disabled="true" />
+
+            <govuk-input asp-for="Email" type="email" disabled="true" />
+
+            <govuk-checkboxes asp-for="IdentityVerified">
+                <govuk-checkboxes-item value="@true">
+                    Identity verified
+
+                    <govuk-checkboxes-item-conditional>
+                        <govuk-textarea asp-for="VerifiedNames" input-class="govuk-" />
+                        <govuk-textarea asp-for="VerifiedDatesOfBirth" />
+                    </govuk-checkboxes-item-conditional>
+                </govuk-checkboxes-item>
+            </govuk-checkboxes>
+
+            <div class="govuk-!-margin-bottom-5">
+                <h2 class="govuk-heading-m">Teaching record</h2>
+
+                @if (Model.Person is not null)
+                {
+                    <govuk-summary-list class="govuk-!-margin-bottom-3">
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.Person.Trn</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.Person.FirstName @Model.Person.LastName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.Person.DateOfBirth?.ToString("dd/MM/yyyy")</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>National insurance number</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.Person.NationalInsuranceNumber</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    </govuk-summary-list>
+
+                    <govuk-checkboxes asp-for="DetachPerson" class="govuk-checkboxes--small">
+                        <govuk-checkboxes-item value="@true">Detach teaching record</govuk-checkboxes-item>
+                    </govuk-checkboxes>
+                }
+                else
+                {
+                    <p class="govuk-body">
+                        <div class="govuk-caption-m">User is not linked to a teaching record.</div>
+                    </p>
+                }
+            </div>
+
+            <govuk-button type="submit">Save and continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
@@ -1,0 +1,155 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages;
+
+[Journey(SignInJourneyState.JourneyName), RequireJourneyInstance]
+public class DebugIdentityModel(
+    TrsDbContext dbContext,
+    SignInJourneyHelper helper,
+    AuthorizeAccessLinkGenerator linkGenerator,
+    IOptions<AuthorizeAccessOptions> optionsAccessor) : PageModel
+{
+    private OneLoginUser? _oneLoginUser;
+
+    public JourneyInstance<SignInJourneyState>? JourneyInstance { get; set; }
+
+    [Display(Name = "Subject")]
+    public string? Subject { get; set; }
+
+    [Display(Name = "Email")]
+    public string? Email { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Identity verified")]
+    public bool IdentityVerified { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Verified names")]
+    public string? VerifiedNames { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Verified dates of birth")]
+    public string? VerifiedDatesOfBirth { get; set; }
+
+    public string? CoreIdentityJwt { get; set; }
+
+    public PersonInfo? Person { get; set; }
+
+    [BindProperty]
+    public bool DetachPerson { get; set; }
+
+    public void OnGet()
+    {
+        IdentityVerified = JourneyInstance!.State.IdentityVerified;
+
+        if (IdentityVerified)
+        {
+            VerifiedNames = string.Join("\n", JourneyInstance.State.VerifiedNames!.Select(name => string.Join(" ", name)));
+            VerifiedDatesOfBirth = string.Join("\n", JourneyInstance.State.VerifiedDatesOfBirth!.Select(dob => dob.ToString("dd/MM/yyyy")));
+        }
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        string[][]? verifiedNames;
+        DateOnly[]? verifiedDatesOfBirth;
+
+        if (IdentityVerified)
+        {
+            verifiedNames = (VerifiedNames ?? string.Empty).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(line => line.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToArray())
+                .ToArray();
+
+            if (verifiedNames.Length == 0)
+            {
+                ModelState.AddModelError(nameof(VerifiedNames), "Enter at least one name");
+            }
+            else if (verifiedNames.Any(name => name.Length < 2))
+            {
+                ModelState.AddModelError(nameof(VerifiedNames), "Each name must have at least two parts");
+            }
+
+            var dobs = (VerifiedDatesOfBirth ?? string.Empty).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(line => DateOnly.TryParse(line, out var parsed) ? parsed : (DateOnly?)null)
+                .ToArray();
+
+            if (dobs.Length == 0)
+            {
+                ModelState.AddModelError(nameof(VerifiedDatesOfBirth), "Enter at least one name");
+            }
+            else if (dobs.Any(dob => dob is null))
+            {
+                ModelState.AddModelError(nameof(VerifiedDatesOfBirth), "Each date of birth must be in the dd/mm/yyyy format");
+            }
+
+            verifiedDatesOfBirth = dobs.Where(d => d.HasValue).Select(d => d!.Value).ToArray();
+        }
+        else
+        {
+            verifiedNames = null;
+            verifiedDatesOfBirth = null;
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.IdentityVerified = IdentityVerified;
+            state.VerifiedNames = verifiedNames;
+            state.VerifiedDatesOfBirth = verifiedDatesOfBirth;
+        });
+
+        if (DetachPerson && _oneLoginUser?.PersonId is not null)
+        {
+            _oneLoginUser.PersonId = null;
+            await dbContext.SaveChangesAsync();
+        }
+
+        await helper.CreateOrUpdateOneLoginUser(JourneyInstance.State);
+
+        return Redirect(linkGenerator.Start(JourneyInstance.InstanceId, skipDebugPage: true));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (!optionsAccessor.Value.ShowDebugPages)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        if (JourneyInstance!.State.OneLoginAuthenticationTicket is null)
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        Subject = User.FindFirstValue("sub");
+        Email = User.FindFirstValue("email");
+
+        _oneLoginUser = await dbContext.OneLoginUsers
+            .Include(o => o.Person)
+            .FirstOrDefaultAsync(o => o.Subject == Subject);
+
+        if (_oneLoginUser?.Person is Person person)
+        {
+            Person = new(person.PersonId, person.Trn, person.FirstName, person.LastName, person.DateOfBirth, person.NationalInsuranceNumber);
+        }
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+    }
+
+    public record PersonInfo(Guid PersonId, string? Trn, string FirstName, string LastName, DateOnly? DateOfBirth, string? NationalInsuranceNumber);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/_ViewImports.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/_ViewImports.cshtml
@@ -2,3 +2,4 @@
 @namespace TeachingRecordSystem.AuthorizeAccessToATeacherRecord.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, GovUk.Frontend.AspNetCore
+@inject TeachingRecordSystem.AuthorizeAccess.AuthorizeAccessLinkGenerator LinkGenerator

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -3,12 +3,16 @@ using GovUk.Frontend.AspNetCore;
 using GovUk.OneLogin.AspNetCore;
 using Joonasw.AspNetCore.SecurityHeaders;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.IdentityModel.Tokens;
 using TeachingRecordSystem;
 using TeachingRecordSystem.AuthorizeAccess;
+using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Conventions;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.FormFlow;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Logging;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Security;
+using TeachingRecordSystem.AuthorizeAccess.TagHelpers;
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.FormFlow;
 using TeachingRecordSystem.ServiceDefaults;
@@ -67,7 +71,10 @@ builder.Services.Configure<AuthenticationOptions>(options =>
 });
 
 builder.Services
-    .AddRazorPages();
+    .AddRazorPages(options =>
+    {
+        options.Conventions.Add(new BindJourneyInstancePropertiesConvention());
+    });
 
 builder.Services
     .AddTrsBaseServices()
@@ -79,7 +86,8 @@ builder.Services
         options.JourneyRegistry.RegisterJourney(SignInJourneyState.JourneyDescriptor);
     })
     .AddSingleton<ICurrentUserIdProvider, DummyCurrentUserIdProvider>()
-    .AddTransient<SignInJourneyHelper>();
+    .AddTransient<SignInJourneyHelper>()
+    .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>();
 
 var app = builder.Build();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
@@ -21,6 +21,8 @@ public class SignInJourneyState(string redirectUri, AuthenticationProperties? au
     [JsonConverter(typeof(AuthenticationTicketJsonConverter))]
     public AuthenticationTicket? OneLoginAuthenticationTicket { get; set; }
 
+    public bool IdentityVerified { get; set; }
+
     public string[][]? VerifiedNames { get; set; }
 
     public DateOnly[]? VerifiedDatesOfBirth { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TagHelpers/FormTagHelperInitializer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TagHelpers/FormTagHelperInitializer.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+
+namespace TeachingRecordSystem.AuthorizeAccess.TagHelpers;
+
+public class FormTagHelperInitializer : ITagHelperInitializer<FormTagHelper>
+{
+    public void Initialize(FormTagHelper helper, ViewContext context)
+    {
+        helper.Antiforgery ??= true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Development.json
@@ -7,5 +7,6 @@
         "Microsoft.AspNetCore": "Warning"
       }
     }
-  }
+  },
+  "ShowDebugPages": true
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using TeachingRecordSystem.AuthorizeAccess.Tests.Infrastructure.FormFlow;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.TestCommon;
@@ -15,9 +16,10 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
         WithDbContext(async dbContext =>
         {
             // Arrange
+            var options = Options.Create(new AuthorizeAccessOptions() { ShowDebugPages = false });
             var userInstanceStateProvider = new InMemoryInstanceStateProvider();
             var clock = new TestableClock();
-            var helper = new SignInJourneyHelper(dbContext, userInstanceStateProvider, clock);
+            var helper = new SignInJourneyHelper(dbContext, options, userInstanceStateProvider, clock);
 
             var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
 
@@ -31,6 +33,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
 
             // Assert
             Assert.NotNull(state.OneLoginAuthenticationTicket);
+            Assert.True(state.IdentityVerified);
             Assert.NotNull(state.VerifiedNames);
             Assert.Collection(state.VerifiedNames, nameParts => Assert.Collection(nameParts, name => Assert.Equal(firstName, name), name => Assert.Equal(lastName, name)));
             Assert.NotNull(state.VerifiedDatesOfBirth);
@@ -42,9 +45,10 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
         WithDbContext(async dbContext =>
         {
             // Arrange
+            var options = Options.Create(new AuthorizeAccessOptions() { ShowDebugPages = false });
             var userInstanceStateProvider = new InMemoryInstanceStateProvider();
             var clock = new TestableClock();
-            var helper = new SignInJourneyHelper(dbContext, userInstanceStateProvider, clock);
+            var helper = new SignInJourneyHelper(dbContext, options, userInstanceStateProvider, clock);
 
             var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
 
@@ -55,6 +59,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
 
             // Assert
             Assert.NotNull(state.OneLoginAuthenticationTicket);
+            Assert.False(state.IdentityVerified);
             Assert.Null(state.VerifiedNames);
             Assert.Null(state.VerifiedDatesOfBirth);
         });
@@ -64,9 +69,10 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
         WithDbContext(async dbContext =>
         {
             // Arrange
+            var options = Options.Create(new AuthorizeAccessOptions() { ShowDebugPages = false });
             var userInstanceStateProvider = new InMemoryInstanceStateProvider();
             var clock = new TestableClock();
-            var helper = new SignInJourneyHelper(dbContext, userInstanceStateProvider, clock);
+            var helper = new SignInJourneyHelper(dbContext, options, userInstanceStateProvider, clock);
 
             var person = await TestData.CreatePerson(b => b.WithTrn(true));
             var user = await TestData.CreateOneLoginUser(personId: person.PersonId);
@@ -93,9 +99,10 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
         WithDbContext(async dbContext =>
         {
             // Arrange
+            var options = Options.Create(new AuthorizeAccessOptions() { ShowDebugPages = false });
             var userInstanceStateProvider = new InMemoryInstanceStateProvider();
             var clock = new TestableClock();
-            var helper = new SignInJourneyHelper(dbContext, userInstanceStateProvider, clock);
+            var helper = new SignInJourneyHelper(dbContext, options, userInstanceStateProvider, clock);
 
             var user = await TestData.CreateOneLoginUser(personId: null);
             clock.Advance();
@@ -120,9 +127,10 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
         WithDbContext(async dbContext =>
         {
             // Arrange
+            var options = Options.Create(new AuthorizeAccessOptions() { ShowDebugPages = false });
             var userInstanceStateProvider = new InMemoryInstanceStateProvider();
             var clock = new TestableClock();
-            var helper = new SignInJourneyHelper(dbContext, userInstanceStateProvider, clock);
+            var helper = new SignInJourneyHelper(dbContext, options, userInstanceStateProvider, clock);
 
             var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
 


### PR DESCRIPTION
We need to be able to override the identity information we get from One Login for testing in non-production environments. This adds a debug page into the start of the journey where we can override that information and detach a `Person`, if one is already assigned.