### PR TITLE
Only request identity verification if required

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Faker.Net" Version="2.0.154" />
     <PackageVersion Include="FakeXrmEasy.v9" Version="3.3.3" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.2.1" />
+    <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.3.0" />
     <PackageVersion Include="GovukNotify" Version="6.1.0" />
     <PackageVersion Include="GovUk.Frontend.AspNetCore" Version="1.5.0" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.7" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/HttpResultActionResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/HttpResultActionResult.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.AuthorizeAccess;
+
+public class HttpResultActionResult(IResult result) : IActionResult
+{
+    public Task ExecuteResultAsync(ActionContext context)
+    {
+        return result.ExecuteAsync(context.HttpContext);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
@@ -50,7 +50,8 @@ public class FormFlowJourneySignInHandler(SignInJourneyHelper helper) : IAuthent
     {
         EnsureInitialized();
 
-        if (properties is null || !properties.Items.TryGetValue(PropertyKeys.JourneyInstanceId, out var serializedInstanceId) ||
+        if (properties is null ||
+            !properties.Items.TryGetValue(PropertyKeys.JourneyInstanceId, out var serializedInstanceId) ||
             serializedInstanceId is null)
         {
             throw new InvalidOperationException($"{PropertyKeys.JourneyInstanceId} must be specified in {nameof(properties)}.");
@@ -66,12 +67,7 @@ public class FormFlowJourneySignInHandler(SignInJourneyHelper helper) : IAuthent
         var result = await helper.OnSignedInWithOneLogin(journeyInstance, ticket);
 
         // Override the redirect done by RemoteAuthenticationHandler
-        _context.Response.OnStarting(
-            () =>
-            {
-                _context.Response.Redirect(result.Location);
-                return Task.CompletedTask;
-            });
+        _context.Response.OnStarting(() => result.ExecuteAsync(_context));
     }
 
     public async Task SignOutAsync(AuthenticationProperties? properties)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/MatchToTeachingRecordAuthenticationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/MatchToTeachingRecordAuthenticationHandler.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using GovUk.OneLogin.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.FormFlow;
 
@@ -40,9 +39,8 @@ public class MatchToTeachingRecordAuthenticationHandler(SignInJourneyHelper help
             createState: () => new SignInJourneyState(properties?.RedirectUri ?? "/", properties),
             updateState: state => state.Reset());
 
-        var delegatedProperties = new AuthenticationProperties();
-        delegatedProperties.Items.Add(FormFlowJourneySignInHandler.PropertyKeys.JourneyInstanceId, journeyInstance.InstanceId.Serialize());
-        await _context.ChallengeAsync(OneLoginDefaults.AuthenticationScheme, delegatedProperties);
+        var result = helper.SignInWithOneLogin(journeyInstance);
+        await result.ExecuteAsync(_context);
     }
 
     public Task ForbidAsync(AuthenticationProperties? properties)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
@@ -116,7 +116,7 @@ public class DebugIdentityModel(
         }
 
         var nextPage = await helper.CreateOrUpdateOneLoginUser(JourneyInstance);
-        return nextPage.ToActionResult();
+        return new HttpResultActionResult(nextPage);
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NationalInsuranceNumber.cshtml.cs
@@ -46,7 +46,7 @@ public class NationalInsuranceNumberModel(SignInJourneyHelper helper, AuthorizeA
 
         if (await helper.TryMatchToTeachingRecord(JourneyInstance!))
         {
-            return helper.GetNextPage(JourneyInstance).ToActionResult();
+            return new RedirectResult(helper.GetNextPage(JourneyInstance));
         }
         else
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotFound.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotFound.cshtml.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.FormFlow;
@@ -25,7 +26,7 @@ public class NotFoundModel(SignInJourneyHelper helper) : PageModel
         else if (!state.NationalInsuranceNumberSpecified || !state.TrnSpecified)
         {
             // Not specified NINO or TRN
-            context.Result = helper.GetNextPage(JourneyInstance).ToActionResult();
+            context.Result = new RedirectResult(helper.GetNextPage(JourneyInstance));
         }
         else if (state.AuthenticationTicket is not null)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Trn.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Trn.cshtml.cs
@@ -37,7 +37,7 @@ public class TrnModel(SignInJourneyHelper helper, AuthorizeAccessLinkGenerator l
 
         if (await helper.TryMatchToTeachingRecord(JourneyInstance!))
         {
-            return helper.GetNextPage(JourneyInstance).ToActionResult();
+            return new RedirectResult(helper.GetNextPage(JourneyInstance));
         }
         else
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -66,7 +66,7 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
         options.CoreIdentityClaimIssuerSigningKey = new ECDsaSecurityKey(coreIdentityIssuer);
         options.CoreIdentityClaimIssuer = "https://identity.integration.account.gov.uk/";
 
-        options.VectorsOfTrust = @"[""Cl.Cm.P2""]";
+        options.VectorOfTrust = @"[""Cl.Cm""]";
 
         options.Claims.Add(OneLoginClaimTypes.CoreIdentity);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
@@ -21,6 +21,8 @@ public class SignInJourneyState(string redirectUri, AuthenticationProperties? au
     [JsonConverter(typeof(AuthenticationTicketJsonConverter))]
     public AuthenticationTicket? OneLoginAuthenticationTicket { get; set; }
 
+    public bool AttemptedIdentityVerification { get; set; }
+
     public bool IdentityVerified { get; set; }
 
     public string[][]? VerifiedNames { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240216151724_RemoveOneLoginUserCoreIdentityVc.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240216151724_RemoveOneLoginUserCoreIdentityVc.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240216151724_RemoveOneLoginUserCoreIdentityVc")]
+    partial class RemoveOneLoginUserCoreIdentityVc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240216151724_RemoveOneLoginUserCoreIdentityVc.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240216151724_RemoveOneLoginUserCoreIdentityVc.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveOneLoginUserCoreIdentityVc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "core_identity_vc",
+                table: "one_login_users");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<JsonDocument>(
+                name: "core_identity_vc",
+                table: "one_login_users",
+                type: "jsonb",
+                nullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
@@ -1,12 +1,9 @@
-using System.Text.Json;
-
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class OneLoginUser
 {
     public required string Subject { get; init; }
     public required string Email { get; set; }
-    public required JsonDocument? CoreIdentityVc { get; set; }
     public required DateTime FirstOneLoginSignIn { get; init; }
     public required DateTime LastOneLoginSignIn { get; set; }
     public DateTime? FirstSignIn { get; set; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
@@ -25,7 +25,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -48,7 +48,13 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var person = await TestData.CreatePerson(b => b.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -70,7 +76,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket();
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var existingNationalInsuranceNumber = haveExistingValueInState ? Faker.Identification.UkNationalInsuranceNumber() : null;
@@ -126,7 +132,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
 
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
-        var ticket = CreateOneLoginAuthenticationTicket(createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -154,9 +160,15 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var nationalInsuranceNumber = person.NationalInsuranceNumber!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: person.PersonId, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: person.PersonId);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -184,9 +196,15 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var nationalInsuranceNumber = "";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -213,9 +231,15 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var nationalInsuranceNumber = "xxx";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -242,9 +266,15 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -279,9 +309,15 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var nationalInsuranceNumber = person.NationalInsuranceNumber!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -321,9 +357,15 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var nationalInsuranceNumber = person.NationalInsuranceNumber!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number/ContinueWithout?{journeyInstance.GetUniqueIdQueryParameter()}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
@@ -25,7 +25,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-found?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -48,7 +48,13 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePerson(b => b.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-found?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -68,7 +74,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket();
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state =>
@@ -93,7 +99,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket();
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state =>
@@ -119,7 +125,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket();
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(async state =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
@@ -25,7 +25,7 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(createCoreIdentityVc: true);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: true);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -44,7 +44,7 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
@@ -25,7 +25,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -48,7 +48,13 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePerson(b => b.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -70,7 +76,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = new SignInJourneyState(redirectUri: "/", authenticationProperties: null);
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket();
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var existingTrn = haveExistingValueInState ? await TestData.GenerateTrn() : null;
@@ -131,7 +137,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var trn = await TestData.GenerateTrn();
 
-        var ticket = CreateOneLoginAuthenticationTicket(createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -159,9 +165,15 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var trn = person.Trn!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: person.PersonId, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: person.PersonId);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -189,9 +201,15 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var trn = "";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state => state.NationalInsuranceNumberSpecified = true);
@@ -220,9 +238,15 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var trn = "xxx";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state => state.NationalInsuranceNumberSpecified = true);
@@ -251,9 +275,15 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var trn = await TestData.GenerateTrn();
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state => state.NationalInsuranceNumberSpecified = true);
@@ -290,9 +320,15 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
         var trn = person.Trn!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, firstName: person.FirstName, lastName: person.LastName, dateOfBirth: person.DateOfBirth);
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
 
-        var ticket = CreateOneLoginAuthenticationTicket(oneLoginUser);
+        var ticket = CreateOneLoginAuthenticationTicket(
+            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
+            sub: oneLoginUser.Subject,
+            email: oneLoginUser.Email,
+            firstName: person.FirstName,
+            lastName: person.LastName,
+            dateOfBirth: person.DateOfBirth);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state => state.NationalInsuranceNumberSpecified = true);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUser.cs
@@ -9,18 +9,12 @@ public partial class TestData
     public Task<OneLoginUser> CreateOneLoginUser(
         Guid? personId,
         string? subject = null,
-        string? email = null,
-        string? firstName = null,
-        string? lastName = null,
-        DateOnly? dateOfBirth = null)
+        string? email = null)
     {
         return WithDbContext(async dbContext =>
         {
             subject ??= CreateOneLoginUserSubject();
             email ??= Faker.Internet.Email();
-            firstName ??= Faker.Name.First();
-            lastName ??= Faker.Name.Last();
-            dateOfBirth ??= DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
 
             var user = new OneLoginUser()
             {
@@ -28,7 +22,6 @@ public partial class TestData
                 Email = email,
                 FirstOneLoginSignIn = Clock.UtcNow,
                 LastOneLoginSignIn = Clock.UtcNow,
-                CoreIdentityVc = CreateOneLoginCoreIdentityVc(firstName, lastName, dateOfBirth.Value),
                 PersonId = personId
             };
 


### PR DESCRIPTION
Currently when we push users to One Login we ask for both authentication and identity verification up front. In some cases this means identity verification is being requested when it's not required (e.g. if we already know a user's TRN). This change moves to a two step process; authentication (only) then, if required, identity verification.