### PR TITLE
Refresh workforce data with "most open" version of establishment

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/EstablishmentRefresher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/EstablishmentRefresher.cs
@@ -1,0 +1,69 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+
+namespace TeachingRecordSystem.Core.Services.Establishments;
+
+public class EstablishmentRefresher(
+    TrsDbContext dbContext,
+    IEstablishmentMasterDataService establishmentMasterDataService)
+{
+    public async Task RefreshEstablishments(CancellationToken cancellationToken)
+    {
+        int i = 0;
+        await foreach (var establishment in establishmentMasterDataService.GetEstablishments())
+        {
+            var existingEstablishment = await dbContext.Establishments.SingleOrDefaultAsync(e => e.Urn == establishment.Urn);
+            if (existingEstablishment == null)
+            {
+                dbContext.Establishments.Add(new()
+                {
+                    EstablishmentId = Guid.NewGuid(),
+                    Urn = establishment.Urn,
+                    LaCode = establishment.LaCode,
+                    LaName = establishment.LaName,
+                    EstablishmentNumber = establishment.EstablishmentNumber,
+                    EstablishmentName = establishment.EstablishmentName,
+                    EstablishmentTypeCode = establishment.EstablishmentTypeCode,
+                    EstablishmentTypeName = establishment.EstablishmentTypeName,
+                    EstablishmentTypeGroupCode = establishment.EstablishmentTypeGroupCode,
+                    EstablishmentTypeGroupName = establishment.EstablishmentTypeGroupName,
+                    EstablishmentStatusCode = establishment.EstablishmentStatusCode,
+                    EstablishmentStatusName = establishment.EstablishmentStatusName,
+                    Street = establishment.Street,
+                    Locality = establishment.Locality,
+                    Address3 = establishment.Address3,
+                    Town = establishment.Town,
+                    County = establishment.County,
+                    Postcode = establishment.Postcode
+                });
+            }
+            else
+            {
+                existingEstablishment.LaCode = establishment.LaCode;
+                existingEstablishment.LaName = establishment.LaName;
+                existingEstablishment.EstablishmentName = establishment.EstablishmentName;
+                existingEstablishment.EstablishmentTypeCode = establishment.EstablishmentTypeCode;
+                existingEstablishment.EstablishmentTypeName = establishment.EstablishmentTypeName;
+                existingEstablishment.EstablishmentTypeGroupCode = establishment.EstablishmentTypeGroupCode;
+                existingEstablishment.EstablishmentTypeGroupName = establishment.EstablishmentTypeGroupName;
+                existingEstablishment.EstablishmentStatusCode = establishment.EstablishmentStatusCode;
+                existingEstablishment.EstablishmentStatusName = establishment.EstablishmentStatusName;
+                existingEstablishment.Street = establishment.Street;
+                existingEstablishment.Locality = establishment.Locality;
+                existingEstablishment.Address3 = establishment.Address3;
+                existingEstablishment.Town = establishment.Town;
+                existingEstablishment.County = establishment.County;
+                existingEstablishment.Postcode = establishment.Postcode;
+            }
+
+            if (++i % 2000 == 0)
+            {
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        if (dbContext.ChangeTracker.HasChanges())
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ServiceCollectionExtensions
                 .ValidateOnStart();
 
             builder.Services
+                .AddSingleton<EstablishmentRefresher>()
                 .AddSingleton<IEstablishmentMasterDataService, CsvDownloadEstablishmentMasterDataService>()
                 .AddHttpClient<IEstablishmentMasterDataService, CsvDownloadEstablishmentMasterDataService>((sp, httpClient) =>
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
@@ -1,0 +1,12 @@
+namespace TeachingRecordSystem.Core.Services.WorkforceData;
+
+public record UpdatedPersonEmploymentEstablishment
+{
+    public required Guid PersonEmploymentId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required Guid CurrentEstablishmentId { get; init; }
+    public required DateOnly StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+    public required EmploymentType EmploymentType { get; init; }
+    public required Guid EstablishmentId { get; init; }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/EstablishmentRefresherTests.cs
@@ -1,15 +1,14 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Dqt;
-using TeachingRecordSystem.Core.Jobs;
 using TeachingRecordSystem.Core.Services.Establishments;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using Establishment = TeachingRecordSystem.Core.Models.Establishment;
 
-namespace TeachingRecordSystem.Core.Tests.Jobs;
+namespace TeachingRecordSystem.Core.Tests.Services.Establishments;
 
-public class RefreshEstablishmentsJobTests
+public class EstablishmentRefresherTests
 {
-    public RefreshEstablishmentsJobTests(
+    public EstablishmentRefresherTests(
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
@@ -36,7 +35,7 @@ public class RefreshEstablishmentsJobTests
     }
 
     [Fact]
-    public Task ExecuteAsync_WhenCalledforNewUrn_AddsNewEstablishments() =>
+    public Task RefreshEstablishments_WhenCalledforNewUrn_AddsNewEstablishments() =>
         DbFixture.WithDbContext(async dbContext =>
         {
             // Arrange
@@ -87,12 +86,12 @@ public class RefreshEstablishmentsJobTests
                 .Setup(s => s.GetEstablishments())
                 .Returns(establishments.ToAsyncEnumerable());
 
-            var job = new RefreshEstablishmentsJob(
+            var establishmentRefresher = new EstablishmentRefresher(
                 dbContext,
                 establishmentMasterDataService);
 
             // Act
-            await job.ExecuteAsync(CancellationToken.None);
+            await establishmentRefresher.RefreshEstablishments(CancellationToken.None);
 
             // Assert
             var establishmentsActual = await dbContext.Establishments.Where(e => e.Urn == establishment1.Urn || e.Urn == establishment2.Urn).OrderBy(e => e.Urn).ToListAsync();
@@ -140,7 +139,7 @@ public class RefreshEstablishmentsJobTests
         });
 
     [Fact]
-    public Task ExecuteAsync_WhenCalledForExistingUrn_UpdatesEstablishment() =>
+    public Task RefreshEstablishments_WhenCalledForExistingUrn_UpdatesEstablishment() =>
         DbFixture.WithDbContext(async dbContext =>
         {
             // Arrange
@@ -196,12 +195,12 @@ public class RefreshEstablishmentsJobTests
                 .Setup(s => s.GetEstablishments())
                 .Returns(establishments.ToAsyncEnumerable());
 
-            var job = new RefreshEstablishmentsJob(
+            var establishmentRefresher = new EstablishmentRefresher(
                 dbContext,
                 establishmentMasterDataService);
 
             // Act
-            await job.ExecuteAsync(CancellationToken.None);
+            await establishmentRefresher.RefreshEstablishments(CancellationToken.None);
 
             // Assert
             var urnEstablishments = await dbContext.Establishments.Where(e => e.Urn == dbEstablishment.Urn).ToListAsync();


### PR DESCRIPTION
Extended establishment refresh job to also upated person_employments table if the "most open" version of an establishment in GIAS has changed (e.g. when a school has become an academy).
