### PR TITLE
Store redirect URIs for One Login clients

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
@@ -35,8 +35,13 @@ public class ApplicationUserMapping : IEntityTypeConfiguration<ApplicationUser>
     public void Configure(EntityTypeBuilder<ApplicationUser> builder)
     {
         builder.Property(e => e.ApiRoles).HasColumnType("varchar[]");
-        builder.Property(e => e.OneLoginClientId).HasMaxLength(50);
+        builder.Property(e => e.OneLoginClientId).HasMaxLength(ApplicationUser.OneLoginClientIdMaxLength);
         builder.Property(e => e.OneLoginPrivateKeyPem).HasMaxLength(2000);
+        builder.Property(e => e.OneLoginAuthenticationSchemeName).HasMaxLength(ApplicationUser.AuthenticationSchemeNameMaxLength);
+        builder.Property(e => e.OneLoginRedirectUriPath).HasMaxLength(ApplicationUser.RedirectUriPathMaxLength);
+        builder.Property(e => e.OneLoginPostLogoutRedirectUriPath).HasMaxLength(ApplicationUser.RedirectUriPathMaxLength);
+        builder.HasIndex(e => e.OneLoginAuthenticationSchemeName).IsUnique().HasDatabaseName(ApplicationUser.OneLoginAuthenticationSchemeNameUniqueIndexName)
+            .HasFilter("one_login_authentication_scheme_name is not null");
     }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240208134232_OneLoginAuthSchemeInfo.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240208134232_OneLoginAuthSchemeInfo.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -12,9 +13,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240208134232_OneLoginAuthSchemeInfo")]
+    partial class OneLoginAuthSchemeInfo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240208134232_OneLoginAuthSchemeInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240208134232_OneLoginAuthSchemeInfo.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class OneLoginAuthSchemeInfo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_oidc_client",
+                table: "users",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "one_login_authentication_scheme_name",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "one_login_post_logout_redirect_uri_path",
+                table: "users",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "one_login_redirect_uri_path",
+                table: "users",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_users_one_login_authentication_scheme_name",
+                table: "users",
+                column: "one_login_authentication_scheme_name",
+                unique: true,
+                filter: "one_login_authentication_scheme_name is not null");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_users_one_login_authentication_scheme_name",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "is_oidc_client",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "one_login_authentication_scheme_name",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "one_login_post_logout_redirect_uri_path",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "one_login_redirect_uri_path",
+                table: "users");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -20,13 +20,20 @@ public class User : UserBase
 
 public class ApplicationUser : UserBase
 {
+    public const int AuthenticationSchemeNameMaxLength = 50;
+    public const int RedirectUriPathMaxLength = 100;
     public const int OneLoginClientIdMaxLength = 50;
     public const string NameUniqueIndexName = "ix_users_application_user_name";
+    public const string OneLoginAuthenticationSchemeNameUniqueIndexName = "ix_users_one_login_authentication_scheme_name";
 
     public required string[] ApiRoles { get; set; }
     public ICollection<ApiKey> ApiKeys { get; } = null!;
+    public bool IsOidcClient { get; set; }
     public string? OneLoginClientId { get; set; }
     public string? OneLoginPrivateKeyPem { get; set; }
+    public string? OneLoginAuthenticationSchemeName { get; set; }
+    public string? OneLoginRedirectUriPath { get; set; }
+    public string? OneLoginPostLogoutRedirectUriPath { get; set; }
 }
 
 public class SystemUser : UserBase

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ApplicationUserUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ApplicationUserUpdatedEvent.cs
@@ -15,5 +15,9 @@ public enum ApplicationUserUpdatedEventChanges
     Name = 1 << 0,
     ApiRoles = 1 << 1,
     OneLoginClientId = 1 << 2,
