### PR TITLE
Fix date parsing on deployed environments

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
@@ -78,7 +78,7 @@ public class DebugIdentityModel(
             }
 
             var dobs = (VerifiedDatesOfBirth ?? string.Empty).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(line => DateOnly.TryParse(line, out var parsed) ? parsed : (DateOnly?)null)
+                .Select(line => DateOnly.TryParseExact(line, "d/M/yyyy", out var parsed) ? parsed : (DateOnly?)null)
                 .ToArray();
 
             if (dobs.Length == 0)


### PR DESCRIPTION
GB date parsing isn't working on deployed environments (likely because of the default `Culture`). This sets an explicit format to parse with.