### PR TITLE
Move libman restore into explicit step

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,8 +43,7 @@ jobs:
       run: just install-tools
 
     - name: Restore
-      run: dotnet restore
-      working-directory: TeachingRecordSystem
+      run: just restore
 
     - name: Lint
       run: |

--- a/TeachingRecordSystem/.config/dotnet-tools.json
+++ b/TeachingRecordSystem/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "dotnet-ef"
       ]
+    },
+    "microsoft.web.librarymanager.cli": {
+      "version": "2.1.175",
+      "commands": [
+        "libman"
+      ]
     }
   }
 }

--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -59,7 +59,6 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.41.2" />
     <PackageVersion Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.16" />
     <PackageVersion Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="1.1.16" />
-    <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="OpenIddict.AspNetCore" Version="5.2.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="GovUk.OneLogin.AspNetCore" />
     <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
     <PackageReference Include="OpenIddict.AspNetCore" />
     <PackageReference Include="Sentry.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Identity.Web" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.Identity.Web.GraphServiceClientBeta" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
     <PackageReference Include="Sentry.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>

--- a/justfile
+++ b/justfile
@@ -12,6 +12,12 @@ install-tools:
   @cd {{solution-root}} && dotnet tool restore
   npm install -g sass
 
+# Restore dependencies
+restore:
+  @cd {{solution-root}} && dotnet restore
+  @cd {{solution-root / "src" / "TeachingRecordSystem.SupportUi" }} && dotnet libman restore
+  @cd {{solution-root / "src" / "TeachingRecordSystem.AuthorizeAccess" }} && dotnet libman restore
+
 # Run the trscli
 cli *ARGS:
   @cd {{solution-root / "src" / "TeachingRecordSystem.Cli"}} && dotnet {{"bin" / "Debug" / "net8.0" / "trscli.dll"}} {{ARGS}}
@@ -77,9 +83,8 @@ watch-worker:
   @cd {{solution-root / "src" / "TeachingRecordSystem.Worker"}} && dotnet watch
 
 # Build the Docker image
-docker-build *ARGS:
-  npm install -g sass
-  @cd {{solution-root}} && dotnet publish -c Release
+docker-build *ARGS: install-tools restore
+  @cd {{solution-root}} && dotnet publish -c Release --no-restore
   @cd {{solution-root}} && docker build . {{ARGS}}
 
 # Set a configuration entry in user secrets for running the apps


### PR DESCRIPTION
We've started to get sporadic LIB003 errors restoring client-side packages with libman's msbuild target. This change moves to an explicit `libman restore` in the build step, which seems to solve the problem.