### PR TITLE
Support trn_token in sign in journeys

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -42,6 +42,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
@@ -48,14 +48,19 @@ public class OAuth2Controller(
             var parameters = Request.HasFormContentType ? Request.Form.ToList() : Request.Query.ToList();
 
             var serviceUrl = new Uri(request.RedirectUri!).GetLeftPart(UriPartial.Authority);
+            var trnToken = parameters.GroupBy(kvp => kvp.Key).FirstOrDefault(kvp => kvp.Key == "trn_token")?.Select(kvp => kvp.Value).FirstOrDefault();
 
             var authenticationProperties = new AuthenticationProperties()
             {
-                RedirectUri = Request.PathBase + Request.Path + QueryString.Create(parameters)
+                RedirectUri = Request.PathBase + Request.Path + QueryString.Create(parameters),
+                Items =
+                {
+                    { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.OneLoginAuthenticationScheme, client.OneLoginAuthenticationSchemeName },
+                    { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.ServiceName, client.Name },
+                    { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.ServiceUrl, serviceUrl },
+                    { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.TrnToken, trnToken },
+                }
             };
-            authenticationProperties.Items.Add(MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.OneLoginAuthenticationScheme, client.OneLoginAuthenticationSchemeName);
-            authenticationProperties.Items.Add(MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.ServiceName, client.Name);
-            authenticationProperties.Items.Add(MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.ServiceUrl, serviceUrl);
 
             return Challenge(authenticationProperties, childAuthenticationScheme);
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/IdDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/IdDbContext.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TeachingRecordSystem.AuthorizeAccess;
+
+public class IdDbContext(DbContextOptions<IdDbContext> options) : DbContext(options)
+{
+    public DbSet<IdTrnToken> TrnTokens => Set<IdTrnToken>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<IdTrnToken>().HasKey(t => t.TrnToken);
+    }
+}
+
+[Table("trn_tokens")]
+public class IdTrnToken
+{
+    [Column("trn_token")]
+    public required string TrnToken { get; set; }
+    [Column("trn")]
+    public required string Trn { get; set; }
+    [Column("email")]
+    public required string Email { get; set; }
+    [Column("created_utc")]
+    public required DateTime CreatedUtc { get; set; }
+    [Column("expires_utc")]
+    public required DateTime ExpiresUtc { get; set; }
+    [Column("user_id")]
+    public Guid? UserId { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
@@ -64,7 +64,7 @@ public class FormFlowJourneySignInHandler(SignInJourneyHelper helper) : IAuthent
 
         var ticket = new AuthenticationTicket(user, properties, _scheme.Name);
 
-        var result = await helper.OnSignedInWithOneLogin(journeyInstance, ticket);
+        var result = await helper.OnOneLoginCallback(journeyInstance, ticket);
 
         // Override the redirect done by RemoteAuthenticationHandler
         _context.Response.OnStarting(() => result.ExecuteAsync(_context));

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/OneLoginAuthenticationSchemeProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/OneLoginAuthenticationSchemeProvider.cs
@@ -187,7 +187,7 @@ public sealed class OneLoginAuthenticationSchemeProvider(
                 var signInJourneyHelper = context.HttpContext.RequestServices.GetRequiredService<SignInJourneyHelper>();
                 var journeyInstance = (await signInJourneyHelper.UserInstanceStateProvider.GetSignInJourneyInstanceAsync(context.HttpContext, journeyInstanceId))!;
 
-                var result = await signInJourneyHelper.OnUserVerificationWithOneLoginFailed(journeyInstance);
+                var result = await signInJourneyHelper.OnVerificationFailed(journeyInstance);
                 await result.ExecuteAsync(context.HttpContext);
             }
         };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml
@@ -1,13 +1,17 @@
 @page "/debug"
 @model TeachingRecordSystem.AuthorizeAccess.Pages.DebugIdentityModel
 @{
-    ViewBag.Title = "Identity information";
+    ViewBag.Title = "Debug One Login journey";
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.DebugIdentity(Model.JourneyInstance!.InstanceId)" method="post">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="TrnToken" disabled="true" />
+
+            <h2 class="govuk-heading-m">User information</h2>
 
             <govuk-input asp-for="Subject" disabled="true" />
 
@@ -43,7 +47,7 @@
                             <govuk-summary-list-row-value>@Model.Person.DateOfBirth?.ToString("dd/MM/yyyy")</govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
-                            <govuk-summary-list-row-key>National insurance number</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>@Model.Person.NationalInsuranceNumber</govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                     </govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml
@@ -4,5 +4,7 @@
 }
 
 <form asp-page="OidcTest" method="post">
+    <govuk-input asp-for="TrnToken" />
+
     <govuk-button type="submit" is-start-button="true">Start</govuk-button>
 </form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/OidcTest/Start.cshtml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -6,6 +7,10 @@ namespace TeachingRecordSystem.AuthorizeAccess.Pages.OidcTest;
 
 public class StartModel : PageModel
 {
+    [BindProperty]
+    [Display(Name = "TRN token")]
+    public string? TrnToken { get; set; }
+
     public void OnGet()
     {
     }
@@ -13,7 +18,11 @@ public class StartModel : PageModel
     public IActionResult OnPost() => Challenge(
         new AuthenticationProperties()
         {
-            RedirectUri = Url.Page("SignedIn")
+            RedirectUri = Url.Page("SignedIn"),
+            Parameters =
+            {
+                { "TrnToken", TrnToken }
+            }
         },
         TestAppConfiguration.AuthenticationSchemeName);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Test.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Test.cshtml.cs
@@ -13,6 +13,9 @@ public class TestModel : PageModel
     [FromQuery(Name = "scheme")]
     public string? AuthenticationScheme { get; set; }
 
+    [FromQuery(Name = "trn_token")]
+    public string? TrnToken { get; set; }
+
     public IActionResult OnGet()
     {
         if (User.Identity?.IsAuthenticated != true)
@@ -24,7 +27,8 @@ public class TestModel : PageModel
                     {
                         { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.OneLoginAuthenticationScheme, AuthenticationScheme },
                         { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.ServiceName, "Test service" },
-                        { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.ServiceUrl, Request.GetEncodedUrl() }
+                        { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.ServiceUrl, Request.GetEncodedUrl() },
+                        { MatchToTeachingRecordAuthenticationHandler.AuthenticationPropertiesItemKeys.TrnToken, TrnToken },
                     },
                     RedirectUri = Request.GetEncodedUrl()
                 },

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -145,6 +145,8 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
         RetryPauseTime = TimeSpan.FromSeconds(1)
     };
     builder.Services.AddDefaultServiceClient(ServiceLifetime.Transient, _ => crmServiceClient.Clone());
+
+    builder.Services.AddDbContext<IdDbContext>(options => options.UseNpgsql(builder.Configuration.GetRequiredConnectionString("Id")));
 }
 
 builder.Services

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
@@ -10,7 +10,8 @@ public class SignInJourneyState(
     string redirectUri,
     string serviceName,
     string serviceUrl,
-    string oneLoginAuthenticationScheme)
+    string oneLoginAuthenticationScheme,
+    string? trnToken = null)
 {
     public const string JourneyName = "SignInJourney";
 
@@ -24,6 +25,8 @@ public class SignInJourneyState(
     public string ServiceUrl { get; } = serviceUrl;
 
     public string OneLoginAuthenticationScheme { get; } = oneLoginAuthenticationScheme;
+
+    public string? TrnToken { get; } = trnToken;
 
     [JsonConverter(typeof(AuthenticationTicketJsonConverter))]
     public AuthenticationTicket? AuthenticationTicket { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TestAppConfiguration.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TestAppConfiguration.cs
@@ -36,13 +36,25 @@ public static class TestAppConfiguration
                     options.MapInboundClaims = false;
                     options.GetClaimsFromUserInfoEndpoint = true;
                     options.SaveTokens = true;
+
                     options.Scope.Clear();
                     options.Scope.Add("openid");
                     options.Scope.Add("email");
                     options.Scope.Add("profile");
                     options.Scope.Add(CustomScopes.TeachingRecord);
+
                     options.ClaimActions.Add(new MapJsonClaimAction(ClaimTypes.OneLoginVerifiedNames));
                     options.ClaimActions.Add(new MapJsonClaimAction(ClaimTypes.OneLoginIdVerifiedBirthDates));
+
+                    options.Events.OnRedirectToIdentityProvider = ctx =>
+                    {
+                        if (ctx.Properties.Parameters.TryGetValue("TrnToken", out var trnTokenObj) && trnTokenObj is string trnToken)
+                        {
+                            ctx.ProtocolMessage.SetParameter("trn_token", trnToken);
+                        }
+
+                        return Task.CompletedTask;
+                    };
                 });
         }
         else

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
@@ -65,6 +65,8 @@ public sealed class HostFixture(IConfiguration configuration) : IAsyncDisposable
                 {
                     DbHelper.ConfigureDbServices(services, context.Configuration.GetRequiredConnectionString("DefaultConnection"));
 
+                    services.AddDbContext<IdDbContext>(options => options.UseInMemoryDatabase("TeacherAuthId"), contextLifetime: ServiceLifetime.Transient);
+
                     services.Configure<AuthenticationOptions>(options =>
                     {
                         options.AddScheme(FakeOneLoginAuthenticationScheme, b => b.HandlerType = typeof(FakeOneLoginHandler));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/Infrastructure/Security/FakeOneLoginHandler.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/Infrastructure/Security/FakeOneLoginHandler.cs
@@ -43,7 +43,7 @@ public class FakeOneLoginHandler(OneLoginCurrentUserProvider currentUserProvider
 
             var journeyInstance = (await signInJourneyHelper.UserInstanceStateProvider.GetSignInJourneyInstanceAsync(_context, journeyInstanceId))!;
 
-            var result = await signInJourneyHelper.OnUserVerificationWithOneLoginFailed(journeyInstance);
+            var result = await signInJourneyHelper.OnVerificationFailed(journeyInstance);
             await result.ExecuteAsync(_context);
 
             return;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/PageExtensions.cs
@@ -11,9 +11,12 @@ public static class PageExtensions
             return asUri.LocalPath == path;
         });
 
-    public static async Task GoToTestStartPage(this IPage page)
+    public static async Task GoToTestStartPage(this IPage page, string? trnToken = null)
     {
-        await page.GotoAsync($"/test?scheme={Uri.EscapeDataString(HostFixture.FakeOneLoginAuthenticationScheme)}");
+        await page.GotoAsync(
+            $"/test" +
+            $"?scheme={Uri.EscapeDataString(HostFixture.FakeOneLoginAuthenticationScheme)}" +
+            $"&trn_token={Uri.EscapeDataString(trnToken ?? "")}");
     }
 
     public static async Task AssertSignedIn(this IPage page, string trn)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="xunit" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/TestBase.cs
@@ -7,6 +7,8 @@ public abstract class TestBase(HostFixture hostFixture)
 {
     public HostFixture HostFixture { get; } = hostFixture;
 
+    public IClock Clock => HostFixture.Services.GetRequiredService<IClock>();
+
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 
     public virtual async Task<T> WithDbContext<T>(Func<TrsDbContext, Task<T>> action)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
@@ -35,6 +35,8 @@ public class HostFixture : WebApplicationFactory<Program>
         {
             DbHelper.ConfigureDbServices(services, context.Configuration.GetRequiredConnectionString("DefaultConnection"));
 
+            services.AddDbContext<IdDbContext>(options => options.UseInMemoryDatabase("TeacherAuthId"), contextLifetime: ServiceLifetime.Transient);
+
             services
                 .Configure<AuthenticationOptions>(options =>
                 {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
@@ -28,7 +28,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -49,7 +49,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
 
@@ -73,7 +73,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
@@ -99,7 +99,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -121,7 +121,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
         var trn = await TestData.GenerateTrn();
@@ -167,7 +167,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -188,7 +188,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
 
@@ -212,7 +212,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
@@ -238,7 +238,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
@@ -26,7 +26,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -48,7 +48,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -70,7 +70,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -104,7 +104,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -126,7 +126,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -148,7 +148,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/connect?{journeyInstance.GetUniqueIdQueryParameter()}");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
@@ -14,7 +14,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
         Debug.Assert(state.AuthenticationTicket is null);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/found?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -38,7 +38,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/found?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -59,7 +59,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
         Debug.Assert(state.AuthenticationTicket is null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/found?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -83,7 +83,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/found?{journeyInstance.GetUniqueIdQueryParameter()}");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
@@ -26,7 +26,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var journeyInstance = await CreateJourneyInstance(state);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -48,7 +48,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -72,7 +72,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var existingNationalInsuranceNumber = haveExistingValueInState ? Faker.Identification.UkNationalInsuranceNumber() : null;
         if (existingNationalInsuranceNumber is not null)
@@ -122,7 +122,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var journeyInstance = await CreateJourneyInstance(state);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
@@ -152,7 +152,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var nationalInsuranceNumber = person.NationalInsuranceNumber!;
 
@@ -182,7 +182,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -208,7 +208,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var nationalInsuranceNumber = "";
 
@@ -238,7 +238,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var nationalInsuranceNumber = "xxx";
 
@@ -268,7 +268,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -301,7 +301,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
@@ -341,7 +341,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var nationalInsuranceNumber = person.NationalInsuranceNumber!;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
@@ -30,7 +30,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: false);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-found?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -52,7 +52,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-found?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -74,7 +74,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
 
@@ -98,7 +98,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
@@ -123,7 +123,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(async state =>
         {
@@ -150,7 +150,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(async state =>
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
@@ -29,7 +29,7 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -51,7 +51,7 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -72,7 +72,7 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: false);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/not-verified?{journeyInstance.GetUniqueIdQueryParameter()}");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
@@ -28,7 +28,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstance(state);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -50,7 +50,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -72,7 +72,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         Debug.Assert(state.NationalInsuranceNumber is null);
 
@@ -98,7 +98,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var existingTrn = haveExistingValueInState ? await TestData.GenerateTrn() : null;
 
@@ -159,7 +159,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var trn = await TestData.GenerateTrn();
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/trn?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -188,7 +188,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var trn = person.Trn!;
 
@@ -219,7 +219,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var trn = await TestData.GenerateTrn();
 
@@ -252,7 +252,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
 
@@ -280,7 +280,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var trn = "";
 
@@ -312,7 +312,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var trn = "xxx";
 
@@ -344,7 +344,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var trn = await TestData.GenerateTrn();
 
@@ -382,7 +382,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var trn = await TestData.GenerateTrn();
 
@@ -424,7 +424,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
-        await GetSignInJourneyHelper().OnSignedInWithOneLogin(journeyInstance, ticket);
+        await GetSignInJourneyHelper().OnOneLoginCallback(journeyInstance, ticket);
 
         var trn = person.Trn!;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TeachingRecordSystem.AuthorizeAccess.Tests.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TeachingRecordSystem.AuthorizeAccess.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Xunit.DependencyInjection" />


### PR DESCRIPTION
We want to support 'magic links' that we've emailed to people inviting them to AYTQ. This adds support for the `trn_token` parameter, as with the current ID solution. The token is associated with a TRN. If the verified last name and DOB match those on the teaching record for the token's TRN we automatically attach the user to the teaching record. If there's a discrepancy we fall back to the regular matching journey.

For now we're reaching directly into the ID database; normally we'd create APIs but this is temporary until we move all the tokens over from ID (at which point we'll likely need direct DB access any way). For testing this uses the EF in memory provider (setting up real DBs for testing this isn't worth it).

Much of this PR is refactoring to allow the Debug page to share some code in `SignInJourneyHelper`; `TryApplyTrnToken` is the meat of the changes.