### PR TITLE
Initial Authorize access journey orchestration

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -1,22 +1,17 @@
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Options;
 using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess;
 
-public class AuthorizeAccessLinkGenerator(LinkGenerator linkGenerator, IOptions<AuthorizeAccessOptions> optionsAccessor)
+public abstract class AuthorizeAccessLinkGenerator
 {
-    public string Start(JourneyInstanceId journeyInstanceId, bool skipDebugPage = false) => optionsAccessor.Value.ShowDebugPages && !skipDebugPage ?
-        DebugIdentity(journeyInstanceId) :
-        Nino(journeyInstanceId);
-
     public string DebugIdentity(JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/DebugIdentity", journeyInstanceId: journeyInstanceId);
 
     public string Nino(JourneyInstanceId journeyInstanceId) => GetRequiredPathByPage("/Nino", journeyInstanceId: journeyInstanceId);
 
-    private string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
+    protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
-        var url = linkGenerator.GetPathByPage(page, handler, values: routeValues) ?? throw new InvalidOperationException("Page was not found.");
+        var url = GetRequiredPathByPage(page, handler, routeValues);
 
         if (journeyInstanceId?.UniqueKey is string journeyInstanceUniqueKey)
         {
@@ -25,4 +20,12 @@ public class AuthorizeAccessLinkGenerator(LinkGenerator linkGenerator, IOptions<
 
         return url;
     }
+
+    protected abstract string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null);
+}
+
+public class RoutingAuthorizeAccessLinkGenerator(LinkGenerator linkGenerator) : AuthorizeAccessLinkGenerator
+{
+    protected override string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null) =>
+        linkGenerator.GetPathByPage(page, handler, values: routeValues) ?? throw new InvalidOperationException("Page was not found.");
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
@@ -63,7 +63,15 @@ public class FormFlowJourneySignInHandler(SignInJourneyHelper helper) : IAuthent
 
         var ticket = new AuthenticationTicket(user, properties, _scheme.Name);
 
-        await journeyInstance.UpdateStateAsync(async state => await helper.OnSignedInWithOneLogin(state, ticket));
+        var result = await helper.OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        // Override the redirect done by RemoteAuthenticationHandler
+        _context.Response.OnStarting(
+            () =>
+            {
+                _context.Response.Redirect(result.Location);
+                return Task.CompletedTask;
+            });
     }
 
     public async Task SignOutAsync(AuthenticationProperties? properties)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/MatchToTeachingRecordAuthenticationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/MatchToTeachingRecordAuthenticationHandler.cs
@@ -5,9 +5,7 @@ using TeachingRecordSystem.AuthorizeAccess.Infrastructure.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Infrastructure.Security;
 
-public class MatchToTeachingRecordAuthenticationHandler(
-    SignInJourneyHelper helper,
-    AuthorizeAccessLinkGenerator linkGenerator) : IAuthenticationHandler
+public class MatchToTeachingRecordAuthenticationHandler(SignInJourneyHelper helper) : IAuthenticationHandler
 {
     private AuthenticationScheme? _scheme;
     private HttpContext? _context;
@@ -37,18 +35,14 @@ public class MatchToTeachingRecordAuthenticationHandler(
     {
         EnsureInitialized();
 
-        properties ??= new();
-        properties.RedirectUri ??= "/";
-
         var journeyInstance = await helper.UserInstanceStateProvider.GetOrCreateSignInJourneyInstanceAsync(
             _context,
-            createState: () => new SignInJourneyState(properties.RedirectUri!, properties),
+            createState: () => new SignInJourneyState(properties?.RedirectUri ?? "/", properties),
             updateState: state => state.Reset());
 
         var delegatedProperties = new AuthenticationProperties();
-        delegatedProperties.RedirectUri = linkGenerator.Start(journeyInstance.InstanceId);
         delegatedProperties.Items.Add(FormFlowJourneySignInHandler.PropertyKeys.JourneyInstanceId, journeyInstance.InstanceId.Serialize());
-        await _context!.ChallengeAsync(OneLoginDefaults.AuthenticationScheme, delegatedProperties);
+        await _context.ChallengeAsync(OneLoginDefaults.AuthenticationScheme, delegatedProperties);
     }
 
     public Task ForbidAsync(AuthenticationProperties? properties)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
@@ -15,7 +15,6 @@ namespace TeachingRecordSystem.AuthorizeAccess.Pages;
 public class DebugIdentityModel(
     TrsDbContext dbContext,
     SignInJourneyHelper helper,
-    AuthorizeAccessLinkGenerator linkGenerator,
     IOptions<AuthorizeAccessOptions> optionsAccessor) : PageModel
 {
     private OneLoginUser? _oneLoginUser;
@@ -117,9 +116,8 @@ public class DebugIdentityModel(
             await dbContext.SaveChangesAsync();
         }
 
-        await helper.CreateOrUpdateOneLoginUser(JourneyInstance.State);
-
-        return Redirect(linkGenerator.Start(JourneyInstance.InstanceId, skipDebugPage: true));
+        var nextPage = await helper.CreateOrUpdateOneLoginUser(JourneyInstance);
+        return nextPage.ToActionResult();
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -92,7 +92,7 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
 
 builder.Services
     .AddTrsBaseServices()
-    .AddTransient<AuthorizeAccessLinkGenerator>()
+    .AddTransient<AuthorizeAccessLinkGenerator, RoutingAuthorizeAccessLinkGenerator>()
     .AddTransient<FormFlowJourneySignInHandler>()
     .AddTransient<MatchToTeachingRecordAuthenticationHandler>()
     .AddFormFlow(options =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/GlobalUsings.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/GlobalUsings.cs
@@ -1,1 +1,2 @@
+global using Moq;
 global using Xunit;


### PR DESCRIPTION
Sets up `SignInJourneyHelper` as the orchestrator of the sign in/registration journey via a new `GetNextPage` method.  Most of the scenarios are stubbed out for now.