### PR TITLE
Fix more MQ journey snags

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationSpecialism.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationSpecialism.cs
@@ -7,7 +7,7 @@ public enum MandatoryQualificationSpecialism
     [MandatoryQualificationSpecialismInfo(name: "auditory", dqtValue: "Auditory", isValidForNewRecord: false)]
     Auditory = 0,
 
-    [MandatoryQualificationSpecialismInfo(name: "deaf education", dqtValue: "Deaf education")]
+    [MandatoryQualificationSpecialismInfo(name: "deaf education", dqtValue: "Deaf education", isValidForNewRecord: false)]
     DeafEducation = 1,
 
     [MandatoryQualificationSpecialismInfo(name: "hearing", dqtValue: "Hearing")]
@@ -16,7 +16,7 @@ public enum MandatoryQualificationSpecialism
     [MandatoryQualificationSpecialismInfo(name: "multi-sensory", dqtValue: "Multi-Sensory")]
     MultiSensory = 3,
 
-    [MandatoryQualificationSpecialismInfo(name: "N/A", dqtValue: "N/A")]
+    [MandatoryQualificationSpecialismInfo(name: "N/A", dqtValue: "N/A", isValidForNewRecord: false)]
     NotApplicable = 4,
 
     [MandatoryQualificationSpecialismInfo(name: "visual", dqtValue: "Visual")]
@@ -28,7 +28,8 @@ public static class MandatoryQualificationSpecialismRegistry
     private static readonly IReadOnlyDictionary<MandatoryQualificationSpecialism, MandatoryQualificationSpecialismInfo> _info =
         Enum.GetValues<MandatoryQualificationSpecialism>().ToDictionary(s => s, s => GetInfo(s));
 
-    public static IReadOnlyCollection<MandatoryQualificationSpecialismInfo> All => _info.Values.ToArray();
+    public static IReadOnlyCollection<MandatoryQualificationSpecialismInfo> GetAll(bool forNewRecord = false) =>
+        _info.Values.Where(i => i.IsValidForNewRecord || !forNewRecord).ToArray();
 
     public static string GetName(this MandatoryQualificationSpecialism specialism) => _info[specialism].Name;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
@@ -9,12 +9,12 @@
     <govuk-back-link href="@LinkGenerator.MqAddStatus(Model.PersonId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
         <form action="@LinkGenerator.MqAddCheckAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
@@ -39,7 +39,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="status">@Model.Status</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value data-testid="status">@Model.Status!.Value.GetTitle()</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.MqAddStatus(Model.PersonId, Model.JourneyInstance!.InstanceId)">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml
@@ -25,11 +25,11 @@
     <govuk-back-link href="@LinkGenerator.PersonQualifications(Model.PersonId)">Back</govuk-back-link>
 }
 
