### PR TITLE
Add OIDC test app & e2e tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
@@ -68,7 +68,7 @@ public class ApiKeyAuthenticationHandler(
             return AuthenticateResult.Fail($"API key is expired.");
         }
 
-        var principal = CreatePrincipal(apiKey.ApplicationUserId.ToString(), apiKey.ApplicationUser.Name, apiKey.ApplicationUser.ApiRoles);
+        var principal = CreatePrincipal(apiKey.ApplicationUserId.ToString(), apiKey.ApplicationUser.Name, apiKey.ApplicationUser.ApiRoles ?? []);
         var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
         LogContext.PushProperty("ClientId", apiKey.ApplicationUser.UserId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OidcController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OidcController.cs
@@ -35,7 +35,6 @@ public class OidcController(
         {
             var parameters = Request.HasFormContentType ? Request.Form.ToList() : Request.Query.ToList();
 
-
             var authenticationProperties = new AuthenticationProperties()
             {
                 RedirectUri = Request.PathBase + Request.Path + QueryString.Create(parameters)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Filters/NotFoundResourceFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Filters/NotFoundResourceFilter.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Infrastructure.Filters;
+
+public class NotFoundResourceFilter : IResourceFilter
+{
+    public void OnResourceExecuted(ResourceExecutedContext context)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void OnResourceExecuting(ResourceExecutingContext context)
+    {
+        context.Result = new NotFoundResult();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/OneLoginAuthenticationSchemeProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/OneLoginAuthenticationSchemeProvider.cs
@@ -155,6 +155,15 @@ public sealed class OneLoginAuthenticationSchemeProvider(
 
         options.SignInScheme = AuthenticationSchemes.FormFlowJourney;
 
+        options.Events.OnRedirectToIdentityProvider = context =>
+        {
+            // A large RedirectUri here can make the state parameter so large that One Login rejects the request.
+            // We have the RedirectUri stashed away on the FormFlow journey any way so we can clear it out.
+            context.Properties.RedirectUri = null;
+
+            return Task.CompletedTask;
+        };
+
         options.Events.OnRedirectToIdentityProviderForSignOut = context =>
         {
             // The standard sign out process will call Authenticate() on SignInScheme then try to extract the id_token from the Principal.

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignOut.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignOut.cshtml
@@ -1,0 +1,11 @@
+@page "/oidc-test/sign-out"
+@addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
+@model TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest.SignOutModel
+@{
+}
+
+<form asp-page="SignOut" method="post">
+    <govuk-button type="submit">Sign out</govuk-button>
+</form>
+
+<script asp-add-nonce="true">document.forms[0].submit();</script>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignOut.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignOut.cshtml.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest;
+
+[Authorize(AuthenticationSchemes = TestAppConfiguration.AuthenticationSchemeName)]
+public class SignOutModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+        return SignOut(
+            new AuthenticationProperties()
+            {
+                RedirectUri = Url.Page("Start")
+            },
+            TestAppConfiguration.AuthenticationSchemeName);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml
@@ -1,0 +1,27 @@
+@page "/oidc-test/signed-in"
+@using System.Text.Json
+@using TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest
+@addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
+@model SignedInModel
+@{
+    var claimsJson = JsonSerializer.Serialize(
+        User.Claims.ToDictionary(c => c.Type, c => c.Value),
+        new JsonSerializerOptions() { WriteIndented = true });
+}
+
+@section Head {
+    <style type="text/css" asp-add-nonce="true">
+        .claims-json {
+            font-family: monospace !important;
+            white-space: nowrap;
+            height: 260px;
+        }
+    </style>
+}
+
+<p class="govuk-body">
+    <govuk-textarea name="Claims" textarea-class="claims-json">
+        <govuk-textarea-label>Claims</govuk-textarea-label>
+        <govuk-textarea-value>@claimsJson</govuk-textarea-value>
+    </govuk-textarea>
+</p>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest;
+
+[Authorize(AuthenticationSchemes = TestAppConfiguration.AuthenticationSchemeName)]
+public class SignedInModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml
@@ -1,0 +1,8 @@
+@page "/oidc-test"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest.StartModel
+@{
+}
+
+<form asp-page="OidcTest" method="post">
+    <govuk-button type="submit" is-start-button="true">Start</govuk-button>
+</form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest;
+
+public class StartModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost() => Challenge(
+        new AuthenticationProperties()
+        {
+            RedirectUri = Url.Page("SignedIn")
+        },
+        TestAppConfiguration.AuthenticationSchemeName);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/_Layout.cshtml
@@ -1,0 +1,29 @@
+@{
+    Layout = "../Shared/_Layout";
+
+    ViewBag.ServiceName = "OIDC Sample";
+}
+
+@section Head {
+    @RenderSection("Head", required: false)
+}
+
+@if (User.Identity?.IsAuthenticated == true)
+{
+    @section Nav {
+        <nav aria-label="Menu" class="govuk-header__navigation">
+            <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" hidden>
+                Menu
+            </button>
+            <ul id="navigation" class="govuk-header__navigation-list">
+                <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+                    <a class="govuk-header__link" asp-page="SignOut">
+                        Sign out
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    }
+}
+
+@RenderBody()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/_ViewStart.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "./_Layout";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/_Layout.cshtml
@@ -1,7 +1,13 @@
+@inject GovUk.Frontend.AspNetCore.PageTemplateHelper PageTemplateHelper
 @{
     Layout = "_GovUkPageTemplate";
 
     var serviceName = ViewBag.ServiceName ?? "Authorise access to a teaching record";
+}
+
+@section Head {
+    @RenderSection("Head", required: false)
+    @PageTemplateHelper.GenerateStyleImports()
 }
 
 @section Header {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -164,6 +164,8 @@ builder.Services.AddOptions<AuthorizeAccessOptions>()
     .ValidateDataAnnotations()
     .ValidateOnStart();
 
+builder.AddTestApp();
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
@@ -189,6 +191,10 @@ app.UseCsp(csp =>
     csp.AllowScripts
         .FromSelf()
         .From(pageTemplateHelper.GetCspScriptHashes())
+        .AddNonce();
+
+    csp.AllowStyles
+        .FromSelf()
         .AddNonce();
 
     // Ensure ASP.NET Core's auto refresh works

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TestAppConfiguration.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TestAppConfiguration.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Filters;
+using static IdentityModel.OidcConstants;
+
+namespace TeachingRecordSystem.AuthorizeAccess;
+
+public static class TestAppConfiguration
+{
+    public const string AuthenticationSchemeName = "OidcTest";
+    public const string ClientId = "test-app";
+    public const string ClientSecret = "Devel0pm3ntSecr4t";
+    public const string RedirectUriPath = "/test-app/callback";
+    public const string PostLogoutRedirectUriPath = "/test-app/logout-callback";
+
+    public static WebApplicationBuilder AddTestApp(this WebApplicationBuilder builder)
+    {
+        if (builder.Environment.IsDevelopment() || builder.Environment.IsEndToEndTests())
+        {
+            builder.Services.AddAuthentication()
+                .AddCookie()
+                .AddOpenIdConnect(AuthenticationSchemeName, options =>
+                {
+                    options.Authority = "https://localhost:7236";
+                    options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    options.ClientId = ClientId;
+                    options.ClientSecret = ClientSecret;
+                    options.CallbackPath = RedirectUriPath;
+                    options.SignedOutCallbackPath = PostLogoutRedirectUriPath;
+                    options.ResponseMode = ResponseModes.Query;
+                    options.ResponseType = ResponseTypes.Code;
+                    options.MapInboundClaims = false;
+                    options.SaveTokens = true;
+                    options.Scope.Clear();
+                    options.Scope.Add("openid");
+                    options.Scope.Add("email");
+                    options.Scope.Add("profile");
+                });
+        }
+        else
+        {
+            builder.Services.Configure<RazorPagesOptions>(options =>
+                options.Conventions.AddFolderApplicationModelConvention(
+                    "/OidcTest", model => model.Filters.Add(new NotFoundResourceFilter())));
+        }
+
+        return builder;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -35,7 +35,7 @@ public class ApplicationUser : UserBase
     public const string ClientIdUniqueIndexName = "ix_users_client_id";
     public const string OneLoginAuthenticationSchemeNameUniqueIndexName = "ix_users_one_login_authentication_scheme_name";
 
-    public required string[] ApiRoles { get; set; }
+    public string[]? ApiRoles { get; set; }
     public ICollection<ApiKey> ApiKeys { get; } = null!;
     public bool IsOidcClient { get; set; }
     public string? ClientId { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
@@ -4,7 +4,7 @@ public record ApplicationUser
 {
     public required Guid UserId { get; init; }
     public required string Name { get; init; }
-    public required string[] ApiRoles { get; init; }
+    public string[]? ApiRoles { get; init; }
     public bool IsOidcClient { get; init; }
     public string? ClientId { get; init; }
     public string? ClientSecret { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
@@ -173,7 +173,7 @@ public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator l
 
         var changes = ApplicationUserUpdatedEventChanges.None |
             (Name != _user!.Name ? ApplicationUserUpdatedEventChanges.Name : 0) |
-            (!new HashSet<string>(_user.ApiRoles).SetEquals(new HashSet<string>(newApiRoles)) ? ApplicationUserUpdatedEventChanges.ApiRoles : 0) |
+            (!new HashSet<string>(_user.ApiRoles ?? []).SetEquals(new HashSet<string>(newApiRoles)) ? ApplicationUserUpdatedEventChanges.ApiRoles : 0) |
             (IsOidcClient != _user.IsOidcClient ? ApplicationUserUpdatedEventChanges.IsOidcClient : 0);
 
         if (IsOidcClient)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/Infrastructure/Security/FakeOneLoginHandler.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/Infrastructure/Security/FakeOneLoginHandler.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Security;
 
 namespace TeachingRecordSystem.AuthorizeAccess.EndToEndTests.Infrastructure.Security;
 
-public class FakeOneLoginHandler(OneLoginCurrentUserProvider currentUserProvider) : IAuthenticationHandler
+public class FakeOneLoginHandler(OneLoginCurrentUserProvider currentUserProvider) : IAuthenticationHandler, IAuthenticationSignOutHandler
 {
     private HttpContext? _context;
 
@@ -49,6 +49,11 @@ public class FakeOneLoginHandler(OneLoginCurrentUserProvider currentUserProvider
     public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context)
     {
         _context = context;
+        return Task.CompletedTask;
+    }
+
+    public Task SignOutAsync(AuthenticationProperties? properties)
+    {
         return Task.CompletedTask;
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+
+namespace TeachingRecordSystem.AuthorizeAccess.EndToEndTests;
+
+public class OidcTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task SignInAndOut()
+    {
+        var person = await TestData.CreatePerson(x => x.WithTrn());
+        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+
+        var coreIdentityVc = TestData.CreateOneLoginCoreIdentityVc(person.FirstName, person.LastName, person.DateOfBirth);
+        SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email, coreIdentityVc));
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync("/oidc-test");
+        await page.ClickButton("Start");
+        await page.WaitForUrlPathAsync("/oidc-test/signed-in");
+
+        var claims = JsonSerializer.Deserialize<Dictionary<string, string>>(await page.GetByLabel("Claims").InputValueAsync()) ?? [];
+        Assert.Equal(oneLoginUser.Subject, claims.GetValueOrDefault("sub"));
+        Assert.Equal(person.Trn, claims.GetValueOrDefault("trn"));
+        Assert.Equal(oneLoginUser.Email, claims.GetValueOrDefault("email"));
+        Assert.NotEmpty(claims.GetValueOrDefault("onelogin_id") ?? "");
+
+        await page.ClickAsync("a:text-is('Sign out')");
+        await page.WaitForUrlPathAsync("/oidc-test");
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
@@ -190,7 +190,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
             Content = new FormUrlEncodedContentBuilder()
             {
                 { "Name", applicationUser.Name },
-                { "ApiRoles", applicationUser.ApiRoles },
+                { "ApiRoles", applicationUser.ApiRoles ?? [] },
                 { "IsOidcClient", bool.TrueString },
                 { "ClientId", clientId },
                 { "ClientSecret", clientSecret },
@@ -260,7 +260,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
         await WithDbContext(async dbContext =>
         {
             applicationUser = await dbContext.ApplicationUsers.SingleAsync(u => u.UserId == applicationUser.UserId);
-            Assert.True(new HashSet<string>(applicationUser.ApiRoles).SetEquals(new HashSet<string>(newRoles)));
+            Assert.True(new HashSet<string>(applicationUser.ApiRoles ?? []).SetEquals(new HashSet<string>(newRoles)));
         });
 
         EventObserver.AssertEventsSaved(
@@ -271,8 +271,8 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
                 Assert.Equal(GetCurrentUserId(), applicationUserUpdatedEvent.RaisedBy.UserId);
                 Assert.Equal(originalName, applicationUserUpdatedEvent.OldApplicationUser.Name);
                 Assert.Equal(newName, applicationUserUpdatedEvent.ApplicationUser.Name);
-                Assert.True(applicationUserUpdatedEvent.ApplicationUser.ApiRoles.SequenceEqual(newRoles));
-                Assert.Empty(applicationUserUpdatedEvent.OldApplicationUser.ApiRoles);
+                Assert.True((applicationUserUpdatedEvent.ApplicationUser.ApiRoles ?? []).SequenceEqual(newRoles));
+                Assert.Empty(applicationUserUpdatedEvent.OldApplicationUser.ApiRoles ?? []);
                 Assert.False(applicationUserUpdatedEvent.OldApplicationUser.IsOidcClient);
                 Assert.Null(applicationUserUpdatedEvent.OldApplicationUser.ClientId);
                 Assert.Null(applicationUserUpdatedEvent.OldApplicationUser.ClientSecret);


### PR DESCRIPTION
This adds a minimal OIDC client app within `AuthorizeAccess` itself plus an e2e test that covers sign in and out. This client app is only enabled for local dev & tests.