### PR TITLE
Added initial code for Request a TRN journey including the start page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -35,6 +35,12 @@ public abstract class AuthorizeAccessLinkGenerator
     public string SignOut(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/SignOut", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrn(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/Index", journeyInstanceId: journeyInstanceId);
+
+    public string RequestTrnEmail(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/Email", journeyInstanceId: journeyInstanceId);
+
     protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
         var url = GetRequiredPathByPage(page, handler, routeValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
@@ -1,0 +1,5 @@
+@page "/request-trn/email"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.EmailModel
+@{
+    ViewBag.Title = "What is your email address?";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class EmailModel : PageModel
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
@@ -1,0 +1,32 @@
+@page "/request-trn"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.IndexModel
+@{
+    ViewBag.Title = "Get a teacher reference number (TRN)";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+        <p class="govuk-body">Use this service to get a teacher reference number (TRN) if you’re registering for a national professional qualification (NPQ).</p>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h2 class="govuk-heading-l">Before you start</h2>
+        <p class="govuk-body">You’ll need your National Insurance number (if you have one) and proof of you’re identity, for example a:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>passport</li>
+            <li>driving licence</li>
+            <li>birth certificate</li>
+            <li>UK work permit</li>
+        </ul>
+    </div>
+</div>
+
+<govuk-button-link href="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId)" class="govuk-button govuk-button--start">
+    Start now
+    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+    </svg>
+</govuk-button-link>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+[Journey(RequestTrnJourneyState.JourneyName), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel : PageModel
+{
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -7,5 +7,5 @@ public class RequestTrnJourneyState
     public const string JourneyName = "RequestTrnJourney";
 
     public static JourneyDescriptor JourneyDescriptor { get; } =
-    new JourneyDescriptor(JourneyName, typeof(RequestTrnJourneyState), requestDataKeys: [], appendUniqueKey: true);
+        new JourneyDescriptor(JourneyName, typeof(RequestTrnJourneyState), requestDataKeys: [], appendUniqueKey: true);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class RequestTrnJourneyState
+{
+    public const string JourneyName = "RequestTrnJourney";
+
+    public static JourneyDescriptor JourneyDescriptor { get; } =
+    new JourneyDescriptor(JourneyName, typeof(RequestTrnJourneyState), requestDataKeys: [], appendUniqueKey: true);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/_Layout.cshtml
@@ -1,0 +1,62 @@
+@using Microsoft.AspNetCore.Authorization;
+@inject IConfiguration Configuration;
+@{
+    Layout = "_GovUkPageTemplate";
+}
+
+@section Head {
+    <meta name="robots" content="noindex">
+    <link rel="stylesheet" asp-href-include="~/Styles/*.css" asp-append-version="true">
+    @RenderSection("Styles", required: false)
+    @RenderSection("Scripts", required: false)
+}
+
+@section Header {
+    <header class="govuk-header" data-module="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+            <div class="govuk-header__logo">
+                <a href="/" class="govuk-header__link govuk-header__link--homepage">
+                    <svg focusable="false"
+                         role="img"
+                         class="govuk-header__logotype"
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewBox="0 0 148 30"
+                         height="30"
+                         width="148"
+                         aria-label="GOV.UK">
+                        <title>GOV.UK</title>
+                        <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+                    </svg>
+                </a>
+            </div>
+            <div class="govuk-header__content">
+                <a asp-page="/Index" class="govuk-header__link govuk-header__service-name">
+                    Get a teacher reference number (TRN)
+                </a>                
+            </div>
+        </div>
+    </header>
+}
+
+@section BeforeContent {
+    @RenderSection("BeforeContent", required: false)
+}
+
+@RenderBody()
+
+@section Footer {
+    <footer class="govuk-footer " role="contentinfo">
+        <div class="govuk-width-container ">
+            <div class="govuk-footer__meta">
+                <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                    <p class="govuk-!-font-size-16">
+                        If you need help, email us at <a class="govuk-link govuk-footer__link" href="mailto:@(Configuration["SupportEmail"])">@(Configuration["SupportEmail"])</a>
+                    </p>
+                </div>
+                <div class="govuk-footer__meta-item">
+                    <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/_Layout.cshtml
@@ -50,7 +50,7 @@
             <div class="govuk-footer__meta">
                 <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
                     <p class="govuk-!-font-size-16">
-                        If you need help, email us at <a class="govuk-link govuk-footer__link" href="mailto:@(Configuration["SupportEmail"])">@(Configuration["SupportEmail"])</a>
+                        If you need help, email us at <a class="govuk-link govuk-footer__link" href="mailto:@(Configuration["RequestTrnSupportEmail"])">@(Configuration["RequestTrnSupportEmail"])</a>
                     </p>
                 </div>
                 <div class="govuk-footer__meta-item">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -16,6 +16,7 @@ using TeachingRecordSystem.AuthorizeAccess.Infrastructure.FormFlow;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Logging;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Oidc;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Security;
+using TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 using TeachingRecordSystem.AuthorizeAccess.TagHelpers;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
@@ -159,6 +160,7 @@ builder.Services
     .AddFormFlow(options =>
     {
         options.JourneyRegistry.RegisterJourney(SignInJourneyState.JourneyDescriptor);
+        options.JourneyRegistry.RegisterJourney(RequestTrnJourneyState.JourneyDescriptor);
     })
     .AddSingleton<ICurrentUserIdProvider, FormFlowSessionCurrentUserIdProvider>()
     .AddTransient<SignInJourneyHelper>()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
@@ -8,5 +8,6 @@
     },
     "Enrich": [ "FromLogContext" ]
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "SupportEmail": "qts.enquiries@education.gov.uk"
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
@@ -9,5 +9,5 @@
     "Enrich": [ "FromLogContext" ]
   },
   "AllowedHosts": "*",
-  "SupportEmail": "qts.enquiries@education.gov.uk"
+  "RequestTrnSupportEmail": "qts.enquiries@education.gov.uk"
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -1,0 +1,15 @@
+namespace TeachingRecordSystem.AuthorizeAccess.EndToEndTests;
+
+public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task RequestTrn()
+    {
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync("/request-trn");
+        await page.ClickButton("Start now");
+        await page.WaitForUrlPathAsync("/request-trn/email");
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IndexTests.cs
@@ -1,0 +1,20 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponse(response);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/TestBase.cs
@@ -1,0 +1,87 @@
+using FakeXrmEasy.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.FormFlow;
+using TeachingRecordSystem.FormFlow.State;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public abstract class TestBase : IDisposable
+{
+    private readonly TestScopedServices _testServices;
+
+    protected TestBase(HostFixture hostFixture)
+    {
+        HostFixture = hostFixture;
+
+        _testServices = TestScopedServices.Reset();
+
+        HttpClient = hostFixture.CreateClient(new()
+        {
+            AllowAutoRedirect = false
+        });
+    }
+
+    public HostFixture HostFixture { get; }
+
+    public CaptureEventObserver EventObserver => _testServices.EventObserver;
+
+    public TestableClock Clock => _testServices.Clock;
+
+    public HttpClient HttpClient { get; }
+
+    public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
+
+    public IXrmFakedContext XrmFakedContext => HostFixture.Services.GetRequiredService<IXrmFakedContext>();
+
+    public async Task<JourneyInstance<RequestTrnJourneyState>> CreateJourneyInstance(RequestTrnJourneyState state)
+    {
+        await using var scope = HostFixture.Services.CreateAsyncScope();
+        var stateProvider = scope.ServiceProvider.GetRequiredService<IUserInstanceStateProvider>();
+        var options = scope.ServiceProvider.GetRequiredService<IOptions<FormFlowOptions>>();
+
+        var journeyDescriptor = RequestTrnJourneyState.JourneyDescriptor;
+
+        var keysDict = new Dictionary<string, StringValues>
+        {
+            { Constants.UniqueKeyQueryParameterName, new StringValues(Guid.NewGuid().ToString()) }
+        };
+
+        var instanceId = new JourneyInstanceId(journeyDescriptor.JourneyName, keysDict);
+
+        var stateType = typeof(RequestTrnJourneyState);
+
+        var instance = await stateProvider.CreateInstanceAsync(instanceId, stateType, state, properties: null);
+        return (JourneyInstance<RequestTrnJourneyState>)instance;
+    }
+
+    public async Task<JourneyInstance<RequestTrnJourneyState>> ReloadJourneyInstance(JourneyInstance<RequestTrnJourneyState> journeyInstance)
+    {
+        await using var scope = HostFixture.Services.CreateAsyncScope();
+        var stateProvider = scope.ServiceProvider.GetRequiredService<IUserInstanceStateProvider>();
+        var reloadedInstance = await stateProvider.GetInstanceAsync(journeyInstance.InstanceId, typeof(RequestTrnJourneyState));
+        return (JourneyInstance<RequestTrnJourneyState>)reloadedInstance!;
+    }
+
+    public RequestTrnJourneyState CreateNewState() => new RequestTrnJourneyState();
+
+    public virtual void Dispose()
+    {
+    }
+
+    public virtual async Task<T> WithDbContext<T>(Func<TrsDbContext, Task<T>> action)
+    {
+        var dbContextFactory = HostFixture.Services.GetRequiredService<IDbContextFactory<TrsDbContext>>();
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync();
+        return await action(dbContext);
+    }
+
+    public virtual Task WithDbContext(Func<TrsDbContext, Task> action) =>
+        WithDbContext(async dbContext =>
+        {
+            await action(dbContext);
+            return 0;
+        });
+}


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

Add a start page following the designs in Figma [Request a TRN] under /request-trn in the AuthorizeAccess project.

Create a new folder RequestTrn under Pages and define a new Layout.

The <head> should include <meta name="robots" content="noindex"> to prevent search engines crawling this journey.

This start page should initialise a new FormFlow journey.

Start now should redirect to /request-trn/email

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
