### PR TITLE
Check created contact can be retrieved

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetOrCreateTrnRequestHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Handlers/GetOrCreateTrnRequestHandler.cs
@@ -146,6 +146,14 @@ public class GetOrCreateTrnRequestHandler : IRequestHandler<GetOrCreateTrnReques
                 throw CreateValidationExceptionFromFailedReasons(createTeacherResult.FailedReasons);
             }
 
+            // We sometimes see issues where the contact created above isn't retrievable
+            // (it seems CRM doesn't create the records even though the request succeeded).
+            // Check we can at least retrieve it here and fail the request if we can't.
+            {
+                var createdContact = await _dataverseAdapter.GetTeacher(createTeacherResult.TeacherId, columnNames: [], resolveMerges: false) ??
+                    throw new Exception($"Created contact '{createTeacherResult.TeacherId}' could not be retrieved.");
+            }
+
             if (request.QtsDate is not null && createTeacherResult.Trn is not null)
             {
                 var trnTokenRequest = new CreateTrnTokenRequest

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.CreateTeacher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.CreateTeacher.cs
@@ -94,9 +94,8 @@ public partial class DataverseAdapter
         }
 
         var txnResponse = (ExecuteTransactionResponse)await _service.ExecuteAsync(txnRequest);
-        var createdContactId = ((CreateResponse)txnResponse.Responses.First()).id;
 
-        return (CreateTeacherResult.Success(createdContactId, trn), txnRequest);
+        return (CreateTeacherResult.Success(helper.TeacherId, trn), txnRequest);
     }
 
     internal class CreateTeacherHelper

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -196,6 +196,9 @@ public class GetOrCreateTrnRequestTests : TestBase
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn))
             .Verifiable();
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
         var slugId = Guid.NewGuid().ToString();
         var request = CreateRequest(req =>
         {
@@ -234,6 +237,9 @@ public class GetOrCreateTrnRequestTests : TestBase
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn))
             .Verifiable();
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
 
         var request = CreateRequest(req => req.Qualification = null);
 
@@ -256,6 +262,9 @@ public class GetOrCreateTrnRequestTests : TestBase
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn))
             .Verifiable();
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
 
         var request = CreateRequest(req => req.Qualification.Subject2 = null);
 
@@ -278,6 +287,9 @@ public class GetOrCreateTrnRequestTests : TestBase
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn))
             .Verifiable();
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
 
         var request = CreateRequest(req => req.Qualification.Subject3 = null);
 
@@ -622,6 +634,9 @@ public class GetOrCreateTrnRequestTests : TestBase
         DataverseAdapterMock
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn));
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
 
         var request = CreateRequest(cmd =>
         {
@@ -649,6 +664,9 @@ public class GetOrCreateTrnRequestTests : TestBase
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn))
             .Verifiable();
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
 
         var request = CreateRequest(req =>
         {
@@ -682,6 +700,9 @@ public class GetOrCreateTrnRequestTests : TestBase
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn))
             .Verifiable();
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
 
         GetAnIdentityApiClientMock
             .Setup(mock => mock.CreateTrnToken(It.IsAny<CreateTrnTokenRequest>()))
@@ -738,6 +759,9 @@ public class GetOrCreateTrnRequestTests : TestBase
             .Setup(mock => mock.CreateTeacher(It.IsAny<CreateTeacherCommand>()))
             .ReturnsAsync(CreateTeacherResult.Success(teacherId, trn))
             .Verifiable();
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacher(teacherId, Array.Empty<string>(), false))
+            .ReturnsAsync(new Contact() { Id = teacherId });
 
         var request = CreateRequest(req =>
         {


### PR DESCRIPTION
This is the latest attempt to narrow down the issue we sometimes see where records created in a TRN request don't actually get created. This adds a simple check after the create to see if we can retrieve it.