### PR TITLE
Amend awardedDate property on QTLS API spec to qtsDate

### DIFF
--- a/docs/api-designs/qtls.md
+++ b/docs/api-designs/qtls.md
@@ -1,6 +1,6 @@
 # Add/remove QTLS API
 
-Draft specification v0.1.
+Draft specification v0.2.
 
 There are two endpoints; one sets or removes the QTLS date for a person and another queries the existing QTLS status.
 In all cases the person is identified by a TRN.
@@ -13,11 +13,11 @@ Response body structure:
 ```json
 {
   "trn": "",
-  "awardedDate": ""
+  "qtsDate": ""
 }
 ```
 
-The `awardedDate` property will be formatted `yyyy-MM-dd`. If the person does not have QTLS awarded then `awardedDate` will be `null`.
+The `qtsDate` property will be formatted `yyyy-MM-dd`. If the person does not have QTLS awarded then `qtsDate` will be `null`.
 
 
 ## `PUT` `/persons/<trn>/qtls`
@@ -25,23 +25,23 @@ The `awardedDate` property will be formatted `yyyy-MM-dd`. If the person does no
 Request body structure:
 ```json
 {
-  "awardedDate": ""
+  "qtsDate": ""
 }
 ```
 
 If no record exists with the specified TRN, a `404 Not Found` status code will be returned.
 
-The `awardedDate` property must be formatted `yyyy-MM-dd` or be `null`. The date cannot be in the future [TBD].
+The `qtsDate` property must be formatted `yyyy-MM-dd` or be `null`. The date cannot be in the future [TBD].
 
-If the `awardedDate` is not `null` then the QTLS status will be added or updated with the provided date.
+If the `qtsDate` is not `null` then the QTLS status will be added or updated with the provided date.
 
-If the `awardedDate` is `null` then any existing QTLS status on the teaching record will be removed.
+If the `qtsDate` is `null` then any existing QTLS status on the teaching record will be removed.
 
 Response body structure:
 ```json
 {
   "trn": "",
-  "awardedDate": ""
+  "qtsDate": ""
 }
 ```
 


### PR DESCRIPTION
The date we will passed over this API will not be QTLS date; it will be the latter of QTLS awarded date and the current SET 
membership start date. As such, I've changed the name to `qtsDate` since it's the 'date of QTS equivalence for QTLS'.