### PR TITLE
Workforce data extract support ageing and non gias establishments

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonEmploymentMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonEmploymentMapping.cs
@@ -14,6 +14,8 @@ public class PersonEmploymentMapping : IEntityTypeConfiguration<PersonEmployment
         builder.Property(e => e.EmploymentType).IsRequired();
         builder.Property(e => e.CreatedOn).IsRequired();
         builder.Property(e => e.UpdatedOn).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(50).IsRequired();
+        builder.HasIndex(x => x.Key).HasDatabaseName(PersonEmployment.KeyIndexName);
         builder.HasIndex(e => e.PersonId).HasDatabaseName(PersonEmployment.PersonIdIndexName);
         builder.HasIndex(e => e.EstablishmentId).HasDatabaseName(PersonEmployment.EstablishmentIdIndexName);
         builder.HasOne<Person>().WithMany().HasForeignKey(e => e.PersonId).HasConstraintName("fk_person_employments_person_id");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsCsvExtractItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsCsvExtractItemMapping.cs
@@ -23,6 +23,8 @@ public class TpsCsvExtractItemMapping : IEntityTypeConfiguration<TpsCsvExtractIt
         builder.Property(x => x.WithdrawlIndicator).HasMaxLength(1).IsFixedLength();
         builder.Property(x => x.Gender).HasMaxLength(10).IsRequired();
         builder.Property(x => x.Created).IsRequired();
+        builder.Property(x => x.Key).HasMaxLength(50).IsRequired();
+        builder.HasIndex(x => x.Key).HasDatabaseName(TpsCsvExtractItem.KeyIndexName);
         builder.HasIndex(x => x.Trn).HasDatabaseName(TpsCsvExtractItem.TrnIndexName);
         builder.HasIndex(x => new { x.LocalAuthorityCode, x.EstablishmentNumber }).HasDatabaseName(TpsCsvExtractItem.LaCodeEstablishmentNumberIndexName);
         builder.HasIndex(x => x.TpsCsvExtractId).HasDatabaseName(TpsCsvExtractItem.TpsCsvExtractIdIndexName);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240507142027_PersonEmploymentsAgeing.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240507142027_PersonEmploymentsAgeing.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240507142027_PersonEmploymentsAgeing")]
