### PR TITLE
Add UI to resolve a Connect One Login user support task

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
@@ -275,8 +275,8 @@ public class SignInJourneyHelper(
 
         var names = state.VerifiedNames;
         var datesOfBirth = state.VerifiedDatesOfBirth;
-        var nationalInsuranceNumber = NormalizeNationalInsuranceNumber(state.NationalInsuranceNumber);
-        var trn = NormalizeTrn(state.Trn);
+        var nationalInsuranceNumber = state.NationalInsuranceNumber;
+        var trn = state.Trn;
 
         var matchResult = await personMatchingService.Match(new(names!, datesOfBirth!, nationalInsuranceNumber, trn));
 
@@ -305,12 +305,6 @@ public class SignInJourneyHelper(
         }
 
         return false;
-
-        static string? NormalizeNationalInsuranceNumber(string? value) =>
-            string.IsNullOrEmpty(value) ? null : new(value.Where(char.IsAsciiLetterOrDigit).ToArray());
-
-        static string? NormalizeTrn(string? value) =>
-            string.IsNullOrEmpty(value) ? null : new(value.Where(char.IsAsciiDigit).ToArray());
     }
 
     public void Complete(SignInJourneyState state, string trn)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchedAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchedAttribute.cs
@@ -7,4 +7,5 @@ public enum OneLoginUserMatchedAttribute
     DateOfBirth = 3,
     NationalInsuranceNumber = 4,
     Trn = 5,
