### PR TITLE
Add ssl statuscake alerts

### DIFF
--- a/terraform/aks/monitoring.tf
+++ b/terraform/aks/monitoring.tf
@@ -11,5 +11,7 @@ module "statuscake" {
     var.statuscake_extra_urls
   )
 
+  ssl_urls = var.ssl_urls
+
   contact_groups = [288912]
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -127,6 +127,12 @@ variable "redis_sku_name" {
   default = "Standard"
 }
 
+# StatusCake variables
+variable "ssl_urls" {
+  type    = list(string)
+  default = []
+}
+
 variable "statuscake_extra_urls" {
   type        = list(string)
   description = "List of extra URLs for StatusCake, on top of the internal teacherservices.cloud ones"

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -17,5 +17,6 @@
   "redis_capacity": 1,
   "redis_family": "P",
   "redis_sku_name": "Premium",
-  "statuscake_extra_urls": ["https://teacher-qualifications-api.education.gov.uk/health"]
+  "statuscake_extra_urls": ["https://teacher-qualifications-api.education.gov.uk/health"],
+  "ssl_urls": ["https://teacher-qualifications-api.education.gov.uk/health"]
 }


### PR DESCRIPTION
### Context

The SSL certificate expired without warning - we need to create monitoring alerts for this so we can renew before future expiries

### Changes proposed in this pull request

Add ssl monitoring alerts to status cake



### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
