### PR TITLE
Refresh webhook specs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/AddWebHookMessagesDocumentFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/AddWebHookMessagesDocumentFilter.cs
@@ -1,0 +1,25 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace TeachingRecordSystem.Api.Infrastructure.OpenApi;
+
+public class AddWebHookMessagesDocumentFilter : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        (int majorVersion, string? minorVersion) = OpenApiDocumentHelper.GetVersionsFromVersionName(swaggerDoc.Info.Version);
+
+        if (majorVersion == 3)
+        {
+            var messagesNamespace = $"TeachingRecordSystem.Api.V3.V{minorVersion}.WebHookMessages";
+
+            var messageTypes = typeof(AddWebHookMessagesDocumentFilter).Assembly.GetTypes()
+                .Where(t => t.Namespace == messagesNamespace);
+
+            foreach (var messageType in messageTypes)
+            {
+                context.SchemaGenerator.GenerateSchema(messageType, context.SchemaRepository);
+            }
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/OpenApiDocumentHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/OpenApiDocumentHelper.cs
@@ -7,5 +7,12 @@ public static class OpenApiDocumentHelper
 
     public static string GetDocumentName(int version, string? minorVersion) => GetVersionName(version, minorVersion);
 
+    public static (int Version, string? MinorVersion) GetVersionsFromVersionName(string name)
+    {
+        var parts = name.Split('_');
+        var majorVersion = int.Parse(parts[0][1..]);
+        return parts.Length == 2 ? (majorVersion, parts[1]) : (majorVersion, null);
+    }
+
     public static string GetVersionName(int version, string? minorVersion) => $"v{version}" + (minorVersion is not null ? $"_{minorVersion}" : "");
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/ServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ public static class ServiceCollectionExtensions
             options.OperationFilter<ContentTypesOperationFilter>();
             options.OperationFilter<AddSecuritySchemeOperationFilter>();
             options.DocumentFilter<MinorVersionHeaderDocumentFilter>();
+            options.DocumentFilter<AddWebHookMessagesDocumentFilter>();
 
             foreach (var (version, minorVersion) in VersionRegistry.GetAllVersions(configuration))
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/Alert.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+public record Alert
+{
+    public required Guid AlertId { get; init; }
+    public required AlertTypeInfo AlertType { get; init; }
+    public required DateOnly? StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertCategoryInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertCategoryInfo.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+public record AlertCategoryInfo
+{
+    public required Guid AlertCategoryId { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertTypeInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertTypeInfo.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+public record AlertTypeInfo
+{
+    public required Guid AlertTypeId { get; init; }
+    public required AlertCategoryInfo AlertCategory { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertCreatedNotification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertCreatedNotification.cs
@@ -1,0 +1,9 @@
+using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+namespace TeachingRecordSystem.Api.V3.VNext.WebHookMessages;
+
+public record AlertCreatedNotification
+{
+    public required string Trn { get; init; }
+    public required Alert Alert { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertDeletedNotification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertDeletedNotification.cs
@@ -1,0 +1,9 @@
+using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+namespace TeachingRecordSystem.Api.V3.VNext.WebHookMessages;
+
+public record AlertDeletedNotification
+{
+    public required string Trn { get; init; }
+    public required Alert Alert { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertUpdatedNotification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertUpdatedNotification.cs
@@ -1,0 +1,9 @@
+using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+namespace TeachingRecordSystem.Api.V3.VNext.WebHookMessages;
+
+public record AlertUpdatedNotification
+{
+    public required string Trn { get; init; }
+    public required Alert Alert { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/PingNotification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/PingNotification.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Api.V3.VNext.WebHookMessages;
+
+public record PingNotification
+{
+    public required Guid PingId { get; init; }
+}

--- a/docs/api-designs/webhooks.md
+++ b/docs/api-designs/webhooks.md
@@ -24,89 +24,6 @@ Webhooks are sent as JSON and follow the guidelines in [Standard Webhooks](https
 `data` is a type-specific object with the details of the event. Each `type` has its own message schema.
 
 
-## Message types
-
-### `ping`
-
-`ping` is used for verifying that a webhook endpoint is reachable and can successfully process messages.
-These messages are sent manually by a TRS developer.
-
-```json
-{
-  "pingId": "<a unique identifier for the ping>"
-}
-```
-
-### `alert.created`
-
-`alert.created` is generated whenever a new alert is added to a `person`:
-
-```json
-{
-  "trn": "",
-  "alert": {
-    "alertId": "",
-    "alertType": {
-      "alertTypeId": "",
-      "description": "",
-      "alertCategory": {
-        "alertCategoryId": "",
-        "description": ""
-      }
-    },
-    "startDate": "",
-    "endDate": ""
-  }
-}
-```
-
-### `alert.updated`
-
-`alert.updated` is generated whenever an existing alert updated for a `person`:
-
-```json
-{
-  "trn": "",
-  "alert": {
-    "alertId": "",
-    "alertType": {
-      "alertTypeId": "",
-      "description": "",
-      "alertCategory": {
-        "alertCategoryId": "",
-        "description": ""
-      }
-    },
-    "startDate": "",
-    "endDate": ""
-  }
-}
-```
-
-### `alert.deleted`
-
-`alert.deleted` is generated whenever an alert is deleted for a `person`:
-
-```json
-{
-  "trn": "",
-  "alert": {
-    "alertId": "",
-    "alertType": {
-      "alertTypeId": "",
-      "description": "",
-      "alertCategory": {
-        "alertCategoryId": "",
-        "description": ""
-      }
-    },
-    "startDate": "",
-    "endDate": ""
-  }
-}
-```
-
-
 ## Receiving webhooks
 
 You need a publicly-accessible HTTPS endpoint that accepts JSON using the POST method. Ask one of the TRS developers to configure your endpoint.
@@ -114,7 +31,7 @@ You will also need to specify the V3 API minor version you want to receive messa
 You will be given a public key with which you can [verify the webhook](#verifying-the-webhook).
 
 Your endpoint should return a success status code (200-299) when the webhook has been processed successfully.
-If an error code is returned, or the endpoint takes longer than 30 seconds to respond, the message will be retried later. The retry intervals are:
+If any other status code is returned, or the endpoint takes longer than 30 seconds to respond, the message will be retried later. The retry intervals are:
 - 5 seconds,
 - 5 minutes,
 - 30 minutes,
@@ -133,4 +50,17 @@ If after the final retry the message was still not delivered successfully no fur
 Follow [the spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md#verifying-signatures) for verifying the webhook's signature.
 We use asymmetric signatures; you will be given the public key to use for verifying webhooks when your endpoint is configured.
 
-The [ping](#ping) message can be used to aid verification.
+The `ping` message can be used to aid verification.
+
+
+## Message types
+
+Reference the API Swagger document for the message schemas for the API version your webhook is registered to use
+e.g. https://preprod.teacher-qualifications-api.education.gov.uk/swagger/v3_20240307.json
+
+| Message `type` | Swagger schema name | Description |
+| - | - | - |
+| `ping` | `PingNotification` | Used for verifying that a webhook endpoint is reachable and can successfully process messages. These messages are sent manually by a TRS developer. |
+| `alert.created` | `AlertCreatedNotification` | Generated whenever a new alert is added to a `person`. |
+| `alert.updated` | `AlertUpdatedNotification` | Generated whenever an existing alert updated for a `person`. |
+| `alert.deleted` | `AlertDeletedNotification` | Generated whenever an alert is deleted for a `person`. |

--- a/docs/api-designs/webhooks.md
+++ b/docs/api-designs/webhooks.md
@@ -2,43 +2,44 @@
 
 TRS uses [webhooks](https://en.wikipedia.org/wiki/Webhook) to push notifications to other services when interesting things happen.
 
-Notifications are sent as JSON and have a common outer schema called the envelope.
+Webhooks are sent as JSON and follow the guidelines in [Standard Webhooks](https://www.standardwebhooks.com/).
 
 ```json
 {
-  "notificationId": "",
-  "timeUtc": "",
-  "messageType": "",
-  "message": {
+  "type": "",
+  "timestamp": "",
+  "apiVersion": "",
+  "data": {
     //...
   }
 }
 ```
 
-`notificationId` is a unique identifier GUID for this notification. If a notification message is sent multiple times (e.g. when retrying after receiving an error code) this ID will remain consistent.
+`type` is a string identifying the type of event that generated the webhook. See [message types](#message-types).
 
-`timeUtc` is a UTC ISO 8601 timestamp describing when the notification was generated.
+`timestamp` is a UTC ISO 8601 timestamp describing when the webhook was generated.
 
-`messageType` is a string identifying the type of event that generated the notification. See [message types](#message-types).
+`apiVersion` is the schema version used to format the `data` and aligns with the `X-Api-Version` header values used when calling the API.
 
-`message` is a type-specific object with the details of the notification. Each `messageType` has its own message schema.
+`data` is a type-specific object with the details of the event. Each `type` has its own message schema.
 
 
 ## Message types
 
-### `Ping`
+### `ping`
 
-`Ping` is generated manually for verifying that a webhook endpoint is reachable and can successfully process messages:
+`ping` is used for verifying that a webhook endpoint is reachable and can successfully process messages.
+These messages are sent manually by a TRS developer.
 
 ```json
 {
-  "pingId": ""
+  "pingId": "<a unique identifier for the ping>"
 }
 ```
 
-### `AlertCreated`
+### `alert.created`
 
-`AlertCreated` is generated whenever a new alert is added to a `person`:
+`alert.created` is generated whenever a new alert is added to a `person`:
 
 ```json
 {
@@ -48,10 +49,10 @@ Notifications are sent as JSON and have a common outer schema called the envelop
     "alertType": {
       "alertTypeId": "",
       "description": "",
-    },
-    "alertCategory": {
-      "alertCategoryId": "",
-      "description": ""
+      "alertCategory": {
+        "alertCategoryId": "",
+        "description": ""
+      }
     },
     "startDate": "",
     "endDate": ""
@@ -59,9 +60,9 @@ Notifications are sent as JSON and have a common outer schema called the envelop
 }
 ```
 
-### `AlertUpdated`
+### `alert.updated`
 
-`AlertUpdated` is generated whenever an existing alert updated for a `person`:
+`alert.updated` is generated whenever an existing alert updated for a `person`:
 
 ```json
 {
@@ -71,10 +72,10 @@ Notifications are sent as JSON and have a common outer schema called the envelop
     "alertType": {
       "alertTypeId": "",
       "description": "",
-    },
-    "alertCategory": {
-      "alertCategoryId": "",
-      "description": ""
+      "alertCategory": {
+        "alertCategoryId": "",
+        "description": ""
+      }
     },
     "startDate": "",
     "endDate": ""
@@ -82,9 +83,9 @@ Notifications are sent as JSON and have a common outer schema called the envelop
 }
 ```
 
-### `AlertDeleted`
+### `alert.deleted`
 
-`AlertDeleted` is generated whenever an alert is deleted for a `person`:
+`alert.deleted` is generated whenever an alert is deleted for a `person`:
 
 ```json
 {
@@ -94,10 +95,10 @@ Notifications are sent as JSON and have a common outer schema called the envelop
     "alertType": {
       "alertTypeId": "",
       "description": "",
-    },
-    "alertCategory": {
-      "alertCategoryId": "",
-      "description": ""
+      "alertCategory": {
+        "alertCategoryId": "",
+        "description": ""
+      }
     },
     "startDate": "",
     "endDate": ""
@@ -109,24 +110,27 @@ Notifications are sent as JSON and have a common outer schema called the envelop
 ## Receiving webhooks
 
 You need a publicly-accessible HTTPS endpoint that accepts JSON using the POST method. Ask one of the TRS developers to configure your endpoint.
-When the endpoint is configured you will receive a secret; this can be used to [verify the webhook's payload](#verifying-the-webhook).
+You will also need to specify the V3 API minor version you want to receive messages with; see [the README.md](../../README.md) for more information on versions.
+You will be given a public key with which you can [verify the webhook](#verifying-the-webhook).
 
 Your endpoint should return a success status code (200-299) when the webhook has been processed successfully.
 If an error code is returned, or the endpoint takes longer than 30 seconds to respond, the message will be retried later. The retry intervals are:
-- 30 seconds,
-- 2 minutes,
-- 10 minutes,
-- 1 hour,
+- 5 seconds,
+- 5 minutes,
+- 30 minutes,
 - 2 hours,
- 8 hours.
+- 5 hours,
+- 10 hours,
+- 14 hours,
+- 20 hours,
+- 24 hours.
 
 If after the final retry the message was still not delivered successfully no further attempts will be made to deliver that message.
 
 
 ## Verifying the webhook
 
-When your endpoint receives a message it should verify that it has been sent by TRS.
-Each HTTP request includes a header - `X-Hub-Signature-256`. This is an HMAC hex digest of the request body generated using the SHA-256 algorithm using the secret above as the key.
-To verify, recalculate this signature and compare it to the header; if the values do not match the message should be disgarded.
+Follow [the spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md#verifying-signatures) for verifying the webhook's signature.
+We use asymmetric signatures; you will be given the public key to use for verifying webhooks when your endpoint is configured.
 
-The [Ping](#ping) message can be used to aid verification.
+The [ping](#ping) message can be used to aid verification.


### PR DESCRIPTION
This updates the draft webhook spec to use [The Webhook Standard](https://www.standardwebhooks.com/), include versioning and adds the message schemas to the Swagger docs.