### PR TITLE
Fix returning inactive contacts from v3 Get Teacher API

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/CreateDateOfBirthChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/CreateDateOfBirthChangeRequest.cs
@@ -20,7 +20,7 @@ public class CreateDateOfBirthChangeRequestHandler(ICrmQueryDispatcher crmQueryD
     public async Task Handle(CreateDateOfBirthChangeRequestCommand command)
     {
         var contact = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactByTrnQuery(command.Trn, new Microsoft.Xrm.Sdk.Query.ColumnSet()));
+            new GetActiveContactByTrnQuery(command.Trn, new Microsoft.Xrm.Sdk.Query.ColumnSet()));
 
         if (contact is null)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/CreateNameChange.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/CreateNameChange.cs
@@ -22,7 +22,7 @@ public class CreateNameChangeRequestHandler(ICrmQueryDispatcher crmQueryDispatch
     public async Task Handle(CreateNameChangeRequestCommand command)
     {
         var contact = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactByTrnQuery(command.Trn, new Microsoft.Xrm.Sdk.Query.ColumnSet()));
+            new GetActiveContactByTrnQuery(command.Trn, new Microsoft.Xrm.Sdk.Query.ColumnSet()));
 
         if (contact is null)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/CreateTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/CreateTrnRequest.cs
