### PR TITLE
Added AllowPIIUpdates to v2 getteacher endpoint to support register

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetTeacherHandler.cs
@@ -32,7 +32,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                 Contact.Fields.dfeta_ActiveSanctions,
                 Contact.Fields.dfeta_NINumber,
                 Contact.Fields.dfeta_TRN,
-                Contact.Fields.dfeta_HUSID
+                Contact.Fields.dfeta_HUSID,
+                Contact.Fields.dfeta_AllowPiiUpdatesFromRegister
             },
             activeOnly: true);
 
@@ -116,7 +117,8 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
                     HusId = i.dfeta_TraineeID,
                     Active = i.StateCode == dfeta_initialteachertrainingState.Active
                 };
-            })
+            }),
+            AllowPIIUpdates = teacher.dfeta_AllowPiiUpdatesFromRegister ?? false
         };
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Responses/GetTeacherResponse.cs
@@ -17,6 +17,7 @@ public class GetTeacherResponse
     public string HusId { get; set; }
     public GetTeacherResponseEarlyYearsStatus EarlyYearsStatus { get; set; }
     public IEnumerable<GetTeacherResponseInitialTeacherTraining> InitialTeacherTraining { get; set; }
+    public bool AllowPIIUpdates { get; set; }
 }
 
 public class GetTeacherResponseEarlyYearsStatus

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTeacherTests.cs
@@ -224,7 +224,8 @@ public class GetTeacherTests : TestBase
                         husId = inactiveittTraineeId,
                         active = false
                     },
-                }
+                },
+                allowpiiupdates = false
             });
     }
 
@@ -355,7 +356,144 @@ public class GetTeacherTests : TestBase
                         husId = ittTraineeId,
                         active = true
                     }
-                }
+                },
+                allowpiiupdates = false
+            });
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    [InlineData(null, false)]
+    public async Task Given_match_returns_returns_ok_with_correct_allowpiiupdates(bool? allowPiiUpdates, bool expectedAllowPiiUpdates)
+    {
+        // Arrange
+        var trn = "1234567";
+        var birthDate = "1990-04-01";
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+        var middleName = Faker.Name.Middle();
+        var nino = Faker.Identification.UkNationalInsuranceNumber();
+        var qtsDate = (DateOnly?)null;
+        var eytsDate = (DateOnly?)new DateOnly(2022, 7, 7);
+        var teacherId = Guid.NewGuid();
+        var earlyYearsStatusId = Guid.NewGuid();
+        var earlyYearsStatusName = "Early Years Teacher Status";
+        var earlyYearsStatusValue = "221";
+        var ittStartDate = new DateOnly(2021, 9, 7);
+        var ittEndDate = new DateOnly(2022, 7, 29);
+        var ittProgrammeType = IttProgrammeType.EYITTGraduateEntry;
+        var ittResult = IttOutcome.Pass;
+        var ittProviderUkprn = "12345";
+        var ittTraineeId = "54321";
+        var husId = "987654";
+
+        var contact = new Contact()
+        {
+            Id = teacherId,
+            BirthDate = DateTime.Parse(birthDate),
+            FirstName = firstName,
+            LastName = lastName,
+            MiddleName = middleName,
+            dfeta_TRN = trn,
+            dfeta_NINumber = nino,
+            StateCode = ContactState.Active,
+            dfeta_EYTSDate = eytsDate.ToDateTime(),
+            dfeta_HUSID = husId,
+            dfeta_AllowPiiUpdatesFromRegister = allowPiiUpdates
+        };
+
+        var qtsRegistration = new dfeta_qtsregistration()
+        {
+            dfeta_PersonId = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacherId),
+            dfeta_EarlyYearsStatusId = new Microsoft.Xrm.Sdk.EntityReference(dfeta_earlyyearsstatus.EntityLogicalName, earlyYearsStatusId),
+            dfeta_EYTSDate = eytsDate.ToDateTime()
+        };
+
+        var earlyYearsStatus = new dfeta_earlyyearsstatus()
+        {
+            Id = earlyYearsStatusId,
+            dfeta_name = earlyYearsStatusName,
+            dfeta_Value = earlyYearsStatusValue
+        };
+
+        var itt = new dfeta_initialteachertraining()
+        {
+            dfeta_PersonId = new Microsoft.Xrm.Sdk.EntityReference(Contact.EntityLogicalName, teacherId),
+            dfeta_ProgrammeStartDate = ittStartDate.ToDateTime(),
+            dfeta_ProgrammeEndDate = ittEndDate.ToDateTime(),
+            dfeta_ProgrammeType = ittProgrammeType.ConvertToIttProgrammeType(),
+            dfeta_Result = ittResult.ConvertToITTResult(),
+            dfeta_TraineeID = ittTraineeId,
+            StateCode = dfeta_initialteachertrainingState.Active
+        };
+        itt.Attributes.Add($"establishment.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"establishment.{Account.Fields.dfeta_UKPRN}", new AliasedValue(Account.EntityLogicalName, Account.Fields.dfeta_UKPRN, ittProviderUkprn));
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacherByTrn(trn, /* columnNames: */ It.IsAny<string[]>(), /* activeOnly: */ true))
+            .ReturnsAsync(contact);
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetQtsRegistrationsByTeacher(teacherId, /* columnNames: */ It.IsAny<string[]>()))
+            .ReturnsAsync(new[] { qtsRegistration });
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetEarlyYearsStatus(earlyYearsStatusId))
+            .ReturnsAsync(earlyYearsStatus);
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetInitialTeacherTrainingByTeacher(
+                teacherId,
+                /* columnNames: */ It.IsAny<string[]>(),
+                /*establishmentColumnNames: */It.IsAny<string[]>(),
+                /*subjectColumnNames: */It.IsAny<string[]>(),
+                /*qualificationColumnNames: */It.IsAny<string[]>(),
+                /*includeinactive */ It.IsAny<bool>()))
+            .ReturnsAsync(new[] { itt });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v2/teachers/{trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                trn = trn,
+                firstName = firstName,
+                lastName = lastName,
+                middleName = middleName,
+                dateOfBirth = birthDate,
+                nationalInsuranceNumber = nino,
+                hasActiveSanctions = false,
+                qtsDate = qtsDate?.ToString("yyyy-MM-dd"),
+                eytsDate = eytsDate?.ToString("yyyy-MM-dd"),
+                husId = husId,
+                earlyYearsStatus = new
+                {
+                    name = earlyYearsStatusName,
+                    value = earlyYearsStatusValue
+                },
+                initialTeacherTraining = new[]
+                {
+                    new
+                    {
+                        programmeStartDate = ittStartDate.ToString("yyyy-MM-dd"),
+                        programmeEndDate = ittEndDate.ToString("yyyy-MM-dd"),
+                        programmeType = ittProgrammeType.ToString(),
+                        result = ittResult.ToString(),
+                        provider = new
+                        {
+                            ukprn = ittProviderUkprn
+                        },
+                        husId = ittTraineeId,
+                        active = true
+                    }
+                },
+                allowpiiupdates = expectedAllowPiiUpdates
             });
     }
 }


### PR DESCRIPTION
There isn't a trello ticket for this. Register require a way of finding out if pii updates are permitted on the v2 **UpdateTeacher** endpoint so that they don't even attempt to send pii updates. Proposed change here is to return the **AllowPIIUpdates** on the **GetTeacher** endpoint.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
