### PR TITLE
Added person search service against TRS DB

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="idunno.Authentication.Basic" Version="2.3.1" />
     <PackageVersion Include="Joonasw.AspNetCore.SecurityHeaders" Version="5.0.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.1.0" />
+    <PackageVersion Include="LinqKit" Version="1.2.5" />
     <PackageVersion Include="MediatR" Version="12.2.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -16,6 +16,7 @@ using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Security;
 using TeachingRecordSystem.AuthorizeAccess.TagHelpers;
 using TeachingRecordSystem.Core;
 using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.PersonSearch;
 using TeachingRecordSystem.FormFlow;
 using TeachingRecordSystem.ServiceDefaults;
 using TeachingRecordSystem.SupportUi.Infrastructure.FormFlow;
@@ -101,7 +102,8 @@ builder.Services
     })
     .AddSingleton<ICurrentUserIdProvider, DummyCurrentUserIdProvider>()
     .AddTransient<SignInJourneyHelper>()
-    .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>();
+    .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>()
+    .AddPersonSearch();
 
 builder.Services.AddOptions<AuthorizeAccessOptions>()
     .Bind(builder.Configuration)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/NameSynonymsMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/NameSynonymsMapping.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class NameSynonymsMapping : IEntityTypeConfiguration<NameSynonyms>
