### PR TITLE
Add person_id column to Event with an index

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -17,5 +17,6 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.HasKey(e => e.EventId);
         builder.HasIndex(e => e.Payload).HasMethod("gin");
         builder.HasIndex(e => e.Key).IsUnique().HasFilter("key is not null").HasDatabaseName(Event.KeyUniqueIndexName);
+        builder.HasIndex(e => new { e.PersonId, e.EventName }).IncludeProperties(e => e.Payload).HasFilter("person_id is not null");
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240307130427_EventPersonId.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240307130427_EventPersonId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -11,9 +12,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240307130427_EventPersonId")]
+    partial class EventPersonId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240307130427_EventPersonId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240307130427_EventPersonId.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EventPersonId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "person_id",
+                table: "events",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.Sql(
+                """
+                update events set person_id = (payload->>'PersonId')::uuid where person_id is null;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_events_person_id_event_name",
+                table: "events",
+                columns: new[] { "person_id", "event_name" },
+                filter: "person_id is not null")
+                .Annotation("Npgsql:IndexInclude", new[] { "payload" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_events_person_id_event_name",
+                table: "events");
+
+            migrationBuilder.DropColumn(
+                name: "person_id",
+                table: "events");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
@@ -11,6 +11,7 @@ public class Event
     public required string Payload { get; init; }
     public string? Key { get; init; }
     public bool Published { get; set; }
+    public Guid? PersonId { get; init; }
 
     public static Event FromEventBase(EventBase @event, DateTime? inserted)
     {
@@ -24,7 +25,8 @@ public class Event
             Created = @event.CreatedUtc,
             Inserted = inserted ?? @event.CreatedUtc,
             Payload = payload,
-            Key = @event is IEventWithKey eventWithKey ? eventWithKey.Key : null
+            Key = (@event as IEventWithKey)?.Key,
+            PersonId = (@event as IEventWithPersonId)?.PersonId
         };
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -1135,7 +1135,8 @@ public class TrsDataSyncHelper(
             "created",
             "inserted",
             "payload",
-            "key"
+            "key",
+            "person_id"
         };
 
         var columnList = string.Join(", ", columnNames);
@@ -1147,7 +1148,8 @@ public class TrsDataSyncHelper(
                 created TIMESTAMP WITH TIME ZONE NOT NULL,
                 inserted TIMESTAMP WITH TIME ZONE NOT NULL,
                 payload JSONB NOT NULL,
-                key VARCHAR(200)
+                key VARCHAR(200),
+                person_id UUID
             )
             """;
 
@@ -1181,6 +1183,7 @@ public class TrsDataSyncHelper(
             writer.WriteValueOrNull(clock.UtcNow, NpgsqlDbType.TimestampTz);
             writer.WriteValueOrNull(payload, NpgsqlDbType.Jsonb);
             writer.WriteValueOrNull(key, NpgsqlDbType.Varchar);
+            writer.WriteValueOrNull((e as IEventWithPersonId)?.PersonId, NpgsqlDbType.Uuid);
         }
 
         await writer.CompleteAsync(cancellationToken);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
@@ -34,7 +34,7 @@ public class ChangeHistoryModel(ICrmQueryDispatcher crmQueryDispatcher, IDbConte
         var notesResult = await crmQueryDispatcher.ExecuteQuery(new GetNotesByContactIdQuery(PersonId));
 
         using var dbContext = await dbContextFactory.CreateDbContextAsync();
-        var personIdString = PersonId.ToString();
+
         var eventsWithUser = await dbContext.Database
             .SqlQuery<EventWithUser>($"""
                 SELECT
@@ -53,7 +53,7 @@ public class ChangeHistoryModel(ICrmQueryDispatcher crmQueryDispatcher, IDbConte
                                     null
                             END = u.user_id
                 WHERE
-                    e.payload ->> 'PersonId' = {personIdString}
+                    e.person_id = {PersonId}
                     AND e.event_name in
                         ('MandatoryQualificationDeletedEvent',
                         'MandatoryQualificationDqtDeactivatedEvent',


### PR DESCRIPTION
Even with a GIN index on the `event` table's `payload` column querying by `person_id` is relatively slow. This adds a separate `person_id` column with an index to improve performance.