### PR TITLE
Tweak TrsDataSyncService config for more reliability

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -23,7 +23,7 @@ public class TrsDataSyncService(
         {
             BackoffType = DelayBackoffType.Exponential,
             Delay = TimeSpan.FromSeconds(30),
-            MaxRetryAttempts = 3
+            MaxRetryAttempts = 10
         })
         .Build();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
@@ -73,10 +73,9 @@
     "RefreshEstablishmentsJobSchedule": "0 2 * * *"
   },
   "TrsSyncService": {
-    "PollIntervalSeconds": 300,
+    "PollIntervalSeconds": 60,
     "ModelTypes": [
-      "Person",
-      "MandatoryQualification"
+      "Person"
     ],
     "IgnoreInvalidData": false,
     "RunService": false


### PR DESCRIPTION
We've had a few instances on the dev environment where transient database errors have caused this service to stop. This change increases the retry attempts to hopefully mitigate that.

I've also decreased the poll interval from five minutes to one minute to reduce the lag.

`MandatoryQualification` sync is removed too since there are no MQ changes being made in DQT any more.