### PR TITLE
Move person detail summary list into a partial

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -1,5 +1,6 @@
 @page "/persons/{personId}"
 @using TeachingRecordSystem.SupportUi.Pages.Common;
+@using TeachingRecordSystem.SupportUi.Pages.Shared
 @model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.IndexModel
 @{
     Layout = "Layout";
@@ -21,56 +22,19 @@
     </govuk-notification-banner>
 }
 
-<govuk-summary-card>
-    <govuk-summary-card-title>Personal Details</govuk-summary-card-title>
-    <govuk-summary-list data-testid="personal-details">
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-name">@Model.Person.Name</govuk-summary-list-row-value>
-            <govuk-summary-list-row-actions>
-                <govuk-summary-list-row-action href="@LinkGenerator.PersonEditName(Model.PersonId, null)" visually-hidden-text="change name" data-testid="name-change-link">Change</govuk-summary-list-row-action>
-            </govuk-summary-list-row-actions>
-        </govuk-summary-list-row>
-        @if (Model.Person.PreviousNames.Length > 0)
-        {
-            <govuk-summary-list-row>
-                <govuk-summary-list-row-key>Previous name(s)</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>
-                    <ul class="govuk-list">
-                        @for (int i = 0; i < Model.Person.PreviousNames.Length; i++)
-                        {
-                            <li data-testid="personal-details-previous-names-@i">@Model.Person.PreviousNames[i]</li>                
-                        }
-                    </ul>
-                </govuk-summary-list-row-value>
-            </govuk-summary-list-row>
-        }
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-date-of-birth" use-empty-fallback>@(Model.Person.DateOfBirth.HasValue ? Model.Person.DateOfBirth.Value.ToString("dd/MM/yyyy") : string.Empty)</govuk-summary-list-row-value>
-            <govuk-summary-list-row-actions>
-                <govuk-summary-list-row-action href="@LinkGenerator.PersonEditDateOfBirth(Model.PersonId, null)" visually-hidden-text="change date of birth" data-testid="date-of-birth-change-link">Change</govuk-summary-list-row-action>
-            </govuk-summary-list-row-actions>
-        </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-gender" use-empty-fallback>@Model.Person.Gender</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-trn" use-empty-fallback>@Model.Person.Trn</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-nino" use-empty-fallback>@Model.Person.NationalInsuranceNumber</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-email" use-empty-fallback>@Model.Person.Email</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value data-testid="personal-details-mobile-number" use-empty-fallback>@Model.Person.MobileNumber</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
-    </govuk-summary-list>
-</govuk-summary-card>
+@{
+    var personDetailModel = new PersonDetailModel()
+    {
+        PersonId = Model.PersonId,
+        ShowChangeLinks = true,
+        Trn = Model.Person.Trn,
+        Name = Model.Person.Name,
+        PreviousNames = Model.Person.PreviousNames,
+        DateOfBirth = Model.Person.DateOfBirth,
+        NationalInsuranceNumber = Model.Person.NationalInsuranceNumber,
+        Gender = Model.Person.Gender,
+        Email = Model.Person.Email,
+        MobileNumber = Model.Person.MobileNumber
+    };
+}
+@await Html.PartialAsync("_PersonDetail", personDetailModel)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/PersonDetailModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/PersonDetailModel.cs
@@ -1,0 +1,15 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Shared;
+
+public record PersonDetailModel
+{
+    public required Guid PersonId { get; init; }
+    public required bool ShowChangeLinks { get; init; }
+    public required string? Trn { get; init; }
+    public required string Name { get; init; }
+    public required string[] PreviousNames { get; init; }
+    public required DateOnly? DateOfBirth { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
+    public required string? Gender { get; init; }
+    public required string? Email { get; init; }
+    public required string? MobileNumber { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
@@ -1,0 +1,61 @@
+@model PersonDetailModel
+
+<govuk-summary-card>
+    <govuk-summary-card-title>Personal Details</govuk-summary-card-title>
+    <govuk-summary-list>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
+            @if (Model.ShowChangeLinks)
+            {
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="@LinkGenerator.PersonEditName(Model.PersonId, journeyInstanceId: null)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            }
+        </govuk-summary-list-row>
+        @if (Model.PreviousNames.Length > 0)
+        {
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Previous name(s)</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>
+                    <ul class="govuk-list">
+                        @foreach (var previousName in Model.PreviousNames)
+                        {
+                            <li>@previousName</li>
+                        }
+                    </ul>
+                </govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        }
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value  use-empty-fallback>@Model.DateOfBirth?.ToString("dd/MM/yyyy")</govuk-summary-list-row-value>
+            @if (Model.ShowChangeLinks)
+            {
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="@LinkGenerator.PersonEditDateOfBirth(Model.PersonId, journeyInstanceId: null)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            }
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.Gender</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.Trn</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.NationalInsuranceNumber</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.Email</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.MobileNumber</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+    </govuk-summary-list>
+</govuk-summary-card>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -49,6 +49,9 @@ public static class PageExtensions
     public static Task ClickLinkForElementWithTestId(this IPage page, string testId) =>
         page.GetByTestId(testId).ClickAsync();
 
+    public static Task ClickChangeLinkForSummaryListRowWithKey(this IPage page, string key) =>
+        page.Locator($".govuk-summary-list__row:has(> dt:text('{key}'))").GetByText("Change").ClickAsync();
+
     public static async Task ClickAddAlertPersonAlertsPage(this IPage page)
     {
         await page.GetByTestId($"add-alert").ClickAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PersonTests.cs
@@ -23,7 +23,7 @@ public class PersonTests : TestBase
 
         await page.AssertOnPersonDetailPage(personId);
 
-        await page.ClickLinkForElementWithTestId("name-change-link");
+        await page.ClickChangeLinkForSummaryListRowWithKey("Name");
 
         await page.AssertOnPersonEditNamePage(personId);
 
@@ -54,7 +54,7 @@ public class PersonTests : TestBase
 
         await page.AssertOnPersonDetailPage(personId);
 
-        await page.ClickLinkForElementWithTestId("date-of-birth-change-link");
+        await page.ClickChangeLinkForSummaryListRowWithKey("Date of birth");
 
         await page.AssertOnPersonEditDateOfBirthPage(personId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
@@ -86,11 +86,17 @@ public static class AngleSharpExtensions
     public static string? GetSummaryListValueForKey(this IDocument doc, string key) =>
         doc.Body?.GetSummaryListValueForKey(key);
 
-    public static string? GetSummaryListValueForKey(this IElement element, string key)
+    public static string? GetSummaryListValueForKey(this IElement element, string key) =>
+        GetSummaryListValueElementForKey(element, key)?.GetCleansedTextContent();
+
+    public static IElement? GetSummaryListValueElementForKey(this IDocument doc, string key) =>
+        doc.Body?.GetSummaryListValueElementForKey(key);
+
+    public static IElement? GetSummaryListValueElementForKey(this IElement element, string key)
     {
         var row = element.GetSummaryListRowForKey(key);
         var rowValue = row?.QuerySelector(".govuk-summary-list__value");
-        return rowValue.GetCleansedTextContent();
+        return rowValue;
     }
 
     /// <summary>


### PR DESCRIPTION
The person detail summary list appears in the support pages for resolving One Login user matches. This moves it into a partial so we can re-use it.