-<span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqAddProvider(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
+
             <govuk-select asp-for="MqEstablishmentValue" label-class="govuk-label--l">
                 <govuk-select-label is-page-heading="true">Training provider</govuk-select-label>
                 <govuk-select-item value=""></govuk-select-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml
@@ -8,22 +8,21 @@
     <govuk-back-link href="@LinkGenerator.MqAddProvider(Model.PersonId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqAddSpecialism(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
+
             <govuk-radios asp-for="Specialism" data-testid="specialism-list">
-                @if (Model.Specialisms is not null)
-                {
-                    @foreach (var specialism in Model.Specialisms)
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--l" />
+                    @foreach (var specialism in Model.Specialisms!)
                     {
                         <govuk-radios-item value="@specialism.Value">
                             @specialism.Title
                         </govuk-radios-item>
                     }
-                }
+                </govuk-radios-fieldset>
             </govuk-radios>
 
             <div class="govuk-button-group">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
@@ -17,6 +17,7 @@ public class SpecialismModel(TrsLinkGenerator linkGenerator) : PageModel
 
     [BindProperty]
     [Required(ErrorMessage = "Select a specialism")]
+    [ValidSpecialism(ErrorMessage = "Select a valid specialism")]
     public MandatoryQualificationSpecialism? Specialism { get; set; }
 
     public MandatoryQualificationSpecialismInfo[]? Specialisms { get; set; }
@@ -43,11 +44,22 @@ public class SpecialismModel(TrsLinkGenerator linkGenerator) : PageModel
     {
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        Specialisms = MandatoryQualificationSpecialismRegistry.All
+        Specialisms = MandatoryQualificationSpecialismRegistry.GetAll(forNewRecord: true)
             .OrderBy(t => t.Title)
             .ToArray();
 
         PersonName = personInfo.Name;
         Specialism ??= JourneyInstance!.State.Specialism;
+    }
+
+    private class ValidSpecialismAttribute : AllowedValuesAttribute
+    {
+        public ValidSpecialismAttribute()
+            : base(GetAllowedValues())
+        {
+        }
+
+        private static object[] GetAllowedValues() =>
+            MandatoryQualificationSpecialismRegistry.GetAll(forNewRecord: true).Select(v => (object)v.Value).ToArray();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml
@@ -8,11 +8,11 @@
     <govuk-back-link href="@LinkGenerator.MqAddSpecialism(Model.PersonId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqAddStartDate(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
+
             <govuk-date-input asp-for="StartDate">
                 <govuk-date-input-fieldset>
                     <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml
@@ -9,38 +9,40 @@
     <govuk-back-link href="@LinkGenerator.MqAddStartDate(Model.PersonId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqAddStatus(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Add a mandatory qualification - @Model.PersonName</span>
+
             <govuk-radios asp-for="Status" data-testid="status-options">
-                <govuk-radios-item value="@MandatoryQualificationStatus.Deferred" data-testid="status-deferred">
-                    Deferred
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Extended" data-testid="status-extended">
-                    Extended
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Failed" data-testid="status-failed">
-                    Failed
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.InProgress" data-testid="status-in-progress">
-                    In Progress
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Passed" data-testid="status-passed">
-                    Passed
-                    <govuk-radios-item-conditional>
-                        <govuk-date-input asp-for="EndDate">
-                            <govuk-date-input-fieldset>
-                                <govuk-date-input-fieldset-legend class="govuk-fieldset__legend--m" />
-                            </govuk-date-input-fieldset>
-                        </govuk-date-input>
-                    </govuk-radios-item-conditional>
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Withdrawn">
-                    Withdrawn
-                </govuk-radios-item>                    
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--l" />
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Deferred" data-testid="status-deferred">
+                        @MandatoryQualificationStatus.Deferred.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Extended" data-testid="status-extended">
+                        @MandatoryQualificationStatus.Extended.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Failed" data-testid="status-failed">
+                        @MandatoryQualificationStatus.Failed.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.InProgress" data-testid="status-in-progress">
+                        @MandatoryQualificationStatus.InProgress.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Passed" data-testid="status-passed">
+                        @MandatoryQualificationStatus.Passed.GetTitle()
+                        <govuk-radios-item-conditional>
+                            <govuk-date-input asp-for="EndDate">
+                                <govuk-date-input-fieldset>
+                                    <govuk-date-input-fieldset-legend class="govuk-fieldset__legend--m" />
+                                </govuk-date-input-fieldset>
+                            </govuk-date-input>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Withdrawn">
+                        Withdrawn
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
             </govuk-radios>
 
             <div class="govuk-button-group">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml
@@ -8,12 +8,12 @@
     <govuk-back-link href="@LinkGenerator.MqDelete(Model.QualificationId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
 }
 
-<span class="govuk-caption-l">Delete qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">Confirm deletion of mandatory qualification</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqDeleteConfirm(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Delete qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">Confirm deletion of mandatory qualification</h1>
+
             <govuk-summary-list data-testid="deletion-summary">
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Reason for deleting</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
@@ -8,17 +8,15 @@
     <govuk-back-link href="@LinkGenerator.PersonQualifications(Model.PersonId!.Value)">Back</govuk-back-link>
 }
 
-<span class="govuk-caption-l">Delete qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">Mandatory qualification@(Model.Specialism is MandatoryQualificationSpecialism specialism ? $" for {specialism.GetName()}" : "")</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqDelete(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Delete qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">Mandatory qualification@(Model.Specialism is MandatoryQualificationSpecialism specialism ? $" for {specialism.GetName()}" : "")</h1>
+
             <govuk-radios asp-for="DeletionReason" data-testid="deletion-reason-options">
                 <govuk-radios-fieldset>
-                    <govuk-radios-fieldset-legend>
-                        <h3 class="govuk-heading-m">Reason for deleting</h3>
-                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
                     <govuk-radios-item value="@MqDeletionReasonOption.AddedInError">
                         @MqDeletionReasonOption.AddedInError.GetDisplayName()
                     </govuk-radios-item>
@@ -38,7 +36,7 @@
 
             <govuk-radios asp-for="UploadEvidence" data-testid="upload-evidence-options">
                 <govuk-radios-fieldset>
