### PR TITLE
Fix out of memory issue for workforce data import

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/NpgsqlExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/NpgsqlExtensions.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres;
+
+public static class NpgsqlExtensions
+{
+    public static void WriteValueOrNull<T>(this NpgsqlBinaryImporter writer, T? value, NpgsqlDbType dbType)
+        where T : struct
+    {
+        if (value.HasValue)
+        {
+            writer.Write(value.Value, dbType);
+        }
+        else
+        {
+            writer.WriteNull();
+        }
+    }
+
+    public static void WriteValueOrNull<T>(this NpgsqlBinaryImporter writer, T? value, NpgsqlDbType dbType)
+        where T : notnull
+    {
+        if (value is null)
+        {
+            writer.WriteNull();
+        }
+        else
+        {
+            writer.Write(value, dbType);
+        }
+    }
+
+    public static async Task<int> SaveEvents(this NpgsqlTransaction transaction, IReadOnlyCollection<EventBase> events, string tempTableSuffix, IClock clock, CancellationToken cancellationToken)
+    {
+        if (events.Count == 0)
+        {
+            return 0;
+        }
+
+        var tempTableName = $"temp_{tempTableSuffix}";
+        var tableName = "events";
+
+        var columnNames = new[]
+        {
+            "event_id",
+            "event_name",
+            "created",
+            "inserted",
+            "payload",
+            "key",
+            "person_id"
+        };
+
+        var columnList = string.Join(", ", columnNames);
+
+        var createTempTableStatement = $"""
+            CREATE TEMP TABLE {tempTableName} (
+                event_id UUID NOT NULL,
+                event_name VARCHAR(200) NOT NULL,
+                created TIMESTAMP WITH TIME ZONE NOT NULL,
+                inserted TIMESTAMP WITH TIME ZONE NOT NULL,
+                payload JSONB NOT NULL,
+                key VARCHAR(200),
+                person_id UUID
+            )
+            ON COMMIT DROP
+            """;
+
+        var copyStatement = $"COPY {tempTableName} ({columnList}) FROM STDIN (FORMAT BINARY)";
+
+        var insertStatement =
+            $"""
+            INSERT INTO {tableName} ({columnList}, published)
+            SELECT {columnList}, false FROM {tempTableName}
+            ON CONFLICT DO NOTHING
+            """;
+
+        using (var createTempTableCommand = transaction.Connection!.CreateCommand())
+        {
+            createTempTableCommand.CommandText = createTempTableStatement;
+            createTempTableCommand.Transaction = transaction;
+            await createTempTableCommand.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using var writer = await transaction.Connection!.BeginBinaryImportAsync(copyStatement, cancellationToken);
+
+        foreach (var e in events)
+        {
+            var payload = JsonSerializer.Serialize(e, e.GetType(), EventBase.JsonSerializerOptions);
+            var key = e is IEventWithKey eventWithKey ? eventWithKey.Key : null;
+
+            writer.StartRow();
+            writer.WriteValueOrNull(e.EventId, NpgsqlDbType.Uuid);
+            writer.WriteValueOrNull(e.GetEventName(), NpgsqlDbType.Varchar);
+            writer.WriteValueOrNull(e.CreatedUtc, NpgsqlDbType.TimestampTz);
+            writer.WriteValueOrNull(clock.UtcNow, NpgsqlDbType.TimestampTz);
+            writer.WriteValueOrNull(payload, NpgsqlDbType.Jsonb);
+            writer.WriteValueOrNull(key, NpgsqlDbType.Varchar);
+            writer.WriteValueOrNull((e as IEventWithPersonId)?.PersonId, NpgsqlDbType.Uuid);
+        }
+
+        await writer.CompleteAsync(cancellationToken);
+        await writer.CloseAsync(cancellationToken);
+
+        using (var mergeCommand = transaction.Connection!.CreateCommand())
+        {
+            mergeCommand.CommandText = insertStatement;
+            mergeCommand.Parameters.Add(new NpgsqlParameter("@now", clock.UtcNow));
+            mergeCommand.Transaction = transaction;
+            await mergeCommand.ExecuteNonQueryAsync();
+        }
+
+        return events.Count;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumberHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumberHelper.cs
@@ -16,7 +16,7 @@ public static partial class NationalInsuranceNumberHelper
         return ValidNinoPattern().IsMatch(normalized);
     }
 
-    [GeneratedRegex("^[A-CEGHJ-PQR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPQR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}$")]
+    [GeneratedRegex("^[A-CEGHJ-PQR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPQR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMUa-dfm]{0,1}$")]
     private static partial Regex ValidNinoPattern();
 
     public static string? NormalizeNationalInsuranceNumber(string? value)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.ServiceModel;
-using System.Text.Json;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -381,7 +380,7 @@ public class TrsDataSyncHelper(
                     await mergeCommand.ExecuteNonQueryAsync();
                 }
 
-                await SyncEvents(events, txn, cancellationToken);
+                await txn.SaveEvents(events, "events_import", clock, cancellationToken);
 
                 await txn.CommitAsync(cancellationToken);
             }
@@ -1118,88 +1117,6 @@ public class TrsDataSyncHelper(
         }
     }
 
