### PR TITLE
Move attribute to root namespace

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/MapErrorAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/MapErrorAttribute.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Api.Validation;
 
-namespace TeachingRecordSystem.Api.Infrastructure.Filters;
+namespace TeachingRecordSystem.Api;
 
 public class MapErrorAttribute : ExceptionFilterAttribute
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/IttOutcomeController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/IttOutcomeController.cs
@@ -2,7 +2,6 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using TeachingRecordSystem.Api.Infrastructure.Filters;
 using TeachingRecordSystem.Api.Infrastructure.Logging;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V2.Requests;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/NpqQualificationsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/NpqQualificationsController.cs
@@ -2,7 +2,6 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using TeachingRecordSystem.Api.Infrastructure.Filters;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V2.Requests;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/TeachersController.cs
@@ -2,7 +2,6 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using TeachingRecordSystem.Api.Infrastructure.Filters;
 using TeachingRecordSystem.Api.Infrastructure.Logging;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V2.Requests;


### PR DESCRIPTION
Things in the `Infrastructure` namespace aren't meant to be referenced by 'regular' API code.