### PR TITLE
Store verification metadata against a One Login user

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/HttpResultActionResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/HttpResultActionResult.cs
@@ -9,3 +9,8 @@ public class HttpResultActionResult(IResult result) : IActionResult
         return result.ExecuteAsync(context.HttpContext);
     }
 }
+
+public static class ResultExtensions
+{
+    public static IActionResult ToActionResult(this IResult result) => new HttpResultActionResult(result);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Found.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Found.cshtml.cs
@@ -14,7 +14,7 @@ public class FoundModel(SignInJourneyHelper helper) : PageModel
     {
     }
 
-    public IActionResult OnPost() => Redirect(helper.GetNextPage(JourneyInstance!));
+    public IActionResult OnPost() => helper.GetNextPage(JourneyInstance!).ToActionResult();
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
@@ -23,7 +23,7 @@ public class FoundModel(SignInJourneyHelper helper) : PageModel
         if (state.AuthenticationTicket is null)
         {
             // Not matched
-            context.Result = Redirect(helper.GetNextPage(JourneyInstance));
+            context.Result = helper.GetNextPage(JourneyInstance).ToActionResult();
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotVerified.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotVerified.cshtml.cs
@@ -5,7 +5,7 @@ using TeachingRecordSystem.FormFlow;
 namespace TeachingRecordSystem.AuthorizeAccess.Pages;
 
 [Journey(SignInJourneyState.JourneyName), RequireJourneyInstance]
-public class NotVerifiedModel : PageModel
+public class NotVerifiedModel(SignInJourneyHelper helper) : PageModel
 {
     public JourneyInstance<SignInJourneyState>? JourneyInstance { get; set; }
 
@@ -17,7 +17,12 @@ public class NotVerifiedModel : PageModel
     {
         var state = JourneyInstance!.State;
 
-        if (state.OneLoginAuthenticationTicket is null)
+        if (state.AuthenticationTicket is not null)
+        {
+            // Already matched to a Teaching Record
+            context.Result = Redirect(helper.GetSafeRedirectUri(JourneyInstance));
+        }
+        else if (state.OneLoginAuthenticationTicket is null)
         {
             // Not authenticated with One Login
             context.Result = BadRequest();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
@@ -11,5 +14,26 @@ public class OneLoginUserMapping : IEntityTypeConfiguration<OneLoginUser>
         builder.Property(o => o.Subject).HasMaxLength(200);
         builder.Property(o => o.Email).HasMaxLength(200);
         builder.HasOne<Person>(o => o.Person).WithOne().HasForeignKey<OneLoginUser>(o => o.PersonId);
+        builder.Property(o => o.VerifiedNames).HasColumnType("jsonb").HasConversion<string>(
+            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+            v => JsonSerializer.Deserialize<string[][]>(v, (JsonSerializerOptions?)null),
+            new ValueComparer<string[][]>(
+                (a, b) => (a == null && b == null) || (a != null && b != null && a.SequenceEqual(b, new StringArrayEqualityComparer())),
+                v => HashCode.Combine(v.Select(names => string.Join(" ", names)))));
+        builder.Property(o => o.VerifiedDatesOfBirth).HasColumnType("jsonb").HasConversion<string>(
+            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+            v => JsonSerializer.Deserialize<DateOnly[]>(v, (JsonSerializerOptions?)null),
+            new ValueComparer<DateOnly[]>(
+                (a, b) => (a == null && b == null) || (a != null && b != null && a.SequenceEqual(b)),
+                v => HashCode.Combine(v)));
     }
+}
+
+file class StringArrayEqualityComparer : IEqualityComparer<string[]>
+{
+    public bool Equals(string[]? x, string[]? y) =>
+        (x is null && y is null) ||
+        (x is not null && y is not null && x.SequenceEqual(y));
+
+    public int GetHashCode([DisallowNull] string[] obj) => HashCode.Combine(obj);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240410164157_OneLoginUserVerified.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240410164157_OneLoginUserVerified.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -12,9 +13,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240410164157_OneLoginUserVerified")]
+    partial class OneLoginUserVerified
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -972,14 +975,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Property<int?>("VerificationRoute")
                         .HasColumnType("integer")
                         .HasColumnName("verification_route");
-
-                    b.Property<string>("VerifiedDatesOfBirth")
-                        .HasColumnType("jsonb")
-                        .HasColumnName("verified_dates_of_birth");
-
-                    b.Property<string>("VerifiedNames")
-                        .HasColumnType("jsonb")
-                        .HasColumnName("verified_names");
 
                     b.Property<DateTime?>("VerifiedOn")
                         .HasColumnType("timestamp with time zone")

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240410164157_OneLoginUserVerified.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240410164157_OneLoginUserVerified.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class OneLoginUserVerified : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "verification_route",
+                table: "one_login_users",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "verified_on",
+                table: "one_login_users",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "verification_route",
+                table: "one_login_users");
+
+            migrationBuilder.DropColumn(
+                name: "verified_on",
+                table: "one_login_users");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240411145144_VerifiedDetails.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240411145144_VerifiedDetails.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -12,9 +13,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240411145144_VerifiedDetails")]
+    partial class VerifiedDetails
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240411145144_VerifiedDetails.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240411145144_VerifiedDetails.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class VerifiedDetails : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "verified_dates_of_birth",
+                table: "one_login_users",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "verified_names",
+                table: "one_login_users",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "verified_dates_of_birth",
+                table: "one_login_users");
+
+            migrationBuilder.DropColumn(
+                name: "verified_names",
+                table: "one_login_users");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
@@ -10,4 +10,8 @@ public class OneLoginUser
     public DateTime? LastSignIn { get; set; }
     public Guid? PersonId { get; set; }
     public Person? Person { get; }
+    public DateTime? VerifiedOn { get; set; }
+    public OneLoginUserVerificationRoute? VerificationRoute { get; set; }
+    public string[][]? VerifiedNames { get; set; }
+    public DateOnly[]? VerifiedDatesOfBirth { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/OneLoginUserVerificationRoute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/OneLoginUserVerificationRoute.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core;
+
+public enum OneLoginUserVerificationRoute
+{
+    OneLogin = 1,
+    Support = 2
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
@@ -8,7 +8,7 @@ public class OidcTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task SignInAndOut()
     {
         var person = await TestData.CreatePerson(x => x.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var coreIdentityVc = TestData.CreateOneLoginCoreIdentityVc(person.FirstName, person.LastName, person.DateOfBirth);
         SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email, coreIdentityVc));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
@@ -183,7 +183,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task SignIn_KnownUser()
     {
         var person = await TestData.CreatePerson(x => x.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var coreIdentityVc = TestData.CreateOneLoginCoreIdentityVc(person.FirstName, person.LastName, person.DateOfBirth);
         SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email, coreIdentityVc));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
@@ -27,7 +27,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -46,7 +46,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
@@ -68,7 +70,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
@@ -92,15 +96,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -120,7 +118,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -166,7 +166,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -185,7 +185,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
@@ -207,7 +209,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
@@ -231,15 +235,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -253,13 +251,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_ValidRequests_RedirectsToNotFoundPage()
+    public async Task Post_ValidRequest_RedirectsToNotFoundPage()
     {
         // Arrange
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
@@ -25,7 +25,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -45,15 +45,9 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -73,7 +67,9 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -107,7 +103,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -127,15 +123,9 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -155,7 +145,9 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
@@ -5,13 +5,15 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests;
 public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_NotAuthenticated_RedirectsToStartOfMatchingJourney()
+    public async Task Get_NotFullyAuthenticated_RedirectsToStartOfMatchingJourney()
     {
         // Arrange
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
         Debug.Assert(state.AuthenticationTicket is null);
 
@@ -33,15 +35,9 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/found?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -60,7 +56,9 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
         Debug.Assert(state.AuthenticationTicket is null);
 
@@ -82,15 +80,9 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/found?{journeyInstance.GetUniqueIdQueryParameter()}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
@@ -25,7 +25,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -45,15 +45,9 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -75,7 +69,9 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var existingNationalInsuranceNumber = haveExistingValueInState ? Faker.Identification.UkNationalInsuranceNumber() : null;
@@ -125,10 +121,10 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
-
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -152,18 +148,13 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var nationalInsuranceNumber = person.NationalInsuranceNumber!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: person.PersonId);
+        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = person.NationalInsuranceNumber!;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -188,16 +179,9 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -221,18 +205,12 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var nationalInsuranceNumber = "";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = "";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -257,18 +235,12 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var nationalInsuranceNumber = "xxx";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = "xxx";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -287,22 +259,15 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
     }
 
     [Fact]
-    public async Task Post_NoNationalInsuranceNumberSpecified_UpdatesStateAndRedirectsToTrnPage()
+    public async Task Post_HaveNationalInsuranceNumberNotSpecified_UpdatesStateAndRedirectsToTrnPage()
     {
         // Arrange
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -333,18 +298,12 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -377,17 +336,14 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var nationalInsuranceNumber = person.NationalInsuranceNumber!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(
+            personId: null,
+            verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = person.NationalInsuranceNumber!;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
@@ -27,7 +27,9 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: false);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-found?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -46,16 +48,10 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-found?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -75,7 +71,9 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
@@ -97,7 +95,9 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
@@ -120,7 +120,9 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(async state =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
@@ -19,13 +19,38 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
+    public async Task Get_AlreadyAuthenticated_RedirectsToStateRedirectUri()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
+        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"{state.RedirectUri}?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_VerifiedWithOneLogin_ReturnsBadRequest()
     {
         // Arrange
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: true);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -44,7 +69,9 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: false);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
@@ -27,7 +27,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -47,15 +47,9 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn());
-        var oneLoginUser = await TestData.CreateOneLoginUser(person.PersonId);
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -75,7 +69,9 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
@@ -99,7 +95,9 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var existingTrn = haveExistingValueInState ? await TestData.GenerateTrn() : null;
@@ -160,7 +158,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var trn = await TestData.GenerateTrn();
 
-        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr, createCoreIdentityVc: false);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -186,18 +184,13 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var trn = person.Trn!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: person.PersonId);
+        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var trn = person.Trn!;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -223,18 +216,12 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var trn = person.Trn!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var trn = await TestData.GenerateTrn();
 
         Debug.Assert(state.NationalInsuranceNumber is null);
 
@@ -262,16 +249,9 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
@@ -297,18 +277,12 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var trn = "";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var trn = "";
 
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
 
@@ -335,18 +309,12 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var trn = "xxx";
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var trn = "xxx";
 
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
 
@@ -373,18 +341,12 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var trn = await TestData.GenerateTrn();
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var trn = await TestData.GenerateTrn();
 
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
 
@@ -417,18 +379,12 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var trn = await TestData.GenerateTrn();
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var trn = await TestData.GenerateTrn();
 
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
 
@@ -463,17 +419,14 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
-        var trn = person.Trn!;
-        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null);
+        var oneLoginUser = await TestData.CreateOneLoginUser(
+            personId: null,
+            verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
-        var ticket = CreateOneLoginAuthenticationTicket(
-            vtr: SignInJourneyHelper.AuthenticationAndIdentityVerificationVtr,
-            sub: oneLoginUser.Subject,
-            email: oneLoginUser.Email,
-            firstName: person.FirstName,
-            lastName: person.LastName,
-            dateOfBirth: person.DateOfBirth);
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
         await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+
+        var trn = person.Trn!;
 
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.FormFlow;
 using TeachingRecordSystem.FormFlow.State;
@@ -145,6 +146,15 @@ public abstract class TestBase : IDisposable
 
         return new AuthenticationTicket(principal, properties, authenticationScheme: "OneLogin");
     }
+
+    public AuthenticationTicket CreateOneLoginAuthenticationTicket(string vtr, OneLoginUser user) =>
+        CreateOneLoginAuthenticationTicket(
+            vtr,
+            user.Subject,
+            user.Email,
+            user.VerifiedNames?.First().First(),
+            user.VerifiedNames?.First().Last(),
+            user.VerifiedDatesOfBirth?.First());
 
     public SignInJourneyState CreateNewState(string redirectUri = "/") =>
         new(redirectUri, serviceName: "Test Service", serviceUrl: "https://service", oneLoginAuthenticationScheme: "dummy");


### PR DESCRIPTION
This change persists verification metadata, specifically how, when and what name/DOB was verified.

Part of this change includes a refactor of `SignInJourneyHelper` to more-clearly split out the authenticate vs verify steps.

This also fixes the One Login verification failure scenario and skips verification for users who have already verified.