+    partial class PersonEmploymentsAgeing
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240507142027_PersonEmploymentsAgeing.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240507142027_PersonEmploymentsAgeing.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersonEmploymentsAgeing : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments");
+
+            migrationBuilder.AddColumn<string>(
+                name: "key",
+                table: "tps_csv_extract_items",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "establishment_id",
+                table: "person_employments",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "key",
+                table: "person_employments",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "last_extract_date",
+                table: "person_employments",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1));
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "last_known_employed_date",
+                table: "person_employments",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1));
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tps_csv_extract_items_key",
+                table: "tps_csv_extract_items",
+                column: "key");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_employments_key",
+                table: "person_employments",
+                column: "key");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments",
+                column: "establishment_id",
+                principalTable: "establishments",
+                principalColumn: "establishment_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tps_csv_extract_items_key",
+                table: "tps_csv_extract_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_person_employments_key",
+                table: "person_employments");
+
+            migrationBuilder.DropColumn(
+                name: "key",
+                table: "tps_csv_extract_items");
+
+            migrationBuilder.DropColumn(
+                name: "key",
+                table: "person_employments");
+
+            migrationBuilder.DropColumn(
+                name: "last_extract_date",
+                table: "person_employments");
+
+            migrationBuilder.DropColumn(
+                name: "last_known_employed_date",
+                table: "person_employments");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "establishment_id",
+                table: "person_employments",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_person_employments_establishment_id",
+                table: "person_employments",
+                column: "establishment_id",
+                principalTable: "establishments",
+                principalColumn: "establishment_id");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonEmployment.cs
@@ -4,13 +4,17 @@ public class PersonEmployment
 {
     public const string PersonIdIndexName = "ix_person_employments_person_id";
     public const string EstablishmentIdIndexName = "ix_person_employments_establishment_id";
+    public const string KeyIndexName = "ix_person_employments_key";
 
     public required Guid PersonEmploymentId { get; set; }
     public required Guid PersonId { get; set; }
-    public required Guid? EstablishmentId { get; set; }
+    public required Guid EstablishmentId { get; set; }
     public required DateOnly StartDate { get; set; }
     public required DateOnly? EndDate { get; set; }
+    public required DateOnly LastKnownEmployedDate { get; set; }
+    public required DateOnly LastExtractDate { get; set; }
     public required EmploymentType EmploymentType { get; set; }
     public required DateTime CreatedOn { get; set; }
     public required DateTime UpdatedOn { get; set; }
+    public required string Key { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsCsvExtractItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsCsvExtractItem.cs
@@ -8,6 +8,7 @@ public class TpsCsvExtractItem
     public const string TpsCsvExtractForeignKeyName = "fk_tps_csv_extract_items_tps_csv_extract_id";
     public const string TpsCsvExtractLoadItemIdIndexName = "ix_tps_csv_extract_items_tps_csv_extract_load_item_id";
     public const string TpsCsvExtractLoadItemIdForeignKeyName = "fk_tps_csv_extract_items_tps_csv_extract_load_item_id";
+    public const string KeyIndexName = "ix_tps_csv_extract_items_key";
 
     public required Guid TpsCsvExtractItemId { get; set; }
     public required Guid TpsCsvExtractId { get; set; }
@@ -31,4 +32,5 @@ public class TpsCsvExtractItem
     public required DateOnly ExtractDate { get; set; }
     public required DateTime Created { get; set; }
     public required TpsCsvExtractItemResult? Result { get; set; }
+    public required string Key { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/PersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/PersonEmployment.cs
@@ -4,10 +4,13 @@ public record PersonEmployment
 {
     public required Guid PersonEmploymentId { get; init; }
     public required Guid PersonId { get; init; }
-    public required Guid? EstablishmentId { get; init; }
+    public required Guid EstablishmentId { get; init; }
     public required DateOnly StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required EmploymentType EmploymentType { get; init; }
+    public required DateOnly LastKnownEmployedDate { get; init; }
+    public required DateOnly LastExtractDate { get; set; }
+    public required string Key { get; init; }
 
     public static PersonEmployment FromModel(DataStore.Postgres.Models.PersonEmployment model) => new()
     {
@@ -16,6 +19,9 @@ public record PersonEmployment
         EstablishmentId = model.EstablishmentId,
         StartDate = model.StartDate,
         EndDate = model.EndDate,
-        EmploymentType = model.EmploymentType
+        EmploymentType = model.EmploymentType,
+        LastKnownEmployedDate = model.LastKnownEmployedDate,
+        LastExtractDate = model.LastExtractDate,
+        Key = model.Key
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonEmploymentUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonEmploymentUpdatedEvent.cs
@@ -17,5 +17,7 @@ public enum PersonEmploymentUpdatedEventChanges
     StartDate = 1 << 0,
     EndDate = 1 << 1,
     EmploymentType = 1 << 2,
-    EstablishmentId = 1 << 3
+    EstablishmentId = 1 << 3,
+    LastKnownEmployedDate = 1 << 4,
+    LastExtractDate = 1 << 5
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -118,6 +118,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<ProcessEndedEmploymentsJob>(
+                    nameof(ProcessEndedEmploymentsJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ProcessEndedEmploymentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ProcessEndedEmploymentsJob.cs
@@ -1,4 +1,4 @@
-﻿using TeachingRecordSystem.Core.Jobs.Scheduling;
+using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Services.WorkforceData;
 
 namespace TeachingRecordSystem.Core.Jobs;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ProcessEndedEmploymentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ProcessEndedEmploymentsJob.cs
@@ -1,12 +1,11 @@
-using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Services.WorkforceData;
 
 namespace TeachingRecordSystem.Core.Jobs;
 
-public class ProcessEndedEmploymentsJob(IBackgroundJobScheduler backgroundJobScheduler)
+public class ProcessEndedEmploymentsJob(TpsCsvExtractProcessor tpsCsvExtractProcessor)
 {
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        await backgroundJobScheduler.Enqueue<TpsCsvExtractProcessor>(j => j.ProcessEndedEmployments(cancellationToken));
+        await tpsCsvExtractProcessor.ProcessEndedEmployments(cancellationToken);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ProcessEndedEmploymentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ProcessEndedEmploymentsJob.cs
@@ -1,0 +1,12 @@
+﻿using TeachingRecordSystem.Core.Jobs.Scheduling;
+using TeachingRecordSystem.Core.Services.WorkforceData;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class ProcessEndedEmploymentsJob(IBackgroundJobScheduler backgroundJobScheduler)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        await backgroundJobScheduler.Enqueue<TpsCsvExtractProcessor>(j => j.ProcessEndedEmployments(cancellationToken));
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/EmploymentType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/EmploymentType.cs
@@ -4,7 +4,8 @@ public enum EmploymentType
 {
     FullTime = 0,
     PartTimeRegular = 1,
-    PartTimeIrregular = 2
+    PartTimeIrregular = 2,
+    PartTime = 3
 }
 
 public static class EmploymentTypeHelper
@@ -16,6 +17,7 @@ public static class EmploymentTypeHelper
             "FT" => EmploymentType.FullTime,
             "PTR" => EmploymentType.PartTimeRegular,
             "PTI" => EmploymentType.PartTimeIrregular,
+            "PT" => EmploymentType.PartTime,
             _ => throw new ArgumentOutOfRangeException(nameof(fullOrPartTimeIndicator))
         };
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/BlobStorageTpsExtractStorageService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/BlobStorageTpsExtractStorageService.cs
@@ -15,14 +15,14 @@ public class BlobStorageTpsExtractStorageService(BlobServiceClient blobServiceCl
     {
         var blobContainerClient = blobServiceClient.GetBlobContainerClient(TpsExtractsContainerName);
         var fileNames = await GetFileNames(blobContainerClient, PendingFolderName, true, cancellationToken);
-        return fileNames;
+        return fileNames.OrderBy(f => f).ToArray();
     }
 
     public async Task<string?> GetPendingEstablishmentImportFileName(CancellationToken cancellationToken)
     {
         var blobContainerClient = blobServiceClient.GetBlobContainerClient(TpsExtractsContainerName);
         var fileNames = await GetFileNames(blobContainerClient, EstablishmentsFolderName, true, cancellationToken);
-        return fileNames?.FirstOrDefault();
+        return fileNames.FirstOrDefault();
     }
 
     public async Task<Stream> GetFile(string fileName, CancellationToken cancellationToken)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewPersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewPersonEmployment.cs
@@ -3,9 +3,14 @@ namespace TeachingRecordSystem.Core.Services.WorkforceData;
 public record NewPersonEmployment
 {
     public required Guid TpsCsvExtractItemId { get; set; }
+    public required string Trn { get; set; }
+    public required string LocalAuthorityCode { get; set; }
+    public required string EstablishmentNumber { get; set; }
     public required Guid PersonId { get; init; }
     public required Guid EstablishmentId { get; init; }
     public required DateOnly StartDate { get; init; }
-    public required DateOnly? EndDate { get; init; }
+    public required DateOnly LastKnownEmployedDate { get; init; }
     public required EmploymentType EmploymentType { get; init; }
+    public required DateOnly LastExtractDate { get; set; }
+    public required string Key { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
@@ -283,7 +283,7 @@ public class TpsCsvExtractProcessor(
 
         await foreach (var item in readDbContext.Database.SqlQuery<UpdatedPersonEmployment>(querySql).AsAsyncEnumerable())
         {
-            var changes = PersonEmploymentUpdatedEventChanges.None |                
+            var changes = PersonEmploymentUpdatedEventChanges.None |
                 (item.CurrentEmploymentType != item.EmploymentType ? PersonEmploymentUpdatedEventChanges.EmploymentType : PersonEmploymentUpdatedEventChanges.None) |
                 (item.CurrentLastKnownEmployedDate != item.LastKnownEmployedDate ? PersonEmploymentUpdatedEventChanges.LastKnownEmployedDate : PersonEmploymentUpdatedEventChanges.None) |
                 (item.CurrentLastExtractDate != item.LastExtractDate ? PersonEmploymentUpdatedEventChanges.LastExtractDate : PersonEmploymentUpdatedEventChanges.None);
@@ -594,7 +594,7 @@ public class TpsCsvExtractProcessor(
                 person_employments
             WHERE
                 end_date IS NULL
-                AND AGE(last_extract_date, last_known_employed_date) > INTERVAL '3 months'
+                AND AGE(last_extract_date, last_known_employed_date) > INTERVAL '5 months'
             """;
 
         var batchCommands = new List<NpgsqlBatchCommand>();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
@@ -122,18 +122,23 @@ public class TpsCsvExtractProcessor(
             )
             SELECT
                 x.tps_csv_extract_item_id,
+                x.trn,
+                x.local_authority_code,
+                x.establishment_number,
                 p.person_id,
                 e.establishment_id,
                 x.employment_start_date as start_date,
-                x.employment_end_date as end_date,
-                x.employment_type
+                x.employment_end_date as last_known_employed_date,
+                x.employment_type,
+                x.extract_date as last_extract_date,
+                x.key
             FROM
                     tps_csv_extract_items x
                 JOIN
                     persons p ON x.trn = p.trn
                 JOIN
                     unique_establishments e ON x.local_authority_code = e.la_code
-                        AND (e.establishment_number = x.establishment_number
+                        AND (x.establishment_number = e.establishment_number
                              OR (e.establishment_type_code = '29' 
                                  AND x.establishment_postcode = e.postcode
                                  AND NOT EXISTS (SELECT
@@ -151,9 +156,7 @@ public class TpsCsvExtractProcessor(
                                 FROM
                                     person_employments pe
                                 WHERE
-                                    pe.person_id = p.person_id
-                                    AND pe.establishment_id = e.establishment_id
-                                    AND pe.start_date = x.employment_start_date)
+                                    pe.key = x.key)
             """;
 
         int i = 0;
@@ -166,10 +169,13 @@ public class TpsCsvExtractProcessor(
                 PersonId = item.PersonId,
                 EstablishmentId = item.EstablishmentId,
                 StartDate = item.StartDate,
-                EndDate = item.EndDate,
+                EndDate = null,
+                LastKnownEmployedDate = item.LastKnownEmployedDate,
+                LastExtractDate = item.LastExtractDate,
                 EmploymentType = item.EmploymentType,
                 CreatedOn = clock.UtcNow,
-                UpdatedOn = clock.UtcNow
+                UpdatedOn = clock.UtcNow,
+                Key = item.Key
             };
 
             writeDbContext.PersonEmployments.Add(personEmployment);
@@ -252,30 +258,20 @@ public class TpsCsvExtractProcessor(
                 pe.person_id,
                 pe.establishment_id,
                 pe.start_date,
-                pe.end_date as current_end_date,
+                pe.end_date,
                 pe.employment_type as current_employment_type,
-                x.employment_end_date as end_date,
-                x.employment_type
+                pe.last_known_employed_date as current_last_known_employed_date,
+                pe.last_extract_date as current_last_extract_date,                
+                x.employment_type,
+                x.employment_end_date as last_known_employed_date,
+                x.extract_date as last_extract_date,
+                x.key
             FROM
                     tps_csv_extract_items x
                 JOIN
                     persons p ON x.trn = p.trn
                 JOIN
-                    unique_establishments e ON x.local_authority_code = e.la_code
-                        AND (e.establishment_number = x.establishment_number
-                             OR (e.establishment_type_code = '29' 
-                                 AND x.establishment_postcode = e.postcode
-                                 AND NOT EXISTS (SELECT
-                                                     1
-                                                 FROM
-                                                     unique_establishments e2
-                                                 WHERE
-                                                     e2.la_code = x.local_authority_code
-                                                     AND e2.establishment_number = x.establishment_number)))
-                JOIN
-                    person_employments pe ON pe.person_id = p.person_id
-                    AND pe.establishment_id = e.establishment_id
-                    AND pe.start_date = x.employment_start_date
+                    person_employments pe ON pe.key = x.key
             WHERE
                 x.tps_csv_extract_id = {tpsCsvExtractId}
                 AND x.result IS NULL
@@ -287,20 +283,24 @@ public class TpsCsvExtractProcessor(
 
         await foreach (var item in readDbContext.Database.SqlQuery<UpdatedPersonEmployment>(querySql).AsAsyncEnumerable())
         {
-            var changes = PersonEmploymentUpdatedEventChanges.None |
-                (item.CurrentEndDate != item.EndDate ? PersonEmploymentUpdatedEventChanges.EndDate : PersonEmploymentUpdatedEventChanges.None) |
-                (item.CurrentEmploymentType != item.EmploymentType ? PersonEmploymentUpdatedEventChanges.EmploymentType : PersonEmploymentUpdatedEventChanges.None);
+            var changes = PersonEmploymentUpdatedEventChanges.None |                
+                (item.CurrentEmploymentType != item.EmploymentType ? PersonEmploymentUpdatedEventChanges.EmploymentType : PersonEmploymentUpdatedEventChanges.None) |
+                (item.CurrentLastKnownEmployedDate != item.LastKnownEmployedDate ? PersonEmploymentUpdatedEventChanges.LastKnownEmployedDate : PersonEmploymentUpdatedEventChanges.None) |
+                (item.CurrentLastExtractDate != item.LastExtractDate ? PersonEmploymentUpdatedEventChanges.LastExtractDate : PersonEmploymentUpdatedEventChanges.None);
 
             if (changes != PersonEmploymentUpdatedEventChanges.None)
             {
-                var formattedEndDate = item.EndDate.HasValue ? $"to_date('{item.EndDate:yyyyMMdd}','YYYYMMDD')" : "NULL";
+                var formattedLastKnownEmployedDate = $"to_date('{item.LastKnownEmployedDate:yyyyMMdd}','YYYYMMDD')";
+                var formattedLastExtractDate = $"to_date('{item.LastExtractDate:yyyyMMdd}','YYYYMMDD')";
                 var updatePersonEmploymentsCommand = new NpgsqlBatchCommand(
                     $"""
                     UPDATE
                         person_employments
                     SET
-                        end_date = {formattedEndDate},
-                        employment_type = {(int)item.EmploymentType}
+                        employment_type = {(int)item.EmploymentType},
+                        last_known_employed_date = {formattedLastKnownEmployedDate},
+                        last_extract_date = {formattedLastExtractDate},
+                        updated_on = now()
                     WHERE
                         person_employment_id = '{item.PersonEmploymentId}'
                     """);
@@ -317,7 +317,10 @@ public class TpsCsvExtractProcessor(
                         EstablishmentId = item.EstablishmentId,
                         StartDate = item.StartDate,
                         EndDate = item.EndDate,
-                        EmploymentType = item.EmploymentType
+                        EmploymentType = item.EmploymentType,
+                        LastKnownEmployedDate = item.LastKnownEmployedDate,
+                        LastExtractDate = item.LastExtractDate,
+                        Key = item.Key
                     },
                     OldPersonEmployment = new()
                     {
@@ -325,8 +328,11 @@ public class TpsCsvExtractProcessor(
                         PersonId = item.PersonId,
                         EstablishmentId = item.EstablishmentId,
                         StartDate = item.StartDate,
-                        EndDate = item.CurrentEndDate,
-                        EmploymentType = item.CurrentEmploymentType
+                        EndDate = item.EndDate,
+                        EmploymentType = item.CurrentEmploymentType,
+                        LastKnownEmployedDate = item.CurrentLastKnownEmployedDate,
+                        LastExtractDate = item.CurrentLastExtractDate,
+                        Key = item.Key
                     },
                     Changes = changes,
                     CreatedUtc = clock.UtcNow,
@@ -460,6 +466,9 @@ public class TpsCsvExtractProcessor(
                 ec.start_date,
                 ec.end_date,
                 ec.employment_type,
+                ec.last_known_employed_date,
+                ec.last_extract_date,
+                ec.key,
                 ue.establishment_id
             from
                     establishment_changes ec
@@ -488,7 +497,8 @@ public class TpsCsvExtractProcessor(
                     UPDATE
                         person_employments
                     SET
-                        establishment_id = '{item.EstablishmentId}'
+                        establishment_id = '{item.EstablishmentId}',
+                        updated_on = now()
                     WHERE
                         person_employment_id = '{item.PersonEmploymentId}'
                     """);
@@ -505,7 +515,10 @@ public class TpsCsvExtractProcessor(
                     EstablishmentId = item.EstablishmentId,
                     StartDate = item.StartDate,
                     EndDate = item.EndDate,
-                    EmploymentType = item.EmploymentType
+                    EmploymentType = item.EmploymentType,
+                    LastKnownEmployedDate = item.LastKnownEmployedDate,
+                    LastExtractDate = item.LastExtractDate,
+                    Key = item.Key
                 },
                 OldPersonEmployment = new()
                 {
@@ -514,9 +527,121 @@ public class TpsCsvExtractProcessor(
                     EstablishmentId = item.CurrentEstablishmentId,
                     StartDate = item.StartDate,
                     EndDate = item.EndDate,
-                    EmploymentType = item.EmploymentType
+                    EmploymentType = item.EmploymentType,
+                    LastKnownEmployedDate = item.LastKnownEmployedDate,
+                    LastExtractDate = item.LastExtractDate,
+                    Key = item.Key
                 },
                 Changes = PersonEmploymentUpdatedEventChanges.EstablishmentId,
+                CreatedUtc = clock.UtcNow,
+                RaisedBy = DataStore.Postgres.Models.SystemUser.SystemUserId
+            });
+
+            if (batchCommands.Count == 50)
+            {
+                await SaveChanges();
+            }
+        }
+
+        if (batchCommands.Any())
+        {
+            await SaveChanges();
+        }
+
+        async Task SaveChanges()
+        {
+            if (writeDbContext.ChangeTracker.HasChanges())
+            {
+                await writeDbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            if (batchCommands.Count > 0)
+            {
+                using var batch = new NpgsqlBatch(connection);
+                foreach (var command in batchCommands)
+                {
+                    batch.BatchCommands.Add(command);
+                }
+
+                await batch.ExecuteNonQueryAsync(cancellationToken);
+                batchCommands.Clear();
+            }
+        }
+    }
+
+    public async Task ProcessEndedEmployments(CancellationToken cancellationToken)
+    {
+        using var readDbContext = dbContextFactory.CreateDbContext();
+        readDbContext.Database.SetCommandTimeout(300);
+        using var writeDbContext = dbContextFactory.CreateDbContext();
+        var connection = (NpgsqlConnection)writeDbContext.Database.GetDbConnection();
+        await connection.OpenAsync(CancellationToken.None);
+
+        FormattableString querySql =
+            $"""
+            SELECT
+                person_employment_id,
+                person_id,
+                establishment_id,
+                start_date,
+                end_date as current_end_date,
+                employment_type,
+                last_known_employed_date,
+                last_extract_date,
+                key,
+                last_known_employed_date as end_date
+            FROM
+                person_employments
+            WHERE
+                end_date IS NULL
+                AND AGE(last_extract_date, last_known_employed_date) > INTERVAL '3 months'
+            """;
+
+        var batchCommands = new List<NpgsqlBatchCommand>();
+
+        await foreach (var item in readDbContext.Database.SqlQuery<UpdatedPersonEmploymentEndDate>(querySql).AsAsyncEnumerable())
+        {
+            var updatePersonEmploymentsCommand = new NpgsqlBatchCommand(
+                $"""
+                    UPDATE
+                        person_employments
+                    SET
+                        end_date = last_known_employed_date,
+                        updated_on = now()
+                    WHERE
+                        person_employment_id = '{item.PersonEmploymentId}'
+                    """);
+
+            batchCommands.Add(updatePersonEmploymentsCommand);
+            writeDbContext.AddEvent(new PersonEmploymentUpdatedEvent
+            {
+                EventId = Guid.NewGuid(),
+                PersonId = item.PersonEmploymentId,
+                PersonEmployment = new()
+                {
+                    PersonEmploymentId = item.PersonEmploymentId,
+                    PersonId = item.PersonId,
+                    EstablishmentId = item.EstablishmentId,
+                    StartDate = item.StartDate,
+                    EndDate = item.CurrentEndDate,
+                    EmploymentType = item.EmploymentType,
+                    LastKnownEmployedDate = item.LastKnownEmployedDate,
+                    LastExtractDate = item.LastExtractDate,
+                    Key = item.Key
+                },
+                OldPersonEmployment = new()
+                {
+                    PersonEmploymentId = item.PersonEmploymentId,
+                    PersonId = item.PersonId,
+                    EstablishmentId = item.EstablishmentId,
+                    StartDate = item.StartDate,
+                    EndDate = item.EndDate,
+                    EmploymentType = item.EmploymentType,
+                    LastKnownEmployedDate = item.LastKnownEmployedDate,
+                    LastExtractDate = item.LastExtractDate,
+                    Key = item.Key
+                },
+                Changes = PersonEmploymentUpdatedEventChanges.EndDate,
                 CreatedUtc = clock.UtcNow,
                 RaisedBy = DataStore.Postgres.Models.SystemUser.SystemUserId
             });

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEndDate.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEndDate.cs
@@ -1,18 +1,15 @@
 namespace TeachingRecordSystem.Core.Services.WorkforceData;
 
-public record UpdatedPersonEmployment
+public record UpdatedPersonEmploymentEndDate
 {
-    public required Guid TpsCsvExtractItemId { get; init; }
     public required Guid PersonEmploymentId { get; init; }
     public required Guid PersonId { get; init; }
     public required Guid EstablishmentId { get; init; }
     public required DateOnly StartDate { get; init; }
-    public required DateOnly? EndDate { get; init; }
-    public required EmploymentType CurrentEmploymentType { get; init; }
-    public required DateOnly CurrentLastKnownEmployedDate { get; init; }
-    public required DateOnly CurrentLastExtractDate { get; init; }
+    public required DateOnly? CurrentEndDate { get; init; }
     public required EmploymentType EmploymentType { get; init; }
     public required DateOnly LastKnownEmployedDate { get; init; }
     public required DateOnly LastExtractDate { get; init; }
     public required string Key { get; init; }
+    public required DateOnly? EndDate { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
@@ -8,5 +8,8 @@ public record UpdatedPersonEmploymentEstablishment
     public required DateOnly StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required EmploymentType EmploymentType { get; init; }
+    public required DateOnly LastKnownEmployedDate { get; init; }
+    public required DateOnly LastExtractDate { get; init; }
+    public required string Key { get; init; }
     public required Guid EstablishmentId { get; init; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
@@ -393,7 +393,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
                     ExtractDate = validFormatExtractDate,
                     Gender = validFormatGender
                 },
-                ExpectedResult = TpsCsvExtractItemLoadErrors.None,
+                ExpectedResult = TpsCsvExtractItemLoadErrors.EmploymentEndDateIncorrectFormat,
             },
             // Invalid Employment End Date
             new ()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -42,7 +42,10 @@ public class TpsCsvExtractProcessorTests
 
         var trn = await TestData.GenerateTrn();
         var tpsCsvExtractId = Guid.NewGuid();
-        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(trn, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, new DateOnly(2023, 02, 03)));
+        var startDate = new DateOnly(2023, 02, 03);
+        var endDate = new DateOnly(2024, 03, 30);
+        var extractDate = new DateOnly(2024, 04, 25);
+        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(trn, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, startDate, endDate, extractDate));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -64,7 +67,10 @@ public class TpsCsvExtractProcessorTests
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "124", establishmentNumber: "1235");
         var nonExistentEstablishmentNumber = "4321";
-        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person.Trn!, establishment1.LaCode, nonExistentEstablishmentNumber, establishment1.Postcode!, new DateOnly(2023, 02, 03)));
+        var startDate = new DateOnly(2023, 02, 03);
+        var endDate = new DateOnly(2024, 03, 30);
+        var extractDate = new DateOnly(2024, 04, 25);
+        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person.Trn!, establishment1.LaCode, nonExistentEstablishmentNumber, establishment1.Postcode!, startDate, endDate, extractDate));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -85,7 +91,10 @@ public class TpsCsvExtractProcessorTests
         var person = await TestData.CreatePerson();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishment(localAuthorityCode: "125", establishmentNumber: "1236");
-        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment.LaCode, establishment.EstablishmentNumber, establishment.Postcode!, new DateOnly(2023, 02, 03)));
+        var startDate = new DateOnly(2023, 02, 03);
+        var endDate = new DateOnly(2024, 03, 30);
+        var extractDate = new DateOnly(2024, 04, 25);
+        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment.LaCode, establishment.EstablishmentNumber, establishment.Postcode!, startDate, endDate, extractDate));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -116,7 +125,10 @@ public class TpsCsvExtractProcessorTests
         var openEstablishment = await TestData.CreateEstablishment(laCode, establishmentNumber: establishmentNumber, establishmentStatusCode: 1, postcode: postcode);
         var proposedToOpenEstablishment = await TestData.CreateEstablishment(laCode, establishmentNumber: establishmentNumber, establishmentStatusCode: 4, postcode: postcode);
         var openButProposedToCloseEstablishment = await TestData.CreateEstablishment(laCode, establishmentNumber: establishmentNumber, establishmentStatusCode: 3, postcode: postcode);
-        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, laCode, establishmentNumber, postcode, new DateOnly(2023, 02, 03)));
+        var startDate = new DateOnly(2023, 02, 03);
+        var endDate = new DateOnly(2024, 03, 30);
+        var extractDate = new DateOnly(2024, 04, 25);
+        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, laCode, establishmentNumber, postcode, startDate, endDate, extractDate));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -149,8 +161,8 @@ public class TpsCsvExtractProcessorTests
         var higherEductionEstablishment = await TestData.CreateEstablishment(laCode1, postcode: postcode2, isHigherEducationInstitution: true);
         await TestData.CreateTpsCsvExtract(
             b => b.WithTpsCsvExtractId(tpsCsvExtractId)
-                .WithItem(person!.Trn!, laCode1, establishmentNumber1, postcode1, new DateOnly(2023, 02, 03))
-                .WithItem(person!.Trn!, laCode1, establishmentNumber2, postcode2, new DateOnly(2023, 04, 05)));
+                .WithItem(person!.Trn!, laCode1, establishmentNumber1, postcode1, new DateOnly(2023, 02, 03), new DateOnly(2024, 03, 30), new DateOnly(2024, 04, 25))
+                .WithItem(person!.Trn!, laCode1, establishmentNumber2, postcode2, new DateOnly(2023, 04, 05), new DateOnly(2024, 03, 30), new DateOnly(2024, 04, 25)));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -175,9 +187,10 @@ public class TpsCsvExtractProcessorTests
         var person = await TestData.CreatePerson();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
-        var existingPersonEmployment = await TestData.CreatePersonEmployment(person.PersonId, establishment1.EstablishmentId, new DateOnly(2023, 02, 02), EmploymentType.FullTime);
-        var updatedEndDate = new DateOnly(2024, 03, 06);
-        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, new DateOnly(2023, 02, 02), updatedEndDate));
+        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25));
+        var updatedEndDate = new DateOnly(2024, 03, 30);
+        var updatedLastExtractDate = new DateOnly(2024, 04, 25);
+        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, new DateOnly(2023, 02, 02), updatedEndDate, updatedLastExtractDate));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -190,7 +203,8 @@ public class TpsCsvExtractProcessorTests
         var items = await dbContext.TpsCsvExtractItems.Where(i => i.TpsCsvExtractId == tpsCsvExtractId).ToListAsync();
         Assert.All(items, i => Assert.Equal(TpsCsvExtractItemResult.ValidDataUpdated, i.Result));
         var updatedPersonEmployment = await dbContext.PersonEmployments.SingleAsync(e => e.PersonEmploymentId == existingPersonEmployment.PersonEmploymentId);
-        Assert.Equal(updatedEndDate, updatedPersonEmployment.EndDate);
+        Assert.Equal(updatedEndDate, updatedPersonEmployment.LastKnownEmployedDate);
+        Assert.Equal(updatedLastExtractDate, updatedPersonEmployment.LastExtractDate);
     }
 
     [Fact]
@@ -200,9 +214,8 @@ public class TpsCsvExtractProcessorTests
         var person = await TestData.CreatePerson();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
-        var existingPersonEmployment = await TestData.CreatePersonEmployment(person.PersonId, establishment1.EstablishmentId, new DateOnly(2023, 02, 02), EmploymentType.FullTime);
-        var updatedEndDate = new DateOnly(2024, 03, 06);
-        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, existingPersonEmployment.StartDate, existingPersonEmployment.EndDate, "FT"));
+        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25));
+        await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, existingPersonEmployment.StartDate, existingPersonEmployment.LastKnownEmployedDate, existingPersonEmployment.LastExtractDate, "FT"));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -223,7 +236,7 @@ public class TpsCsvExtractProcessorTests
         var person = await TestData.CreatePerson();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 2); // Closed
         var establishment2 = await TestData.CreateEstablishment(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 1); // Open
-        var existingPersonEmployment = await TestData.CreatePersonEmployment(person.PersonId, establishment1.EstablishmentId, new DateOnly(2023, 02, 02), EmploymentType.FullTime);
+        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25));
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -235,6 +248,33 @@ public class TpsCsvExtractProcessorTests
         using var dbContext = TestData.DbContextFactory.CreateDbContext();
         var updatedPersonEmployment = await dbContext.PersonEmployments.SingleAsync(e => e.PersonEmploymentId == existingPersonEmployment.PersonEmploymentId);
         Assert.Equal(establishment2.EstablishmentId, updatedPersonEmployment.EstablishmentId);
+    }
+
+    [Fact]
+    public async Task ProcessEndedEmployments_WithLastKnownEmployedDateGreaterThanThreeMonthsBeforeLastExtractDate_SetsEndDateOnPersonEmploymentRecord()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "128", establishmentNumber: "1239");
+        var establishment2 = await TestData.CreateEstablishment(localAuthorityCode: "128", establishmentNumber: "1240");
+        var extractDate = new DateOnly(2024, 04, 25);
+        var lastKnownEmployedDateWithinThreeMonthsOfExtractDate = new DateOnly(2024, 02, 29);
+        var lastKnownEmployedDateOutsideThreeMonthsOfExtractDate = new DateOnly(2023, 11, 30);        
+        var personEmploymentWhichHasEnded = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), lastKnownEmployedDateOutsideThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
+        var personEmploymentWhichHasNotEnded = await TestData.CreatePersonEmployment(person, establishment2, new DateOnly(2023, 02, 02), lastKnownEmployedDateWithinThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
+
+        // Act
+        var processor = new TpsCsvExtractProcessor(
+            TestData.DbContextFactory,
+            TestData.Clock);
+        await processor.ProcessEndedEmployments(CancellationToken.None);
+
+        // Assert
+        using var dbContext = TestData.DbContextFactory.CreateDbContext();
+        var updatedPersonEmploymentWhichShouldHaveEndDateSet = await dbContext.PersonEmployments.SingleAsync(e => e.PersonEmploymentId == personEmploymentWhichHasEnded.PersonEmploymentId);
+        var updatedPersonEmploymentWhichShouldNotHaveEndDateSet = await dbContext.PersonEmployments.SingleAsync(e => e.PersonEmploymentId == personEmploymentWhichHasNotEnded.PersonEmploymentId);
+        Assert.Equal(lastKnownEmployedDateOutsideThreeMonthsOfExtractDate, updatedPersonEmploymentWhichShouldHaveEndDateSet.EndDate);
+        Assert.Null(updatedPersonEmploymentWhichShouldNotHaveEndDateSet.EndDate);
     }
 
     private DbFixture DbFixture { get; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -259,7 +259,7 @@ public class TpsCsvExtractProcessorTests
         var establishment2 = await TestData.CreateEstablishment(localAuthorityCode: "128", establishmentNumber: "1240");
         var extractDate = new DateOnly(2024, 04, 25);
         var lastKnownEmployedDateWithinThreeMonthsOfExtractDate = new DateOnly(2024, 02, 29);
-        var lastKnownEmployedDateOutsideThreeMonthsOfExtractDate = new DateOnly(2023, 11, 30);        
+        var lastKnownEmployedDateOutsideThreeMonthsOfExtractDate = new DateOnly(2023, 11, 30);
         var personEmploymentWhichHasEnded = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), lastKnownEmployedDateOutsideThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
         var personEmploymentWhichHasNotEnded = await TestData.CreatePersonEmployment(person, establishment2, new DateOnly(2023, 02, 02), lastKnownEmployedDateWithinThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -259,7 +259,7 @@ public class TpsCsvExtractProcessorTests
         var establishment2 = await TestData.CreateEstablishment(localAuthorityCode: "128", establishmentNumber: "1240");
         var extractDate = new DateOnly(2024, 04, 25);
         var lastKnownEmployedDateWithinThreeMonthsOfExtractDate = new DateOnly(2024, 02, 29);
-        var lastKnownEmployedDateOutsideThreeMonthsOfExtractDate = new DateOnly(2023, 11, 30);
+        var lastKnownEmployedDateOutsideThreeMonthsOfExtractDate = new DateOnly(2023, 09, 30);
         var personEmploymentWhichHasEnded = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), lastKnownEmployedDateOutsideThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
         var personEmploymentWhichHasNotEnded = await TestData.CreatePersonEmployment(person, establishment2, new DateOnly(2023, 02, 02), lastKnownEmployedDateWithinThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
@@ -1,28 +1,36 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using Establishment = TeachingRecordSystem.Core.DataStore.Postgres.Models.Establishment;
 
 namespace TeachingRecordSystem.TestCommon;
 
 public partial class TestData
 {
     public async Task<PersonEmployment> CreatePersonEmployment(
-        Guid personId,
-        Guid establishmentId,
-        DateOnly startDate,
+        CreatePersonResult person,
+        Establishment establishment,
+        DateOnly startDate,        
+        DateOnly lastKnownEmployedDate,
         EmploymentType employmentType,
+        DateOnly lastExtractDate,
         DateOnly? endDate = null)
     {
+        var key = $"{person.Trn}.{establishment.LaCode}.{establishment.EstablishmentNumber}.{startDate:yyyyMMdd}";
+
         var personEmployment = await WithDbContext(async dbContext =>
         {
             var personEmployment = new PersonEmployment
             {
                 PersonEmploymentId = Guid.NewGuid(),
-                PersonId = personId,
-                EstablishmentId = establishmentId,
+                PersonId = person.PersonId,
+                EstablishmentId = establishment.EstablishmentId,
                 StartDate = startDate,
                 EndDate = endDate,
                 EmploymentType = employmentType,
+                LastKnownEmployedDate = lastKnownEmployedDate,
+                LastExtractDate = lastExtractDate,
                 CreatedOn = Clock.UtcNow,
-                UpdatedOn = Clock.UtcNow
+                UpdatedOn = Clock.UtcNow,
+                Key = key
             };
 
             dbContext.PersonEmployments.Add(personEmployment);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
@@ -8,7 +8,7 @@ public partial class TestData
     public async Task<PersonEmployment> CreatePersonEmployment(
         CreatePersonResult person,
         Establishment establishment,
-        DateOnly startDate,        
+        DateOnly startDate,
         DateOnly lastKnownEmployedDate,
         EmploymentType employmentType,
         DateOnly lastExtractDate,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateTpsCsvExtract.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateTpsCsvExtract.cs
@@ -47,7 +47,8 @@ public partial class TestData
             string? establishmentNumber,
             string establishmentPostcode,
             DateOnly startDate,
-            DateOnly? endDate = null,
+            DateOnly endDate,
+            DateOnly extractDate,
             string? fullOrPartTimeIndicator = null,
             string? nationalInsuranceNumber = null,
             DateOnly? dateOfBirth = null)
@@ -56,7 +57,7 @@ public partial class TestData
             dateOfBirth ??= DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
             fullOrPartTimeIndicator ??= validFullOrPartTimeIndicatorValues[Faker.RandomNumber.Next(0, 2)];
 
-            _items.Add(new TpsCsvExtractItem(trn, nationalInsuranceNumber, dateOfBirth.Value, localAuthorityCode, establishmentPostcode, establishmentNumber, startDate, endDate, fullOrPartTimeIndicator));
+            _items.Add(new TpsCsvExtractItem(trn, nationalInsuranceNumber, dateOfBirth.Value, localAuthorityCode, establishmentPostcode, establishmentNumber, startDate, endDate, fullOrPartTimeIndicator, extractDate));
             return this;
         }
 
@@ -69,7 +70,6 @@ public partial class TestData
 
             _tpsCsvExtractId ??= Guid.NewGuid();
             _filename ??= "test.csv";
-            var extractDate = testData.Clock.Today;
             var createdOn = testData.Clock.UtcNow;
 
             var tpsCsvExtract = new TpsCsvExtract
@@ -101,10 +101,10 @@ public partial class TestData
                         EstablishmentEmailAddress = null,
                         MemberId = memberId++.ToString(),
                         EmploymentStartDate = item.StartDate.ToString("dd/MM/yyyy"),
-                        EmploymentEndDate = item.EndDate?.ToString("dd/MM/yyyy"),
+                        EmploymentEndDate = item.EndDate.ToString("dd/MM/yyyy"),
                         FullOrPartTimeIndicator = item.FullOrPartTimeIndicator,
                         WithdrawlIndicator = null,
-                        ExtractDate = extractDate.ToString("dd/MM/yyyy"),
+                        ExtractDate = item.ExtractDate.ToString("dd/MM/yyyy"),
                         Gender = validGenderValues[Faker.RandomNumber.Next(0, 1)],
                         Errors = TpsCsvExtractItemLoadErrors.None,
                         Created = DateTime.UtcNow
@@ -133,9 +133,10 @@ public partial class TestData
                         EmploymentEndDate = item.EndDate,
                         EmploymentType = EmploymentTypeHelper.FromFullOrPartTimeIndicator(loadItem.FullOrPartTimeIndicator),
                         WithdrawlIndicator = loadItem.WithdrawlIndicator,
-                        ExtractDate = extractDate,
+                        ExtractDate = item.ExtractDate,
                         Created = createdOn,
-                        Result = null
+                        Result = null,
+                        Key = $"{item.Trn}.{item.LocalAuthorityCode}.{item.EstablishmentNumber}.{item.StartDate:yyyyMMdd}"
                     };
 
                     dbContext.TpsCsvExtractItems.Add(validItem);
@@ -146,5 +147,5 @@ public partial class TestData
         }
     }
 
-    public record TpsCsvExtractItem(string Trn, string NationalInsuranceNumber, DateOnly DateOfBirth, string LocalAuthorityCode, string EstablishmentPostcode, string? EstablishmentNumber, DateOnly StartDate, DateOnly? EndDate, string FullOrPartTimeIndicator);
+    public record TpsCsvExtractItem(string Trn, string NationalInsuranceNumber, DateOnly DateOfBirth, string LocalAuthorityCode, string EstablishmentPostcode, string? EstablishmentNumber, DateOnly StartDate, DateOnly EndDate, string FullOrPartTimeIndicator, DateOnly ExtractDate);
 }


### PR DESCRIPTION
### Context

Since the original job to import TPS extract data was written, we have discovered that the end date field is actually the "last known employed date".
To deduce an actual end date we need to use a combination of this date and the last extract date to see if this has stayed the same for over x months as an indication that this teacher is no longer working at this employed.
Also, now that we have imported establishments based on a spreadsheet + some range mappings provided by TPS, there is no longer the need to have certain fields be nullable.

### Changes proposed in this pull request

DB changes, changes to the import process + an adhoc job to age the data (this maybe be removed at a later date if we don't believe the data is reliable enough) + test changes.

### Guidance to review

Not a huge amount of code changes in the end

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
