### PR TITLE
Added new CRM command to create a TRN request task

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTrnRequestTaskQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTrnRequestTaskQuery.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record CreateTrnRequestTaskQuery : ICrmQuery<Guid>
+{
+    public required string Description { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required Stream EvidenceFileContent { get; init; }
+    public required string EvidenceFileMimeType { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateTrnRequestTaskHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateTrnRequestTaskHandler.cs
@@ -1,0 +1,38 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class CreateTrnRequestTaskHandler : ICrmQueryHandler<CreateTrnRequestTaskQuery, Guid>
+{
+    public async Task<Guid> Execute(CreateTrnRequestTaskQuery query, IOrganizationServiceAsync organizationService)
+    {
+        var crmTask = new CrmTask()
+        {
+            Id = Guid.NewGuid(),
+            Subject = "TRN Request",
+            Description = query.Description
+        };
+
+        var annotationBody = await StreamHelper.GetBase64EncodedFileContent(query.EvidenceFileContent);
+
+        var annotation = new Annotation()
+        {
+            ObjectId = crmTask.Id.ToEntityReference(CrmTask.EntityLogicalName),
+            ObjectTypeCode = CrmTask.EntityLogicalName,
+            Subject = query.EvidenceFileName,
+            DocumentBody = annotationBody,
+            MimeType = query.EvidenceFileMimeType,
+            FileName = query.EvidenceFileName,
+            NoteText = string.Empty
+        };
+
+        var requestBuilder = RequestBuilder.CreateTransaction(organizationService);
+        requestBuilder.AddRequest<CreateResponse>(new CreateRequest() { Target = crmTask });
+        requestBuilder.AddRequest(new CreateRequest() { Target = annotation });
+        await requestBuilder.Execute();
+
+        return crmTask.Id;
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateDateOfBirthChangeIncidentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateDateOfBirthChangeIncidentTests.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace TeachingRecordSystem.Core.Dqt.CrmIntegrationTests.QueryTests;
 
 public class CreateDateOfBirthChangeIncidentTests : IAsyncLifetime
@@ -24,9 +22,10 @@ public class CreateDateOfBirthChangeIncidentTests : IAsyncLifetime
         var createPersonResult = await _dataScope.TestData.CreatePerson();
 
         var newDateOfBirth = _dataScope.TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth);
-        var evidenceFileName = "evidence.txt";
-        var evidenceFileContent = new MemoryStream(Encoding.UTF8.GetBytes("Test file"));
-        var evidenceFileMimeType = "text/plain";
+        var uniqueId = Guid.NewGuid();
+        var evidenceFileName = $"evidence-{uniqueId}.jpg";
+        var evidenceFileContent = new MemoryStream(TestCommon.TestData.JpegImage);
+        var evidenceFileMimeType = "image/jpeg";
 
         var query = new CreateDateOfBirthChangeIncidentQuery()
         {
@@ -51,5 +50,16 @@ public class CreateDateOfBirthChangeIncidentTests : IAsyncLifetime
         Assert.Equal("Request to change date of birth", createdIncident.Title);
         Assert.Equal(newDateOfBirth, DateOnly.FromDateTime(createdIncident.dfeta_NewDateofBirth!.Value));
         Assert.Equal(query.FromIdentity, createdIncident.dfeta_FromIdentity);
+
+        var createdDocument = ctx.dfeta_documentSet.SingleOrDefault(i => i.GetAttributeValue<string>(dfeta_document.Fields.dfeta_name) == evidenceFileName);
+        Assert.NotNull(createdDocument);
+        Assert.Equal(createPersonResult.ContactId, createdDocument.dfeta_PersonId.Id);
+        Assert.Equal(createdIncident.Id, createdDocument.dfeta_CaseId.Id);
+        Assert.Equal(dfeta_DocumentType.ChangeofNameDOBEvidence, createdDocument.dfeta_Type);
+
+        var createdAnnotation = ctx.AnnotationSet.SingleOrDefault(i => i.GetAttributeValue<string>(Annotation.Fields.FileName) == evidenceFileName);
+        Assert.NotNull(createdAnnotation);
+        Assert.Equal(createdDocument.Id, createdAnnotation.ObjectId.Id);
+        Assert.Equal(dfeta_document.EntityLogicalName, createdAnnotation.ObjectTypeCode);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateTrnRequestTaskTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateTrnRequestTaskTests.cs
@@ -1,0 +1,52 @@
+namespace TeachingRecordSystem.Core.Dqt.CrmIntegrationTests.QueryTests;
+
+public class CreateTrnRequestTaskTests : IAsyncLifetime
+{
+    private readonly CrmClientFixture.TestDataScope _dataScope;
+    private readonly CrmQueryDispatcher _crmQueryDispatcher;
+
+    public CreateTrnRequestTaskTests(CrmClientFixture crmClientFixture)
+    {
+        _dataScope = crmClientFixture.CreateTestDataScope();
+        _crmQueryDispatcher = _dataScope.CreateQueryDispatcher();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync() => await _dataScope.DisposeAsync();
+
+    [Fact]
+    public async Task QueryExecutesSuccessfully()
+    {
+        // Arrange        
+        var description = "Test description";
+        var uniqueId = Guid.NewGuid();
+        var evidenceFileName = $"evidence-{uniqueId}.jpg";
+        var evidenceFileContent = new MemoryStream(TestCommon.TestData.JpegImage);
+        var evidenceFileMimeType = "image/jpeg";
+
+        var query = new CreateTrnRequestTaskQuery()
+        {
+            Description = description,
+            EvidenceFileName = evidenceFileName,
+            EvidenceFileContent = evidenceFileContent,
+            EvidenceFileMimeType = evidenceFileMimeType
+        };
+
+        // Act
+        var crmTaskId = await _crmQueryDispatcher.ExecuteQuery(query);
+
+        // Assert
+        using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);
+
+        var createdCrmTask = ctx.TaskSet.SingleOrDefault(i => i.GetAttributeValue<Guid>(CrmTask.PrimaryIdAttribute) == crmTaskId);
+        Assert.NotNull(createdCrmTask);
+        Assert.Equal("TRN Request", createdCrmTask.Subject);
+        Assert.Equal(description, createdCrmTask.Description);
+
+        var createdAnnotation = ctx.AnnotationSet.SingleOrDefault(i => i.GetAttributeValue<string>(Annotation.Fields.FileName) == evidenceFileName);
+        Assert.NotNull(createdAnnotation);
+        Assert.Equal(createdCrmTask.Id, createdAnnotation.ObjectId.Id);
+        Assert.Equal(CrmTask.EntityLogicalName, createdAnnotation.ObjectTypeCode);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveIncidentsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveIncidentsTests.cs
@@ -27,7 +27,7 @@ public class GetActiveIncidentsTests : IAsyncLifetime
         var approvedCreateDateOfBirthChangeIncidentResult = await _dataScope.TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId).WithApprovedStatus());
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveIncidentsQuery(1, 15));
+        var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveIncidentsQuery(1, 50));
 
         // Assert        
         Assert.Contains(result.Incidents, i => i.Id == activeCreateNameChangeIncidentResult.IncidentId);


### PR DESCRIPTION
### Context

We’re building a journey where NPQ participants who don’t have a TRN can request one using an online form. The data needs to go into a CRM Task so it can be processed.

### Changes proposed in this pull request

Add a new command that creates a CRM Task with a subject - TRN request. The command should accept a file (like CreateNameChangeIncidentQuery) and a Description parameter.

### Guidance to review

Also improved some existing tests for commands which upload evidence.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
