### PR TITLE
Create a support task when automatic matching fails

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -23,6 +23,9 @@ public abstract class AuthorizeAccessLinkGenerator
     public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/CheckAnswers", journeyInstanceId: journeyInstanceId);
 
+    public string SupportRequestSubmitted(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/SupportRequestSubmitted", journeyInstanceId: journeyInstanceId);
+
     public string Found(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/Found", journeyInstanceId: journeyInstanceId);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotFound.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotFound.cshtml
@@ -9,10 +9,10 @@
 }
 
 <form action="@LinkGenerator.NotFound(Model.JourneyInstance!.InstanceId)" method="post">
-    <div class="govuk-panel govuk-panel--interruption">
-        <h1 class="govuk-panel__title">@ViewBag.Title</h1>
+    <govuk-panel class="govuk-panel--interruption">
+        <govuk-panel-title>@ViewBag.Title</govuk-panel-title>
 
-        <div class="govuk-panel__body">
+        <govuk-panel-body class="govuk-panel__body">
             <div class="trs-two-thirds">
                 <p class="govuk-body govuk-!-margin-bottom-0">
                     We’ve been unable to match your answers to a teaching record.
@@ -30,6 +30,6 @@
 
                 <govuk-button class="govuk-!-margin-bottom-0">Check your answers</govuk-button>
             </div>
-        </div>
-    </div>
+        </govuk-panel-body>
+    </govuk-panel>
 </form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/SupportRequestSubmitted.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/SupportRequestSubmitted.cshtml
@@ -1,0 +1,13 @@
+@page "/request-submitted"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.SupportRequestSubmittedModel
+@{
+    ViewBag.Title = "Support request submitted";
+}
+
+<govuk-panel>
+    <govuk-panel-title>@ViewBag.Title</govuk-panel-title>
+    <govuk-panel-body>
+        We’ll contact you within<br />
+        <strong>5 days</strong>
+    </govuk-panel-body>
+</govuk-panel>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/SupportRequestSubmitted.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/SupportRequestSubmitted.cshtml.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages;
+
+[Journey(SignInJourneyState.JourneyName), RequireJourneyInstance]
+public class SupportRequestSubmittedModel(SignInJourneyHelper helper) : PageModel
+{
+    public JourneyInstance<SignInJourneyState>? JourneyInstance { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var state = JourneyInstance!.State;
+
+        if (state.OneLoginAuthenticationTicket is null || !state.IdentityVerified)
+        {
+            // Not authenticated/verified with One Login
+            context.Result = BadRequest();
+        }
+        else if (state.AuthenticationTicket is not null)
+        {
+            // Already matched to a Teaching Record
+            context.Result = Redirect(helper.GetSafeRedirectUri(JourneyInstance));
+        }
+        else if (!state.HaveNationalInsuranceNumber.HasValue)
+        {
+            // Not answered the NINO question
+            context.Result = Redirect(helper.LinkGenerator.NationalInsuranceNumber(JourneyInstance.InstanceId));
+        }
+        else if (!state.HaveTrn.HasValue)
+        {
+            // Not answered the TRN question
+            context.Result = Redirect(helper.LinkGenerator.Trn(JourneyInstance.InstanceId));
+        }
+        else if (!state.HasPendingSupportRequest)
+        {
+            // Not submitted a submit request
+            context.Result = Redirect(helper.LinkGenerator.CheckAnswers(JourneyInstance.InstanceId));
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyState.cs
@@ -36,6 +36,8 @@ public class SignInJourneyState(
 
     public bool AttemptedIdentityVerification { get; set; }
 
+    public bool HasPendingSupportRequest { get; set; }
+
     [JsonInclude]
     public bool IdentityVerified { get; private set; }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
@@ -14,5 +15,7 @@ public class SupportTaskMapping : IEntityTypeConfiguration<SupportTask>
         builder.HasOne<Person>().WithMany().HasForeignKey(p => p.PersonId).HasConstraintName("fk_support_tasks_person");
         builder.HasIndex(t => t.OneLoginUserSubject);
         builder.HasIndex(t => t.PersonId);
+        builder.Property<JsonDocument>("_data").HasColumnName("data").IsRequired();
+        builder.Ignore(t => t.Data);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class SupportTaskMapping : IEntityTypeConfiguration<SupportTask>
+{
+    public void Configure(EntityTypeBuilder<SupportTask> builder)
+    {
+        builder.ToTable("support_tasks");
+        builder.HasKey(p => p.SupportTaskReference);
+        builder.Property(p => p.SupportTaskReference).HasMaxLength(16);
+        builder.HasOne<OneLoginUser>().WithMany().HasForeignKey(o => o.OneLoginUserSubject).HasConstraintName("fk_support_tasks_one_login_user");
+        builder.HasOne<Person>().WithMany().HasForeignKey(p => p.PersonId).HasConstraintName("fk_support_tasks_person");
+        builder.HasIndex(t => t.OneLoginUserSubject);
+        builder.HasIndex(t => t.PersonId);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240417152506_SupportTasks.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240417152506_SupportTasks.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240417152506_SupportTasks")]
+    partial class SupportTasks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240417152506_SupportTasks.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240417152506_SupportTasks.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SupportTasks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "support_tasks",
+                columns: table => new
+                {
+                    support_task_reference = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    support_task_type = table.Column<int>(type: "integer", nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    data = table.Column<JsonDocument>(type: "jsonb", nullable: false),
+                    one_login_user_subject = table.Column<string>(type: "character varying(255)", nullable: true),
+                    person_id = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_support_tasks", x => x.support_task_reference);
+                    table.ForeignKey(
+                        name: "fk_support_tasks_one_login_user",
+                        column: x => x.one_login_user_subject,
+                        principalTable: "one_login_users",
+                        principalColumn: "subject");
+                    table.ForeignKey(
+                        name: "fk_support_tasks_person",
+                        column: x => x.person_id,
+                        principalTable: "persons",
+                        principalColumn: "person_id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_support_tasks_one_login_user_subject",
+                table: "support_tasks",
+                column: "one_login_user_subject");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_support_tasks_person_id",
+                table: "support_tasks",
+                column: "person_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "support_tasks");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240425141449_SupportTaskCreatedOn.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240425141449_SupportTaskCreatedOn.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240425141449_SupportTaskCreatedOn")]
+    partial class SupportTaskCreatedOn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240425141449_SupportTaskCreatedOn.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240425141449_SupportTaskCreatedOn.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SupportTaskCreatedOn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_on",
+                table: "support_tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_on",
+                table: "support_tasks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "created_on",
+                table: "support_tasks");
+
+            migrationBuilder.DropColumn(
+                name: "updated_on",
+                table: "support_tasks");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -1,0 +1,66 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class SupportTask
+{
+    private static readonly char[] _validReferenceChars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".ToCharArray();
+
+    public required string SupportTaskReference { get; init; }
+    public required SupportTaskType SupportTaskType { get; init; }
+    public required SupportTaskStatus Status { get; set; }
+    public required JsonDocument Data { get; set; }
+    public string? OneLoginUserSubject { get; init; }
+    public Guid? PersonId { get; init; }
+
+    public static string GenerateSupportTaskReference()
+    {
+        var random = GetEncodedRandomBytes();
+        var checkDigit = GetCheckDigit(random);
+
+        return $"TRS-{random}{checkDigit}";
+
+        static string GetEncodedRandomBytes()
+        {
+            var randomData = RandomNumberGenerator.GetBytes(7);
+
+            var result = new StringBuilder(randomData.Length);
+            var counter = 0;
+
+            foreach (var value in randomData)
+            {
+                counter = (counter + value) % (_validReferenceChars.Length - 1);
+                result.Append(_validReferenceChars[counter]);
+            }
+
+            return result.ToString();
+        }
+
+        static char GetCheckDigit(string input)
+        {
+            // Luhn_mod_N_algorithm
+
+            int factor = 2;
+            int sum = 0;
+            int n = _validReferenceChars.Length;
+
+            for (int i = input.Length - 1; i >= 0; i--)
+            {
+                int codePoint = Array.IndexOf(_validReferenceChars, input[i]);
+                int addend = factor * codePoint;
+
+                factor = (factor == 2) ? 1 : 2;
+
+                addend = (addend / n) + (addend % n);
+                sum += addend;
+            }
+
+            int remainder = sum % n;
+            int checkCodePoint = (n - remainder) % n;
+
+            return _validReferenceChars[checkCodePoint];
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -72,6 +72,8 @@ public class TrsDbContext : DbContext
 
     public DbSet<PersonEmployment> PersonEmployments => Set<PersonEmployment>();
 
+    public DbSet<SupportTask> SupportTasks => Set<SupportTask>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString, int? commandTimeout = null)
     {
         Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o.CommandTimeout(commandTimeout);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/SupportTask.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record SupportTask
+{
+    [JsonInclude]
+    [JsonPropertyName("Data")]
+    private JsonDocument _data = null!;
+
+    public required string SupportTaskReference { get; init; }
+    public required SupportTaskType SupportTaskType { get; init; }
+    public required SupportTaskStatus Status { get; init; }
+    public required string? OneLoginUserSubject { get; init; }
+    public required Guid? PersonId { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    public object Data
+    {
+        get => JsonSerializer.Deserialize(_data, DataStore.Postgres.Models.SupportTask.GetDataType(SupportTaskType), DataStore.Postgres.Models.SupportTask.SerializerOptions)!;
+        init => _data = JsonSerializer.SerializeToDocument(value, DataStore.Postgres.Models.SupportTask.GetDataType(SupportTaskType), DataStore.Postgres.Models.SupportTask.SerializerOptions);
+    }
+
+    public static SupportTask FromModel(DataStore.Postgres.Models.SupportTask model) => new()
+    {
+        SupportTaskReference = model.SupportTaskReference,
+        SupportTaskType = model.SupportTaskType,
+        Status = model.Status,
+        OneLoginUserSubject = model.OneLoginUserSubject,
+        PersonId = model.PersonId,
+        Data = model.Data
+    };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/SupportTaskCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/SupportTaskCreatedEvent.cs
@@ -1,0 +1,8 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record SupportTaskCreatedEvent : EventBase
+{
+    public required SupportTask SupportTask { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserVerificationRoute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserVerificationRoute.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Core;
+namespace TeachingRecordSystem.Core.Models;
 
 public enum OneLoginUserVerificationRoute
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ConnectOneLoginUserData.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ConnectOneLoginUserData.cs
@@ -1,0 +1,13 @@
+namespace TeachingRecordSystem.Core.Models.SupportTaskData;
+
+public record ConnectOneLoginUserData
+{
+    public required bool Verified { get; init; }
+    public required string OneLoginUserSubject { get; init; }
+    public required string OneLoginUserEmail { get; init; }
+    public required string[][]? VerifiedNames { get; init; }
+    public required DateOnly[]? VerifiedDatesOfBirth { get; init; }
+    public required string? StatedNationalInsuranceNumber { get; init; }
+    public required string? StatedTrn { get; init; }
+    public Guid? PersonId { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskStatus.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Models;
+
+public enum SupportTaskStatus
+{
+    Open = 0,
+    Closed = 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Models;
+
+public enum SupportTaskType
+{
+    ConnectOneLoginUserToATeachingRecord = 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
@@ -2,5 +2,5 @@ namespace TeachingRecordSystem.Core.Models;
 
 public enum SupportTaskType
 {
-    ConnectOneLoginUserToATeachingRecord = 1
+    ConnectOneLoginUser = 1
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
@@ -145,6 +145,9 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.ClickButton("Check your answers");
 
         await page.WaitForUrlPathAsync("/check-answers");
+        await page.ClickButton("Submit support request");
+
+        await page.WaitForUrlPathAsync("/request-submitted");
     }
 
     [Fact]
@@ -177,6 +180,9 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.ClickButton("Check your answers");
 
         await page.WaitForUrlPathAsync("/check-answers");
+        await page.ClickButton("Submit support request");
+
+        await page.WaitForUrlPathAsync("/request-submitted");
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
@@ -1,0 +1,175 @@
+using System.Diagnostics;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests;
+
+public class SupportRequestSubmittedTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_NotAuthenticatedWithOneLogin_ReturnsBadRequest()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_NotVerifiedWithOneLogin_ReturnsBadRequest()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, createCoreIdentityVc: false);
+        await GetSignInJourneyHelper().OnUserAuthenticated(journeyInstance, ticket);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_NationalInsuranceNumberNotSpecified_RedirectsToNationalInsuranceNumberPage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
+        await GetSignInJourneyHelper().OnUserAuthenticated(journeyInstance, ticket);
+
+        Debug.Assert(state.NationalInsuranceNumber is null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_TrnNotSpecified_RedirectsToTrnPage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
+        await GetSignInJourneyHelper().OnUserAuthenticated(journeyInstance, ticket);
+
+        Debug.Assert(state.NationalInsuranceNumber is null);
+        await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, TestData.GenerateNationalInsuranceNumber()));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/trn?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_AlreadyAuthenticated_RedirectsToStateRedirectUri()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var oneLoginUser = await TestData.CreateOneLoginUser(person);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
+        await GetSignInJourneyHelper().OnUserAuthenticated(journeyInstance, ticket);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"{state.RedirectUri}?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_SupportTicketNotCreated_RedirectsToCheckAnswersPage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
+        await GetSignInJourneyHelper().OnUserAuthenticated(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var trn = await TestData.GenerateTrn();
+
+        await journeyInstance.UpdateStateAsync(state =>
+        {
+            state.SetNationalInsuranceNumber(true, nationalInsuranceNumber);
+            state.SetTrn(true, trn);
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsExpectedContent()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var oneLoginUser = await TestData.CreateOneLoginUser(verified: true);
+
+        var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
+        await GetSignInJourneyHelper().OnUserAuthenticated(journeyInstance, ticket);
+
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var trn = await TestData.GenerateTrn();
+
+        await journeyInstance.UpdateStateAsync(state =>
+        {
+            state.SetNationalInsuranceNumber(true, nationalInsuranceNumber);
+            state.SetTrn(true, trn);
+            state.HasPendingSupportRequest = true;
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponse(response);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
@@ -43,6 +43,8 @@ public abstract class TestBase : IDisposable
 
     public HostFixture HostFixture { get; }
 
+    public CaptureEventObserver EventObserver => _testServices.EventObserver;
+
     public TestableClock Clock => _testServices.Clock;
 
     public HttpClient HttpClient { get; }


### PR DESCRIPTION
When automatic matching fails a support task needs to be raised for support to find the record and associate it with the One Login User. This adds the DB schema for support tasks and wires up the journey to create one when a user is verified but the matching fails.