-    private async Task<int> SyncEvents(IReadOnlyCollection<EventBase> events, NpgsqlTransaction transaction, CancellationToken cancellationToken)
-    {
-        if (events.Count == 0)
-        {
-            return 0;
-        }
-
-        var tempTableName = "temp_events_import";
-        var tableName = "events";
-
-        var columnNames = new[]
-        {
-            "event_id",
-            "event_name",
-            "created",
-            "inserted",
-            "payload",
-            "key",
-            "person_id"
-        };
-
-        var columnList = string.Join(", ", columnNames);
-
-        var createTempTableStatement = $"""
-            CREATE TEMP TABLE {tempTableName} (
-                event_id UUID NOT NULL,
-                event_name VARCHAR(200) NOT NULL,
-                created TIMESTAMP WITH TIME ZONE NOT NULL,
-                inserted TIMESTAMP WITH TIME ZONE NOT NULL,
-                payload JSONB NOT NULL,
-                key VARCHAR(200),
-                person_id UUID
-            )
-            """;
-
-        var copyStatement = $"COPY {tempTableName} ({columnList}) FROM STDIN (FORMAT BINARY)";
-
-        var insertStatement =
-            $"""
-            INSERT INTO {tableName} ({columnList}, published)
-            SELECT {columnList}, false FROM {tempTableName}
-            ON CONFLICT DO NOTHING
-            """;
-
-        using (var createTempTableCommand = transaction.Connection!.CreateCommand())
-        {
-            createTempTableCommand.CommandText = createTempTableStatement;
-            createTempTableCommand.Transaction = transaction;
-            await createTempTableCommand.ExecuteNonQueryAsync(cancellationToken);
-        }
-
-        using var writer = await transaction.Connection!.BeginBinaryImportAsync(copyStatement, cancellationToken);
-
-        foreach (var e in events)
-        {
-            var payload = JsonSerializer.Serialize(e, e.GetType(), EventBase.JsonSerializerOptions);
-            var key = e is IEventWithKey eventWithKey ? eventWithKey.Key : null;
-
-            writer.StartRow();
-            writer.WriteValueOrNull(e.EventId, NpgsqlDbType.Uuid);
-            writer.WriteValueOrNull(e.GetEventName(), NpgsqlDbType.Varchar);
-            writer.WriteValueOrNull(e.CreatedUtc, NpgsqlDbType.TimestampTz);
-            writer.WriteValueOrNull(clock.UtcNow, NpgsqlDbType.TimestampTz);
-            writer.WriteValueOrNull(payload, NpgsqlDbType.Jsonb);
-            writer.WriteValueOrNull(key, NpgsqlDbType.Varchar);
-            writer.WriteValueOrNull((e as IEventWithPersonId)?.PersonId, NpgsqlDbType.Uuid);
-        }
-
-        await writer.CompleteAsync(cancellationToken);
-        await writer.CloseAsync(cancellationToken);
-
-        using (var mergeCommand = transaction.Connection!.CreateCommand())
-        {
-            mergeCommand.CommandText = insertStatement;
-            mergeCommand.Parameters.Add(new NpgsqlParameter(NowParameterName, clock.UtcNow));
-            mergeCommand.Transaction = transaction;
-            await mergeCommand.ExecuteNonQueryAsync();
-        }
-
-        return events.Count;
-    }
-
     private record ModelTypeSyncInfo
     {
         public required string CreateTempTableStatement { get; init; }
@@ -1253,30 +1170,4 @@ file static class Extensions
     /// Returns <c>null</c> if <paramref name="value"/> is empty or whitespace.
     /// </summary>
     public static string? NormalizeString(this string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
-
-    public static void WriteValueOrNull<T>(this NpgsqlBinaryImporter writer, T? value, NpgsqlDbType dbType)
-        where T : struct
-    {
-        if (value.HasValue)
-        {
-            writer.Write(value.Value, dbType);
-        }
-        else
-        {
-            writer.WriteNull();
-        }
-    }
-
-    public static void WriteValueOrNull<T>(this NpgsqlBinaryImporter writer, T? value, NpgsqlDbType dbType)
-        where T : notnull
-    {
-        if (value is null)
-        {
-            writer.WriteNull();
-        }
-        else
-        {
-            writer.Write(value, dbType);
-        }
-    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewPersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewPersonEmployment.cs
@@ -2,15 +2,14 @@ namespace TeachingRecordSystem.Core.Services.WorkforceData;
 
 public record NewPersonEmployment
 {
-    public required Guid TpsCsvExtractItemId { get; set; }
-    public required string Trn { get; set; }
-    public required string LocalAuthorityCode { get; set; }
-    public required string EstablishmentNumber { get; set; }
+    public required Guid PersonEmploymentId { get; init; }
     public required Guid PersonId { get; init; }
     public required Guid EstablishmentId { get; init; }
     public required DateOnly StartDate { get; init; }
     public required DateOnly LastKnownEmployedDate { get; init; }
     public required EmploymentType EmploymentType { get; init; }
-    public required DateOnly LastExtractDate { get; set; }
-    public required string Key { get; set; }
+    public required DateOnly LastExtractDate { get; init; }
+    public required string Key { get; init; }
+    public required DateTime CreatedOn { get; init; }
+    public required DateTime UpdatedOn { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmployment.cs
@@ -2,7 +2,6 @@ namespace TeachingRecordSystem.Core.Services.WorkforceData;
 
 public record UpdatedPersonEmployment
 {
-    public required Guid TpsCsvExtractItemId { get; init; }
     public required Guid PersonEmploymentId { get; init; }
     public required Guid PersonId { get; init; }
     public required Guid EstablishmentId { get; init; }
@@ -11,8 +10,8 @@ public record UpdatedPersonEmployment
     public required EmploymentType CurrentEmploymentType { get; init; }
     public required DateOnly CurrentLastKnownEmployedDate { get; init; }
     public required DateOnly CurrentLastExtractDate { get; init; }
-    public required EmploymentType EmploymentType { get; init; }
-    public required DateOnly LastKnownEmployedDate { get; init; }
-    public required DateOnly LastExtractDate { get; init; }
+    public required EmploymentType NewEmploymentType { get; init; }
+    public required DateOnly NewLastKnownEmployedDate { get; init; }
+    public required DateOnly NewLastExtractDate { get; init; }
     public required string Key { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEndDate.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEndDate.cs
@@ -11,5 +11,5 @@ public record UpdatedPersonEmploymentEndDate
     public required DateOnly LastKnownEmployedDate { get; init; }
     public required DateOnly LastExtractDate { get; init; }
     public required string Key { get; init; }
-    public required DateOnly? EndDate { get; init; }
+    public required DateOnly? NewEndDate { get; init; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
@@ -10,7 +10,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
     {
         var validFormatTrn = "1234567";
         var invalidFormatTrn = "12345678";
-        var validFormatNationalInsuranceNumber = "QQ123456A";
+        var validFormatNationalInsuranceNumber = "QQ123456U";
         var invalidFormatNationalInsuranceNumber = "1234";
         var validFormatDateOfBirth = "01/01/1980";
         var invalidFormatDateOfBirth = "1234";


### PR DESCRIPTION
### Context

While running the job to import the 2nd months workforce data System.OutOfMemoryException was thrown.

Initial investigation has lead us to believe this is related the EF change tracking on a large number of entities (specifically all the Events that get raised as part of the processing).

### Changes proposed in this pull request

Amended the SQL to update as much as possible in each call to the database.
Added transactions and improved events generation (removed need for EF change tracking).

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
