### PR TITLE
Added support for multiple establishment sources

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EstablishmentMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EstablishmentMapping.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using Establishment = TeachingRecordSystem.Core.DataStore.Postgres.Models.Establishment;
 
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
@@ -9,6 +10,7 @@ public class EstablishmentMapping : IEntityTypeConfiguration<Establishment>
     {
         builder.ToTable("establishments");
         builder.HasKey(e => e.EstablishmentId);
+        builder.Property(e => e.EstablishmentSourceId).IsRequired().HasDefaultValue(1);
         builder.HasIndex(e => e.Urn).HasDatabaseName(Establishment.UrnUniqueIndexName).IsUnique();
         builder.HasIndex(e => new { e.LaCode, e.EstablishmentNumber }).HasDatabaseName(Establishment.LaCodeEstablishmentNumberIndexName);
         builder.Property(e => e.Urn).HasMaxLength(6).IsFixedLength();
@@ -26,5 +28,7 @@ public class EstablishmentMapping : IEntityTypeConfiguration<Establishment>
         builder.Property(e => e.Town).HasMaxLength(100).UseCollation("case_insensitive");
         builder.Property(e => e.County).HasMaxLength(100).UseCollation("case_insensitive");
         builder.Property(e => e.Postcode).HasMaxLength(10).UseCollation("case_insensitive");
+        builder.HasIndex(e => e.EstablishmentSourceId).HasDatabaseName(Establishment.EstablishmentSourceIdIndexName);
+        builder.HasOne<EstablishmentSource>().WithMany().HasForeignKey(e => e.EstablishmentSourceId).HasConstraintName("fk_establishments_establishment_source_id");
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EstablishmentSourceMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EstablishmentSourceMapping.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class EstablishmentSourceMapping : IEntityTypeConfiguration<EstablishmentSource>
+{
+    public void Configure(EntityTypeBuilder<EstablishmentSource> builder)
+    {
+        builder.ToTable("establishment_sources");
+        builder.HasKey(e => e.EstablishmentSourceId);
+        builder.Property(e => e.Name).HasMaxLength(50).UseCollation("case_insensitive").IsRequired();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonEmploymentMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonEmploymentMapping.cs
@@ -10,11 +10,12 @@ public class PersonEmploymentMapping : IEntityTypeConfiguration<PersonEmployment
     {
         builder.ToTable("person_employments");
         builder.HasKey(e => e.PersonEmploymentId);
-        builder.Property(e => e.EstablishmentId).IsRequired();
         builder.Property(e => e.StartDate).IsRequired();
         builder.Property(e => e.EmploymentType).IsRequired();
         builder.Property(e => e.CreatedOn).IsRequired();
         builder.Property(e => e.UpdatedOn).IsRequired();
+        builder.HasIndex(e => e.PersonId).HasDatabaseName(PersonEmployment.PersonIdIndexName);
+        builder.HasIndex(e => e.EstablishmentId).HasDatabaseName(PersonEmployment.EstablishmentIdIndexName);
         builder.HasOne<Person>().WithMany().HasForeignKey(e => e.PersonId).HasConstraintName("fk_person_employments_person_id");
         builder.HasOne<Establishment>().WithMany().HasForeignKey(e => e.EstablishmentId).HasConstraintName("fk_person_employments_establishment_id");
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240405101844_EstablishmentSources.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240405101844_EstablishmentSources.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -12,9 +13,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240405101844_EstablishmentSources")]
+    partial class EstablishmentSources
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240405101844_EstablishmentSources.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240405101844_EstablishmentSources.cs
@@ -1,0 +1,316 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EstablishmentSources : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "establishment_id",
+                table: "person_employments",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "urn",
+                table: "establishments",
+                type: "integer",
+                fixedLength: true,
+                maxLength: 6,
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldFixedLength: true,
+                oldMaxLength: 6);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "la_name",
+                table: "establishments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_type_name",
+                table: "establishments",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_type_group_name",
+                table: "establishments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "establishment_type_group_code",
+                table: "establishments",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_type_code",
+                table: "establishments",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(3)",
+                oldMaxLength: 3);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_status_name",
+                table: "establishments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "establishment_status_code",
+                table: "establishments",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "establishment_source_id",
+                table: "establishments",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.CreateTable(
+                name: "establishment_sources",
+                columns: table => new
+                {
+                    establishment_source_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false, collation: "case_insensitive")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_establishment_sources", x => x.establishment_source_id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_employments_establishment_id",
+                table: "person_employments",
+                column: "establishment_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_employments_person_id",
+                table: "person_employments",
+                column: "person_id");
+
+            migrationBuilder.InsertData(
+                table: "establishment_sources",
+                columns: new[] { "establishment_source_id", "name" },
+                values: new object[,]
+                {
+                    { 1, "GIAS" },
+                    { 2, "TPS" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_establishment_establishment_source_id",
+                table: "establishments",
+                column: "establishment_source_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_establishments_establishment_source_id",
+                table: "establishments",
+                column: "establishment_source_id",
+                principalTable: "establishment_sources",
+                principalColumn: "establishment_source_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments",
+                column: "establishment_id",
+                principalTable: "establishments",
+                principalColumn: "establishment_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_establishments_establishment_source_id",
+                table: "establishments");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments");
+
+            migrationBuilder.DropTable(
+                name: "establishment_sources");
+
+            migrationBuilder.DropIndex(
+                name: "ix_person_employments_establishment_id",
+                table: "person_employments");
+
+            migrationBuilder.DropIndex(
+                name: "ix_person_employments_person_id",
+                table: "person_employments");
+
+            migrationBuilder.DropIndex(
+                name: "ix_establishment_establishment_source_id",
+                table: "establishments");
+
+            migrationBuilder.DropColumn(
+                name: "establishment_source_id",
+                table: "establishments");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "establishment_id",
+                table: "person_employments",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "urn",
+                table: "establishments",
+                type: "integer",
+                fixedLength: true,
+                maxLength: 6,
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldFixedLength: true,
+                oldMaxLength: 6,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "la_name",
+                table: "establishments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_type_name",
+                table: "establishments",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_type_group_name",
+                table: "establishments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "establishment_type_group_code",
+                table: "establishments",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_type_code",
+                table: "establishments",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(3)",
+                oldMaxLength: 3,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "establishment_status_name",
+                table: "establishments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "establishment_status_code",
+                table: "establishments",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments",
+                column: "establishment_id",
+                principalTable: "establishments",
+                principalColumn: "establishment_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Establishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Establishment.cs
@@ -4,19 +4,21 @@ public class Establishment
 {
     public const string UrnUniqueIndexName = "ix_establishment_urn";
     public const string LaCodeEstablishmentNumberIndexName = "ix_establishment_la_code_establishment_number";
+    public const string EstablishmentSourceIdIndexName = "ix_establishment_establishment_source_id";
 
     public required Guid EstablishmentId { get; init; }
-    public required int Urn { get; init; }
+    public required int EstablishmentSourceId { get; set; }
+    public required int? Urn { get; init; }
     public required string LaCode { get; set; }
-    public required string LaName { get; set; }
+    public required string? LaName { get; set; }
     public required string? EstablishmentNumber { get; set; }
     public required string EstablishmentName { get; set; }
-    public required string EstablishmentTypeCode { get; set; }
-    public required string EstablishmentTypeName { get; set; }
-    public required int EstablishmentTypeGroupCode { get; set; }
-    public required string EstablishmentTypeGroupName { get; set; }
-    public required int EstablishmentStatusCode { get; set; }
-    public required string EstablishmentStatusName { get; set; }
+    public required string? EstablishmentTypeCode { get; set; }
+    public required string? EstablishmentTypeName { get; set; }
+    public required int? EstablishmentTypeGroupCode { get; set; }
+    public required string? EstablishmentTypeGroupName { get; set; }
+    public required int? EstablishmentStatusCode { get; set; }
+    public required string? EstablishmentStatusName { get; set; }
     public required string? Street { get; set; }
     public required string? Locality { get; set; }
     public required string? Address3 { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EstablishmentSource.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EstablishmentSource.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class EstablishmentSource
+{
+    public required int EstablishmentSourceId { get; set; }
+    public required string Name { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonEmployment.cs
@@ -7,7 +7,7 @@ public class PersonEmployment
 
     public required Guid PersonEmploymentId { get; set; }
     public required Guid PersonId { get; set; }
-    public required Guid EstablishmentId { get; set; }
+    public required Guid? EstablishmentId { get; set; }
     public required DateOnly StartDate { get; set; }
     public required DateOnly? EndDate { get; set; }
     public required EmploymentType EmploymentType { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/PersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/PersonEmployment.cs
@@ -4,7 +4,7 @@ public record PersonEmployment
 {
     public required Guid PersonEmploymentId { get; init; }
     public required Guid PersonId { get; init; }
-    public required Guid EstablishmentId { get; init; }
+    public required Guid? EstablishmentId { get; init; }
     public required DateOnly StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required EmploymentType EmploymentType { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
@@ -1,6 +1,5 @@
 using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Services.Establishments;
-using TeachingRecordSystem.Core.Services.WorkforceData;
 
 namespace TeachingRecordSystem.Core.Jobs;
 
@@ -9,6 +8,8 @@ public class RefreshEstablishmentsJob(IBackgroundJobScheduler backgroundJobSched
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var refreshJobId = await backgroundJobScheduler.Enqueue<EstablishmentRefresher>(j => j.RefreshEstablishments(cancellationToken));
-        await backgroundJobScheduler.ContinueJobWith<TpsCsvExtractProcessor>(refreshJobId, j => j.UpdateLatestEstablishmentVersions(cancellationToken));
+
+        // The following is temporarily commented out as the current query was take over an hour to return and needs further investigation
+        // await backgroundJobScheduler.ContinueJobWith<TpsCsvExtractProcessor>(refreshJobId, j => j.UpdateLatestEstablishmentVersions(cancellationToken));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/CsvDownloadEstablishmentMasterDataService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/CsvDownloadEstablishmentMasterDataService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using CsvHelper;
 using CsvHelper.Configuration;
 
@@ -24,7 +25,8 @@ public class CsvDownloadEstablishmentMasterDataService : IEstablishmentMasterDat
         response.EnsureSuccessStatusCode();
 
         using var stream = await response.Content.ReadAsStreamAsync();
-        using var reader = new StreamReader(stream);
+        // The CSV file is encoded in Windows 1252 encoding which is almost identical to Latin1 and allows Welsh and other special characters to be read correctly
+        using var reader = new StreamReader(stream, Encoding.Latin1);
         using var csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture) { HasHeaderRecord = true });
 
         await foreach (var item in csv.GetRecordsAsync<EstablishmentCsvRow>())

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/EstablishmentRefresher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/EstablishmentRefresher.cs
@@ -17,6 +17,7 @@ public class EstablishmentRefresher(
                 dbContext.Establishments.Add(new()
                 {
                     EstablishmentId = Guid.NewGuid(),
+                    EstablishmentSourceId = 1,
                     Urn = establishment.Urn,
                     LaCode = establishment.LaCode,
                     LaName = establishment.LaName,
@@ -38,6 +39,7 @@ public class EstablishmentRefresher(
             }
             else
             {
+                existingEstablishment.EstablishmentSourceId = 1;
                 existingEstablishment.LaCode = establishment.LaCode;
                 existingEstablishment.LaName = establishment.LaName;
                 existingEstablishment.EstablishmentName = establishment.EstablishmentName;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
@@ -411,7 +411,7 @@ public class TpsCsvExtractProcessor(
     public async Task UpdateLatestEstablishmentVersions(CancellationToken cancellationToken)
     {
         using var readDbContext = dbContextFactory.CreateDbContext();
-        readDbContext.Database.SetCommandTimeout(600);
+        readDbContext.Database.SetCommandTimeout(5400);
         using var writeDbContext = dbContextFactory.CreateDbContext();
         var connection = (NpgsqlConnection)writeDbContext.Database.GetDbConnection();
         await connection.OpenAsync(CancellationToken.None);
@@ -434,7 +434,7 @@ public class TpsCsvExtractProcessor(
                         establishment_name,
                         establishment_type_code,
                         postcode,
-                        ROW_NUMBER() OVER (PARTITION BY la_code, establishment_number, CASE WHEN establishment_number IS NULL THEN postcode ELSE NULL END ORDER BY translate(establishment_status_code::text, '1234', '1324'), urn desc) as row_number
+                        ROW_NUMBER() OVER (PARTITION BY la_code, establishment_number, CASE WHEN establishment_number IS NULL THEN postcode ELSE NULL END ORDER BY translate(COALESCE(establishment_status_code, 1)::text, '1234', '1324'), urn desc) as row_number
                     FROM
                         establishments) e
                     WHERE

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/EstablishmentRefresherTests.cs
@@ -149,6 +149,7 @@ public class EstablishmentRefresherTests
             var dbEstablishment = new Core.DataStore.Postgres.Models.Establishment()
             {
                 EstablishmentId = Guid.NewGuid(),
+                EstablishmentSourceId = 1,
                 Urn = urn,
                 LaCode = "123",
                 LaName = "Test LA",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateEstablishment.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateEstablishment.cs
@@ -49,6 +49,7 @@ public partial class TestData
             var establishment = new Core.DataStore.Postgres.Models.Establishment
             {
                 EstablishmentId = Guid.NewGuid(),
+                EstablishmentSourceId = 1,
                 Urn = urn.Value,
                 LaCode = localAuthorityCode,
                 LaName = localAuthorityName,


### PR DESCRIPTION
### Context

The TPS extract for workforce data contains Local Authority Code and Establishment Number combinations which do not map to GIAS establishments but DO map to other employers held internally in TPS tables.

### Changes proposed in this pull request

Amend the existing TRS database schema to have an establishment source associated with an establishment.
