### PR TITLE
Remove unnecessary QTS assignment for adding an MQ in tests

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateMandatoryQualificationTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateMandatoryQualificationTests.cs
@@ -22,7 +22,7 @@ public class CreateMandatoryQualificationTests : IAsyncLifetime
     {
         // Arrange
         var qualificationId = Guid.NewGuid();
-        var person = await _dataScope.TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), teacherStatusValue: "213", createdDate: new DateTime(2021, 10, 5)));
+        var person = await _dataScope.TestData.CreatePerson();
         var mqEstablishment = await _dataScope.TestData.ReferenceDataCache.GetMqEstablishmentByValue("955"); // University of Birmingham
         var specialism = await _dataScope.TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
         var startDate = new DateOnly(2023, 01, 5);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationByIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationByIdTests.cs
@@ -32,9 +32,7 @@ public class GetQualificationByIdTests : IAsyncLifetime
     public async Task WhenCalled_WithQualificationIdForExistingQualification_ReturnsQualification()
     {
         // Arrange
-        var person = await _dataScope.TestData.CreatePerson(
-            x => x.WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
-                    .WithMandatoryQualification());
+        var person = await _dataScope.TestData.CreatePerson(x => x.WithMandatoryQualification());
 
         var qualification = person.MandatoryQualifications.First();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetQualificationsByContactIdTests.cs
@@ -33,7 +33,6 @@ public class GetQualificationsByContactIdTests : IAsyncLifetime
     {
         // Arrange
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification()
             .WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue("959").WithSpecialism(MandatoryQualificationSpecialism.Visual)));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationEstablishmentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationEstablishmentTests.cs
@@ -25,7 +25,6 @@ public class UpdateMandatoryQualificationEstablishmentTests : IAsyncLifetime
         var newMqEstablishment = await _dataScope.TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5), teacherStatusValue: "213", createdDate: new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithDqtMqEstablishmentValue(originalMqEstablishmentValue)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationSpecialismTests.cs
@@ -25,7 +25,6 @@ public class UpdateMandatoryQualificationSpecialismTests : IAsyncLifetime
         var newSpecialism = await _dataScope.TestData.ReferenceDataCache.GetMqSpecialismByValue(MandatoryQualificationSpecialism.Hearing.GetDqtValue());
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithSpecialism(originalSpecialism)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStartDateTests.cs
@@ -25,7 +25,6 @@ public class UpdateMandatoryQualificationStartDateTests : IAsyncLifetime
         var newStartDate = new DateOnly(2020, 11, 7);
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithStartDate(originalStartDate)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateMandatoryQualificationStatusTests.cs
@@ -31,7 +31,6 @@ public class UpdateMandatoryQualificationStatusTests : IAsyncLifetime
         DateOnly? newEndDate = !string.IsNullOrEmpty(newEndDateString) ? DateOnly.Parse(newEndDateString) : null;
 
         var person = await _dataScope.TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "213", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q.WithStatus(originalMqStatus, originalEndDate)));
 
         var qualification = person.MandatoryQualifications.First();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/MqTests.cs
@@ -10,17 +10,12 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Status;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
-public class MqTests : TestBase
+public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public MqTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task AddMq()
     {
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = await TestData.ReferenceDataCache.GetMqSpecialismByValue("Hearing");
         var startDate = new DateOnly(2021, 3, 1);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -4,18 +4,14 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class CheckAnswersTests : TestBase
+public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public CheckAnswersTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
     {
         // Arrange
         var personId = Guid.NewGuid();
+
         var journeyInstance = await CreateJourneyInstance(personId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/check-answers?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -31,8 +27,7 @@ public class CheckAnswersTests : TestBase
     public async Task Get_WithPersonIdForValidPersonReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
-
+        var person = await TestData.CreatePerson();
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
@@ -66,8 +61,7 @@ public class CheckAnswersTests : TestBase
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState(MandatoryQualificationStatus status)
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
-
+        var person = await TestData.CreatePerson();
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
@@ -110,6 +104,7 @@ public class CheckAnswersTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
+
         var journeyInstance = await CreateJourneyInstance(personId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/check-answers?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -131,10 +126,8 @@ public class CheckAnswersTests : TestBase
     public async Task Post_Confirm_CreatesMqCreatesEventCompletesJourneyAndRedirectsWithFlashMessage(MandatoryQualificationStatus status)
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
-
+        var person = await TestData.CreatePerson();
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
-
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
         DateOnly? endDate = status == MandatoryQualificationStatus.Passed ? new DateOnly(2021, 11, 5) : null;
@@ -214,12 +207,13 @@ public class CheckAnswersTests : TestBase
     public async Task Post_Cancel_DeletesJourneyRedirectsAndDoesNotCreateMq()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValue("959"); // University of Leeds
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
         var status = MandatoryQualificationStatus.Passed;
         DateOnly? endDate = new DateOnly(2021, 11, 5);
+
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
             new AddMqState()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ProviderTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ProviderTests.cs
@@ -26,7 +26,7 @@ public class ProviderTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithPersonIdForValidPerson_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
@@ -43,7 +43,7 @@ public class ProviderTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var mqEstablishmentValue = "959"; // University of Leeds
 
         var journeyInstance = await CreateJourneyInstance(
@@ -90,7 +90,7 @@ public class ProviderTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenNoProviderIsSelected_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
@@ -110,7 +110,7 @@ public class ProviderTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenProviderIsSelected_RedirectsToSpecialismPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var mqEstablishmentValue = "959"; // University of Leeds
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
@@ -25,7 +25,7 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ProviderMissingFromState_RedirectsToProvider()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.ContactId, state => state.MqEstablishmentValue = null);
 
@@ -43,7 +43,7 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var specialism = MandatoryQualificationSpecialism.Hearing;
 
         var journeyInstance = await CreateJourneyInstance(person.ContactId, state => state.Specialism = specialism);
@@ -90,8 +90,7 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ProviderMissingFromState_RedirectsToProvider()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
-
+        var person = await TestData.CreatePerson();
         var specialism = MandatoryQualificationSpecialism.Hearing;
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId, state => state.MqEstablishmentValue = null);
@@ -116,7 +115,7 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenNoSpecialismIsSelected_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
@@ -136,8 +135,7 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenSpecialismIsSelected_RedirectsToStartDatePage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
-
+        var person = await TestData.CreatePerson();
         var specialism = MandatoryQualificationSpecialism.Hearing;
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StartDateTests.cs
@@ -25,7 +25,7 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_SpecialismMissingFromState_RedirectsToSpecialism()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId, state => state.Specialism = null);
 
@@ -43,7 +43,7 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithPersonIdForValidPerson_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
@@ -60,7 +60,7 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var startDate = new DateOnly(2021, 10, 5);
 
         var journeyInstance = await CreateJourneyInstance(
@@ -109,7 +109,7 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SpecialismMissingFromState_RedirectToSpecialism()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var startDate = new DateOnly(2021, 11, 5);
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId, state => state.Specialism = null);
@@ -136,13 +136,13 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenNoStartDateIsEntered_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>())
+            Content = new FormUrlEncodedContentBuilder()
         };
 
         // Act