+    FirstName = 6,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/IPersonMatchingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/IPersonMatchingService.cs
@@ -4,4 +4,5 @@ public interface IPersonMatchingService
 {
     Task<MatchResult?> Match(MatchRequest request);
     Task<IReadOnlyCollection<SuggestedMatch>> GetSuggestedMatches(GetSuggestedMatchesRequest request);
+    Task<IReadOnlyCollection<KeyValuePair<OneLoginUserMatchedAttribute, string>>> GetMatchedAttributes(GetSuggestedMatchesRequest request, Guid personId);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckSupportTaskExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckSupportTaskExistsFilter.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+public class CheckSupportTaskExistsFilter(TrsDbContext dbContext, bool openOnly, SupportTaskType? supportTaskType) : IAsyncResourceFilter
+{
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        if (context.RouteData.Values["supportTaskReference"] is not string supportTaskReference)
+        {
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        var currentSupportTask = await dbContext.SupportTasks.SingleOrDefaultAsync(t => t.SupportTaskReference == supportTaskReference);
+
+        if (currentSupportTask is null ||
+            (supportTaskType is SupportTaskType type && currentSupportTask.SupportTaskType != type) ||
+            (openOnly && currentSupportTask.Status != SupportTaskStatus.Open))
+        {
+            context.Result = new NotFoundResult();
+            return;
+        }
+
+        context.HttpContext.SetCurrentSupportTaskFeature(new(currentSupportTask));
+
+        await next();
+    }
+}
+
+public class CheckSupportTaskExistsFilterFactory(bool openOnly, SupportTaskType? supportTaskType = null) : IFilterFactory, IOrderedFilter
+{
+    public bool IsReusable => false;
+
+    public int Order => -200;
+
+    public IFilterMetadata CreateInstance(IServiceProvider serviceProvider) =>
+        ActivatorUtilities.CreateInstance<CheckSupportTaskExistsFilter>(serviceProvider, openOnly, supportTaskType!);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
@@ -26,6 +26,12 @@ public static class HttpContextExtensions
 
     public static void SetCurrentMandatoryQualificationFeature(this HttpContext context, CurrentMandatoryQualificationFeature currentMandatoryQualificationFeature) =>
         context.Features.Set(currentMandatoryQualificationFeature);
+
+    public static CurrentSupportTaskFeature GetCurrentSupportTaskFeature(this HttpContext context) =>
+        context.Features.GetRequiredFeature<CurrentSupportTaskFeature>();
+
+    public static void SetCurrentSupportTaskFeature(this HttpContext context, CurrentSupportTaskFeature currentSupportTaskFeature) =>
+        context.Features.Set(currentSupportTaskFeature);
 }
 
 public record CurrentPersonFeature(Guid PersonId, string FirstName, string MiddleName, string LastName)
@@ -34,3 +40,5 @@ public record CurrentPersonFeature(Guid PersonId, string FirstName, string Middl
 }
 
 public record CurrentMandatoryQualificationFeature(MandatoryQualification MandatoryQualification);
+
+public record CurrentSupportTaskFeature(SupportTask SupportTask);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -23,10 +23,10 @@
 }
 
 @{
-    var personDetailModel = new PersonDetailModel()
+    var personDetailModel = new PersonDetailViewModel()
     {
         PersonId = Model.PersonId,
-        ShowChangeLinks = true,
+        Options = PersonDetailViewModelOptions.ShowAll,
         Trn = Model.Person.Trn,
         Name = Model.Person.Name,
         PreviousNames = Model.Person.PreviousNames,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/PersonDetailViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/PersonDetailViewModel.cs
@@ -1,9 +1,9 @@
 namespace TeachingRecordSystem.SupportUi.Pages.Shared;
 
-public record PersonDetailModel
+public record PersonDetailViewModel
 {
     public required Guid PersonId { get; init; }
-    public required bool ShowChangeLinks { get; init; }
+    public required PersonDetailViewModelOptions Options { get; init; }
     public required string? Trn { get; init; }
     public required string Name { get; init; }
     public required string[] PreviousNames { get; init; }
@@ -12,4 +12,15 @@ public record PersonDetailModel
     public required string? Gender { get; init; }
     public required string? Email { get; init; }
     public required string? MobileNumber { get; init; }
+}
+
+[Flags]
+public enum PersonDetailViewModelOptions
+{
+    None = 0,
+    ShowChangeLinks = 1 << 0,
+    ShowGender = 1 << 1,
+    ShowEmail = 1 << 2,
+    ShowMobileNumber = 1 << 3,
+    ShowAll = ShowChangeLinks | ShowGender | ShowEmail | ShowMobileNumber
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
@@ -1,4 +1,4 @@
-@model PersonDetailModel
+@model PersonDetailViewModel
 
 <govuk-summary-card>
     <govuk-summary-card-title>Personal Details</govuk-summary-card-title>
@@ -6,7 +6,7 @@
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
             <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
-            @if (Model.ShowChangeLinks)
+            @if (Model.Options.HasFlag(PersonDetailViewModelOptions.ShowChangeLinks))
             {
                 <govuk-summary-list-row-actions>
                     <govuk-summary-list-row-action href="@LinkGenerator.PersonEditName(Model.PersonId, journeyInstanceId: null)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
@@ -30,17 +30,20 @@
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
             <govuk-summary-list-row-value  use-empty-fallback>@Model.DateOfBirth?.ToString("dd/MM/yyyy")</govuk-summary-list-row-value>
-            @if (Model.ShowChangeLinks)
+            @if (Model.Options.HasFlag(PersonDetailViewModelOptions.ShowChangeLinks))
             {
                 <govuk-summary-list-row-actions>
                     <govuk-summary-list-row-action href="@LinkGenerator.PersonEditDateOfBirth(Model.PersonId, journeyInstanceId: null)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             }
         </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value use-empty-fallback>@Model.Gender</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
+        @if (Model.Options.HasFlag(PersonDetailViewModelOptions.ShowGender))
+        {
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value use-empty-fallback>@Model.Gender</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        }
         <govuk-summary-list-row>
             <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
             <govuk-summary-list-row-value use-empty-fallback>@Model.Trn</govuk-summary-list-row-value>
@@ -49,13 +52,19 @@
             <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
             <govuk-summary-list-row-value use-empty-fallback>@Model.NationalInsuranceNumber</govuk-summary-list-row-value>
         </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value use-empty-fallback>@Model.Email</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
-        <govuk-summary-list-row>
-            <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
-            <govuk-summary-list-row-value use-empty-fallback>@Model.MobileNumber</govuk-summary-list-row-value>
-        </govuk-summary-list-row>
+        @if (Model.Options.HasFlag(PersonDetailViewModelOptions.ShowEmail))
+        {
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value use-empty-fallback>@Model.Email</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        }
+        @if (Model.Options.HasFlag(PersonDetailViewModelOptions.ShowMobileNumber))
+        {
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value use-empty-fallback>@Model.MobileNumber</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        }
     </govuk-summary-list>
 </govuk-summary-card>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml
@@ -1,0 +1,28 @@
+@page "/support-tasks/connect-one-login-user/{supportTaskReference}/connect"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ConnectOneLoginUser.ConnectModel
+@{
+    ViewBag.Title = "Confirm connect";
+}
+
+<form action="@LinkGenerator.ConnectOneLoginUserSupportTaskConnect(Model.SupportTaskReference!, Model.Trn!)" method="post">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <h1 class="govuk-heading-l">
+                <span class="govuk-caption-l">Connect to a record - @Model.SupportTaskReference</span>
+                @ViewBag.Title
+            </h1>
+        </div>
+        <div class="govuk-grid-column-full">
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <partial name="_PersonDetail" model="@Model.PersonDetail" />
+
+            <govuk-button type="submit">Connect record</govuk-button>
+        </div>
+    </div>
+</form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+using TeachingRecordSystem.Core.Services.PersonMatching;
+using TeachingRecordSystem.SupportUi.Pages.Shared;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ConnectOneLoginUser;
+
+public class ConnectModel(TrsDbContext dbContext, IPersonMatchingService personMatchingService, TrsLinkGenerator linkGenerator) : PageModel
+{
+    private SupportTask? _supportTask;
+
+    [FromRoute]
+    public string? SupportTaskReference { get; set; }
+
+    [FromQuery]
+    public string? Trn { get; set; }
+
+    public string? Email { get; set; }
+
+    public PersonDetailViewModel? PersonDetail { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        dbContext.SupportTasks.Attach(_supportTask!);
+        var data = (ConnectOneLoginUserData)_supportTask!.Data;
+        _supportTask.Data = data with
+        {
+            PersonId = PersonDetail!.PersonId
+        };
+        _supportTask.Status = SupportTaskStatus.Closed;
+
+        var oneLoginUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == data.OneLoginUserSubject);
+        oneLoginUser.PersonId = PersonDetail!.PersonId;
+        oneLoginUser.MatchedAttributes = (await personMatchingService
+            .GetMatchedAttributes(
+                new(data.VerifiedNames!, data.VerifiedDatesOfBirth!, data.StatedNationalInsuranceNumber, data.StatedTrn, data.TrnTokenTrn),
+                PersonDetail.PersonId))
+            .ToArray();
+        oneLoginUser.MatchRoute = OneLoginUserMatchRoute.Support;
+
+        await dbContext.SaveChangesAsync();
+
+        TempData.SetFlashSuccess(
+            heading: "Teaching record connected",
+            message: $"{PersonDetail.Name} will get an email to say they can sign in.");
+
+        return Redirect(linkGenerator.SupportTasks());
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (Trn is null)
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        _supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        var data = (ConnectOneLoginUserData)_supportTask.Data;
+
+        PersonDetail = await dbContext.Persons
+            .Where(p => p.Trn == Trn && p.DqtState == 0)
+            .Select(p => new PersonDetailViewModel()
+            {
+                PersonId = p.PersonId,
+                Options = PersonDetailViewModelOptions.None,
+                Trn = p.Trn,
+                Name = $"{p.FirstName} {p.MiddleName} {p.LastName}",
+                PreviousNames = Array.Empty<string>(),  // TODO When we've got previous names synced to TRS
+                DateOfBirth = p.DateOfBirth,
+                NationalInsuranceNumber = p.NationalInsuranceNumber,
+                Gender = null,  // Not shown
+                Email = p.EmailAddress,
+                MobileNumber = null  // Not shown
+            })
+            .SingleOrDefaultAsync();
+
+        if (PersonDetail is null)
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        Email = data.OneLoginUserEmail;
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Index.cshtml
@@ -1,0 +1,113 @@
+@page "/support-tasks/connect-one-login-user/{supportTaskReference}"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ConnectOneLoginUser.IndexModel
+@{
+    ViewBag.Title = "Unable to connect GOV.UK One Login user to a teaching record";
+}
+
+<form action="@LinkGenerator.ConnectOneLoginUserSupportTask(Model.SupportTaskReference!)" method="post">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <h1 class="govuk-heading-l">
+                <span class="govuk-caption-l">Connect to a record - @Model.SupportTaskReference</span>
+                @ViewBag.Title
+            </h1>
+
+            <p class="govuk-body">
+                The user was able to sign in and verify their identity with GOV.UK One Login, but we haven’t been able to connect these details automatically to a teaching record.
+            </p>
+        </div>
+        <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-l">Support request details</h2>
+
+            <h3 class="govuk-heading-m">GOV.UK One Login verified</h3>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.VerifiedName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Previous names</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.VerifiedPreviousNames!.Length > 0)
+                        {
+                            <ul class="govuk-list">
+                                @foreach (var name in Model.VerifiedPreviousNames)
+                                {
+                                    <li>@name</li>
+                                }
+                            </ul>
+                        }
+                        else
+                        {
+                            <text>None</text>
+                        }
+                    </govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.VerifiedDateOfBirth.ToString("dd/MM/yyyy")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <h3 class="govuk-heading-m">Additional</h3>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@(Model.StatedNationalInsuranceNumber ?? "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@(Model.StatedTrn ?? "None")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            @functions {
+#pragma warning disable CS1998
+                async Task RenderConnectToTrnOption()
+                {
+                    <p class="govuk-body">
+                        <a href="@LinkGenerator.Persons()" target="_blank" rel="noreferrer" class="govuk-link">Find a record (opens in a new tab)</a>
+                    </p>
+
+                    <govuk-input asp-for="TrnOverride" input-class="govuk-input--width-10" label-class="govuk-label--s">
+                        <govuk-input-label>Connect to TRN (optional)</govuk-input-label>
+                    </govuk-input>
+                }
+#pragma warning restore CS1998
+            }
+
+            @if (Model.SuggestedMatches!.Length > 0)
+            {
+                <h2 class="govuk-heading-l">Suggested matches</h2>
+
+                @foreach (var suggestion in Model.SuggestedMatches)
+                {
+                    <partial name="_PersonDetail" model="@suggestion" />
+                }
+
+                <h2 class="govuk-heading-l">Which record do you wish to connect?</h2>
+
+                <govuk-radios asp-for="Trn">
+                    @foreach (var suggestion in Model.SuggestedMatches)
+                    {
+                        <govuk-radios-item value="@suggestion.Trn">@suggestion.Name</govuk-radios-item>
+                    }
+                    <govuk-radios-item value="@IndexModel.NoneOfTheAboveTrnSentinel">
+                        None of the above
+                        <govuk-radios-item-conditional>
+                            @{ await RenderConnectToTrnOption(); }
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                </govuk-radios>
+            }
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </div>
+    </div>
+</form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Index.cshtml.cs
@@ -1,0 +1,100 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+using TeachingRecordSystem.Core.Services.PersonMatching;
+using TeachingRecordSystem.SupportUi.Pages.Shared;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ConnectOneLoginUser;
+
+public class IndexModel(TrsDbContext dbContext, IPersonMatchingService personMatchingService, TrsLinkGenerator linkGenerator) : PageModel
+{
+    public const string NoneOfTheAboveTrnSentinel = "0000000";
+
+    [FromRoute]
+    public string? SupportTaskReference { get; set; }
+
+    [BindProperty]
+    public string? Trn { get; set; }
+
+    [BindProperty]
+    public string? TrnOverride { get; set; }
+
+    public string? Email { get; set; }
+    public string? VerifiedName { get; set; }
+    public string[]? VerifiedPreviousNames { get; set; }
+    public DateOnly VerifiedDateOfBirth { get; set; }
+    public string? StatedNationalInsuranceNumber { get; set; }
+    public string? StatedTrn { get; set; }
+    public PersonDetailViewModel[]? SuggestedMatches { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (SuggestedMatches!.Length > 0 && Trn is null)
+        {
+            ModelState.AddModelError(nameof(Trn), "Select the record you wish to connect");
+            return this.PageWithErrors();
+        }
+
+        var trn = Trn!;
+
+        if (Trn == NoneOfTheAboveTrnSentinel)
+        {
+            trn = TrnOverride!;
+
+            if (!await dbContext.Persons.AnyAsync(p => p.Trn == trn && p.DqtState == 0))
+            {
+                ModelState.AddModelError(nameof(TrnOverride), "Enter a valid TRN");
+                return this.PageWithErrors();
+            }
+        }
+
+        return Redirect(linkGenerator.ConnectOneLoginUserSupportTaskConnect(SupportTaskReference!, trn));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        var data = (ConnectOneLoginUserData)supportTask.Data;
+
+        var suggestedMatches = await personMatchingService.GetSuggestedMatches(new(
+            data.VerifiedNames!,
+            data.VerifiedDatesOfBirth!,
+            data.StatedNationalInsuranceNumber,
+            data.StatedTrn,
+            data.TrnTokenTrn));
+
+        SupportTaskReference = supportTask.SupportTaskReference;
+        Email = data.OneLoginUserEmail;
+        VerifiedName = FormatName(data.VerifiedNames!.First());
+        VerifiedPreviousNames = data.VerifiedNames!.Skip(1).Select(FormatName).ToArray();
+        VerifiedDateOfBirth = data.VerifiedDatesOfBirth!.First();
+        StatedNationalInsuranceNumber = data.StatedNationalInsuranceNumber;
+        StatedTrn = data.StatedTrn;
+
+        SuggestedMatches = suggestedMatches
+            .Select(m => new PersonDetailViewModel()
+            {
+                PersonId = m.PersonId,
+                Options = PersonDetailViewModelOptions.None,
+                Trn = m.Trn,
+                Name = $"{m.FirstName} {m.MiddleName} {m.LastName}",
+                PreviousNames = [],  // TODO When we've got previous names synced to TRS
+                DateOfBirth = m.DateOfBirth,
+                NationalInsuranceNumber = m.NationalInsuranceNumber,
+                Gender = null,  // Not shown
+                Email = m.Email,
+                MobileNumber = null  // Not shown
+            })
+            .ToArray();
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+
+        static string FormatName(string[] nameParts) => string.Join(" ", nameParts);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Index.cshtml
@@ -17,7 +17,7 @@
                         <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s">Filter by category</govuk-checkboxes-fieldset-legend>
                         @foreach (var type in Model.SupportTaskCategories)
                         {
-                            <govuk-checkboxes-item value="@type.SupportTaskCategory">@type.SupportTaskCategoryDescription (@type.Count)</govuk-checkboxes-item>
+                            <govuk-checkboxes-item value="@type.SupportTaskCategory" label-class="trs-!-max-width-none">@type.SupportTaskCategoryDescription (@type.Count)</govuk-checkboxes-item>
                         }
                     </govuk-checkboxes-fieldset>
                 </govuk-checkboxes>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem;
 using TeachingRecordSystem.Core.Infrastructure;
 using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.PersonMatching;
 using TeachingRecordSystem.ServiceDefaults;
 using TeachingRecordSystem.SupportUi;
 using TeachingRecordSystem.SupportUi.Infrastructure;
@@ -114,6 +115,13 @@ builder.Services
             model =>
             {
                 model.Filters.Add(new ServiceFilterAttribute<CheckMandatoryQualificationExistsFilter>() { Order = -200 });
+            });
+
+        options.Conventions.AddFolderApplicationModelConvention(
+            "/SupportTasks/ConnectOneLoginUser",
+            model =>
+            {
+                model.Filters.Add(new CheckSupportTaskExistsFilterFactory(openOnly: true, supportTaskType: SupportTaskType.ConnectOneLoginUser));
             });
     })
     .AddMvcOptions(options =>
@@ -259,7 +267,8 @@ builder.Services
     .AddSingleton<ReferenceDataCache>()
     .AddSingleton<SanctionTextLookup>()
     .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>()
-    .AddFileService();
+    .AddFileService()
+    .AddPersonMatching();
 
 var app = builder.Build();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -187,8 +187,19 @@ public class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string SupportTasks(SupportTaskCategory[]? categories = null, Pages.SupportTasks.IndexModel.SortByOption? sortBy = null, string? reference = null, bool? filtersApplied = null) =>
         GetRequiredPathByPage("/SupportTasks/Index", routeValues: new { category = categories, sortBy, reference, _f = filtersApplied == true ? "1" : null });
 
-    public string SupportTaskDetail(string reference, SupportTaskType supportTaskType) =>
-        reference.StartsWith("CAS-") ? EditChangeRequest(reference) : "#";
+    public string SupportTaskDetail(string supportTaskReference, SupportTaskType supportTaskType) =>
+        supportTaskReference.StartsWith("CAS-") ? EditChangeRequest(supportTaskReference) :
+        supportTaskType switch
+        {
+            SupportTaskType.ConnectOneLoginUser => ConnectOneLoginUserSupportTask(supportTaskReference),
+            _ => throw new ArgumentException($"Unknown {nameof(SupportTaskType)}: '{supportTaskType}'.", nameof(supportTaskType))
+        };
+
+    public string ConnectOneLoginUserSupportTask(string supportTaskReference) =>
+        GetRequiredPathByPage("/SupportTasks/ConnectOneLoginUser/Index", routeValues: new { supportTaskReference });
+
+    public string ConnectOneLoginUserSupportTaskConnect(string supportTaskReference, string trn) =>
+        GetRequiredPathByPage("/SupportTasks/ConnectOneLoginUser/Connect", routeValues: new { supportTaskReference, trn });
 
     private string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -63,3 +63,7 @@
 .trs-\!-width-200 {
   width: 200px;
 }
+
+.trs-\!-max-width-none {
+  max-width: none;
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/SupportTaskTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/SupportTaskTests.cs
@@ -1,0 +1,27 @@
+namespace TeachingRecordSystem.SupportUi.EndToEndTests;
+
+public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task ConnectOneLoginUser()
+    {
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync("/support-tasks");
+        await page.ClickAsync($"a:text-is('{supportTask.SupportTaskReference}')");
+
+        await page.WaitForUrlPathAsync($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}");
+        await page.ClickAsync($"label:text-is('{person.FirstName} {person.MiddleName} {person.LastName}')");
+        await page.ClickContinueButton();
+
+        await page.WaitForUrlPathAsync($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect");
+        await page.ClickButton("Connect record");
+
+        await page.WaitForUrlPathAsync("/support-tasks");
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/ConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/ConnectTests.cs
@@ -1,0 +1,169 @@
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.ConnectOneLoginUser;
+
+public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_SupportTaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/connect-one-login-user/TRS-000/connect?trn=0000000");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact(Skip = "Waiting for another support task type")]
+    public Task Get_SupportTaskIsNotConnectOneLoginUserType_ReturnsNotFound()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task Get_SupportTaskIsNotOpen_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        await WithDbContext(dbContext => dbContext.SupportTasks
+            .Where(t => t.SupportTaskReference == supportTask.SupportTaskReference)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.Status, _ => SupportTaskStatus.Closed)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn={person.Trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_TrnDoesNotExist_ReturnsBadRequest()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn=0000000");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsExpectedContent()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn={person.Trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(oneLoginUser.Email, doc.GetSummaryListValueForKey("Email address"));
+    }
+
+    [Fact]
+    public async Task Post_SupportTaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/TRS-000/connect?trn=0000000");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact(Skip = "Waiting for another support task type")]
+    public Task Post_SupportTaskIsNotConnectOneLoginUserType_ReturnsNotFound()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task Post_SupportTaskIsNotOpen_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        await WithDbContext(dbContext => dbContext.SupportTasks
+            .Where(t => t.SupportTaskReference == supportTask.SupportTaskReference)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.Status, _ => SupportTaskStatus.Closed)));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn={person.Trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_TrnDoesNotExist_ReturnsBadRequest()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn=0000000");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_ClosesTaskConnectsUserToPersonAndRedirectsToSupportTaskList()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn={person.Trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal("/support-tasks", response.Headers.Location?.OriginalString);
+
+        await WithDbContext(async dbContext =>
+        {
+            supportTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskStatus.Closed, supportTask.Status);
+            var data = (ConnectOneLoginUserData)supportTask.Data;
+            Assert.Equal(person.PersonId, data.PersonId);
+
+            oneLoginUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLoginUser.Subject);
+            Assert.Equal(person.PersonId, oneLoginUser.PersonId);
+            Assert.Equal(OneLoginUserMatchRoute.Support, oneLoginUser.MatchRoute);
+            Assert.NotEmpty(oneLoginUser.MatchedAttributes!);
+        });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/IndexTests.cs
@@ -1,0 +1,188 @@
+using ConnectOneLoginUserIndexModel = TeachingRecordSystem.SupportUi.Pages.SupportTasks.ConnectOneLoginUser.IndexModel;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.ConnectOneLoginUser;
+
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_SupportTaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/connect-one-login-user/TRS-000");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact(Skip = "Waiting for another support task type")]
+    public Task Get_SupportTaskIsNotConnectOneLoginUserType_ReturnsNotFound()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task Get_SupportTaskIsNotOpen_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        await WithDbContext(dbContext => dbContext.SupportTasks
+            .Where(t => t.SupportTaskReference == supportTask.SupportTaskReference)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.Status, _ => SupportTaskStatus.Closed)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var statedNationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var statedTrn = person.Trn;
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject, statedNationalInsuranceNumber: statedNationalInsuranceNumber, statedTrn: statedTrn);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(oneLoginUser.Email, doc.GetSummaryListValueForKey("Email address"));
+        Assert.Equal($"{person.FirstName} {person.LastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal(person.DateOfBirth.ToString("dd/MM/yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal(statedNationalInsuranceNumber, doc.GetSummaryListValueForKey("National Insurance number"));
+        Assert.Equal(statedTrn, doc.GetSummaryListValueForKey("TRN"));
+    }
+
+    [Fact]
+    public async Task Post_SupportTaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/TRS-000")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact(Skip = "Waiting for another support task type")]
+    public Task Post_SupportTaskIsNotConnectOneLoginUserType_ReturnsNotFound()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task Post_SupportTaskIsNotOpen_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        await WithDbContext(dbContext => dbContext.SupportTasks
+            .Where(t => t.SupportTaskReference == supportTask.SupportTaskReference)
+            .ExecuteUpdateAsync(s => s.SetProperty(t => t.Status, _ => SupportTaskStatus.Closed)));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Trn", person.Trn! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoSuggestionChosen_RendersError()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Trn", "Select the record you wish to connect");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequestFromSuggestion_RedirectsToConnectPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Trn", person.Trn! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn={person.Trn!}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequestWithOverridenTrn_RedirectsToConnectPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
+        var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Trn", ConnectOneLoginUserIndexModel.NoneOfTheAboveTrnSentinel },
+                { "TrnOverride", person.Trn! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect?trn={person.Trn!}", response.Headers.Location?.OriginalString);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -183,6 +183,21 @@ public partial class TestData
             return this;
         }
 
+        public CreatePersonBuilder WithNationalInsuranceNumber(string nationalInsuranceNumber)
+        {
+            var hasNationalInsuranceNumber = true;
+
+            if ((_hasNationalInsuranceNumber is not null && _hasNationalInsuranceNumber != hasNationalInsuranceNumber)
+                || (_nationalInsuranceNumber is not null && _nationalInsuranceNumber != nationalInsuranceNumber))
+            {
+                throw new InvalidOperationException("WithNationalInsuranceNumber cannot be changed after it's set.");
+            }
+
+            _hasNationalInsuranceNumber = hasNationalInsuranceNumber;
+            _nationalInsuranceNumber = nationalInsuranceNumber;
+            return this;
+        }
+
         public CreatePersonBuilder WithQts(DateOnly? qtsDate = null)
         {
             _qtsRegistrations.Add(


### PR DESCRIPTION
This adds UI for successfully resolving support tasks to connect a One Login user to a teaching record. The verification and unhappy path will follow separately.

There are a few tweaks to the `GetSuggestedMatches` method on `PersonMatchingService` as well to consider first name when scoring results.