### PR TITLE
Fix sign in for known users

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
@@ -77,7 +77,8 @@ public class SignInJourneyHelper(
                 oneLoginUser.LastSignIn = clock.UtcNow;
                 await dbContext.SaveChangesAsync();
 
-                CreateAndAssignPrincipal(journeyInstance.State, oneLoginUser.Person.PersonId, oneLoginUser.Person.Trn!);
+                await journeyInstance.UpdateStateAsync(state =>
+                    CreateAndAssignPrincipal(state, oneLoginUser.Person.PersonId, oneLoginUser.Person.Trn!));
             }
         }
         else

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
@@ -267,6 +267,8 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/trn?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        state = journeyInstance.State;
         Assert.Equal(nationalInsuranceNumber, state.NationalInsuranceNumber);
         Assert.True(state.NationalInsuranceNumberSpecified);
         Assert.Null(state.AuthenticationTicket);
@@ -302,6 +304,8 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"{redirectUri}?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        state = journeyInstance.State;
         Assert.Equal(nationalInsuranceNumber, state.NationalInsuranceNumber);
         Assert.True(state.NationalInsuranceNumberSpecified);
         Assert.NotNull(state.AuthenticationTicket);
@@ -336,6 +340,8 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/trn?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        state = journeyInstance.State;
         Assert.Null(state.NationalInsuranceNumber);
         Assert.True(state.NationalInsuranceNumberSpecified);
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
@@ -278,6 +278,8 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/not-found?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        state = journeyInstance.State;
         Assert.Equal(trn, state.Trn);
         Assert.True(state.TrnSpecified);
         Assert.Null(state.AuthenticationTicket);
@@ -315,6 +317,8 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"{redirectUri}?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        state = journeyInstance.State;
         Assert.Equal(trn, state.Trn);
         Assert.True(state.TrnSpecified);
         Assert.NotNull(state.AuthenticationTicket);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
@@ -74,6 +74,14 @@ public abstract class TestBase : IDisposable
         return (JourneyInstance<SignInJourneyState>)instance;
     }
 
+    public async Task<JourneyInstance<SignInJourneyState>> ReloadJourneyInstance(JourneyInstance<SignInJourneyState> journeyInstance)
+    {
+        await using var scope = HostFixture.Services.CreateAsyncScope();
+        var stateProvider = scope.ServiceProvider.GetRequiredService<IUserInstanceStateProvider>();
+        var reloadedInstance = await stateProvider.GetInstanceAsync(journeyInstance.InstanceId, typeof(SignInJourneyState));
+        return (JourneyInstance<SignInJourneyState>)reloadedInstance!;
+    }
+
     public virtual void Dispose()
     {
         _trsSyncSubscription.Dispose();


### PR DESCRIPTION
Also fixes our test state storage provider to behave more like a real, DB-backed provider (i.e. we can't just modify a state object directly and forget to persist it).