### PR TITLE
Store how the One Login user was matched

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
@@ -27,6 +27,12 @@ public class OneLoginUserMapping : IEntityTypeConfiguration<OneLoginUser>
                 (a, b) => (a == null && b == null) || (a != null && b != null && a.SequenceEqual(b)),
                 v => HashCode.Combine(v)));
         builder.Property(o => o.LastCoreIdentityVc).HasColumnType("jsonb");
+        builder.Property(o => o.MatchedAttributes).HasColumnType("jsonb").HasConversion<string>(
+            v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+            v => JsonSerializer.Deserialize<KeyValuePair<OneLoginUserMatchedAttribute, string>[]>(v, (JsonSerializerOptions?)null),
+            new ValueComparer<KeyValuePair<OneLoginUserMatchedAttribute, string>[]>(
+                (a, b) => a == b,  // Reference equality is fine here; we'll always replace the entire collection
+                v => v.GetHashCode()));
     }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240501095154_OneLoginUserMatchRoute.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240501095154_OneLoginUserMatchRoute.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240501095154_OneLoginUserMatchRoute")]
+    partial class OneLoginUserMatchRoute
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240501095154_OneLoginUserMatchRoute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240501095154_OneLoginUserMatchRoute.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class OneLoginUserMatchRoute : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "match_route",
+                table: "one_login_users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "matched_attributes",
+                table: "one_login_users",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "match_route",
+                table: "one_login_users");
+
+            migrationBuilder.DropColumn(
+                name: "matched_attributes",
+                table: "one_login_users");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
@@ -15,4 +15,6 @@ public class OneLoginUser
     public string[][]? VerifiedNames { get; set; }
     public DateOnly[]? VerifiedDatesOfBirth { get; set; }
     public string? LastCoreIdentityVc { get; set; }
+    public OneLoginUserMatchRoute MatchRoute { get; set; }
+    public KeyValuePair<OneLoginUserMatchedAttribute, string>[]? MatchedAttributes { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchRoute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchRoute.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Core.Models;
+
+public enum OneLoginUserMatchRoute
+{
+    Automatic = 1,
+    Interactive = 2,
+    TrnToken = 3,
+    Support = 4
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchedAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchedAttribute.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.Core.Models;
+
+public enum OneLoginUserMatchedAttribute
+{
+    FullName = 1,
+    LastName = 2,
+    DateOfBirth = 3,
+    NationalInsuranceNumber = 4,
+    Trn = 5,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/IPersonMatchingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/IPersonMatchingService.cs
@@ -2,6 +2,6 @@ namespace TeachingRecordSystem.Core.Services.PersonMatching;
 
 public interface IPersonMatchingService
 {
-    Task<(Guid PersonId, string Trn)?> Match(MatchRequest request);
+    Task<MatchResult?> Match(MatchRequest request);
     Task<IReadOnlyCollection<SuggestedMatch>> GetSuggestedMatches(GetSuggestedMatchesRequest request);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/MatchResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/MatchResult.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Core.Services.PersonMatching;
+
+public record MatchResult(Guid PersonId, string Trn, IReadOnlyCollection<KeyValuePair<OneLoginUserMatchedAttribute, string>> MatchedAttributes);


### PR DESCRIPTION
This adds a `OneLoginUserMatchRoute` so we can store how we've matched the user to a teaching record. In addition it stores the specific attributes and their values that we matched on; that's not something we have in ID and it would have helped in diagnosing issues. It will also help to inform how well our matching policy is working.