### PR TITLE
Added job to refresh establishments sourced from TPS spreadsheet

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EstablishmentMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EstablishmentMapping.cs
@@ -11,7 +11,7 @@ public class EstablishmentMapping : IEntityTypeConfiguration<Establishment>
         builder.ToTable("establishments");
         builder.HasKey(e => e.EstablishmentId);
         builder.Property(e => e.EstablishmentSourceId).IsRequired().HasDefaultValue(1);
-        builder.HasIndex(e => e.Urn).HasDatabaseName(Establishment.UrnUniqueIndexName).IsUnique();
+        builder.HasIndex(e => e.Urn).HasDatabaseName(Establishment.UrnIndexName);
         builder.HasIndex(e => new { e.LaCode, e.EstablishmentNumber }).HasDatabaseName(Establishment.LaCodeEstablishmentNumberIndexName);
         builder.Property(e => e.Urn).HasMaxLength(6).IsFixedLength();
         builder.Property(e => e.LaCode).HasMaxLength(3).IsFixedLength();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEstablishmentMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEstablishmentMapping.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class TpsEstablishmentMapping : IEntityTypeConfiguration<TpsEstablishment>
+{
+    public void Configure(EntityTypeBuilder<TpsEstablishment> builder)
+    {
+        builder.ToTable("tps_establishments");
+        builder.HasKey(e => e.TpsEstablishmentId);
+        builder.Property(e => e.LaCode).HasMaxLength(3).IsFixedLength().IsRequired();
+        builder.Property(e => e.EstablishmentCode).HasMaxLength(4).IsFixedLength().IsRequired();
+        builder.Property(e => e.EmployersName).HasMaxLength(200).IsRequired();
+        builder.Property(e => e.SchoolGiasName).HasMaxLength(200);
+        builder.HasIndex(e => new { e.LaCode, e.EstablishmentCode }).HasDatabaseName(TpsEstablishment.LaCodeEstablishmentCodeIndexName);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEstablishmentTypeMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEstablishmentTypeMapping.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class TpsEstablishmentTypeMapping : IEntityTypeConfiguration<TpsEstablishmentType>
+{
+    public void Configure(EntityTypeBuilder<TpsEstablishmentType> builder)
+    {
+        builder.ToTable("tps_establishment_types");
+        builder.HasKey(e => e.TpsEstablishmentTypeId);
+        builder.Property(e => e.EstablishmentRangeFrom).HasMaxLength(4).IsFixedLength().IsRequired();
+        builder.Property(e => e.EstablishmentRangeTo).HasMaxLength(4).IsFixedLength().IsRequired();
+        builder.Property(e => e.Description).HasMaxLength(300).IsRequired();
+        builder.Property(e => e.ShortDescription).HasMaxLength(120).IsRequired();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240426143546_TpsEstablishments.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240426143546_TpsEstablishments.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240426143546_TpsEstablishments")]
+    partial class TpsEstablishments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240426143546_TpsEstablishments.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240426143546_TpsEstablishments.cs
@@ -1,0 +1,164 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TpsEstablishments : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_establishment_urn",
+                table: "establishments");
+
+            migrationBuilder.CreateTable(
+                name: "tps_establishment_types",
+                columns: table => new
+                {
+                    tps_establishment_type_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    establishment_range_from = table.Column<string>(type: "character(4)", fixedLength: true, maxLength: 4, nullable: false),
+                    establishment_range_to = table.Column<string>(type: "character(4)", fixedLength: true, maxLength: 4, nullable: false),
+                    description = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    short_description = table.Column<string>(type: "character varying(120)", maxLength: 120, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_tps_establishment_types", x => x.tps_establishment_type_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "tps_establishments",
+                columns: table => new
+                {
+                    tps_establishment_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    la_code = table.Column<string>(type: "character(3)", fixedLength: true, maxLength: 3, nullable: false),
+                    establishment_code = table.Column<string>(type: "character(4)", fixedLength: true, maxLength: 4, nullable: false),
+                    employers_name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    school_gias_name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    school_closed_date = table.Column<DateOnly>(type: "date", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_tps_establishments", x => x.tps_establishment_id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_establishment_urn",
+                table: "establishments",
+                column: "urn");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tps_establishments_la_code_establishment_number",
+                table: "tps_establishments",
+                columns: new[] { "la_code", "establishment_code" });
+
+            migrationBuilder.InsertData(
+                table: "tps_establishment_types",
+                columns: new[] { "tps_establishment_type_id", "establishment_range_from", "establishment_range_to", "description", "short_description" },
+                values: new object[,]
+                {
+                    { 1, "0001", "0099", "Homes set up under the Children and Young Persons Act (e.g. Community Homes)", "Homes set up under the Children and Young Persons Act (e.g. Community Homes)" },
+                    { 2, "0200", "0399", "Homes set up under the Children and Young Persons Act (e.g. Community Homes)", "Homes set up under the Children and Young Persons Act (e.g. Community Homes)" },
+                    { 3, "0400", "0524", "Training and occupation centres and other DSS establishments (except day nurseries)", "Training and occupation centres and other DSS establishments (except day nurseries)" },
+                    { 4, "0525", "0549", "Special Hospitals provided under Part VII of the Mental Health Act 1959", "Special Hospitals provided under Part VII of the Mental Health Act 1959" },
+                    { 5, "0550", "0574", "Teachers' Superannuation (Army Civilian Lecturer) Scheme 1951 Schools or schools formerly under that Scheme", "Teachers' Superannuation (Army Civilian Lecturer) Scheme 1951 Schools or schools formerly under that Scheme" },
+                    { 6, "0575", "0599", "Education Forum", "Education Forum"},
+                    { 7, "0600", "0600", "CAY", "CAY" },
+                    { 8, "0601", "0601", "PAY", "PAY"},
+                    { 9, "0625", "0625", "DSS day nurseries", "DSS day nurseries" },
+                    { 10, "0626", "0674", "Schools and institutions controlled by other government departments", "Schools and institutions controlled by other government departments" },
+                    { 11, "0675", "0750", "Employment under voluntary youth organisations", "Employment under voluntary youth organisations" },
+                    { 12, "0100", "0199", "Employment under voluntary youth organisations", "Employment under voluntary youth organisations" },
+                    { 13, "0751", "0939", "Employment under adult and miscellaneous organisations", "Employment under adult and miscellaneous organisations" },
+                    { 14, "0940", "0949", "Playing for Success Centres", "Playing for Success Centres" },
+                    { 15, "1000", "1099", "LA nursery schools", "LA nursery schools" },
+                    { 16, "1100", "1150", "Pupil referral units", "Pupil referral units" },
+                    { 75, "1151", "1799", "LA nursery schools", "LA nursery schools" },
+                    { 17, "1800", "1899", "Direct-grant nursery schools", "Direct-grant nursery schools" },
+                    { 18, "1900", "1999", "Independent nursery education establishment recognised as efficient", "Independent nursery education establishment recognised as efficient" },
+                    { 19, "2000", "3999", "Maintained primary schools and schools which have converted to academies", "Maintained primary schools and schools which have converted to academies" },
+                    { 20, "4000", "4999", "Maintained secondary schools and schools which have converted to academies", "Maintained secondary schools and schools which have converted to academies" },
+                    { 21, "5000", "5099", "Direct-grant schools (recorded up to October 1980)", "Direct-grant schools (recorded up to October 1980)" },
+                    { 22, "5100", "5198", "Practical instruction centres (not all such centres have been allocated individual numbers but where a number has already been allocated its use is continued. All new centres are numbered 5199)", "Practical instruction centres" },
+                    { 23, "5200", "5299", "Grant-maintained primary/middle deemed primary schools and schools which have converted to academies" , "Grant-maintained primary/middle deemed primary schools and schools which have converted to academies" },
+                    { 24, "5300", "5399", "Camps, holiday classes etc.", "Camps, holiday classes etc." },
+                    { 25, "5400", "5499", "Grant-maintained secondary/middle deemed secondary schools and schools which have converted to academies", "Grant-maintained secondary/middle deemed secondary schools and schools which have converted to academies" },
+                    { 26, "5500", "5548", "Immigrant centres", "Immigrant centres" },
+                    { 27, "5601", "5899", "Grant-maintained primary, middle and secondary schools (overflow) schools which have converted to academies", "Grant-maintained primary, middle and secondary schools (overflow) schools which have converted to academies"},
+                    { 28, "5900", "5949", "Grant-maintained schools (formally Independent) schools which have converted to academies", "Grant-maintained schools (formally Independent) schools which have converted to academies" },
+                    { 29, "5950", "5999", "Grant-maintained special schools and schools which have converted to academies", "Grant-maintained special schools and schools which have converted to academies" },
+                    { 30, "6000", "6899", "Independent schools", "Independent schools" },
+                    { 31, "6900", "6904", "City technology colleges", "City technology colleges" },
+                    { 32, "6905", "6924", "City Academies", "City Academies" },
+                    { 33, "7000", "7749", "Special schools (except as below)" , "Special schools" },
+                    { 34, "7750", "7798", "Special schools for nursery age children" , "Special schools for nursery age children" },
+                    { 35, "7800", "7899", "Boarding homes for handicapped pupils", "Boarding homes for handicapped pupils" },
+                    { 36, "7900", "7999", "Establishments for further education and training of disabled persons", "Establishments for further education and training of disabled persons" },
+                    { 37, "8000", "8149", "Maintained and assisted major FE establishments (not included below)", "Maintained and assisted major FE establishments" },
+                    { 38, "8150", "8199", "Maintained and assisted art establishments", "Maintained and assisted art establishments"},
+                    { 39, "8200", "8219", "Direct-grant major FE establishments", "Direct-grant major FE establishments" },
+                    { 40, "8220", "8269", "Independent (Efficient-Rules 16) FE establishments", "Independent (Efficient-Rules 16) FE establishments" },
+                    { 41, "8270", "8284", "National colleges", "National colleges"},
+                    { 42, "8300", "8349", "LA farm institutes", "LA farm institutes"},
+                    { 43, "8350", "8389", "LA agricultural centres", "LA agricultural centres"},
+                    { 44, "8390", "8399", "Direct-grant and independent agricultural establishments", "Direct-grant and independent agricultural establishments" },
+                    { 45, "8400", "8499", "LA youth welfare", "LA youth welfare" },
+                    { 46, "8500", "8599", "LA adult welfare", "LA adult welfare" },
+                    { 47, "8600", "8699", "Sixth form colleges", "Sixth form colleges" },
+                    { 48, "8700", "8898", "Polytechnics/New Style Universities", "Polytechnics/New Style Universities" },
+                    { 49, "9300", "9599", "LA colleges of education", "LA colleges of education" },
+                    { 50, "9600", "9899", "Voluntary colleges of education", "Voluntary colleges of education" },
+                    { 51, "0950", "0950", "Teacher /organiser (employed primarily as a teacher)", "Teacher /organiser (employed primarily as a teacher)" },
+                    { 52, "0951", "0951", "Divided service between Primary and Secondary Schools" , "Divided service between Primary and Secondary Schools" },
+                    { 53, "0952", "0952", "Divided service between Further Education and P & S Schools", "Divided service between Further Education and P & S Schools" },
+                    { 54, "0954", "0954", "Adult Miscellaneous Organisation", "Adult Miscellaneous Organisation" },
+                    { 55, "7799", "7799", "Divided service between Special Schools", "Divided service between Special Schools" },
+                    { 56, "8999", "8999", "Divided service between FE establishments", "Divided service between FE establishments" },
+                    { 57, "0953", "0953", "Adult Miscellaneous Organisation (not allocated an Estab No) - ie teacher paid under FE document, employed providing FE or Adult Education (eg Community College)", "Adult Miscellaneous Organisation (not allocated an Estab No)" },
+                    { 58, "0955", "0955", "Teacher employed by Ministry of Defence (UK based)", "Teacher employed by Ministry of Defence (UK based)" },
+                    { 59, "0960", "0960", "Unattached regular engagement in Primary Schools - ie Permanent 'supply' teacher under contract", "Unattached regular engagement in Primary Schools - ie Permanent 'supply' teacher under contract" },
+                    { 60, "0961", "0961", "Unattached regular engagement in Secondary or P & S - ie Permanent 'supply' teacher under contract", "Unattached regular engagement in Secondary or P & S - ie Permanent 'supply' teacher under contract" },
+                    { 61, "0962", "0962", "Visiting Teacher Primary - peripatetic teacher (eg specialist subject teacher visiting different schools)", "Visiting Teacher Primary - peripatetic teacher (eg specialist subject teacher visiting different schools)" },
+                    { 62, "0963", "0963", "Visiting Teacher Secondary or P & S - peripatetic teacher (eg specialist subject teacher visiting different schools)", "Visiting Teacher Secondary or P & S - peripatetic teacher (eg specialist subject teacher visiting different schools)" },
+                    { 63, "0964", "0964", "P & S teaching under Section 56 of Education Act 1944 - ie teaching other than at a school (eg at home or in a hospital, or teachers in penal establishments)", "P & S teaching under Section 56 of Education Act 1944 - ie teaching other than at a school" },
+                    { 64, "0965", "0965", "Peripatetic support wholly for SEN or disabled not in a special school.", "Peripatetic support wholly for SEN or disabled not in a special school." },
+                    { 65, "0966", "0966", "School supply teacher - whose contract is terminable without notice. Teacher who is employed temporarily in place of a regularly employed teacher. Teacher has made a part-time election." , "School supply teacher - whose contract is terminable without notice" },
+                    { 66, "0970", "0971", "Full-time Organiser - employment involves the performance of duties in connection with the provision of education or service ancillary to education (accepted in TPS only if previously accepted under 1967 Teachers' Pension Regulations)" , "Full-time Organiser" },
+                    { 67, "0972", "0972", "Full and Part-Time Youth and Community Worker" , "Full and Part-Time Youth and Community Worker" },
+                    { 68, "5199", "5199", "Service as a teacher in Practical Instruction Centres - providing P & S education (previously allocated individual numbers in range 5100-5199)(not schools - unattached units). (Service other than as a teacher would have to be considered by the Department)" , "Service as a teacher in Practical Instruction Centres - providing P & S education" },
+                    { 69, "5549", "5549", "Service as a teacher in Remedial Centres and Support Units - providing P & S education (not schools - unattached units). (Service other than as a teacher would have to be considered by the Department", "Service as a teacher in Remedial Centres and Support Units - providing P & S education (not schools - unattached units)" },
+                    { 70, "5599", "5599", "Service as a teacher in any other P & S Centre (ie not PI or Remedial)(eg Assessment Centres outdoor pursuit centres, Teacher Centres [if paid P & S]). Service other than as a teacher would have to be considered by Teachers' Pensions)", "Service as a teacher in any other P & S Centre (ie not PI or Remedial)"},
+                    { 71, "5600", "5600", "Service in Intermediate Treatment Centres - providing P & S education (not schools - unattached units)", "Service in Intermediate Treatment Centres - providing P & S education (not schools - unattached units)" },
+                    { 72, "9099", "9099", "Function Provider within a LEA", "Function Provider within a LEA" },
+                    { 73, "8899", "8899", "Adult Education Service (residential adult education estabs have numbers allocated in range 8290-8294). Teacher Centres if paid on FE Scales, Adult Literacy Scheme staff (LA)" , "Adult Education Service" },
+                    { 74, "0999", "0999", "Service of any other kind (eg full-time educational officers in penal estabs Job Creation Schemes). Normally this code will not be used where a teacher is in receipt of a mandatory Burnham salary", "Service of any other kind (eg full-time educational officers in penal estabs Job Creation Schemes)" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tps_establishment_types");
+
+            migrationBuilder.DropTable(
+                name: "tps_establishments");
+
+            migrationBuilder.DropIndex(
+                name: "ix_establishment_urn",
+                table: "establishments");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_establishment_urn",
+                table: "establishments",
+                column: "urn",
+                unique: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Establishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Establishment.cs
@@ -2,7 +2,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class Establishment
 {
-    public const string UrnUniqueIndexName = "ix_establishment_urn";
+    public const string UrnIndexName = "ix_establishment_urn";
     public const string LaCodeEstablishmentNumberIndexName = "ix_establishment_la_code_establishment_number";
     public const string EstablishmentSourceIdIndexName = "ix_establishment_establishment_source_id";
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsEstablishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsEstablishment.cs
@@ -1,0 +1,13 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class TpsEstablishment
+{
+    public const string LaCodeEstablishmentCodeIndexName = "ix_tps_establishments_la_code_establishment_number";
+
+    public required Guid TpsEstablishmentId { get; set; }
+    public required string LaCode { get; set; }
+    public required string EstablishmentCode { get; set; }
+    public required string EmployersName { get; set; }
+    public required string? SchoolGiasName { get; set; }
+    public required DateOnly? SchoolClosedDate { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsEstablishmentType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsEstablishmentType.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class TpsEstablishmentType
+{
+    public required int TpsEstablishmentTypeId { get; set; }
+    public required string EstablishmentRangeFrom { get; set; }
+    public required string EstablishmentRangeTo { get; set; }
+    public required string Description { get; set; }
+    public required string ShortDescription { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -64,6 +64,8 @@ public class TrsDbContext : DbContext
 
     public DbSet<Establishment> Establishments => Set<Establishment>();
 
+    public DbSet<EstablishmentSource> EstablishmentSources => Set<EstablishmentSource>();
+
     public DbSet<TpsCsvExtract> TpsCsvExtracts => Set<TpsCsvExtract>();
 
     public DbSet<TpsCsvExtractLoadItem> TpsCsvExtractLoadItems => Set<TpsCsvExtractLoadItem>();
@@ -73,6 +75,10 @@ public class TrsDbContext : DbContext
     public DbSet<PersonEmployment> PersonEmployments => Set<PersonEmployment>();
 
     public DbSet<SupportTask> SupportTasks => Set<SupportTask>();
+    
+    public DbSet<TpsEstablishment> TpsEstablishments => Set<TpsEstablishment>();    
+
+    public DbSet<TpsEstablishmentType> TpsEstablishmentTypes => Set<TpsEstablishmentType>();
 
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString, int? commandTimeout = null)
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -75,8 +75,8 @@ public class TrsDbContext : DbContext
     public DbSet<PersonEmployment> PersonEmployments => Set<PersonEmployment>();
 
     public DbSet<SupportTask> SupportTasks => Set<SupportTask>();
-    
-    public DbSet<TpsEstablishment> TpsEstablishments => Set<TpsEstablishment>();    
+
+    public DbSet<TpsEstablishment> TpsEstablishments => Set<TpsEstablishment>();
 
     public DbSet<TpsEstablishmentType> TpsEstablishmentTypes => Set<TpsEstablishmentType>();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
-using TeachingRecordSystem.Core.Services.Establishments;
+using TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 namespace TeachingRecordSystem.Core.Jobs;
 
@@ -110,6 +110,11 @@ public static class HostApplicationBuilderExtensions
 
                 recurringJobManager.AddOrUpdate<ImportTpsCsvExtractFileJob>(
                     nameof(ImportTpsCsvExtractFileJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<TpsRefreshEstablishmentsJob>(
+                    nameof(TpsRefreshEstablishmentsJob),
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
@@ -1,5 +1,5 @@
 using TeachingRecordSystem.Core.Jobs.Scheduling;
-using TeachingRecordSystem.Core.Services.Establishments;
+using TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 namespace TeachingRecordSystem.Core.Jobs;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TpsRefreshEstablishmentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TpsRefreshEstablishmentsJob.cs
@@ -1,0 +1,23 @@
+using TeachingRecordSystem.Core.Jobs.Scheduling;
+using TeachingRecordSystem.Core.Services.Establishments.Tps;
+using TeachingRecordSystem.Core.Services.WorkforceData;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class TpsRefreshEstablishmentsJob(
+    ITpsExtractStorageService tpsExtractStorageService,
+    IBackgroundJobScheduler backgroundJobScheduler)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    { 
+        var tpsEstablishmentFileName = await tpsExtractStorageService.GetPendingEstablishmentImportFileName(cancellationToken);
+        if (tpsEstablishmentFileName == null)
+        {
+            return;
+        }
+
+        var importJobId = await backgroundJobScheduler.Enqueue<TpsEstablishmentRefresher>(j => j.ImportFile(tpsEstablishmentFileName, cancellationToken));
+        var archiveJobId = await backgroundJobScheduler.ContinueJobWith<ITpsExtractStorageService>(importJobId, j => j.ArchiveFile(tpsEstablishmentFileName, cancellationToken));
+        var refreshJobId = await backgroundJobScheduler.ContinueJobWith<TpsEstablishmentRefresher>(archiveJobId, j => j.RefreshEstablishments(cancellationToken));
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TpsRefreshEstablishmentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TpsRefreshEstablishmentsJob.cs
@@ -9,7 +9,7 @@ public class TpsRefreshEstablishmentsJob(
     IBackgroundJobScheduler backgroundJobScheduler)
 {
     public async Task ExecuteAsync(CancellationToken cancellationToken)
-    { 
+    {
         var tpsEstablishmentFileName = await tpsExtractStorageService.GetPendingEstablishmentImportFileName(cancellationToken);
         if (tpsEstablishmentFileName == null)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/CsvDownloadEstablishmentMasterDataService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/CsvDownloadEstablishmentMasterDataService.cs
@@ -3,7 +3,7 @@ using System.Text;
 using CsvHelper;
 using CsvHelper.Configuration;
 
-namespace TeachingRecordSystem.Core.Services.Establishments;
+namespace TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 public class CsvDownloadEstablishmentMasterDataService : IEstablishmentMasterDataService
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/EstablishmentCsvRow.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/EstablishmentCsvRow.cs
@@ -1,6 +1,6 @@
 using CsvHelper.Configuration.Attributes;
 
-namespace TeachingRecordSystem.Core.Services.Establishments;
+namespace TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 public class EstablishmentCsvRow
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/EstablishmentRefresher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/EstablishmentRefresher.cs
@@ -1,6 +1,6 @@
 using TeachingRecordSystem.Core.DataStore.Postgres;
 
-namespace TeachingRecordSystem.Core.Services.Establishments;
+namespace TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 public class EstablishmentRefresher(
     TrsDbContext dbContext,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/GiasOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/GiasOptions.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace TeachingRecordSystem.Core.Services.Establishments;
+namespace TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 public class GiasOptions
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/IEstablishmentMasterDataService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Gias/IEstablishmentMasterDataService.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Core.Services.Establishments;
+namespace TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 public interface IEstablishmentMasterDataService
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using TeachingRecordSystem.Core.Services.Establishments.Gias;
 
 namespace TeachingRecordSystem.Core.Services.Establishments;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/NewEstablishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/NewEstablishment.cs
@@ -5,5 +5,5 @@ public class NewEstablishment
     public required string LaCode { get; set; }
     public required string? LaName { get; set; }
     public required string EstablishmentNumber { get; set; }
-    public required string EstablishmentName { get; set; }    
+    public required string EstablishmentName { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/NewEstablishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/NewEstablishment.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Core.Services.Establishments.Tps;
+
+public class NewEstablishment
+{
+    public required string LaCode { get; set; }
+    public required string? LaName { get; set; }
+    public required string EstablishmentNumber { get; set; }
+    public required string EstablishmentName { get; set; }    
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/TpsEstablishmentCsvRow.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/TpsEstablishmentCsvRow.cs
@@ -5,14 +5,11 @@ namespace TeachingRecordSystem.Core.Services.Establishments.Tps;
 public class TpsEstablishmentCsvRow
 {
     [Name("LA Code")]
-    [NullValues("")]
-    public required string? LaCode { get; set; }
+    public required string LaCode { get; set; }
     [Name("Establishment Code")]
-    [NullValues("")]
-    public required string? EstablishmentCode { get; set; }
+    public required string EstablishmentCode { get; set; }
     [Name("EMPS Name")]
-    [NullValues("")]
-    public required string? EmployersName { get; set; }
+    public required string EmployersName { get; set; }
     [Name("SCHL (GIAS) Name")]
     [NullValues("")]
     public required string? SchoolGiasName { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/TpsEstablishmentCsvRow.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/TpsEstablishmentCsvRow.cs
@@ -1,0 +1,22 @@
+using CsvHelper.Configuration.Attributes;
+
+namespace TeachingRecordSystem.Core.Services.Establishments.Tps;
+
+public class TpsEstablishmentCsvRow
+{
+    [Name("LA Code")]
+    [NullValues("")]
+    public required string? LaCode { get; set; }
+    [Name("Establishment Code")]
+    [NullValues("")]
+    public required string? EstablishmentCode { get; set; }
+    [Name("EMPS Name")]
+    [NullValues("")]
+    public required string? EmployersName { get; set; }
+    [Name("SCHL (GIAS) Name")]
+    [NullValues("")]
+    public required string? SchoolGiasName { get; set; }
+    [Name("School Closed Date")]
+    [NullValues("")]
+    public required string? SchoolClosedDate { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/TpsEstablishmentRefresher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Establishments/Tps/TpsEstablishmentRefresher.cs
@@ -1,0 +1,241 @@
+using CsvHelper.Configuration;
+using CsvHelper;
+using System.Globalization;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.WorkforceData;
+using Npgsql;
+using NpgsqlTypes;
+using System.Text.RegularExpressions;
+
+namespace TeachingRecordSystem.Core.Services.Establishments.Tps;
+
+public class TpsEstablishmentRefresher(
+    ITpsExtractStorageService tpsExtractStorageService,
+    IDbContextFactory<TrsDbContext> dbContextFactory)
+{
+    public async Task ImportFile(string fileName, CancellationToken cancellationToken)
+    {
+        using var dbContext = dbContextFactory.CreateDbContext();
+        var truncateSql = "TRUNCATE TABLE tps_establishments";
+        await dbContext.Database.ExecuteSqlRawAsync(truncateSql, cancellationToken);
+
+        var connection = (NpgsqlConnection)dbContext.Database.GetDbConnection();
+        await connection.OpenAsync(cancellationToken);
+
+        using var writer = await connection.BeginBinaryImportAsync(
+            $"""
+            COPY
+                tps_establishments (
+                    tps_establishment_id,
+                    la_code,
+                    establishment_code,
+                    employers_name,
+                    school_gias_name,
+                    school_closed_date
+                )
+            FROM
+                STDIN (FORMAT BINARY)
+            """);
+
+        var stream = await tpsExtractStorageService.GetFile(fileName, cancellationToken);
+        using var streamReader = new StreamReader(stream);
+        using var csvReader = new CsvReader(streamReader, new CsvConfiguration(CultureInfo.CurrentCulture) { HasHeaderRecord = true });
+
+        await foreach (var row in csvReader.GetRecordsAsync<TpsEstablishmentCsvRow>())
+        {
+            if (string.IsNullOrEmpty(row.LaCode) || !Regex.IsMatch(row.LaCode, @"^\d{3}$")
+                || string.IsNullOrEmpty(row.EstablishmentCode) || !Regex.IsMatch(row.EstablishmentCode, @"^\d{4}$")
+                || string.IsNullOrEmpty(row.EmployersName) ||
+                (!string.IsNullOrEmpty(row.SchoolClosedDate) && !DateOnly.TryParseExact(row.SchoolClosedDate, "dd/MM/yyyy", out _)))
+            {
+                continue;
+            }
+
+            writer.StartRow();
+            writer.Write(Guid.NewGuid(), NpgsqlDbType.Uuid);
+            writer.Write(row.LaCode, NpgsqlDbType.Char);
+            writer.Write(row.EstablishmentCode, NpgsqlDbType.Char);
+            writer.Write(row.EmployersName, NpgsqlDbType.Varchar);
+            writer.Write(row.SchoolGiasName, NpgsqlDbType.Varchar);
+            writer.Write(!string.IsNullOrEmpty(row.SchoolClosedDate) ? DateOnly.ParseExact(row.SchoolClosedDate, "dd/MM/yyyy") : (DateOnly?)null, NpgsqlDbType.Date);
+        }
+
+        await writer.CompleteAsync(cancellationToken);
+        await writer.CloseAsync(cancellationToken);
+    }
+
+    public async Task RefreshEstablishments(CancellationToken cancellationToken)
+    {
+        using var readDbContext = dbContextFactory.CreateDbContext();
+        readDbContext.Database.SetCommandTimeout(300);
+        using var writeDbContext = dbContextFactory.CreateDbContext();
+
+        FormattableString querySql =
+            $"""
+            WITH unique_gias_establishments AS (
+                SELECT
+                    establishment_id,
+                    la_code,
+                    la_name,
+                    establishment_number,
+                    establishment_name,
+                    establishment_type_code,
+                    postcode
+                FROM
+                    (SELECT
+                        establishment_id,
+                        la_code,
+                        la_name,
+                        establishment_number,
+                        establishment_name,
+                        establishment_type_code,
+                        postcode,
+                        ROW_NUMBER() OVER (PARTITION BY la_code, establishment_number, CASE WHEN establishment_number IS NULL THEN postcode ELSE NULL END ORDER BY translate(establishment_status_code::text, '1234', '1324'), urn desc) as row_number
+                    FROM
+                        establishments
+                    WHERE
+                        establishment_source_id = 1) e
+                WHERE
+                    e.row_number = 1
+            ),
+            gias_la_codes AS (
+                SELECT
+                    la_code,
+                    MAX(la_name) as la_name
+                FROM
+                    unique_gias_establishments
+                GROUP BY
+                    la_code
+            ),
+            unique_tps_establishments AS (
+                SELECT
+                    tps_establishment_id,
+                    la_code,
+                    establishment_code,
+                    employers_name,
+                    school_gias_name,
+                    school_closed_date
+                FROM
+                    (SELECT
+                        tps_establishment_id,
+                        la_code,
+                        establishment_code,
+                        employers_name,
+                        school_gias_name,
+                        school_closed_date,
+                        ROW_NUMBER() OVER (PARTITION BY la_code, establishment_code ORDER BY CASE WHEN school_closed_date IS NULL THEN 1 ELSE 2 END) as row_number
+                     FROM
+                        tps_establishments) e
+                WHERE
+                    e.row_number = 1
+            ),
+            tps_la_names AS (
+            	SELECT
+            		*
+            	FROM
+            		(VALUES
+            		('CORPORATION OF LONDON'),
+            		('HAMMERSMITH & FULHAM'),
+            		('KENSINGTON & CHELSEA'),
+            		('BARKING & DAGENHAM'),
+            		('KINGSTON-UPON-THAMES'),
+            		('RICHMOND-UPON-THAMES'),
+            		('ST HELENS'),
+            		('NEWCASTLE-UPON-TYNE'),
+            		('INNER LONDON'),
+            		('ANGLESEY'),
+            		('CARDIGANSHIRE'),
+            		('NEATH & PORT TALBOT'),
+            		('RHONDDA CYNON TAFF'),
+            		('BATH & NORTH EAST SOMERSET'),
+            		('CITY OF BRISTOL'),
+            		('REDCAR & CLEVELAND'),
+            		('CITY OF KINGSTON UPON HULL'),
+            		('BEDFORD BOROUGH'),
+            		('CITY OF DERBY'),
+            		('BRIGHTON & HOVE'),
+            		('LEICESTER CITY'),
+            		('STOKE ON TRENT'),
+            		('HEREFORDSHIRE'),
+            		('MEDWAY TOWNS'),
+            		('NOTTINGHAM CITY'),
+            		('THE WREKIN'),
+            		('BEDFORDSHIRE'),
+            		('BERKSHIRE'),
+            		('CHESHIRE'),
+            		('CUMBRIA'),
+            		('DURHAM'),
+            		('HEREFORD & WORCESTER')) as t (name)
+            )
+            SELECT
+                e.la_code,
+                CASE WHEN g.la_code IS NULL THEN NULL ELSE g.la_name END as la_name,
+                e.establishment_code as establishment_number,
+                CASE WHEN t.short_description IS NULL OR (UPPER(g.la_name) != trim(e.employers_name) AND l.name IS NULL) THEN trim(e.employers_name) ELSE t.short_description END as establishment_name
+            FROM
+                    unique_tps_establishments e
+                LEFT JOIN
+                    tps_establishment_types t ON e.establishment_code::int >= t.establishment_range_from::int
+                                                 AND e.establishment_code::int <= t.establishment_range_to::int
+                LEFT JOIN
+                    gias_la_codes g ON e.la_code = g.la_code
+                LEFT JOIN
+                    tps_la_names l ON trim(e.employers_name) = l.name
+            WHERE
+                NOT EXISTS (SELECT
+                                1
+                            FROM
+                                unique_gias_establishments g
+                            WHERE
+                                g.la_code = e.la_code
+                                AND g.establishment_number = e.establishment_code)
+            """;
+
+        int i = 0;
+        await foreach (var item in readDbContext.Database.SqlQuery<NewEstablishment>(querySql).AsAsyncEnumerable())
+        {
+            var existingEstablishment = await writeDbContext.Establishments.SingleOrDefaultAsync(e => e.LaCode == item.LaCode && e.EstablishmentNumber == item.EstablishmentNumber);
+            if (existingEstablishment == null)
+            {
+                writeDbContext.Establishments.Add(new()
+                {
+                    EstablishmentId = Guid.NewGuid(),
+                    EstablishmentSourceId = 2,
+                    Urn = null,
+                    LaCode = item.LaCode,
+                    LaName = item.LaName,
+                    EstablishmentNumber = item.EstablishmentNumber,
+                    EstablishmentName = item.EstablishmentName,
+                    EstablishmentTypeCode = null,
+                    EstablishmentTypeName = null,
+                    EstablishmentTypeGroupCode = null,
+                    EstablishmentTypeGroupName = null,
+                    EstablishmentStatusCode = null,
+                    EstablishmentStatusName = null,
+                    Street = null,
+                    Locality = null,
+                    Address3 = null,
+                    Town = null,
+                    County = null,
+                    Postcode = null
+                });
+            }
+            else
+            {
+                existingEstablishment.EstablishmentSourceId = 2;                
+                existingEstablishment.LaName = item.LaName;
+                existingEstablishment.EstablishmentName = item.EstablishmentName;
+            }
+
+            if (++i % 2000 == 0)
+            {
+                await writeDbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        if (writeDbContext.ChangeTracker.HasChanges())
+        {
+            await writeDbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/BlobStorageTpsExtractStorageService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/BlobStorageTpsExtractStorageService.cs
@@ -7,6 +7,7 @@ namespace TeachingRecordSystem.Core.Services.WorkforceData;
 public class BlobStorageTpsExtractStorageService(BlobServiceClient blobServiceClient) : ITpsExtractStorageService
 {
     private const string TpsExtractsContainerName = "tps-extracts";
+    private const string EstablishmentsFolderName = "establishments";
     private const string PendingFolderName = "pending";
     private const string ImportedFolderName = "imported";
 
@@ -16,6 +17,14 @@ public class BlobStorageTpsExtractStorageService(BlobServiceClient blobServiceCl
         var fileNames = new List<string>();
         await GetFileNamesAsync(blobContainerClient, PendingFolderName, true, fileNames, cancellationToken);
         return fileNames.ToArray();
+    }
+
+    public async Task<string?> GetPendingEstablishmentImportFileName(CancellationToken cancellationToken)
+    {
+        var blobContainerClient = blobServiceClient.GetBlobContainerClient(TpsExtractsContainerName);
+        var fileNames = new List<string>();
+        await GetFileNamesAsync(blobContainerClient, EstablishmentsFolderName, true, fileNames, cancellationToken);
+        return fileNames?.FirstOrDefault();
     }
 
     public async Task<Stream> GetFile(string fileName, CancellationToken cancellationToken)
@@ -80,5 +89,5 @@ public class BlobStorageTpsExtractStorageService(BlobServiceClient blobServiceCl
                 }
             }
         }
-    }
+    }    
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ITpsExtractStorageService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ITpsExtractStorageService.cs
@@ -4,6 +4,8 @@ public interface ITpsExtractStorageService
 {
     Task<string[]> GetPendingImportFileNames(CancellationToken cancellationToken);
 
+    Task<string?> GetPendingEstablishmentImportFileName(CancellationToken cancellationToken);
+
     Task<Stream> GetFile(string fileName, CancellationToken cancellationToken);
 
     Task ArchiveFile(string fileName, CancellationToken cancellationToken);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using TeachingRecordSystem.Core.Services.Establishments.Tps;
 
 namespace TeachingRecordSystem.Core.Services.WorkforceData;
 
@@ -9,6 +10,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ITpsExtractStorageService, BlobStorageTpsExtractStorageService>();
         services.AddSingleton<TpsCsvExtractFileImporter>();
         services.AddSingleton<TpsCsvExtractProcessor>();
+        services.AddSingleton<TpsEstablishmentRefresher>();
 
         return services;
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
@@ -1,10 +1,10 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Dqt;
-using TeachingRecordSystem.Core.Services.Establishments;
+using TeachingRecordSystem.Core.Services.Establishments.Gias;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using Establishment = TeachingRecordSystem.Core.Models.Establishment;
 
-namespace TeachingRecordSystem.Core.Tests.Services.Establishments;
+namespace TeachingRecordSystem.Core.Tests.Services.Establishments.Gias;
 
 public class EstablishmentRefresherTests
 {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
@@ -14,7 +14,7 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
     private const string KnownGiasLaCodeHackney = "204";
     private const string KnownGiasLaNameHackney = "Hackney";
     private const string KnownGiasEstablishmentNumberHackney = "2654";
-    private const string KnownGiasEstablishmentNameHackney = "Woodberry Down Community Primary School";    
+    private const string KnownGiasEstablishmentNameHackney = "Woodberry Down Community Primary School";
     private const string KnownGiasLaCodeCityOfLondon = "201";
     private const string KnownGiasLaNameCityOfLondon = "City of London";
     private const string KnownGiasEstablishmentNumberCityOfLondon = "6007";
@@ -326,7 +326,7 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
         {
             Assert.Empty(nonGiasEstablishments);
         }
-    }    
+    }
 
     public Task InitializeAsync() => Task.CompletedTask;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
@@ -1,0 +1,356 @@
+using System.Text;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.Establishments.Tps;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+using TeachingRecordSystem.Core.Services.WorkforceData;
+
+namespace TeachingRecordSystem.Core.Tests.Services.Establishments.Tps;
+
+[Collection(nameof(DisableParallelization))]
+public class TpsEstablishmentRefresherTests : IAsyncLifetime
+{
+    private const string KnownGiasLaCodeHackney = "204";
+    private const string KnownGiasLaNameHackney = "Hackney";
+    private const string KnownGiasEstablishmentNumberHackney = "2654";
+    private const string KnownGiasEstablishmentNameHackney = "Woodberry Down Community Primary School";    
+    private const string KnownGiasLaCodeCityOfLondon = "201";
+    private const string KnownGiasLaNameCityOfLondon = "City of London";
+    private const string KnownGiasEstablishmentNumberCityOfLondon = "6007";
+    private const string KnownGiasEstablishmentNameCityOfLondon = "City of London School";
+    private const string KnownTpsLaNameCorporationOfLondon = "CORPORATION OF LONDON";
+    private const string KnownTpsLaCode = "751";
+    private const string KnownTpsEstablishmentNumberWithinTpsEstablishmentTypeRange = "0972";
+    private const string KnownTpsEstablishmentTypeShortDescription = "Full and Part-Time Youth and Community Worker";
+    private const string KnownTpsEstablishmentNumberOutsideTpsEstablishmentTypeRange = "0000";
+
+    public TpsEstablishmentRefresherTests(
+        DbFixture dbFixture,
+        IOrganizationServiceAsync2 organizationService,
+        ReferenceDataCache referenceDataCache,
+        FakeTrnGenerator trnGenerator)
+    {
+        DbFixture = dbFixture;
+        Clock = new();
+
+        var dbContextFactory = dbFixture.GetDbContextFactory();
+
+        Helper = new TrsDataSyncHelper(
+            dbContextFactory,
+            organizationService,
+            referenceDataCache,
+            Clock);
+
+        TestData = new TestData(
+            dbContextFactory,
+            organizationService,
+            referenceDataCache,
+            Clock,
+            trnGenerator,
+            TestDataSyncConfiguration.Sync(Helper));
+    }
+
+    public static TheoryData<TpsEstablishmentFileImportTestScenarioData> GetImportFileTestScenarioData()
+    {
+        var validFormatLocalAuthorityCode = "123";
+        var invalidFormatLocalAuthorityCode = "1234";
+        var validFormatEstablishmentNumber = "1234";
+        var invalidFormatEstablishmentNumber = "12345";
+        var validFormatSchoolClosedDate = "03/02/2023";
+        var invalidFormatSchoolClosedDate = "1234";
+
+        return new TheoryData<TpsEstablishmentFileImportTestScenarioData>
+        {
+            new TpsEstablishmentFileImportTestScenarioData
+            {
+                Row = new TpsEstablishmentCsvRow
+                {
+                    LaCode = validFormatLocalAuthorityCode,
+                    EstablishmentCode = validFormatEstablishmentNumber,
+                    EmployersName = "Employers Name",
+                    SchoolGiasName = "School Gias Name",
+                    SchoolClosedDate = validFormatSchoolClosedDate
+                },
+                IsExpectedToBeImported = true
+            },
+            new TpsEstablishmentFileImportTestScenarioData
+            {
+                Row = new TpsEstablishmentCsvRow
+                {
+                    LaCode = invalidFormatLocalAuthorityCode,
+                    EstablishmentCode = validFormatEstablishmentNumber,
+                    EmployersName = "Employers Name",
+                    SchoolGiasName = "School Gias Name",
+                    SchoolClosedDate = validFormatSchoolClosedDate
+                },
+                IsExpectedToBeImported = false
+            },
+            new TpsEstablishmentFileImportTestScenarioData
+            {
+                Row = new TpsEstablishmentCsvRow
+                {
+                    LaCode = validFormatLocalAuthorityCode,
+                    EstablishmentCode = invalidFormatEstablishmentNumber,
+                    EmployersName = "Employers Name",
+                    SchoolGiasName = "School Gias Name",
+                    SchoolClosedDate = validFormatSchoolClosedDate
+                },
+                IsExpectedToBeImported = false
+            },
+            new TpsEstablishmentFileImportTestScenarioData
+            {
+                Row = new TpsEstablishmentCsvRow
+                {
+                    LaCode = validFormatLocalAuthorityCode,
+                    EstablishmentCode = validFormatEstablishmentNumber,
+                    EmployersName = "Employers Name",
+                    SchoolGiasName = "School Gias Name",
+                    SchoolClosedDate = invalidFormatSchoolClosedDate
+                },
+                IsExpectedToBeImported = false
+            }
+        };
+    }
+
+    public static TheoryData<TpsEstablishmentRefreshTestScenarioData> GetRefreshEstablishmentsTestScenarioData()
+    {
+        return new TheoryData<TpsEstablishmentRefreshTestScenarioData>
+        {
+            // Don't add a new establishment for TPS source if it already exists in GIAS
+            new TpsEstablishmentRefreshTestScenarioData
+            {
+                TpsEstablishments = new[]
+                {
+                    new TpsEstablishment
+                    {
+                        TpsEstablishmentId = Guid.NewGuid(),
+                        LaCode = KnownGiasLaCodeHackney,
+                        EstablishmentCode = KnownGiasEstablishmentNumberHackney,
+                        EmployersName = KnownGiasLaNameHackney,
+                        SchoolGiasName = null,
+                        SchoolClosedDate = null
+                    }
+                },
+                IsExpectedToGenerateEstablishment = false,
+                ExpectedLaName = null,
+                ExpectedEstablishmentName = null
+            },
+            // If the establishment is within the range of TPS establishment types and the employers name corresponds to an LA name from GIAS, use the short description from TPS establishment types
+            new TpsEstablishmentRefreshTestScenarioData
+            {
+                TpsEstablishments = new[]
+                {
+                    new TpsEstablishment
+                    {
+                        TpsEstablishmentId = Guid.NewGuid(),
+                        LaCode = KnownGiasLaCodeHackney,
+                        EstablishmentCode = KnownTpsEstablishmentNumberWithinTpsEstablishmentTypeRange,
+                        EmployersName = KnownGiasLaNameHackney,
+                        SchoolGiasName = null,
+                        SchoolClosedDate = null
+                    }
+                },
+                IsExpectedToGenerateEstablishment = true,
+                ExpectedLaName = KnownGiasLaNameHackney,
+                ExpectedEstablishmentName = KnownTpsEstablishmentTypeShortDescription
+            },
+            // If the establishment is within the range of TPS establishment types and the employers name corresponds to an LA name from TPS, use the short description from TPS establishment types
+            new TpsEstablishmentRefreshTestScenarioData
+            {
+                TpsEstablishments = new[]
+                {
+                    new TpsEstablishment
+                    {
+                        TpsEstablishmentId = Guid.NewGuid(),
+                        LaCode = KnownGiasLaCodeCityOfLondon,
+                        EstablishmentCode = KnownTpsEstablishmentNumberWithinTpsEstablishmentTypeRange,
+                        EmployersName = KnownTpsLaNameCorporationOfLondon,
+                        SchoolGiasName = null,
+                        SchoolClosedDate = null
+                    }
+                },
+                IsExpectedToGenerateEstablishment = true,
+                ExpectedLaName = KnownGiasLaNameCityOfLondon,
+                ExpectedEstablishmentName = KnownTpsEstablishmentTypeShortDescription
+            },
+            // If the establishment is within the range of TPS establishment types and the employers name does not correspond to an LA name from GIAS, use the employers name from TPS
+            new TpsEstablishmentRefreshTestScenarioData
+            {
+                TpsEstablishments = new[]
+                {
+                    new TpsEstablishment
+                    {
+                        TpsEstablishmentId = Guid.NewGuid(),
+                        LaCode = KnownGiasLaCodeHackney,
+                        EstablishmentCode = KnownTpsEstablishmentNumberOutsideTpsEstablishmentTypeRange,
+                        EmployersName = "Employers Name",
+                        SchoolGiasName = null,
+                        SchoolClosedDate = null
+                    }
+                },
+                IsExpectedToGenerateEstablishment = true,
+                ExpectedLaName = KnownGiasLaNameHackney,
+                ExpectedEstablishmentName = "Employers Name"
+            },
+            // If the LA code is not in the GIAS data, set the LA Name to null
+            new TpsEstablishmentRefreshTestScenarioData
+            {
+                TpsEstablishments = new[]
+                {
+                    new TpsEstablishment
+                    {
+                        TpsEstablishmentId = Guid.NewGuid(),
+                        LaCode = KnownTpsLaCode,
+                        EstablishmentCode = KnownTpsEstablishmentNumberOutsideTpsEstablishmentTypeRange,
+                        EmployersName = "Employers Name",
+                        SchoolGiasName = "School Gias Name",
+                        SchoolClosedDate = null
+                    }
+                },
+                IsExpectedToGenerateEstablishment = true,
+                ExpectedLaName = null,
+                ExpectedEstablishmentName = "Employers Name"
+            },
+            // If there are multiple records for the same LA code and establishment code, prefer the first one where the school closed date is null
+            new TpsEstablishmentRefreshTestScenarioData
+            {
+                TpsEstablishments = new[]
+                {
+                    new TpsEstablishment
+                    {
+                        TpsEstablishmentId = Guid.NewGuid(),
+                        LaCode = KnownGiasLaCodeHackney,
+                        EstablishmentCode = KnownTpsEstablishmentNumberOutsideTpsEstablishmentTypeRange,
+                        EmployersName = "Employers Name 1",
+                        SchoolGiasName = null,
+                        SchoolClosedDate = DateOnly.ParseExact("01/01/2023", "dd/MM/yyyy")
+                    },
+                    new TpsEstablishment
+                    {
+                        TpsEstablishmentId = Guid.NewGuid(),
+                        LaCode = KnownGiasLaCodeHackney,
+                        EstablishmentCode = KnownTpsEstablishmentNumberOutsideTpsEstablishmentTypeRange,
+                        EmployersName = "Employers Name 2",
+                        SchoolGiasName = null,
+                        SchoolClosedDate = null
+                    }
+                },
+                IsExpectedToGenerateEstablishment = true,
+                ExpectedLaName = KnownGiasLaNameHackney,
+                ExpectedEstablishmentName = "Employers Name 2"
+            }
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetImportFileTestScenarioData))]
+    public async Task ImportFile_WithRowData_InsertsRecordsAsExpected(TpsEstablishmentFileImportTestScenarioData scenarioData)
+    {
+        // Arrange
+        var tpsExtractStorageService = Mock.Of<ITpsExtractStorageService>();
+        var dbContextFactory = DbFixture.GetDbContextFactory();
+        var clock = new TestableClock();
+        var tpsCsvExtractId = Guid.NewGuid();
+        var filename = "establishments/test.csv";
+        var csvContent = new StringBuilder();
+        csvContent.AppendLine("LA Code,Establishment Code,EMPS Name,SCHL (GIAS) Name,School Closed Date");
+        csvContent.AppendLine($"{scenarioData.Row.LaCode},{scenarioData.Row.EstablishmentCode},{scenarioData.Row.EmployersName},{scenarioData.Row.SchoolGiasName},{scenarioData.Row.SchoolClosedDate}");
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csvContent.ToString()));
+        Mock.Get(tpsExtractStorageService)
+            .Setup(x => x.GetFile(filename, CancellationToken.None))
+            .ReturnsAsync(stream);
+
+        // Act
+        var refresher = new TpsEstablishmentRefresher(
+            tpsExtractStorageService,
+            dbContextFactory);
+        await refresher.ImportFile(filename, CancellationToken.None);
+
+        // Assert
+        using var dbContext = dbContextFactory.CreateDbContext();
+        var establishment = dbContext.TpsEstablishments.FirstOrDefault();
+        if (scenarioData.IsExpectedToBeImported)
+        {
+            Assert.NotNull(establishment);
+            Assert.Equal(scenarioData.Row.LaCode, establishment.LaCode);
+            Assert.Equal(scenarioData.Row.EstablishmentCode, establishment.EstablishmentCode);
+            Assert.Equal(scenarioData.Row.EmployersName, establishment.EmployersName);
+            Assert.Equal(scenarioData.Row.SchoolGiasName, establishment.SchoolGiasName);
+            if (!string.IsNullOrEmpty(scenarioData.Row.SchoolClosedDate))
+            {
+                Assert.Equal(DateOnly.ParseExact(scenarioData.Row.SchoolClosedDate, "dd/MM/yyyy"), establishment.SchoolClosedDate);
+            }
+        }
+        else
+        {
+            Assert.Null(establishment);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetRefreshEstablishmentsTestScenarioData))]
+    public async Task RefreshEstablishments_WithTpsEstablishments_UpdatesEstablishmentsAsExpected(TpsEstablishmentRefreshTestScenarioData scenarioData)
+    {
+        // Arrange
+        var tpsExtractStorageService = Mock.Of<ITpsExtractStorageService>();
+        var dbContextFactory = DbFixture.GetDbContextFactory();
+        var giasEstablishmentHackney = await TestData.CreateEstablishment(localAuthorityCode: KnownGiasLaCodeHackney, localAuthorityName: KnownGiasLaNameHackney, establishmentNumber: KnownGiasEstablishmentNumberHackney, establishmentName: KnownGiasEstablishmentNameHackney);
+        var giasEstablishmentCityOfLondon = await TestData.CreateEstablishment(localAuthorityCode: KnownGiasLaCodeCityOfLondon, localAuthorityName: KnownGiasLaNameCityOfLondon, establishmentNumber: KnownGiasEstablishmentNumberCityOfLondon, establishmentName: KnownGiasEstablishmentNameCityOfLondon);
+
+        using var dbContext = dbContextFactory.CreateDbContext();
+        foreach (var tpsEstablishment in scenarioData.TpsEstablishments)
+        {
+            await dbContext.TpsEstablishments.AddAsync(tpsEstablishment);
+        }
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        var refresher = new TpsEstablishmentRefresher(
+            tpsExtractStorageService,
+            dbContextFactory);
+        await refresher.RefreshEstablishments(CancellationToken.None);
+
+        // Assert
+        var nonGiasEstablishments = await dbContext.Establishments
+            .Where(e => e.EstablishmentSourceId == 2)
+            .ToListAsync();
+        if (scenarioData.IsExpectedToGenerateEstablishment)
+        {
+            var establishment = Assert.Single(nonGiasEstablishments);
+            Assert.Equal(scenarioData.ExpectedLaName, establishment.LaName);
+            Assert.Equal(scenarioData.ExpectedEstablishmentName, establishment.EstablishmentName);
+        }
+        else
+        {
+            Assert.Empty(nonGiasEstablishments);
+        }
+    }    
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => DbFixture.DbHelper.ClearData();
+
+    private DbFixture DbFixture { get; }
+
+    private TestData TestData { get; }
+
+    private TestableClock Clock { get; }
+
+    public TrsDataSyncHelper Helper { get; }
+}
+
+public class TpsEstablishmentFileImportTestScenarioData
+{
+    public required TpsEstablishmentCsvRow Row { get; init; }
+    public required bool IsExpectedToBeImported { get; init; }
+}
+
+public class TpsEstablishmentRefreshTestScenarioData
+{
+    public required TpsEstablishment[] TpsEstablishments { get; init; }
+    public required bool IsExpectedToGenerateEstablishment { get; init; }
+    public required string? ExpectedLaName { get; init; }
+    public required string? ExpectedEstablishmentName { get; init; }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
@@ -106,6 +106,6 @@ public class DbHelper(string connectionString)
             new RespawnerOptions()
             {
                 DbAdapter = DbAdapter.Postgres,
-                TablesToIgnore = ["mandatory_qualification_providers"]
+                TablesToIgnore = ["mandatory_qualification_providers", "establishment_sources", "tps_establishment_types"]
             });
 }


### PR DESCRIPTION
### Context

TPS includes establishments which are not in GIAS.

Capita have provided a spreadsheet which includes some additional mappings of local authority code / establishment number to establishment which we need to use as an additional source of establishments to GIAS.

### Changes proposed in this pull request

Create an ad-hoc hangfire job to grab the TPS Establishments CSV from blob storage, parse it with CsvHelper and dump it into the tps_establishments table and then process the data in this table to populate additional data in the Establishments table with an establishment source of TPS.

### Guidance to review

Db changes + job & helper classes  + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
