### PR TITLE
Use the contact ID returned from CRM

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.CreateTeacher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.CreateTeacher.cs
@@ -94,8 +94,9 @@ public partial class DataverseAdapter
         }
 
         var txnResponse = (ExecuteTransactionResponse)await _service.ExecuteAsync(txnRequest);
+        var createdContactId = ((CreateResponse)txnResponse.Responses.First()).id;
 
-        return (CreateTeacherResult.Success(helper.TeacherId, trn), txnRequest);
+        return (CreateTeacherResult.Success(createdContactId, trn), txnRequest);
     }
 
     internal class CreateTeacherHelper


### PR DESCRIPTION
Sometimes we get cases where the contact we created via `DataverseAdapter.CreateTeacher` doesn't exist, even though it succeeded successfully. We explicitly specify an ID here so that we can create the `contact` and several things that relate to it in a single transaction. This is a bit of a mystery; it may be the case that CRM is ignoring the ID we're passing in these cases and using its own. This change modifies the method to return the ID that CRM itself returned rather than the one we're passing in. If this is indeed the problem, that should solve it.