-                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m"/>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
@@ -35,8 +35,8 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
     public DateOnly? EndDate { get; set; }
 
     [BindProperty]
-    [Required(ErrorMessage = "Select a reason for deleting")]
     [Display(Name = "Reason for deleting")]
+    [Required(ErrorMessage = "Select a reason for deleting")]
     public MqDeletionReasonOption? DeletionReason { get; set; }
 
     [BindProperty]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml
@@ -8,12 +8,12 @@
     <govuk-back-link href="@LinkGenerator.MqEditProviderReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
         <form action="@LinkGenerator.MqEditProviderConfirm(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             <govuk-summary-list data-testid="change-summary">
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Current training provider</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml
@@ -25,11 +25,11 @@
     <govuk-back-link href="@LinkGenerator.PersonQualifications(Model.PersonId!.Value)">Back</govuk-back-link>
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditProvider(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+
             <govuk-select asp-for="MqEstablishmentValue" label-class="govuk-label--l">
                 <govuk-select-label is-page-heading="true">Training provider</govuk-select-label>
                 <govuk-select-item value=""></govuk-select-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml
@@ -8,17 +8,15 @@
     <govuk-back-link href="@LinkGenerator.MqEditProvider(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditProviderReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
                 <govuk-radios-fieldset>
-                    <govuk-radios-fieldset-legend>
-                        <h3 class="govuk-heading-m">Reason for change</h3>
-                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
                     <govuk-radios-item value="@MqChangeProviderReasonOption.IncorrectTrainingProvider">
                         @MqChangeProviderReasonOption.IncorrectTrainingProvider.GetDisplayName()
                     </govuk-radios-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml.cs
@@ -25,8 +25,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
     public string? PersonName { get; set; }
 
     [BindProperty]
-    [Required(ErrorMessage = "Select a reason for change")]
     [Display(Name = "Reason for change")]
+    [Required(ErrorMessage = "Select a reason for change")]
     public MqChangeProviderReasonOption? ChangeReason { get; set; }
 
     [BindProperty]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml
@@ -8,12 +8,12 @@
     <govuk-back-link href="@LinkGenerator.MqEditSpecialismReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
         <form action="@LinkGenerator.MqEditSpecialismConfirm(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             <govuk-summary-list data-testid="change-summary">
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Current specialism</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml
@@ -8,22 +8,21 @@
     <govuk-back-link href="@LinkGenerator.PersonQualifications(Model.PersonId!.Value)">Back</govuk-back-link>
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditSpecialism(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+
             <govuk-radios asp-for="Specialism" data-testid="specialism-list">
-                @if (Model.Specialisms is not null)
-                {
-                    @foreach (var specialism in Model.Specialisms)
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--l" />
+                    @foreach (var specialism in Model.Specialisms!)
                     {
                         <govuk-radios-item value="@specialism.Value">
                             @specialism.Title
                         </govuk-radios-item>
                     }
-                }
+                </govuk-radios-fieldset>
             </govuk-radios>
 
             <div class="govuk-button-group">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml.cs
@@ -61,7 +61,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
 
-        Specialisms = MandatoryQualificationSpecialismRegistry.All
+        Specialisms = MandatoryQualificationSpecialismRegistry.GetAll()
             .OrderBy(t => t.Title)
             .ToArray();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml
@@ -8,17 +8,15 @@
     <govuk-back-link href="@LinkGenerator.MqEditSpecialism(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditSpecialismReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
                 <govuk-radios-fieldset>
-                    <govuk-radios-fieldset-legend>
-                        <h3 class="govuk-heading-m">Reason for change</h3>
-                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
                     <govuk-radios-item value="@MqChangeSpecialismReasonOption.IncorrectSpecialism">
                         @MqChangeSpecialismReasonOption.IncorrectSpecialism.GetDisplayName()
                     </govuk-radios-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml.cs
@@ -25,8 +25,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
     public string? PersonName { get; set; }
 
     [BindProperty]
-    [Required(ErrorMessage = "Select a reason for change")]
     [Display(Name = "Reason for change")]
+    [Required(ErrorMessage = "Select a reason for change")]
     public MqChangeSpecialismReasonOption? ChangeReason { get; set; }
 
     [BindProperty]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml
@@ -8,11 +8,11 @@
     <govuk-back-link href="@LinkGenerator.MqEditStartDateReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
+        <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+        <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
         <form action="@LinkGenerator.MqEditStartDateConfirm(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
             <govuk-summary-list data-testid="change-summary">
                 <govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml
@@ -8,11 +8,11 @@
     <govuk-back-link href="@LinkGenerator.PersonQualifications(Model.PersonId!.Value)">Back</govuk-back-link>
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditStartDate(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+
             <govuk-date-input asp-for="StartDate">
                 <govuk-date-input-fieldset>
                     <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml
@@ -8,17 +8,15 @@
     <govuk-back-link href="@LinkGenerator.MqEditStartDate(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditStartDateReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
                 <govuk-radios-fieldset>
-                    <govuk-radios-fieldset-legend>
-                        <h3 class="govuk-heading-m">Reason for change</h3>
-                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m">Reason for change</govuk-radios-fieldset-legend>
                     <govuk-radios-item value="@MqChangeStartDateReasonOption.IncorrectStartDate">
                         @MqChangeStartDateReasonOption.IncorrectStartDate.GetDisplayName()
                     </govuk-radios-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml.cs
@@ -25,8 +25,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
     public string? PersonName { get; set; }
 
     [BindProperty]
-    [Required(ErrorMessage = "Select a reason for change")]
     [Display(Name = "Reason for change")]
+    [Required(ErrorMessage = "Select a reason for change")]
     public MqChangeStartDateReasonOption? ChangeReason { get; set; }
 
     [BindProperty]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml
@@ -8,12 +8,12 @@
     <govuk-back-link href="@LinkGenerator.MqEditStatusReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditStatusConfirm(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             <govuk-summary-list data-testid="change-summary">
                 @if (Model.IsStatusChange!.Value)
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Index.cshtml
@@ -9,38 +9,42 @@
     <govuk-back-link href="@LinkGenerator.PersonQualifications(Model.PersonId!.Value)">Back</govuk-back-link>
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditStatus(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+
             <govuk-radios asp-for="Status" data-testid="result-options">
-                <govuk-radios-item value="@MandatoryQualificationStatus.InProgress" data-testid="result-in-progress">
-                    @MandatoryQualificationStatus.InProgress.GetTitle()
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Deferred" data-testid="result-deferred">
-                    @MandatoryQualificationStatus.Deferred.GetTitle()
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Extended" data-testid="result-extended">
-                    @MandatoryQualificationStatus.Extended.GetTitle()
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Failed" data-testid="result-failed">
-                    @MandatoryQualificationStatus.Failed.GetTitle()
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Passed" data-testid="result-passed">
-                    @MandatoryQualificationStatus.Passed.GetTitle()
-                    <govuk-radios-item-conditional>
-                        <govuk-date-input asp-for="EndDate">
-                            <govuk-date-input-fieldset>
-                                <govuk-date-input-fieldset-legend class="govuk-fieldset__legend--m" />
-                            </govuk-date-input-fieldset>
-                        </govuk-date-input>
-                    </govuk-radios-item-conditional>
-                </govuk-radios-item>
-                <govuk-radios-item value="@MandatoryQualificationStatus.Withdrawn" date-testid="result-withdrawn">
-                    @MandatoryQualificationStatus.Withdrawn.GetTitle()
-                </govuk-radios-item>
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--l">
+                        @ViewBag.Title
+                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.InProgress" data-testid="result-in-progress">
+                        @MandatoryQualificationStatus.InProgress.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Deferred" data-testid="result-deferred">
+                        @MandatoryQualificationStatus.Deferred.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Extended" data-testid="result-extended">
+                        @MandatoryQualificationStatus.Extended.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Failed" data-testid="result-failed">
+                        @MandatoryQualificationStatus.Failed.GetTitle()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Passed" data-testid="result-passed">
+                        @MandatoryQualificationStatus.Passed.GetTitle()
+                        <govuk-radios-item-conditional>
+                            <govuk-date-input asp-for="EndDate">
+                                <govuk-date-input-fieldset>
+                                    <govuk-date-input-fieldset-legend class="govuk-fieldset__legend--m" />
+                                </govuk-date-input-fieldset>
+                            </govuk-date-input>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@MandatoryQualificationStatus.Withdrawn" date-testid="result-withdrawn">
+                        @MandatoryQualificationStatus.Withdrawn.GetTitle()
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
             </govuk-radios>
 
             <div class="govuk-button-group">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Reason.cshtml
@@ -8,19 +8,17 @@
     <govuk-back-link href="@LinkGenerator.MqEditStatus(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
 }
 
-<span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
-<h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.MqEditStatusReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Change a mandatory qualification - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
             @if (Model.IsEndDateChange!.Value && !Model.IsStatusChange!.Value)
             {
                 <govuk-radios asp-for="EndDateChangeReason" data-testid="change-reason-options">
                     <govuk-radios-fieldset>
-                        <govuk-radios-fieldset-legend>
-                            <h3 class="govuk-heading-m">Reason for change</h3>
-                        </govuk-radios-fieldset-legend>
+                        <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
                         <govuk-radios-item value="@MqChangeEndDateReasonOption.IncorrectEndDate">
                             @MqChangeEndDateReasonOption.IncorrectEndDate.GetDisplayName()
                         </govuk-radios-item>
@@ -40,9 +38,7 @@
             {
                 <govuk-radios asp-for="StatusChangeReason" data-testid="change-reason-options">
                     <govuk-radios-fieldset>
-                        <govuk-radios-fieldset-legend>
-                            <h3 class="govuk-heading-m">Reason for change</h3>
-                        </govuk-radios-fieldset-legend>
+                        <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
                         <govuk-radios-item value="@MqChangeStatusReasonOption.IncorrectStatus">
                             @MqChangeStatusReasonOption.IncorrectStatus.GetDisplayName()
                         </govuk-radios-item>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -94,7 +94,7 @@ public class CheckAnswersTests : TestBase
         Assert.Equal(mqEstablishment.dfeta_name, doc.GetElementByTestId("provider")!.TextContent);
         Assert.Equal(specialism.GetTitle(), doc.GetElementByTestId("specialism")!.TextContent);
         Assert.Equal(startDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("start-date")!.TextContent);
-        Assert.Equal(status.ToString(), doc.GetElementByTestId("status")!.TextContent);
+        Assert.Equal(status.GetTitle(), doc.GetElementByTestId("status")!.TextContent);
         if (status == MandatoryQualificationStatus.Passed)
         {
             Assert.Equal(endDate!.Value.ToString("d MMMM yyyy"), doc.GetElementByTestId("end-date")!.TextContent);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
@@ -576,7 +576,7 @@ public class ChangeLogTests : TestBase
 
                 if (changes.HasFlag(MandatoryQualificationUpdatedEventChanges.Specialism))
                 {
-                    newSpecialism = MandatoryQualificationSpecialismRegistry.All.Where(s => s.Title != "Deaf education").RandomOne().Value;
+                    newSpecialism = MandatoryQualificationSpecialismRegistry.GetAll().Where(s => s.Title != "Deaf education").RandomOne().Value;
                     changeReason = "Change of specialism";
                     changeCount++;
                 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
@@ -250,7 +250,7 @@ public class SeedCrmReferenceData : IStartupTask
 
     private void AddSpecialisms()
     {
-        foreach (var specialism in MandatoryQualificationSpecialismRegistry.All)
+        foreach (var specialism in MandatoryQualificationSpecialismRegistry.GetAll())
         {
             _xrmFakedContext.CreateEntity(new dfeta_specialism()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -477,7 +477,7 @@ public partial class TestData
             var personId = createPersonBuilder.PersonId;
 
             var dqtMqEstablishmentValue = _dqtMqEstablishmentValue.ValueOr(mqEstablishments.RandomOne().dfeta_Value);
-            var specialism = _specialism.ValueOr(MandatoryQualificationSpecialismRegistry.All.Where(s => s.Title != "Deaf education").RandomOne().Value);  // Build env is missing Deaf education
+            var specialism = _specialism.ValueOr(MandatoryQualificationSpecialismRegistry.GetAll().Where(s => s.Title != "Deaf education").RandomOne().Value);  // Build env is missing Deaf education
             var status = _status.ValueOr(_endDate.ValueOrDefault() is DateOnly ? MandatoryQualificationStatus.Passed : MandatoryQualificationStatusRegistry.All.RandomOne().Value);
             var startDate = _startDate.ValueOr(testData.GenerateDate(min: new DateOnly(2000, 1, 1)));
             var endDate = _endDate.ValueOr(status == MandatoryQualificationStatus.Passed ? testData.GenerateDate(min: (startDate ?? new DateOnly(2000, 1, 1)).AddYears(1)) : null);


### PR DESCRIPTION
This makes the generated error summary appear above the heading and caption.

Also removes some MQ specialisms from the Add MQ journey; we don't want new records creating with legacy specialisms.