### PR TITLE
Add support for downloading evidence files from Blob Storage

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/DownloadEvidenceFilesFromBlobStorageHttpHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/DownloadEvidenceFilesFromBlobStorageHttpHandler.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel.DataAnnotations;
+using System.Net;
+using Azure;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Options;
+
+namespace TeachingRecordSystem.Api;
+
+public class DownloadEvidenceFilesFromBlobStorageHttpHandler(IOptions<EvidenceFilesOptions> optionsAccessor) : DelegatingHandler
+{
+    protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        throw new NotSupportedException();
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (request.Method != HttpMethod.Get)
+        {
+            throw new NotSupportedException();
+        }
+
+        var knownBlobStorageAccounts = optionsAccessor.Value.KnownBlobStorageAccounts ?? [];
+
+        foreach (var knownServiceAccount in knownBlobStorageAccounts)
+        {
+            if (request.RequestUri?.GetLeftPart(UriPartial.Authority) == knownServiceAccount.Uri.TrimEnd('/'))
+            {
+                var credential = new StorageSharedKeyCredential(knownServiceAccount.AccountName, knownServiceAccount.AccountKey);
+                var blobClient = new BlobClient(request.RequestUri, credential);
+
+                try
+                {
+                    var downloadResponse = await blobClient.DownloadStreamingAsync(cancellationToken: cancellationToken);
+
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StreamContent(downloadResponse.Value.Content)
+                    };
+                }
+                catch (RequestFailedException ex)
+                {
+                    return new HttpResponseMessage((HttpStatusCode)ex.Status);
+                }
+            }
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}
+
+public class EvidenceFilesOptions
+{
+    public KnownBlobStorageAccount[]? KnownBlobStorageAccounts { get; set; }
+
+    public class KnownBlobStorageAccount
+    {
+        [Required]
+        public required string Uri { get; set; }
+        [Required]
+        public required string AccountName { get; set; }
+        [Required]
+        public required string AccountKey { get; set; }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -208,11 +208,18 @@ public class Program
         services.AddMemoryCache();
         services.AddSingleton<AddTrnToSentryScopeResourceFilter>();
 
-        services.AddHttpClient("EvidenceFiles", client =>
-        {
-            client.MaxResponseContentBufferSize = 5 * 1024 * 1024;  // 5MB
-            client.Timeout = TimeSpan.FromSeconds(30);
-        });
+        builder.Services.AddOptions<EvidenceFilesOptions>()
+            .Bind(builder.Configuration.GetSection("EvidenceFiles"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+        services
+            .AddTransient<DownloadEvidenceFilesFromBlobStorageHttpHandler>()
+            .AddHttpClient("EvidenceFiles", client =>
+            {
+                client.MaxResponseContentBufferSize = 5 * 1024 * 1024;  // 5MB
+                client.Timeout = TimeSpan.FromSeconds(30);
+            })
+            .AddHttpMessageHandler<DownloadEvidenceFilesFromBlobStorageHttpHandler>();
 
         builder
             .AddBlobStorage()


### PR DESCRIPTION
AYTQ cannot easily give us a blob URI with a SAS token. This adds support for retrieving evidence files using an authenticated `BlobClient` for pre-configured blob storage accounts. It uses a `DelegatingHandler` to intercept the request, check if it matches a known blob storage account URI then uses `BlobClient` (with a configured token) to download the file and create an `HttpResponseMessage`.