@@ -158,7 +158,7 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_StartDateIsAfterOrEqualToEndDate_RendersError(int daysAfter)
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var startDate = new DateOnly(2021, 11, 5);
         var endDate = startDate.AddDays(-daysAfter);
 
@@ -185,7 +185,7 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenStartDateIsEntered_RedirectsToResultPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var startDate = new DateOnly(2021, 11, 5);
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
@@ -24,7 +24,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_StartDateMissingFromState_RedirectsToStartDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(
             person.ContactId,
@@ -44,7 +44,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
 
@@ -77,7 +77,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithPersonIdForValidPerson_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
@@ -122,7 +122,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_StartDateMissingFromState_RedirectsToStartDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
 
@@ -151,7 +151,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenResultIsNotSelected_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
 
@@ -171,7 +171,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenResultIsPassedAndEndDateHasNotBeenEntered_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var status = MandatoryQualificationStatus.Passed;
 
         var journeyInstance = await CreateJourneyInstance(person.PersonId);
@@ -197,7 +197,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_EndDateIsBeforeOrEqualToStartDate_RendersError(int daysBefore)
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
         var startDate = endDate.AddDays(daysBefore);
@@ -226,7 +226,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequest_RedirectsToResultPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5)));
+        var person = await TestData.CreatePerson();
         var status = MandatoryQualificationStatus.Passed;
         var endDate = new DateOnly(2021, 11, 5);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
@@ -1,12 +1,7 @@
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
 
-public class QualificationsTests : TestBase
+public class QualificationsTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public QualificationsTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
     {
@@ -54,8 +49,8 @@ public class QualificationsTests : TestBase
         var mqEstablishment = !string.IsNullOrEmpty(providerValue) ? await TestData.ReferenceDataCache.GetMqEstablishmentByValue(providerValue) : null;
         DateOnly? startDate = !string.IsNullOrEmpty(startDateString) ? DateOnly.Parse(startDateString) : null;
         DateOnly? endDate = !string.IsNullOrEmpty(endDateString) ? DateOnly.Parse(endDateString) : null;
+
         var person = await TestData.CreatePerson(x => x
-            .WithQts(qtsDate: new DateOnly(2021, 10, 5), "212", new DateTime(2021, 10, 5))
             .WithMandatoryQualification(q => q
                 .WithDqtMqEstablishmentValue(providerValue)
                 .WithSpecialism(specialism)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -23,7 +23,6 @@ public partial class TestData
     public class CreatePersonBuilder
     {
         private const string TeacherStatusQualifiedTeacherTrained = "71";
-        private const string EaryYearsStatusProfessionalStatus = "222";
 
         private bool? _syncEnabledOverride;
         private DateOnly? _dateOfBirth;
@@ -172,9 +171,16 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithQts(DateOnly? qtsDate, string? teacherStatusValue, DateTime? createdDate)
+        public CreatePersonBuilder WithQts(DateOnly? qtsDate = null)
         {
-            _qtsRegistrations.Add(new QtsRegistration(qtsDate, teacherStatusValue, createdDate, null, null));
+            _qtsRegistrations.Add(
+                new QtsRegistration(
+                    qtsDate ?? new DateOnly(2022, 9, 1),
+                    TeacherStatusValue: TeacherStatusQualifiedTeacherTrained,
+                    CreatedOn: null,
+                    EytsDate: null,
+                    EytsStatusValue: null));
+
             return this;
         }
 


### PR DESCRIPTION
I amended the signature of `WithQts()` too; we don't use it here any more but it'll be useful in future.