### PR TITLE
Amended validation to allow NINOs starting with QQ

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumberHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumberHelper.cs
@@ -16,7 +16,7 @@ public static partial class NationalInsuranceNumberHelper
         return ValidNinoPattern().IsMatch(normalized);
     }
 
-    [GeneratedRegex("^[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}$")]
+    [GeneratedRegex("^[A-CEGHJ-PQR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPQR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}$")]
     private static partial Regex ValidNinoPattern();
 
     public static string? NormalizeNationalInsuranceNumber(string? value)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
@@ -10,7 +10,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
     {
         var validFormatTrn = "1234567";
         var invalidFormatTrn = "12345678";
-        var validFormatNationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
+        var validFormatNationalInsuranceNumber = "QQ123456A";
         var invalidFormatNationalInsuranceNumber = "1234";
         var validFormatDateOfBirth = "01/01/1980";
         var invalidFormatDateOfBirth = "1234";


### PR DESCRIPTION
### Context

During testing of the CSV extract we noticed that there were some National Insurance Numbers in the file which started with QQ and were seen as invalid using the existing Regex we have for NINO validation.

QQ is used for temporary NINOs and is valid so we should allow this everywhere we validate a NINO.

### Changes proposed in this pull request

Amend the NINO validation helper to allow NINOs starting with QQ