### PR TITLE
Explicitly define the issuer for Authorize access

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -81,6 +81,8 @@ builder.Services.AddOpenIddict()
             .SetTokenEndpointUris("oauth2/token")
             .SetUserinfoEndpointUris("oauth2/userinfo");
 
+        options.SetIssuer(builder.Configuration.GetRequiredValue("AuthorizeAccessIssuer"));
+
         options.RegisterScopes(Scopes.Email, Scopes.Profile, CustomScopes.TeachingRecord);
 
         options.AllowAuthorizationCodeFlow();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "AuthorizeAccessIssuer": "https://localhost:7236",
   "DetailedErrors": true,
   "Serilog": {
     "MinimumLevel": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.EndToEndTests.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.EndToEndTests.json
@@ -1,5 +1,5 @@
 {
-  "AuthorizeAccessIssuer": "https://localhost",
+  "AuthorizeAccessIssuer": "http://localhost:55649",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Error",


### PR DESCRIPTION
OpenIddict will use the incoming request to derive an issuer by default but it's better for us to be explicit since we'll be available on multiple domains and the API will need a specific issuer to check against.