+{
+    public void Configure(EntityTypeBuilder<NameSynonyms> builder)
+    {
+        builder.ToTable("name_synonyms");
+        builder.HasKey(e => e.NameSynonymsId);
+        builder.Property(e => e.Name).HasMaxLength(NameSynonyms.NameMaxLength).IsRequired().UseCollation("case_insensitive");
+        builder.HasIndex(e => e.Name).IsUnique().HasDatabaseName(NameSynonyms.NameSynonymsIndexName);
+        builder.Property(e => e.Synonyms).IsRequired().UseCollation("case_insensitive");
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonSearchAttributeMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonSearchAttributeMapping.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class PersonSearchAttributeMapping : IEntityTypeConfiguration<PersonSearchAttribute>
+{
+    public void Configure(EntityTypeBuilder<PersonSearchAttribute> builder)
+    {
+        builder.ToTable("person_search_attributes");
+        builder.HasKey(e => e.PersonSearchAttributeId);
+        builder.Property(e => e.PersonId).IsRequired();
+        builder.HasIndex(e => e.PersonId).HasDatabaseName(PersonSearchAttribute.PersonIdIndexName);
+        builder.Property(e => e.AttributeType).HasMaxLength(PersonSearchAttribute.AttributeTypeMaxLength).IsRequired().UseCollation("case_insensitive");
+        builder.Property(e => e.AttributeValue).HasMaxLength(PersonSearchAttribute.AttributeValueMaxLength).IsRequired().UseCollation("case_insensitive");
+        builder.Property(e => e.AttributeKey).HasMaxLength(PersonSearchAttribute.AttributeKeyMaxLength).UseCollation("case_insensitive");
+        builder.HasIndex(e => new { e.AttributeType, e.AttributeValue }).HasDatabaseName(PersonSearchAttribute.AttributeTypeAndValueIndexName);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240201153254_PersonSearchAttributeAndNameSynonyms.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240201153254_PersonSearchAttributeAndNameSynonyms.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -12,9 +13,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240201153254_PersonSearchAttributeAndNameSynonyms")]
+    partial class PersonSearchAttributeAndNameSynonyms
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240201153254_PersonSearchAttributeAndNameSynonyms.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240201153254_PersonSearchAttributeAndNameSynonyms.cs
@@ -1,0 +1,267 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersonSearchAttributeAndNameSynonyms : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "name_synonyms",
+                columns: table => new
+                {
+                    name_synonyms_id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false, collation: "case_insensitive"),
+                    synonyms = table.Column<string[]>(type: "text[]", nullable: false, collation: "case_insensitive")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_name_synonyms", x => x.name_synonyms_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "person_search_attributes",
+                columns: table => new
+                {
+                    person_search_attribute_id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    person_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    attribute_type = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false, collation: "case_insensitive"),
+                    attribute_value = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false, collation: "case_insensitive"),
+                    tags = table.Column<string[]>(type: "text[]", nullable: false),
+                    attribute_key = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true, collation: "case_insensitive")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_person_search_attributes", x => x.person_search_attribute_id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_name_synonyms_name",
+                table: "name_synonyms",
+                column: "name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_search_attributes_attribute_type_and_value",
+                table: "person_search_attributes",
+                columns: new[] { "attribute_type", "attribute_value" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_search_attributes_person_id",
+                table: "person_search_attributes",
+                column: "person_id");
+
+            var refreshNameProcedureSql = @"
+CREATE OR REPLACE PROCEDURE public.p_refresh_name_person_search_attributes(
+    IN p_person_id uuid,
+    IN p_first_name character varying,
+    IN p_last_name character varying,
+    IN p_attribute_key character varying)
+LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    DELETE FROM
+        person_search_attributes
+    WHERE
+        person_id = p_person_id
+        AND attribute_key = p_attribute_key;
+
+    INSERT INTO
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags,
+            attribute_key
+        )
+    SELECT
+        p_person_id,
+        attribs.attribute_type,
+        attribs.attribute_value,
+        ARRAY[]::text[],
+        p_attribute_key
+    FROM
+        (VALUES
+         ('FirstName', p_first_name),
+         ('LastName', p_last_name)) AS attribs (attribute_type, attribute_value)
+    WHERE
+        attribs.attribute_value IS NOT NULL;
+    
+    -- Insert synonyms of first name
+    INSERT INTO
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags,
+            attribute_key
+        )
+    SELECT
+        p_person_id,
+        'FirstName',
+        UNNEST(synonyms),
+        ARRAY[CONCAT('Synonym:', p_first_name)],
+        p_attribute_key
+    FROM
+        name_synonyms
+    WHERE
+        name = p_first_name;
+        
+    -- Insert full name as a searchable attribute
+    INSERT INTO 
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags,
+            attribute_key
+        )
+    SELECT 
+        first_names.person_id, 
+        'FullName', 
+        first_names.attribute_value || ' ' || last_names.attribute_value, 
+        '{}',
+        first_names.attribute_key
+    FROM
+            person_search_attributes first_names
+        JOIN
+            person_search_attributes last_names ON first_names.person_id = last_names.person_id AND first_names.attribute_key = last_names.attribute_key
+    WHERE
+        first_names.person_id = p_person_id
+        AND first_names.attribute_type = 'FirstName'
+        AND last_names.attribute_type = 'LastName';
+END;
+$BODY$;
+";
+            migrationBuilder.Sql(refreshNameProcedureSql);
+
+            var refreshProcedureSql = @"
+CREATE OR REPLACE PROCEDURE public.p_refresh_person_search_attributes(
+    IN p_person_id uuid,
+    IN p_first_name character varying(100),
+    IN p_last_name character varying(100),
+    IN p_date_of_birth date,
+    IN p_national_insurance_number character(9),
+    IN p_trn character(7))
+LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    DELETE FROM
+        person_search_attributes
+    WHERE
+        person_id = p_person_id
+        AND attribute_key IS NULL;
+    
+    INSERT INTO
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags
+        )
+    SELECT
+        p_person_id,
+        attribs.attribute_type,
+        attribs.attribute_value,
+        '{}'
+    FROM
+        (VALUES 		 
+         ('DateOfBirth', CASE WHEN p_date_of_birth IS NULL THEN NULL ELSE to_char(p_date_of_birth, 'yyyy-mm-dd') END),
+         ('NationalInsuranceNumber', p_national_insurance_number),
+         ('Trn', p_trn)) AS attribs (attribute_type, attribute_value)
+    WHERE
+        attribs.attribute_value IS NOT NULL;
+
+    CALL p_refresh_name_person_search_attributes(
+        p_person_id,
+        p_first_name,
+        p_last_name,
+        '1');
+END;
+$BODY$;
+";
+            migrationBuilder.Sql(refreshProcedureSql);
+
+            var triggerFunctionSql = @"
+CREATE OR REPLACE FUNCTION fn_update_person_search_attributes()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    IF ((TG_OP = 'DELETE')) THEN
+        DELETE FROM
+            person_search_attributes
+        WHERE
+            person_id = OLD.person_id;
+    END IF;
+    
+    IF (((TG_OP = 'INSERT') OR (TG_OP = 'UPDATE')) AND NEW.deleted_on IS NULL) THEN
+        CALL p_refresh_person_search_attributes(
+            NEW.person_id,
+            NEW.first_name,
+            NEW.last_name,
+            NEW.date_of_birth,
+            NEW.national_insurance_number,
+            NEW.trn);
+    END IF;
+    
+    RETURN NULL; -- result is ignored since this is an AFTER trigger
+END;
+$BODY$
+";
+            migrationBuilder.Sql(triggerFunctionSql);
+
+            var triggerSql = @"
+CREATE TRIGGER trg_update_person_search_attributes
+    AFTER INSERT OR DELETE OR UPDATE OF first_name, last_name, date_of_birth, national_insurance_number, trn, deleted_on
+    ON persons
+    FOR EACH ROW
+    EXECUTE FUNCTION fn_update_person_search_attributes()
+";
+            migrationBuilder.Sql(triggerSql);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            var dropTriggerSql = @"
+DROP TRIGGER trg_update_person_search_attributes ON persons
+";
+            migrationBuilder.Sql(dropTriggerSql);
+
+            var dropTriggerFunctionSql = @"
+DROP FUNCTION fn_update_person_search_attributes()
+";
+            migrationBuilder.Sql(dropTriggerFunctionSql);
+
+            var dropRefreshProcedureSql = @"
+DROP PROCEDURE public.p_refresh_person_search_attributes(uuid, character varying, character varying, date, character, character)
+";
+            migrationBuilder.Sql(dropRefreshProcedureSql);
+
+            var dropRefreshNameProcedureSql = @"
+DROP PROCEDURE public.p_refresh_name_person_search_attributes(uuid, character varying, character varying, character varying)
+";
+
+            migrationBuilder.Sql(dropRefreshNameProcedureSql);
+
+            migrationBuilder.DropTable(
+                name: "name_synonyms");
+
+            migrationBuilder.DropTable(
+                name: "person_search_attributes");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/NameSynonyms.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/NameSynonyms.cs
@@ -1,0 +1,13 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class NameSynonyms
+{
+    public const int NameMaxLength = 100;
+    public const string NameSynonymsIndexName = "ix_name_synonyms_name";
+
+    public long NameSynonymsId { get; init; }
+
+    public required string Name { get; init; }
+
+    public required string[] Synonyms { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonSearchAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonSearchAttribute.cs
@@ -1,0 +1,22 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class PersonSearchAttribute
+{
+    public const int AttributeTypeMaxLength = 50;
+    public const int AttributeValueMaxLength = 100;
+    public const int AttributeKeyMaxLength = 50;
+    public const string PersonIdIndexName = "ix_person_search_attributes_person_id";
+    public const string AttributeTypeAndValueIndexName = "ix_person_search_attributes_attribute_type_and_value";
+
+    public long PersonSearchAttributeId { get; init; }
+
+    public required Guid PersonId { get; init; }
+
+    public required string AttributeType { get; init; }
+
+    public required string AttributeValue { get; init; }
+
+    public required string[] Tags { get; init; }
+
+    public string? AttributeKey { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -55,6 +55,10 @@ public class TrsDbContext : DbContext
 
     public DbSet<OneLoginUser> OneLoginUsers => Set<OneLoginUser>();
 
+    public DbSet<NameSynonyms> NameSynonyms => Set<NameSynonyms>();
+
+    public DbSet<PersonSearchAttribute> PersonSearchAttributes => Set<PersonSearchAttribute>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString, int? commandTimeout = null)
     {
         Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o.CommandTimeout(commandTimeout);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -44,6 +44,7 @@ public static class HostApplicationBuilderExtensions
                 builder.Services.AddTransient<EytsAwardedEmailJobDispatcher>();
                 builder.Services.AddTransient<SendInductionCompletedEmailJob>();
                 builder.Services.AddTransient<InductionCompletedEmailJobDispatcher>();
+                builder.Services.AddHttpClient<PopulateNameSynonymsJob>();
 
                 builder.Services.AddStartupTask(sp =>
                 {
@@ -88,6 +89,16 @@ public static class HostApplicationBuilderExtensions
                 recurringJobManager.AddOrUpdate<SyncAllMqsFromCrmJob>(
                     nameof(SyncAllMqsFromCrmJob),
                     job => job.Execute(CancellationToken.None),
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<PopulateNameSynonymsJob>(
+                    nameof(PopulateNameSynonymsJob),
+                    job => job.Execute(CancellationToken.None),
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<PopulateAllPersonsSearchAttributesJob>(
+                    nameof(PopulateAllPersonsSearchAttributesJob),
+                    job => job.Execute(),
                     Cron.Never);
 
                 return Task.CompletedTask;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulateAllPersonsSearchAttributesJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulateAllPersonsSearchAttributesJob.cs
@@ -1,0 +1,18 @@
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Jobs.Scheduling;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+[AutomaticRetry(Attempts = 0)]
+public class PopulateAllPersonsSearchAttributesJob(TrsDbContext dbContext, IBackgroundJobScheduler backgroundJobScheduler)
+{
+    public async Task Execute()
+    {
+        await foreach (var personId in dbContext.Persons.AsNoTracking().Select(p => p.PersonId).AsAsyncEnumerable())
+        {
+            await backgroundJobScheduler.Enqueue<PopulatePersonSearchAttributesJob>(j => j.Execute(personId));
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulateNameSynonymsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulateNameSynonymsJob.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class PopulateNameSynonymsJob(TrsDbContext dbContext, HttpClient httpClient)
+{
+    public async Task Execute(CancellationToken cancellationToken)
+    {
+        using var stream = await httpClient.GetStreamAsync("https://raw.githubusercontent.com/carltonnorthern/nicknames/master/names.csv");
+        using var reader = new StreamReader(stream);
+
+        var namesLookup = new Dictionary<string, HashSet<string>>();
+        string? line = null;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (line.Length == 0 || line[0] == '#')
+            {
+                continue; // ignore empty lines and comments
+            }
+
+            var names = line.Split(',');
+            foreach (var name in names)
+            {
+                HashSet<string>? synonyms;
+                if (!namesLookup.TryGetValue(name, out synonyms))
+                {
+                    synonyms = new HashSet<string>();
+                    namesLookup[name] = synonyms;
+                }
+
+                foreach (var altName in names)
+                {
+                    // Don't add anything as a synonym of itself
+                    if (altName != name)
+                    {
+                        synonyms.Add(altName);
+                    }
+                }
+            }
+        }
+
+        foreach (var (name, synonyms) in namesLookup)
+        {
+            var nameSynonyms = await dbContext.NameSynonyms
+                .Where(ns => ns.Name == name)
+                .SingleOrDefaultAsync(cancellationToken);
+
+            if (nameSynonyms == null)
+            {
+                nameSynonyms = new NameSynonyms
+                {
+                    Name = name,
+                    Synonyms = synonyms.ToArray(),
+                };
+
+                dbContext.NameSynonyms.Add(nameSynonyms);
+            }
+            else
+            {
+                nameSynonyms.Synonyms = synonyms.ToArray();
+            }
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulatePersonSearchAttributesJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulatePersonSearchAttributesJob.cs
@@ -1,0 +1,24 @@
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+[AutomaticRetry(Attempts = 0)]
+public class PopulatePersonSearchAttributesJob(TrsDbContext dbContext)
+{
+    public async Task Execute(Guid personId)
+    {
+        var person = await dbContext.Persons.AsNoTracking().SingleAsync(p => p.PersonId == personId);
+        _ = await dbContext.Database.ExecuteSqlAsync(
+            $"""
+            CALL p_refresh_person_search_attributes(
+                {personId},
+                {person.FirstName},
+                {person.LastName},
+                {person.DateOfBirth},
+                {person.NationalInsuranceNumber},
+                {person.Trn})
+            """);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/PersonSearchResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/PersonSearchResult.cs
@@ -1,0 +1,12 @@
+namespace TeachingRecordSystem.Core.Models;
+
+public class PersonSearchResult
+{
+    public required Guid PersonId { get; set; }
+    public required string FirstName { get; set; }
+    public required string MiddleName { get; set; }
+    public required string LastName { get; set; }
+    public required DateOnly? DateOfBirth { get; set; }
+    public required string? Trn { get; set; }
+    public string? NationalInsuranceNumber { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonSearch/IPersonSearchService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonSearch/IPersonSearchService.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Services.PersonSearch;
+
+public interface IPersonSearchService
+{
+    Task<IReadOnlyCollection<PersonSearchResult>> Search(IEnumerable<string[]> name, IEnumerable<DateOnly> dateOfBirth, string? nino, string? trn);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonSearch/PersonSearchService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonSearch/PersonSearchService.cs
@@ -1,0 +1,58 @@
+using LinqKit;
+using Microsoft.EntityFrameworkCore;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Services.PersonSearch;
+
+public class PersonSearchService(TrsDbContext dbContext) : IPersonSearchService
+{
+    public async Task<IReadOnlyCollection<PersonSearchResult>> Search(IEnumerable<string[]> name, IEnumerable<DateOnly> dateOfBirth, string? nino, string? trn)
+    {
+        var fullNames = name.Select(n => (FirstName: n.First(), LastName: n.Where(n => n.Length > 1).LastOrDefault())).Where(n => n.LastName is not null).Select(n => $"{n.FirstName} {n.LastName}").ToList();
+        if (!fullNames.Any() || !dateOfBirth.Any() || (nino is null && trn is null))
+        {
+            return Array.Empty<PersonSearchResult>();
+        }
+
+        var searchResults = new List<PersonSearchResult>();
+        var dateOfBirthList = dateOfBirth.Select(d => d.ToString("yyyy-MM-dd")).ToList();
+
+        var searchPredicate = PredicateBuilder.New<PersonSearchAttribute>(false);
+        foreach (var fullName in fullNames)
+        {
+            searchPredicate = searchPredicate.Or(a => a.AttributeType == "FullName" && a.AttributeValue == fullName);
+        }
+
+        searchPredicate = searchPredicate.Or(a => a.AttributeType == "DateOfBirth" && dateOfBirthList.Contains(a.AttributeValue));
+
+        if (trn is not null)
+        {
+            searchPredicate = searchPredicate.Or(a => a.AttributeType == "Trn" && a.AttributeValue == trn);
+        }
+
+        if (nino is not null)
+        {
+            searchPredicate = searchPredicate.Or(a => a.AttributeType == "NationalInsuranceNumber" && a.AttributeValue == nino);
+        }
+
+        var results = await dbContext.PersonSearchAttributes
+            .Where(searchPredicate)
+            .GroupBy(a => a.PersonId)
+            .Where(g => g.Any(a => a.AttributeType == "FullName") && g.Any(a => a.AttributeType == "DateOfBirth") && (g.Any(a => a.AttributeType == "NationalInsuranceNumber") || g.Any(a => a.AttributeType == "Trn")))
+            .Select(g => dbContext.Persons.Where(p => p.PersonId == g.Key).ToList())
+            .ToListAsync();
+        var persons = results.SelectMany(p => p).ToArray();
+
+        return persons.Select(p => new PersonSearchResult
+        {
+            PersonId = p.PersonId,
+            FirstName = p.FirstName,
+            MiddleName = p.MiddleName,
+            LastName = p.LastName,
+            DateOfBirth = p.DateOfBirth,
+            Trn = p.Trn,
+            NationalInsuranceNumber = p.NationalInsuranceNumber
+        }).AsReadOnly();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonSearch/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonSearch/ServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TeachingRecordSystem.Core.Services.PersonSearch;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddPersonSearch(this IServiceCollection services)
+    {
+        services.AddSingleton<IPersonSearchService, PersonSearchService>();
+        return services;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="GovukNotify" />
     <PackageReference Include="Hangfire.Core" />
     <PackageReference Include="IdentityModel" />
+    <PackageReference Include="LinqKit" />
     <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonSearch/PersonSearchServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonSearch/PersonSearchServiceTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.PersonSearch;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Tests.Services.PersonSearch;
+
+public class PersonSearchServiceTests
+{
+    public PersonSearchServiceTests(
+        DbFixture dbFixture,
+        IOrganizationServiceAsync2 organizationService,
+        ReferenceDataCache referenceDataCache,
+        FakeTrnGenerator trnGenerator)
+    {
+        DbFixture = dbFixture;
+        Clock = new();
+
+        var dbContextFactory = dbFixture.GetDbContextFactory();
+
+        Helper = new TrsDataSyncHelper(
+            dbContextFactory,
+            organizationService,
+            referenceDataCache,
+            Clock);
+
+        TestData = new TestData(
+            dbContextFactory,
+            organizationService,
+            referenceDataCache,
+            Clock,
+            trnGenerator,
+            TestDataSyncConfiguration.Sync(Helper));
+    }
+
+    [Theory]
+    [InlineData(true, false, false, false)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, false, true, false)]
+    [InlineData(false, false, false, true)]
+    [InlineData(true, true, false, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, false, false, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(false, true, false, true)]
+    [InlineData(false, false, true, true)]
+    [InlineData(true, true, true, false)]
+    [InlineData(true, true, false, true)]
+    [InlineData(true, false, true, true)]
+    [InlineData(false, true, true, true)]
+    public Task Search_WithMissingParameters_ReturnsEmptyArray(bool hasNames, bool hasDatesOfBirth, bool hasNino, bool hasTrn) =>
+        DbFixture.WithDbContext(async dbContext =>
+        {
+            // Arrange
+            var names = hasNames ? [["John", "Doe"]] : Array.Empty<string[]>();
+            var datesOfBirth = hasDatesOfBirth ? new[] { new DateOnly(1980, 1, 1) } : Array.Empty<DateOnly>();
+            var nino = hasNino ? Faker.Identification.UkNationalInsuranceNumber() : null;
+            var trn = hasTrn ? await TestData.GenerateTrn() : null;
+
+            // Act
+            var personSearchService = new PersonSearchService(dbContext);
+            var results = await personSearchService.Search(names, datesOfBirth, nino, trn);
+
+            // Assert
+            Assert.Empty(results);
+        });
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public Task Search_WithMatch_ReturnsResults(bool matchOnSynonym, bool matchOnNino) =>
+        DbFixture.WithDbContext(async dbContext =>
+        {
+            // Arrange
+            var firstName = "John";
+            var nickName = "Johnny";
+            dbContext.NameSynonyms.Add(new NameSynonyms
+            {
+                Name = firstName,
+                Synonyms = new[] { nickName },
+            });
+            await dbContext.SaveChangesAsync();
+
+            var person = await TestData.CreatePerson(b => b.WithFirstName(firstName).WithNationalInsuranceNumber());
+            var name = new[] { new[] { matchOnSynonym ? nickName : firstName, person.LastName } };
+            var dateOfBirth = new[] { person.DateOfBirth };
+            var nino = matchOnNino ? person.NationalInsuranceNumber : null;
+            var trn = matchOnNino ? null : person.Trn;
+
+            // Act
+            var personSearchService = new PersonSearchService(dbContext);
+            var results = await personSearchService.Search(name, dateOfBirth, nino, trn);
+
+            // Assert
+            Assert.NotEmpty(results);
+            Assert.Contains(results, r => r.PersonId == person.PersonId);
+            await dbContext.NameSynonyms.Where(ns => ns.Name == firstName).ExecuteDeleteAsync();
+        });
+
+    [Fact]
+    public Task Search_WithMatchForMultipleNames_ReturnsMultipleResults() =>
+        DbFixture.WithDbContext(async dbContext =>
+        {
+            // Arrange
+            var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+            var person1 = await TestData.CreatePerson(b => b.WithFirstName("John").WithLastName("Doe").WithNationalInsuranceNumber());
+            var person2 = await TestData.CreatePerson(b => b.WithFirstName("Jane").WithLastName("Doe"));
+            var name = new[] { new[] { "John", "Doe" }, new[] { "Jane", "Doe" } };
+            var dateOfBirth = new[] { person1.DateOfBirth, person2.DateOfBirth };
+
+            // Act
+            var personSearchService = new PersonSearchService(dbContext);
+            var results = await personSearchService.Search(name, dateOfBirth, person1.NationalInsuranceNumber, person2.Trn);
+
+            // Assert
+            Assert.NotEmpty(results);
+            Assert.Contains(results, r => r.PersonId == person1.PersonId);
+            Assert.Contains(results, r => r.PersonId == person2.PersonId);
+        });
+
+    private DbFixture DbFixture { get; }
+
+    private TestData TestData { get; }
+
+    private TestableClock Clock { get; }
+
+    public TrsDataSyncHelper Helper { get; }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -35,6 +35,7 @@ public partial class TestData
         private string? _mobileNumber;
         private Contact_GenderCode? _gender;
         private bool? _hasNationalInsuranceNumber;
+        private string? _nationalInsuranceNumber;
         private readonly List<MandatoryQualificationInfo> _mandatoryQualifications = new();
         private readonly List<QtsRegistration> _qtsRegistrations = new();
         private readonly List<Sanction> _sanctions = [];
@@ -158,14 +159,16 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithNationalInsuranceNumber(bool? hasNationalInsuranceNumber = true)
+        public CreatePersonBuilder WithNationalInsuranceNumber(bool? hasNationalInsuranceNumber = true, string? nationalInsuranceNumber = null)
         {
-            if (_hasNationalInsuranceNumber is not null && _hasNationalInsuranceNumber != hasNationalInsuranceNumber)
+            if ((_hasNationalInsuranceNumber is not null && _hasNationalInsuranceNumber != hasNationalInsuranceNumber)
+                || (_nationalInsuranceNumber is not null && _nationalInsuranceNumber != nationalInsuranceNumber))
             {
                 throw new InvalidOperationException("WithNationalInsuranceNumber cannot be changed after it's set.");
             }
 
             _hasNationalInsuranceNumber = hasNationalInsuranceNumber;
+            _nationalInsuranceNumber = nationalInsuranceNumber;
             return this;
         }
 
@@ -226,7 +229,7 @@ public partial class TestData
 
             if (_hasNationalInsuranceNumber ?? false)
             {
-                contact.dfeta_NINumber = testData.GenerateNationalInsuranceNumber();
+                contact.dfeta_NINumber = _nationalInsuranceNumber ?? testData.GenerateNationalInsuranceNumber();
             }
 
             var txnRequestBuilder = RequestBuilder.CreateTransaction(testData.OrganizationService);


### PR DESCRIPTION
### Context

There are several places where we do a person search against DQT. Each of these searches has different matching criteria. We’ve been constrained by CRM on how smart we can make these searches since we don’t have access to the underlying DB. Now that we’re syncing person data to the TRS DB, we can do better.

This ticket is to begin a new search service that can be used with Authorize access only (initially).

### Changes proposed in this pull request

Create a PersonSearchService with the following signature:

class PersonSearchService
{
  Task<IReadOnlyCollection<PersonSearchResult>> Search(IEnumerable<string[]> name, IEnumerable<DateOnly> dateOfBirth, string? nino, string? trn);
}
Note that the name and dateOfBirth parameter take collections (since we can get multiple names and/or DOBs from One Login).

The method should return all Person records that match on a first name + last name, a DOB then at least one of NINO or TRN.

The service should search the TRS DB, not DQT.

Name matching should allow for aliases.

For this iteration searching on previous names is out of scope, though the implementation should allow for adding this later.