### PR TITLE
Add TRN to Sentry scope

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Filters/AddTrnToSentryScopeResourceFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Filters/AddTrnToSentryScopeResourceFilter.cs
@@ -1,0 +1,24 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+
+namespace TeachingRecordSystem.Api.Infrastructure.Filters;
+
+public class AddTrnToSentryScopeResourceFilter(IAuthorizationService authorizationService) : IAsyncResourceFilter
+{
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        var user = context.HttpContext.User;
+        var identityUserAuthorizeResult = await authorizationService.AuthorizeAsync(user, AuthorizationPolicies.IdentityUserWithTrn);
+
+        if (identityUserAuthorizeResult.Succeeded)
+        {
+            var trn = user.FindFirstValue("trn")!;
+
+            SentrySdk.ConfigureScope(scope => scope.SetTag("trn", trn));
+        }
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -151,6 +151,7 @@ public class Program
             {
                 options.AddHybridBodyModelBinderProvider();
 
+                options.Filters.Add(new ServiceFilterAttribute<AddTrnToSentryScopeResourceFilter>() { Order = -1 });
                 options.Filters.Add(new CrmServiceProtectionFaultExceptionFilter());
                 options.Filters.Add(new DefaultErrorExceptionFilter(statusCode: StatusCodes.Status400BadRequest));
                 options.Filters.Add(new ValidationExceptionFilter());
@@ -200,6 +201,7 @@ public class Program
         services.AddSingleton<ICurrentClientProvider, ClaimsPrincipalCurrentClientProvider>();
         services.AddSingleton<IClock, Clock>();
         services.AddMemoryCache();
+        services.AddSingleton<AddTrnToSentryScopeResourceFilter>();
 
         services.AddHttpClient("EvidenceFiles", client =>
         {


### PR DESCRIPTION
For endpoints authorized with an ID access token we can't see the TRN in Sentry when errors occur (since it's not in the endpoint). This adds a tag with the TRN.