### PR TITLE
Nino validation for v3 trn request endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Logging/RemoveRedactedUrlParametersEventProcessor.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Logging/RemoveRedactedUrlParametersEventProcessor.cs
@@ -1,4 +1,3 @@
-using Sentry;
 using Sentry.Extensibility;
 
 namespace TeachingRecordSystem.Api.Infrastructure.Logging;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.Designer.cs
@@ -97,6 +97,15 @@ namespace TeachingRecordSystem.Api.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enter a National Insurance number in the correct format.
+        /// </summary>
+        public static string ErrorMessages_EnterNinoNumberInCorrectFormat {
+            get {
+                return ResourceManager.GetString("ErrorMessages.EnterNinoNumberInCorrectFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to InTraining outcome not permitted for AssessmentOnlyRoute ProgrammeType..
         /// </summary>
         public static string ErrorMessages_InTrainingOutcomeNotValidForAssessmentOnlyRoute {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.resx
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Properties/StringResources.resx
@@ -129,6 +129,9 @@
   <data name="ErrorMessages.BirthDateIsOutOfRange" xml:space="preserve">
     <value>Birth date is out of expected range.</value>
   </data>
+  <data name="ErrorMessages.EnterNinoNumberInCorrectFormat" xml:space="preserve">
+    <value>Enter a National Insurance number in the correct format</value>
+  </data>
   <data name="ErrorMessages.InTrainingOutcomeNotValidForAssessmentOnlyRoute" xml:space="preserve">
     <value>InTraining outcome not permitted for AssessmentOnlyRoute ProgrammeType.</value>
   </data>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/CreateTrnRequestRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/CreateTrnRequestRequestValidator.cs
@@ -42,7 +42,12 @@ public class CreateTrnRequestRequestValidator : AbstractValidator<CreateTrnReque
             .MaximumLength(AttributeConstraints.Contact.EMailAddress1MaxLength);
 
         RuleFor(r => r.Person.NationalInsuranceNumber)
-            .MaximumLength(AttributeConstraints.Contact.NationalInsuranceNumber_MaxLength)
-            .WithMessage(StringResources.ErrorMessages_NationalInsuranceNumberMustBe9CharactersOrLess);
+            .Custom((value, ctx) =>
+            {
+                if (!string.IsNullOrEmpty(value) && !NationalInsuranceNumberHelper.IsValid(value))
+                {
+                    ctx.AddFailure(ctx.PropertyName, StringResources.ErrorMessages_EnterNinoNumberInCorrectFormat);
+                }
+            });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NationalInsuranceNumber.cshtml.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core;
 using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
@@ -29,7 +29,7 @@ public class CreateContactHandler : ICrmQueryHandler<CreateContactQuery, Guid>
             BirthDate = query.DateOfBirth.ToDateTimeWithDqtBstFix(isLocalTime: false),
             dfeta_NINumber = query.NationalInsuranceNumber,
             EMailAddress1 = query.Email,
-            dfeta_AllowPiiUpdatesFromRegister = true
+            dfeta_AllowPiiUpdatesFromRegister = false
         };
 
         // only set trn if there is not any potential duplicate matches on the query

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumberHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumberHelper.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace TeachingRecordSystem.AuthorizeAccess;
+namespace TeachingRecordSystem.Core;
 
 public static partial class NationalInsuranceNumberHelper
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Infrastructure/Logging/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Infrastructure/Logging/HostApplicationBuilderExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Sentry;
 using Serilog;
 using TeachingRecordSystem.Hosting;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateTeacherTests.cs
@@ -52,7 +52,7 @@ public class CreateTeacherTests : IAsyncLifetime
         Assert.Equal(middleName, contact.MiddleName);
         Assert.Equal(lastName, contact.LastName);
         Assert.Equal(email, contact.EMailAddress1);
-        Assert.True(contact.dfeta_AllowPiiUpdatesFromRegister);
+        Assert.False(contact.dfeta_AllowPiiUpdatesFromRegister);
         Assert.Equal(ni, contact.dfeta_NINumber);
         Assert.Equal(dob, contact.BirthDate.ToDateOnlyWithDqtBstFix(true));
     }


### PR DESCRIPTION
Change v3 trn request endpoint to use a common nino validator.

https://trello.com/c/bauxANrV/1731-trn-api-post-endpoint

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
