### PR TITLE
Add version query param to style and script imports

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
 
 @section Head {
     <meta name="robots" content="noindex">
-    <link rel="stylesheet" asp-href-include="~/Styles/*.css">
+    <link rel="stylesheet" asp-href-include="~/Styles/*.css" asp-append-version="true">
     @RenderSection("Styles", required: false)
 }
 
@@ -160,7 +160,7 @@
 
 @section BodyEnd {
     @PageTemplateHelper.GenerateScriptImports(NonceService.GetNonce())
-    <script src="~/Scripts/service-header.js" asp-add-nonce="true"></script>
-    <script src="~/Scripts/init-service-header.js" asp-add-nonce="true"></script>
+    <script src="~/Scripts/service-header.js" asp-add-nonce="true" asp-append-version="true"></script>
+    <script src="~/Scripts/init-service-header.js" asp-add-nonce="true" asp-append-version="true"></script>
     @RenderSection("Scripts", required: false)
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml
@@ -10,7 +10,7 @@
 }
 
 @section Scripts {
-    <script src="~/Scripts/Components/accessible-autocomplete.min.js"></script>
+    <script src="~/Scripts/Components/accessible-autocomplete.min.js" asp-append-version="true"></script>
     <script asp-add-nonce="true">
         window.onload = function () {
             accessibleAutocomplete.enhanceSelectElement({

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml
@@ -10,7 +10,7 @@
 }
 
 @section Scripts {
-    <script src="~/Scripts/Components/accessible-autocomplete.min.js"></script>
+    <script src="~/Scripts/Components/accessible-autocomplete.min.js" asp-append-version="true"></script>
     <script asp-add-nonce="true">
         window.onload = function () {
             accessibleAutocomplete.enhanceSelectElement({

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
@@ -8,7 +8,7 @@
 
 @section Head {
     <meta name="robots" content="noindex">
-    <link rel="stylesheet" asp-href-include="~/Styles/*.css">
+    <link rel="stylesheet" asp-href-include="~/Styles/*.css" asp-append-version="true">
     @RenderSection("Styles", required: false)
     @RenderSection("Scripts", required: false)
 }


### PR DESCRIPTION
I noticed when we last deployed a CSS change that it required manually refreshing the page to get the latest version. This change adds `asp-append-version="true"` to all our script and style imports so that any changes will be seen by the browser without an explicit refresh.