### PR TITLE
Allow API access with a token from Authorize access

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "AllowVNextEndpoints": true,
+  "AuthorizeAccessIssuer": "https://localhost:7236",
   "DetailedErrors": true,
   "Serilog": {
     "MinimumLevel": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
@@ -1,5 +1,6 @@
 {
   "AllowVNextEndpoints": true,
+  "AuthorizeAccessIssuer": "https://dummy",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Error",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml
@@ -3,25 +3,23 @@
 @using TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 @model SignedInModel
-@{
-    var claimsJson = JsonSerializer.Serialize(
-        User.Claims.ToDictionary(c => c.Type, c => c.Value),
-        new JsonSerializerOptions() { WriteIndented = true });
-}
 
 @section Styles {
     <style type="text/css" asp-add-nonce="true">
         .claims-json {
             font-family: monospace !important;
-            white-space: nowrap;
             height: 260px;
+            white-space: pre-wrap;
+        }
+
+        .access-token {
+            font-family: monospace !important;
         }
     </style>
 }
 
 <p class="govuk-body">
-    <govuk-textarea name="Claims" textarea-class="claims-json">
-        <govuk-textarea-label>Claims</govuk-textarea-label>
-        <govuk-textarea-value>@claimsJson</govuk-textarea-value>
-    </govuk-textarea>
+    <govuk-input asp-for="AccessToken" input-class="access-token" disabled="true" />
+
+    <govuk-textarea asp-for="ClaimsJson" textarea-class="claims-json" disabled="true" />
 </p>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/SignedIn.cshtml.cs
@@ -1,12 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using static IdentityModel.OidcConstants;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest;
 
 [Authorize(AuthenticationSchemes = TestAppConfiguration.AuthenticationSchemeName)]
 public class SignedInModel : PageModel
 {
-    public void OnGet()
+    [Display(Name = "Access token")]
+    public string? AccessToken { get; set; }
+
+    [Display(Name = "Claims")]
+    public string? ClaimsJson { get; set; }
+
+    public async Task OnGet()
     {
+        AccessToken = await HttpContext.GetTokenAsync(TestAppConfiguration.AuthenticationSchemeName, TokenTypes.AccessToken);
+
+        ClaimsJson = JsonSerializer.Serialize(
+            User.Claims.ToDictionary(c => c.Type, c => c.Value),
+            new JsonSerializerOptions() { WriteIndented = true });
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/HostFixture.cs
@@ -87,7 +87,7 @@ public class HostFixture : WebApplicationFactory<Program>
                 .AddHttpMessageHandler(_ => EvidenceFilesHttpClientInterceptorOptions.CreateHttpMessageHandler())
                 .ConfigurePrimaryHttpMessageHandler(_ => new NotFoundHandler());
 
-            services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+            services.PostConfigure<JwtBearerOptions>("IdAccessToken", options =>
             {
                 options.TokenValidationParameters.ValidateIssuer = false;
                 options.TokenValidationParameters.IssuerSigningKey = JwtSigningCredentials.Key;


### PR DESCRIPTION
The `/v3/teacher` endpoint currently only allows access via an access token issued by ID. This changes that to also allow an access token from Authorize access.