@@ -72,7 +72,7 @@ public class CreateTrnRequestHandler(
 
         // re-fetch teacher that was just created.
         var teacher = (await _crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 contactId,
                 new ColumnSet(
                     Contact.Fields.dfeta_TRN,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindTeachers.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindTeachers.cs
@@ -29,7 +29,7 @@ public class FindTeachersHandler(ICrmQueryDispatcher crmQueryDispatcher, IConfig
     public async Task<FindTeachersResult> Handle(FindTeachersCommand command)
     {
         var contacts = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactsByLastNameAndDateOfBirthQuery(
+            new GetActiveContactsByLastNameAndDateOfBirthQuery(
                 command.LastName!,
                 command.DateOfBirth!.Value,
                 new ColumnSet(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Handlers/GetTeacherHandler.cs
@@ -27,7 +27,7 @@ public class GetTeacherHandler(
     public async Task<GetTeacherResponse?> Handle(GetTeacherRequest request, CancellationToken cancellationToken)
     {
         var contactDetail = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByTrnQuery(
+            new GetActiveContactDetailByTrnQuery(
                 request.Trn,
                 new ColumnSet(
                     Contact.Fields.FirstName,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
@@ -43,7 +43,7 @@ public partial class Commands
                 var syncHelper = services.GetRequiredService<TrsDataSyncHelper>();
 
                 var entityInfo = TrsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person);
-                var contact = await crmQueryDispatcher.ExecuteQuery(new GetContactByTrnQuery(trn, new Microsoft.Xrm.Sdk.Query.ColumnSet(entityInfo.AttributeNames)));
+                var contact = await crmQueryDispatcher.ExecuteQuery(new GetActiveContactByTrnQuery(trn, new Microsoft.Xrm.Sdk.Query.ColumnSet(entityInfo.AttributeNames)));
 
                 if (contact is null)
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactByTrnQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactByTrnQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveContactByTrnQuery(string Trn, ColumnSet ColumnSet) : ICrmQuery<Contact?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByIdQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByIdQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveContactDetailByIdQuery(Guid ContactId, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByTrnQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByTrnQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveContactDetailByTrnQuery(string Trn, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByDateOfBirthQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByDateOfBirthQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveContactsByDateOfBirthQuery(DateOnly DateOfBirth, ContactSearchSortByOption SortBy, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByLastNameAndDateOfBirthQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByLastNameAndDateOfBirthQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveContactsByLastNameAndDateOfBirthQuery(string LastName, DateOnly DateOfBirth, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByNameQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByNameQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveContactsByNameQuery(string Name, ContactSearchSortByOption SortBy, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllActiveHeQualificationsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllActiveHeQualificationsQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetAllActiveHeQualificationsQuery : ICrmQuery<dfeta_hequalification[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllActiveHeSubjectsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllActiveHeSubjectsQuery.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetAllActiveHeSubjectsQuery : ICrmQuery<dfeta_hesubject[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllEarlyYearsStatusesQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllEarlyYearsStatusesQuery.cs
@@ -1,3 +1,3 @@
 namespace TeachingRecordSystem.Core.Dqt.Queries;
 
-public record GetAllEarlyYearsStatusesQuery : ICrmQuery<dfeta_earlyyearsstatus[]>;
+public record GetAllActiveEarlyYearsStatusesQuery : ICrmQuery<dfeta_earlyyearsstatus[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllHeQualificationsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllHeQualificationsQuery.cs
@@ -1,3 +1,0 @@
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetAllHeQualificationsQuery : ICrmQuery<dfeta_hequalification[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllHeSubjectsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllHeSubjectsQuery.cs
@@ -1,3 +1,0 @@
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetAllHeSubjectsQuery : ICrmQuery<dfeta_hesubject[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllSanctionCodesQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetAllSanctionCodesQuery.cs
@@ -1,3 +1,3 @@
 namespace TeachingRecordSystem.Core.Dqt.Queries;
 
-public record GetAllSanctionCodesQuery : ICrmQuery<dfeta_sanctioncode[]>;
+public record GetAllActiveSanctionCodesQuery : ICrmQuery<dfeta_sanctioncode[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactByTrnQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactByTrnQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetContactByTrnQuery(string Trn, ColumnSet ColumnSet) : ICrmQuery<Contact?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByIdQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByIdQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetContactDetailByIdQuery(Guid ContactId, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByTrnQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByTrnQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetContactDetailByTrnQuery(string Trn, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByDateOfBirthQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByDateOfBirthQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetContactsByDateOfBirthQuery(DateOnly DateOfBirth, ContactSearchSortByOption SortBy, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByLastNameAndDateOfBirthQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByLastNameAndDateOfBirthQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetContactsByLastNameAndDateOfBirthQuery(string LastName, DateOnly DateOfBirth, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByNameQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactsByNameQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetContactsByNameQuery(string Name, ContactSearchSortByOption SortBy, int MaxRecordCount, ColumnSet ColumnSet) : ICrmQuery<Contact[]>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactByTrnHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactByTrnHandler.cs
@@ -4,9 +4,9 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetContactByTrnHandler : ICrmQueryHandler<GetContactByTrnQuery, Contact?>
+public class GetActiveContactByTrnHandler : ICrmQueryHandler<GetActiveContactByTrnQuery, Contact?>
 {
-    public async Task<Contact?> Execute(GetContactByTrnQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<Contact?> Execute(GetActiveContactByTrnQuery query, IOrganizationServiceAsync organizationService)
     {
         var queryByAttribute = new QueryByAttribute()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactDetailByIdHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactDetailByIdHandler.cs
@@ -5,12 +5,13 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetContactDetailByIdHandler : ICrmQueryHandler<GetContactDetailByIdQuery, ContactDetail?>
+public class GetActiveContactDetailByIdHandler : ICrmQueryHandler<GetActiveContactDetailByIdQuery, ContactDetail?>
 {
-    public async Task<ContactDetail?> Execute(GetContactDetailByIdQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<ContactDetail?> Execute(GetActiveContactDetailByIdQuery query, IOrganizationServiceAsync organizationService)
     {
         var contactFilter = new FilterExpression();
         contactFilter.AddCondition(Contact.PrimaryIdAttribute, ConditionOperator.Equal, query.ContactId);
+        contactFilter.AddCondition(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active);
         var contactQueryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = query.ColumnSet,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactDetailByTrnHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactDetailByTrnHandler.cs
@@ -5,12 +5,13 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetContactDetailByTrnHandler : ICrmQueryHandler<GetContactDetailByTrnQuery, ContactDetail?>
+public class GetActiveContactDetailByTrnHandler : ICrmQueryHandler<GetActiveContactDetailByTrnQuery, ContactDetail?>
 {
-    public async Task<ContactDetail?> Execute(GetContactDetailByTrnQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<ContactDetail?> Execute(GetActiveContactDetailByTrnQuery query, IOrganizationServiceAsync organizationService)
     {
         var contactFilter = new FilterExpression();
         contactFilter.AddCondition(Contact.Fields.dfeta_TRN, ConditionOperator.Equal, query.Trn);
+        contactFilter.AddCondition(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active);
         var contactQueryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = query.ColumnSet,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByDateOfBirthHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByDateOfBirthHandler.cs
@@ -4,9 +4,9 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetContactsByDateOfBirthHandler : ICrmQueryHandler<GetContactsByDateOfBirthQuery, Contact[]>
+public class GetActiveContactsByDateOfBirthHandler : ICrmQueryHandler<GetActiveContactsByDateOfBirthQuery, Contact[]>
 {
-    public async Task<Contact[]> Execute(GetContactsByDateOfBirthQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<Contact[]> Execute(GetActiveContactsByDateOfBirthQuery query, IOrganizationServiceAsync organizationService)
     {
         var queryByAttribute = new QueryByAttribute()
         {
@@ -14,8 +14,10 @@ public class GetContactsByDateOfBirthHandler : ICrmQueryHandler<GetContactsByDat
             ColumnSet = query.ColumnSet,
             TopCount = query.MaxRecordCount
         };
+
         queryByAttribute.AddAttributeValue(Contact.Fields.StateCode, (int)ContactState.Active);
         queryByAttribute.AddAttributeValue(Contact.Fields.BirthDate, query.DateOfBirth.ToDateTime());
+
         switch (query.SortBy)
         {
             case ContactSearchSortByOption.LastNameAscending:

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByLastNameAndDateOfBirthHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByLastNameAndDateOfBirthHandler.cs
@@ -4,9 +4,9 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetContactsByLastNameAndDateOfBirthHandler : ICrmQueryHandler<GetContactsByLastNameAndDateOfBirthQuery, Contact[]>
+public class GetActiveContactsByLastNameAndDateOfBirthHandler : ICrmQueryHandler<GetActiveContactsByLastNameAndDateOfBirthQuery, Contact[]>
 {
-    public async Task<Contact[]> Execute(GetContactsByLastNameAndDateOfBirthQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<Contact[]> Execute(GetActiveContactsByLastNameAndDateOfBirthQuery query, IOrganizationServiceAsync organizationService)
     {
         var queryExpression = new QueryExpression(Contact.EntityLogicalName)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByNameHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByNameHandler.cs
@@ -4,15 +4,19 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetContactsByNameHandler : ICrmQueryHandler<GetContactsByNameQuery, Contact[]>
+public class GetActiveContactsByNameHandler : ICrmQueryHandler<GetActiveContactsByNameQuery, Contact[]>
 {
-    public async Task<Contact[]> Execute(GetContactsByNameQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<Contact[]> Execute(GetActiveContactsByNameQuery query, IOrganizationServiceAsync organizationService)
     {
-        var filter = new FilterExpression(LogicalOperator.Or);
-        filter.AddCondition(Contact.Fields.FirstName, ConditionOperator.Like, $"{query.Name}%");
-        filter.AddCondition(Contact.Fields.MiddleName, ConditionOperator.Like, $"{query.Name}%");
-        filter.AddCondition(Contact.Fields.LastName, ConditionOperator.Like, $"{query.Name}%");
-        filter.AddCondition(Contact.Fields.FullName, ConditionOperator.Like, $"{query.Name}%");
+        var nameFilter = new FilterExpression(LogicalOperator.Or);
+        nameFilter.AddCondition(Contact.Fields.FirstName, ConditionOperator.Like, $"{query.Name}%");
+        nameFilter.AddCondition(Contact.Fields.MiddleName, ConditionOperator.Like, $"{query.Name}%");
+        nameFilter.AddCondition(Contact.Fields.LastName, ConditionOperator.Like, $"{query.Name}%");
+        nameFilter.AddCondition(Contact.Fields.FullName, ConditionOperator.Like, $"{query.Name}%");
+
+        var filter = new FilterExpression(LogicalOperator.And);
+        filter.AddCondition(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active);
+        filter.AddFilter(nameFilter);
 
         var queryExpression = new QueryExpression(Contact.EntityLogicalName)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveEarlyYearsStatusesHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveEarlyYearsStatusesHandler.cs
@@ -5,9 +5,9 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetAllEarlyYearsStatusesHandler : ICrmQueryHandler<GetAllEarlyYearsStatusesQuery, dfeta_earlyyearsstatus[]>
+public class GetAllActiveEarlyYearsStatusesHandler : ICrmQueryHandler<GetAllActiveEarlyYearsStatusesQuery, dfeta_earlyyearsstatus[]>
 {
-    public async Task<dfeta_earlyyearsstatus[]> Execute(GetAllEarlyYearsStatusesQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<dfeta_earlyyearsstatus[]> Execute(GetAllActiveEarlyYearsStatusesQuery query, IOrganizationServiceAsync organizationService)
     {
         var queryExpression = new QueryExpression()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveHeQualificationsHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveHeQualificationsHandler.cs
@@ -5,9 +5,9 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetAllHeQualificationsHandler : ICrmQueryHandler<GetAllHeQualificationsQuery, dfeta_hequalification[]>
+public class GetAllActiveHeQualificationsHandler : ICrmQueryHandler<GetAllActiveHeQualificationsQuery, dfeta_hequalification[]>
 {
-    public async Task<dfeta_hequalification[]> Execute(GetAllHeQualificationsQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<dfeta_hequalification[]> Execute(GetAllActiveHeQualificationsQuery query, IOrganizationServiceAsync organizationService)
     {
         var queryExpression = new QueryExpression()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveHeSubjectsHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveHeSubjectsHandler.cs
@@ -5,9 +5,9 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetAllHeSubjectsHandler : ICrmQueryHandler<GetAllHeSubjectsQuery, dfeta_hesubject[]>
+public class GetAllActiveHeSubjectsHandler : ICrmQueryHandler<GetAllActiveHeSubjectsQuery, dfeta_hesubject[]>
 {
-    public async Task<dfeta_hesubject[]> Execute(GetAllHeSubjectsQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<dfeta_hesubject[]> Execute(GetAllActiveHeSubjectsQuery query, IOrganizationServiceAsync organizationService)
     {
         var queryExpression = new QueryExpression()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveSanctionCodesHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetAllActiveSanctionCodesHandler.cs
@@ -5,9 +5,9 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetAllSanctionCodesHandler : ICrmQueryHandler<GetAllSanctionCodesQuery, dfeta_sanctioncode[]>
+public class GetAllActiveSanctionCodesHandler : ICrmQueryHandler<GetAllActiveSanctionCodesQuery, dfeta_sanctioncode[]>
 {
-    public async Task<dfeta_sanctioncode[]> Execute(GetAllSanctionCodesQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<dfeta_sanctioncode[]> Execute(GetAllActiveSanctionCodesQuery query, IOrganizationServiceAsync organizationService)
     {
         var queryExpression = new QueryExpression()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactWithParentByIdHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactWithParentByIdHandler.cs
@@ -26,16 +26,15 @@ public class GetContactWithParentByIdHandler : ICrmQueryHandler<GetContactWithPa
             var queryExpression = new QueryExpression(Contact.EntityLogicalName)
             {
                 ColumnSet = new ColumnSet(
-                            Contact.Fields.dfeta_TRN,
-                            Contact.Fields.FirstName,
-                            Contact.Fields.MiddleName,
-                            Contact.Fields.LastName,
-                            Contact.Fields.EMailAddress1,
-                            Contact.Fields.dfeta_NINumber,
-                            Contact.Fields.BirthDate,
-                            Contact.Fields.Merged,
-                            Contact.Fields.MasterId
-                    ),
+                    Contact.Fields.dfeta_TRN,
+                    Contact.Fields.FirstName,
+                    Contact.Fields.MiddleName,
+                    Contact.Fields.LastName,
+                    Contact.Fields.EMailAddress1,
+                    Contact.Fields.dfeta_NINumber,
+                    Contact.Fields.BirthDate,
+                    Contact.Fields.Merged,
+                    Contact.Fields.MasterId),
                 Criteria = filter
             };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
@@ -135,7 +135,7 @@ public class ReferenceDataCache : IStartupTask
     private Task<dfeta_sanctioncode[]> EnsureSanctionCodes() =>
         LazyInitializer.EnsureInitialized(
             ref _getSanctionCodesTask,
-            () => _crmQueryDispatcher.ExecuteQuery(new GetAllSanctionCodesQuery()));
+            () => _crmQueryDispatcher.ExecuteQuery(new GetAllActiveSanctionCodesQuery()));
 
     private Task<Subject[]> EnsureSubjects() =>
         LazyInitializer.EnsureInitialized(
@@ -150,7 +150,7 @@ public class ReferenceDataCache : IStartupTask
     private Task<dfeta_earlyyearsstatus[]> EnsureEarlyYearsStatuses() =>
         LazyInitializer.EnsureInitialized(
             ref _getEarlyYearsStatusesTask,
-            () => _crmQueryDispatcher.ExecuteQuery(new GetAllEarlyYearsStatusesQuery()));
+            () => _crmQueryDispatcher.ExecuteQuery(new GetAllActiveEarlyYearsStatusesQuery()));
 
     private Task<dfeta_specialism[]> EnsureSpecialisms() =>
         LazyInitializer.EnsureInitialized(
@@ -165,12 +165,12 @@ public class ReferenceDataCache : IStartupTask
     private Task<dfeta_hequalification[]> EnsureHeQualifications() =>
         LazyInitializer.EnsureInitialized(
             ref _getHeQualificationsTask,
-            () => _crmQueryDispatcher.ExecuteQuery(new GetAllHeQualificationsQuery()));
+            () => _crmQueryDispatcher.ExecuteQuery(new GetAllActiveHeQualificationsQuery()));
 
     private Task<dfeta_hesubject[]> EnsureHeSubjects() =>
         LazyInitializer.EnsureInitialized(
             ref _getHeSubjectsTask,
-            () => _crmQueryDispatcher.ExecuteQuery(new GetAllHeSubjectsQuery()));
+            () => _crmQueryDispatcher.ExecuteQuery(new GetAllActiveHeSubjectsQuery()));
 
     async Task IStartupTask.Execute()
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/AssignCurrentPersonInfoFilterBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/AssignCurrentPersonInfoFilterBase.cs
@@ -10,7 +10,7 @@ public abstract class AssignCurrentPersonInfoFilterBase(ICrmQueryDispatcher crmQ
     protected async Task<bool> TryAssignCurrentPersonInfo(Guid personId, HttpContext httpContext)
     {
         var contactDetail = await CrmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 personId,
                 new ColumnSet(
                     Contact.Fields.Id,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -37,7 +37,7 @@ public class CheckPersonExistsFilter(
         }
 
         var person = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 personId,
                 new ColumnSet(
                     Contact.Fields.Id,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Confirm.cshtml.cs
@@ -59,7 +59,7 @@ public class ConfirmModel : PageModel
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        var person = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(PersonId, new ColumnSet(Contact.Fields.Id)));
+        var person = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByIdQuery(PersonId, new ColumnSet(Contact.Fields.Id)));
         if (person is null)
         {
             context.Result = NotFound();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Index.cshtml.cs
@@ -92,7 +92,7 @@ public class IndexModel : PageModel
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        var person = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(PersonId, new ColumnSet(Contact.Fields.Id)));
+        var person = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByIdQuery(PersonId, new ColumnSet(Contact.Fields.Id)));
         if (person is null)
         {
             context.Result = NotFound();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -86,16 +86,16 @@ public partial class IndexModel : PageModel
         // Check if the search string is a date of birth, TRN or one or more names
         if (DateOnly.TryParse(Search, out var dateOfBirth))
         {
-            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByDateOfBirthQuery(dateOfBirth, SortBy, MaxSearchResultCount, columnSet));
+            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactsByDateOfBirthQuery(dateOfBirth, SortBy, MaxSearchResultCount, columnSet));
         }
         else if (TrnRegex().IsMatch(Search!))
         {
-            var contact = await _crmQueryDispatcher.ExecuteQuery(new GetContactByTrnQuery(Search!, columnSet));
+            var contact = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactByTrnQuery(Search!, columnSet));
             contacts = contact is not null ? [contact] : [];
         }
         else
         {
-            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByNameQuery(Search!, SortBy, MaxSearchResultCount, columnSet));
+            contacts = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactsByNameQuery(Search!, SortBy, MaxSearchResultCount, columnSet));
         }
         Debug.Assert(contacts is not null);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
@@ -36,7 +36,7 @@ public partial class AlertsModel : PageModel
     public async Task<IActionResult> OnGet()
     {
         var contactDetail = await _crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 PersonId,
                 new ColumnSet(
                     Contact.Fields.FirstName,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml.cs
@@ -53,7 +53,7 @@ public class ConfirmModel : PageModel
         }
 
         var person = await _crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 PersonId,
                 new ColumnSet(
                     Contact.PrimaryIdAttribute,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/EditDateOfBirthState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/EditDateOfBirthState.cs
@@ -23,7 +23,7 @@ public class EditDateOfBirthState
         }
 
         var person = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 personId,
                 new ColumnSet(
                     Contact.PrimaryIdAttribute,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
@@ -55,7 +55,7 @@ public class ConfirmModel : PageModel
         }
 
         var person = await _crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 PersonId,
                 new ColumnSet(
                     Contact.PrimaryIdAttribute,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/EditNameState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/EditNameState.cs
@@ -27,7 +27,7 @@ public class EditNameState
         }
 
         var person = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 personId,
                 new ColumnSet(
                     Contact.PrimaryIdAttribute,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -29,7 +29,7 @@ public class IndexModel(
     public async Task OnGet()
     {
         var contactDetail = await crmQueryDispatcher.ExecuteQuery(
-            new GetContactDetailByIdQuery(
+            new GetActiveContactDetailByIdQuery(
                 PersonId,
                 new ColumnSet(
                     Contact.Fields.dfeta_TRN,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllEarlyYearsStatusesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllEarlyYearsStatusesTests.cs
@@ -13,7 +13,7 @@ public class GetAllEarlyYearsStatusesTests
     public async Task QueryExecutesSuccessfully()
     {
         // Arrange
-        var query = new GetAllEarlyYearsStatusesQuery();
+        var query = new GetAllActiveEarlyYearsStatusesQuery();
 
         // Act
         var result = await _crmQueryDispatcher.ExecuteQuery(query);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllHeQualificationsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllHeQualificationsTests.cs
@@ -13,7 +13,7 @@ public class GetAllHeQualificationsTests
     public async Task QueryExecutesSuccessfully()
     {
         // Arrange
-        var query = new GetAllHeQualificationsQuery();
+        var query = new GetAllActiveHeQualificationsQuery();
 
         // Act
         var result = await _crmQueryDispatcher.ExecuteQuery(query);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllHeSubjectsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllHeSubjectsTests.cs
@@ -13,7 +13,7 @@ public class GetAllHeSubjectsTests
     public async Task QueryExecutesSuccessfully()
     {
         // Arrange
-        var query = new GetAllHeSubjectsQuery();
+        var query = new GetAllActiveHeSubjectsQuery();
 
         // Act
         var result = await _crmQueryDispatcher.ExecuteQuery(query);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllSanctionCodesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetAllSanctionCodesTests.cs
@@ -13,7 +13,7 @@ public class GetAllSanctionCodesTests
     public async Task QueryExecutesSuccessfully()
     {
         // Arrange
-        var query = new GetAllSanctionCodesQuery();
+        var query = new GetAllActiveSanctionCodesQuery();
 
         // Act
         var result = await _crmQueryDispatcher.ExecuteQuery(query);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactByTrnTests.cs
@@ -24,7 +24,7 @@ public class GetContactByTrnTests : IAsyncLifetime
         var trn = "DodgyTrn";
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactByTrnQuery(trn, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactByTrnQuery(trn, new ColumnSet()));
 
         // Assert
         Assert.Null(result);
@@ -37,7 +37,7 @@ public class GetContactByTrnTests : IAsyncLifetime
         var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactByTrnQuery(person.Trn!, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactByTrnQuery(person.Trn!, new ColumnSet()));
 
         // Assert
         Assert.NotNull(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactDetailByIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactDetailByIdTests.cs
@@ -24,7 +24,7 @@ public class GetContactDetailByIdTests : IAsyncLifetime
         var contactId = Guid.NewGuid();
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(contactId, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByIdQuery(contactId, new ColumnSet()));
 
         // Assert
         Assert.Null(result);
@@ -37,7 +37,7 @@ public class GetContactDetailByIdTests : IAsyncLifetime
         var person = await _dataScope.TestData.CreatePerson();
 
         // Act
-        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(person.ContactId, new ColumnSet()));
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByIdQuery(person.ContactId, new ColumnSet()));
 
         // Assert
         Assert.NotNull(results);
@@ -56,7 +56,7 @@ public class GetContactDetailByIdTests : IAsyncLifetime
         await _dataScope.TestData.UpdatePerson(b => b.WithPersonId(person.ContactId).WithUpdatedName(updatedFirstName, updatedMiddleName, updatedLastName));
 
         // Act
-        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByIdQuery(person.ContactId, new ColumnSet()));
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByIdQuery(person.ContactId, new ColumnSet()));
 
         // Assert
         Assert.NotNull(results);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactDetailByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactDetailByTrnTests.cs
@@ -24,7 +24,7 @@ public class GetContactDetailByTrnTests : IAsyncLifetime
         var trn = "DodgyTrn";
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByTrnQuery(trn, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByTrnQuery(trn, new ColumnSet()));
 
         // Assert
         Assert.Null(result);
@@ -37,7 +37,7 @@ public class GetContactDetailByTrnTests : IAsyncLifetime
         var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
 
         // Assert
         Assert.NotNull(result);
@@ -56,7 +56,7 @@ public class GetContactDetailByTrnTests : IAsyncLifetime
         await _dataScope.TestData.UpdatePerson(b => b.WithPersonId(person.ContactId).WithUpdatedName(updatedFirstName, updatedMiddleName, updatedLastName));
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
 
         // Assert
         Assert.NotNull(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByDateOfBirthTests.cs
@@ -81,7 +81,7 @@ public class GetContactsByDateOfBirthTests : IAsyncLifetime
         var person3 = await _dataScope.TestData.CreatePerson(b => b.WithDateOfBirth(dateOfBirth));
 
         // Act
-        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByDateOfBirthQuery(dateOfBirth, testScenarioData.SortBy, maxRecordCount, columnSet));
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactsByDateOfBirthQuery(dateOfBirth, testScenarioData.SortBy, maxRecordCount, columnSet));
 
         // Assert
         Assert.NotNull(results);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByLastNameAndDateOfBirthTests.cs
@@ -28,7 +28,7 @@ public class GetContactsByLastNameAndDateOfBirthTests : IAsyncLifetime
         var person2 = await _dataScope.TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
         // Act
-        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByLastNameAndDateOfBirthQuery(lastName, dateOfBirth, new ColumnSet()));
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactsByLastNameAndDateOfBirthQuery(lastName, dateOfBirth, new ColumnSet()));
 
         // Assert
         Assert.NotNull(results);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByNameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByNameTests.cs
@@ -76,7 +76,7 @@ public class GetContactsByNameTests : IAsyncLifetime
             Contact.Fields.FullName);
 
         // Act
-        var results = await _crmQueryDispatcher.ExecuteQuery(new GetContactsByNameQuery(name, testScenarioData.SortBy, maxRecordCount, columnSet));
+        var results = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactsByNameQuery(name, testScenarioData.SortBy, maxRecordCount, columnSet));
 
         // Assert
         Assert.NotNull(results);


### PR DESCRIPTION
There are a few queries where we're not correctly excluding inactive `contact` records. I've now fixed them all up and gone through and renamed queries that only return `Active` records so it's more obvious.