-    OneLoginPrivateKeyPem = 1 << 3
+    OneLoginPrivateKeyPem = 1 << 3,
+    IsOidcClient = 1 << 4,
+    OneLoginAuthenticationSchemeName = 1 << 5,
+    OneLoginRedirectUriPath = 1 << 6,
+    OneLoginPostLogoutRedirectUriPath = 1 << 7,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
@@ -4,16 +4,24 @@ public record ApplicationUser
 {
     public required Guid UserId { get; init; }
     public required string Name { get; init; }
-    public required string[] ApiRoles { get; set; }
-    public string? OneLoginClientId { get; set; }
-    public string? OneLoginPrivateKeyPem { get; set; }
+    public required string[] ApiRoles { get; init; }
+    public bool IsOidcClient { get; init; }
+    public string? OneLoginClientId { get; init; }
+    public string? OneLoginPrivateKeyPem { get; init; }
+    public string? OneLoginAuthenticationSchemeName { get; init; }
+    public string? OneLoginRedirectUriPath { get; init; }
+    public string? OneLoginPostLogoutRedirectUriPath { get; init; }
 
     public static ApplicationUser FromModel(DataStore.Postgres.Models.ApplicationUser user) => new()
     {
         UserId = user.UserId,
         Name = user.Name,
         ApiRoles = user.ApiRoles,
+        IsOidcClient = user.IsOidcClient,
         OneLoginClientId = user.OneLoginClientId,
-        OneLoginPrivateKeyPem = user.OneLoginPrivateKeyPem
+        OneLoginPrivateKeyPem = user.OneLoginPrivateKeyPem,
+        OneLoginAuthenticationSchemeName = user.OneLoginAuthenticationSchemeName,
+        OneLoginRedirectUriPath = user.OneLoginRedirectUriPath,
+        OneLoginPostLogoutRedirectUriPath = user.OneLoginPostLogoutRedirectUriPath
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey.cshtml
@@ -13,7 +13,7 @@
         <form action="@LinkGenerator.AddApiKey(Model.ApplicationUserId)" method="post">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
-            <govuk-input asp-for="Key" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" label-class="govuk-label--m" autocomplete="off" />
+            <govuk-input asp-for="Key" input-class="govuk-input--width-20 trs-monospace" label-class="govuk-label--m" autocomplete="off" />
 
             <govuk-button type="submit">Save</govuk-button>
         </form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey.cshtml
@@ -14,7 +14,7 @@
         <form method="post">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
-            <govuk-input asp-for="Key" disabled="true" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" label-class="govuk-label--m" />
+            <govuk-input asp-for="Key" disabled="true" input-class="govuk-input--width-20 trs-monospace" label-class="govuk-label--m" />
 
             <govuk-button
                 type="submit"
@@ -36,7 +36,7 @@
 
 <script type="text/javascript" asp-add-nonce="true">
     if ('content' in document.createElement('template')) {
-        const keyInput = document.querySelector("#Key");
+        const keyInput = document.querySelector("#@Html.IdFor(m => m.Key)");
 
         const showKeyTemplate = document.querySelector('#showkey');
         const showKey = showKeyTemplate.content.cloneNode(true);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml
@@ -1,4 +1,5 @@
 @page "/application-users/{userId}"
+@addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 @model TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.EditApplicationUserModel
 @inject IClock Clock
 @{
@@ -41,7 +42,7 @@
                         {
                             <tr class="govuk-table__row">
                                 <td class="govuk-table__cell">
-                                    <a href="@LinkGenerator.EditApiKey(key.ApiKeyId)" class="govuk-link" data-testid="EditApiKey-@key.ApiKeyId">@key.ApiKeyId</a>
+                                    <a href="@LinkGenerator.EditApiKey(key.ApiKeyId)" class="govuk-link trs-monospace" data-testid="EditApiKey-@key.ApiKeyId">@key.ApiKeyId</a>
                                 </td>
                                 <td class="govuk-table__cell" data-testid="Expiry">
                                     @if (key.Expires is DateTime expires)
@@ -75,11 +76,54 @@
                 <govuk-button-link href="@LinkGenerator.AddApiKey(Model.UserId)" class="govuk-button--secondary" data-testid="AddApiKey">Add API key</govuk-button-link>
             </div>
 
-            <h2 class="govuk-heading-m">One Login</h2>
-            <govuk-input asp-for="OneLoginClientId" label-class="govuk-label--s" autocomplete="off" />
-            <govuk-textarea asp-for="OneLoginPrivateKeyPem" label-class="govuk-label--s" />
+            <govuk-checkboxes asp-for="IsOidcClient">
+                <govuk-checkboxes-item value="@true" label-class="govuk-label--m">
+                    @Html.DisplayNameFor(m => m.IsOidcClient)
+                    <govuk-checkboxes-item-conditional>
+                        <govuk-input asp-for="OneLoginAuthenticationSchemeName" label-class="govuk-label--s" input-class="govuk-!-width-one-half trs-monospace" autocomplete="off" spellcheck="false" />
+
+                        <govuk-input asp-for="OneLoginClientId" label-class="govuk-label--s" input-class="trs-monospace" autocomplete="off" spellcheck="false" />
+
+                        <govuk-textarea asp-for="OneLoginPrivateKeyPem" label-class="govuk-label--s" textarea-class="trs-monospace trs-nowrap" autocomplete="off" spellcheck="false" />
+
+                        <govuk-input asp-for="OneLoginRedirectUriPath" label-class="govuk-label--s" autocomplete="off" spellcheck="false">
+                            <govuk-input-prefix>@Model.OneLoginRedirectUriBase</govuk-input-prefix>
+                        </govuk-input>
+
+                        <govuk-input asp-for="OneLoginPostLogoutRedirectUriPath" label-class="govuk-label--s" autocomplete="off" spellcheck="false">
+                            <govuk-input-prefix>@Model.OneLoginRedirectUriBase</govuk-input-prefix>
+                        </govuk-input>
+                    </govuk-checkboxes-item-conditional>
+                </govuk-checkboxes-item>
+            </govuk-checkboxes>
 
             <govuk-button type="submit">Save changes</govuk-button>
         </form>
     </div>
 </div>
+
+<template id="showkey">
+    <govuk-checkboxes name="ShowKey" input-id="ShowKey" class="govuk-checkboxes--small">
+        <govuk-checkboxes-item value="true">Show key</govuk-checkboxes-item>
+    </govuk-checkboxes>
+</template>
+
+<script type="text/javascript" asp-add-nonce="true">
+    if ('content' in document.createElement('template')) {
+        const keyInput = document.querySelector("#@Html.IdFor(m => m.OneLoginPrivateKeyPem)");
+
+        if (keyInput.value) {
+            const showKeyTemplate = document.querySelector('#showkey');
+            const showKey = showKeyTemplate.content.cloneNode(true);
+            const showKeyCheckbox = showKey.querySelector('input');
+            const setInputTypeFromShowKeyValue = () => keyInput.style.display = showKeyCheckbox.checked ? '' : 'none';
+
+            setInputTypeFromShowKeyValue();
+            showKeyCheckbox.addEventListener('change', setInputTypeFromShowKeyValue);
+
+            const keyFormGroup = keyInput.parentNode;
+            keyInput.classList.add('govuk-!-margin-bottom-0');
+            keyFormGroup.querySelector('.govuk-hint').after(showKey);
+        }
+    }
+</script>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -27,3 +27,11 @@
 .trs-subtle-emphasis {
   color: govuk-colour("mid-grey");
 }
+
+.trs-monospace {
+  font-family: monospace;
+}
+
+.trs-nowrap {
+  white-space: nowrap;
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/ApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/ApplicationUserTests.cs
@@ -43,8 +43,11 @@ public class ApplicationUserTests(HostFixture hostFixture) : TestBase(hostFixtur
         var applicationUser = await TestData.CreateApplicationUser();
         var applicationUserId = applicationUser.UserId;
         var newApplicationUserName = TestData.GenerateChangedApplicationUserName(applicationUser.Name);
+        var newAuthenticationSchemeName = Guid.NewGuid().ToString();
         var newOneLoginClientId = Guid.NewGuid().ToString();
         var newOneLoginPrivateKeyPem = TestCommon.TestData.GeneratePrivateKeyPem();
+        var newOneLoginRedirectUri = $"/_onelogin/{newAuthenticationSchemeName}/callback";
+        var newOneLoginPostLogoutRedirectUri = $"/_onelogin/{newAuthenticationSchemeName}/logout-callback";
 
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -60,8 +63,12 @@ public class ApplicationUserTests(HostFixture hostFixture) : TestBase(hostFixtur
         await page.FillAsync("text=Name", newApplicationUserName);
         await page.SetCheckedAsync($"label:text-is('{ApiRoles.GetPerson}')", true);
         await page.SetCheckedAsync($"label:text-is('{ApiRoles.UpdatePerson}')", true);
-        await page.FillAsync("text=Client ID", newOneLoginClientId);
-        await page.FillAsync("text=Private Key PEM", newOneLoginPrivateKeyPem);
+        await page.SetCheckedAsync($"label:text-is('OIDC client')", true);
+        await page.FillAsync("text=Authentication scheme name", newAuthenticationSchemeName);
+        await page.FillAsync("text=One Login client ID", newOneLoginClientId);
+        await page.FillAsync("text=One Login private key", newOneLoginPrivateKeyPem);
+        await page.FillAsync("text=One Login redirect URI path", newOneLoginRedirectUri);
+        await page.FillAsync("text=One Login post logout redirect URI path", newOneLoginPostLogoutRedirectUri);
 
         await page.ClickButton("Save changes");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
@@ -15,12 +15,20 @@ public partial class TestData
         {
             name ??= GenerateApplicationUserName();
             apiRoles ??= [];
+            hasOneLoginSettings ??= false;
             string? oneLoginClientId = null;
             string? oneLoginPrivateKeyPem = null;
+            string? oneLoginAuthenticationSchemeName = null;
+            string? oneLoginRedirectUriPath = null;
+            string? oneLoginPostLogoutRedirectUriPath = null;
+
             if (hasOneLoginSettings == true)
             {
                 oneLoginClientId = Guid.NewGuid().ToString();
                 oneLoginPrivateKeyPem = GeneratePrivateKeyPem();
+                oneLoginAuthenticationSchemeName = Guid.NewGuid().ToString();
+                oneLoginRedirectUriPath = $"/_onelogin/{oneLoginAuthenticationSchemeName}/callback";
+                oneLoginPostLogoutRedirectUriPath = $"/_onelogin/{oneLoginAuthenticationSchemeName}/logout-callback";
             }
 
             var user = new ApplicationUser()
@@ -28,8 +36,12 @@ public partial class TestData
                 Name = name,
                 UserId = Guid.NewGuid(),
                 ApiRoles = apiRoles,
+                IsOidcClient = hasOneLoginSettings.Value,
                 OneLoginClientId = oneLoginClientId,
-                OneLoginPrivateKeyPem = oneLoginPrivateKeyPem
+                OneLoginPrivateKeyPem = oneLoginPrivateKeyPem,
+                OneLoginAuthenticationSchemeName = oneLoginAuthenticationSchemeName,
+                OneLoginRedirectUriPath = oneLoginRedirectUriPath,
+                OneLoginPostLogoutRedirectUriPath = oneLoginPostLogoutRedirectUriPath
             };
 
             dbContext.ApplicationUsers.Add(user);
@@ -53,6 +65,7 @@ public partial class TestData
 
     public static string GeneratePrivateKeyPem()
     {
-        return RSA.Create().ExportRSAPrivateKeyPem();
+        using var rsa = RSA.Create();
+        return rsa.ExportRSAPrivateKeyPem();
     }
 }


### PR DESCRIPTION
Adds redirect URI, post logout redirect URI and an authentication scheme name to `ApplicationUser` for One Login clients. Also adds an explicit `IsOidcClient` flag.

I've also hidden the private key by default (it's visible by clicking a 'Show key' checkbox).