### PR TITLE
Return verified names & birthdates from userinfo endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/ClaimTypes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/ClaimTypes.cs
@@ -6,4 +6,6 @@ public static class ClaimTypes
     public const string Subject = "sub";
     public const string Trn = "trn";
     public const string OneLoginIdToken = "onelogin_id";
+    public const string OneLoginVerifiedNames = "onelogin_verified_names";
+    public const string OneLoginIdVerifiedBirthDates = "onelogin_verified_birthdates";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
@@ -120,12 +120,14 @@ public class SignInJourneyHelper(
         {
             var verifiedNames = ticket.Principal.GetCoreIdentityNames().Select(n => n.NameParts.Select(part => part.Value).ToArray()).ToArray();
             var verifiedDatesOfBirth = ticket.Principal.GetCoreIdentityBirthDates().Select(d => d.Value).ToArray();
+            var coreIdentityClaimVc = ticket.Principal.FindFirstValue("vc") ?? throw new InvalidOperationException("No vc claim present.");
 
             var oneLoginUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == sub);
             oneLoginUser.VerifiedOn = clock.UtcNow;
             oneLoginUser.VerificationRoute = OneLoginUserVerificationRoute.OneLogin;
             oneLoginUser.VerifiedNames = verifiedNames;
             oneLoginUser.VerifiedDatesOfBirth = verifiedDatesOfBirth;
+            oneLoginUser.LastCoreIdentityVc = coreIdentityClaimVc;
             await dbContext.SaveChangesAsync();
 
             await journeyInstance.UpdateStateAsync(state =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
@@ -11,7 +11,7 @@ public class OneLoginUserMapping : IEntityTypeConfiguration<OneLoginUser>
     public void Configure(EntityTypeBuilder<OneLoginUser> builder)
     {
         builder.HasKey(o => o.Subject);
-        builder.Property(o => o.Subject).HasMaxLength(200);
+        builder.Property(o => o.Subject).HasMaxLength(255);
         builder.Property(o => o.Email).HasMaxLength(200);
         builder.HasOne<Person>(o => o.Person).WithOne().HasForeignKey<OneLoginUser>(o => o.PersonId);
         builder.Property(o => o.VerifiedNames).HasColumnType("jsonb").HasConversion<string>(
@@ -26,6 +26,7 @@ public class OneLoginUserMapping : IEntityTypeConfiguration<OneLoginUser>
             new ValueComparer<DateOnly[]>(
                 (a, b) => (a == null && b == null) || (a != null && b != null && a.SequenceEqual(b)),
                 v => HashCode.Combine(v)));
+        builder.Property(o => o.LastCoreIdentityVc).HasColumnType("jsonb");
     }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240416104642_LastCoreIdentityVc.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240416104642_LastCoreIdentityVc.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -12,9 +13,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240416104642_LastCoreIdentityVc")]
+    partial class LastCoreIdentityVc
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240416104642_LastCoreIdentityVc.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240416104642_LastCoreIdentityVc.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class LastCoreIdentityVc : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "subject",
+                table: "one_login_users",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200);
+
+            migrationBuilder.AddColumn<string>(
+                name: "last_core_identity_vc",
+                table: "one_login_users",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_core_identity_vc",
+                table: "one_login_users");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "subject",
+                table: "one_login_users",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldMaxLength: 255);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
@@ -14,4 +14,5 @@ public class OneLoginUser
     public OneLoginUserVerificationRoute? VerificationRoute { get; set; }
     public string[][]? VerifiedNames { get; set; }
     public DateOnly[]? VerifiedDatesOfBirth { get; set; }
+    public string? LastCoreIdentityVc { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
@@ -20,11 +20,16 @@ public class OidcTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.ClickButton("Start");
         await page.WaitForUrlPathAsync("/oidc-test/signed-in");
 
+        string[][] expectedVerifiedNames = [[person.FirstName, person.LastName]];
+        DateOnly[] expectedVerifiedBirthDates = [person.DateOfBirth];
+
         var claims = JsonSerializer.Deserialize<Dictionary<string, string>>(await page.GetByLabel("Claims").InputValueAsync()) ?? [];
         Assert.Equal(oneLoginUser.Subject, claims.GetValueOrDefault("sub"));
         Assert.Equal(person.Trn, claims.GetValueOrDefault("trn"));
         Assert.Equal(oneLoginUser.Email, claims.GetValueOrDefault("email"));
         Assert.NotEmpty(claims.GetValueOrDefault("onelogin_id") ?? "");
+        Assert.Equal(expectedVerifiedNames, JsonSerializer.Deserialize<string[][]>(claims.GetValueOrDefault("onelogin_verified_names") ?? "[]"));
+        Assert.Equal(expectedVerifiedBirthDates, JsonSerializer.Deserialize<DateOnly[]>(claims.GetValueOrDefault("onelogin_verified_birthdates") ?? "[]"));
 
         await page.ClickAsync("a:text-is('Sign out')");
         await page.WaitForUrlPathAsync("/oidc-test");


### PR DESCRIPTION
We need to show the user's verified info on the account page. This adds two new claims to the `userinfo` endpoint for verified names and birth dates, respectively. Both claims are formatted as JSON.