### PR TITLE
Added email page to get a TRN journey + tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -41,6 +41,9 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrnEmail(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/Email", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrnName(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/Name", journeyInstanceId: journeyInstanceId);
+
     protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
         var url = GetRequiredPathByPage(page, handler, routeValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EmailAddressAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EmailAddressAttribute.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class EmailAddressAttribute : ValidationAttribute
+{
+    public override bool IsValid(object? value)
+    {
+        return value is string str && EmailAddress.TryParse(str, out _);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
@@ -1,5 +1,22 @@
 @page "/request-trn/email"
 @model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.EmailModel
 @{
-    ViewBag.Title = "What is your email address?";
+    ViewBag.Title = Html.DisplayNameFor(m => m.Email);
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrn(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId)" method="post">            
+
+            <govuk-input asp-for="Email" type="email" autocomplete="email">
+                <govuk-input-label is-page-heading="true" class="govuk-label--l" />
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
@@ -1,7 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class EmailModel : PageModel
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class EmailModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
 {
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    [BindProperty]
+    [Display(Name = "What is your email address?", Description = "We’ll only use this to send you your TRN if you’re eligible for one.")]
+    [Required(ErrorMessage = "Enter your email address")]
+    [EmailAddress(ErrorMessage = "Enter a valid email address")]
+    public string? Email { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state => state.Email = Email);
+
+        return Redirect(linkGenerator.RequestTrnName(JourneyInstance.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        Email ??= JourneyInstance!.State.Email;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
@@ -1,0 +1,5 @@
+@page "/request-trn/name"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.NameModel
+@{
+    ViewBag.Title = "What is your name?";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class NameModel : PageModel
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -2,10 +2,12 @@ using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class RequestTrnJourneyState
+public class RequestTrnJourneyState()
 {
     public const string JourneyName = "RequestTrnJourney";
 
     public static JourneyDescriptor JourneyDescriptor { get; } =
         new JourneyDescriptor(JourneyName, typeof(RequestTrnJourneyState), requestDataKeys: [], appendUniqueKey: true);
+
+    public string? Email { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EmailAddress.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EmailAddress.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace TeachingRecordSystem.Core;
+
+/// <summary>
+/// Represents a valid email address (code ported from Notify).
+/// </summary>
+[DebuggerDisplay("{_normalizedValue}")]
+public sealed class EmailAddress : IEquatable<EmailAddress>, IParsable<EmailAddress>
+{
+    public const int EmailAddressMaxLength = 200;
+
+    private const string ValidLocalChars = @"a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\-";
+    private const string EmailRegexPattern = @"^[" + ValidLocalChars + @"]+@([^.@][^@\s]+)$";
+
+    private const string ObscureZeroWidthWhitespace = "\u180E\u200B\u200C\u200D\u2060\uFEFF";
+    private const string ObscureFullWidthWhitespace = "\u00A0\u202F";
+
+    private static readonly Regex _hostnamePartRegex = new Regex(@"^(xn|[a-z0-9]+)(-?-[a-z0-9]+)*$", RegexOptions.IgnoreCase);
+    private static readonly Regex _tldPartRegex = new Regex(@"^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$", RegexOptions.IgnoreCase);
+
+    private readonly string _normalizedValue;
+
+    private EmailAddress(string normalizedValue)
+    {
+        _normalizedValue = normalizedValue;
+    }
+
+    public static EmailAddress Parse(string? emailAddress)
+    {
+        if (!TryParseCore(emailAddress, out var result, out var error))
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    public static bool TryParse(string? emailAddress, [MaybeNullWhen(false)] out EmailAddress result) =>
+        TryParseCore(emailAddress, out result, out _);
+
+    static EmailAddress IParsable<EmailAddress>.Parse(string? s, IFormatProvider? provider) => Parse(s);
+
+    static bool IParsable<EmailAddress>.TryParse(
+        string? s,
+        IFormatProvider? provider,
+        [MaybeNullWhen(false)] out EmailAddress result)
+    {
+        if (s is null)
+        {
+            result = null;
+            return false;
+        }
+
+        return TryParse(s, out result);
+    }
+
+    private static bool TryParseCore(
+        string? emailAddress,
+        [MaybeNullWhen(false)] out EmailAddress result,
+        [MaybeNullWhen(true)] out FormatException error)
+    {
+        if (emailAddress is null)
+        {
+            error = new FormatException("Email address must have a value.");
+            result = default;
+            return false;
+        }
+
+        var normalizedEmailAddress = StripAndRemoveObscureWhitespace(emailAddress);
+        Match match = Regex.Match(normalizedEmailAddress, EmailRegexPattern);
+
+        if (normalizedEmailAddress.Length > 320)
+        {
+            error = new FormatException("Email address too long.");
+            result = default;
+            return false;
+        }
+
+        // not an email
+        if (!match.Success || normalizedEmailAddress.Contains(".."))
+        {
+            error = new FormatException("Not a valid email address.");
+            result = default;
+            return false;
+        }
+
+        string hostname = match.Groups[1].Value;
+
+        // idna = "Internationalized domain name" - this mapping converts unicode into its accurate ascii
+        // representation as the web uses. '例え.テスト'.encode('idna') == b'xn--r8jz45g.xn--zckzah'
+        try
+        {
+            hostname = new IdnMapping().GetAscii(hostname);
+        }
+        catch (ArgumentException)
+        {
+            error = new FormatException("Failed to convert to ASCII representation.");
+            result = default;
+            return false;
+        }
+
+        string[] parts = hostname.Split('.');
+
+        if (hostname.Length > 253 || parts.Length < 2)
+        {
+            error = new FormatException("Hostname invalid length.");
+            result = default;
+            return false;
+        }
+
+        foreach (string part in parts)
+        {
+            if (string.IsNullOrEmpty(part) || part.Length > 63 || !_hostnamePartRegex.IsMatch(part))
+            {
+                error = new FormatException("Invalid hostname.");
+                result = default;
+                return false;
+            }
+        }
+
+        // if the part after the last . is not a valid TLD then bail out
+        if (!_tldPartRegex.IsMatch(parts[^1]))
+        {
+            error = new FormatException("Invalid top level domain");
+            result = default;
+            return false;
+        }
+
+        result = new EmailAddress(normalizedEmailAddress);
+        error = default;
+        return true;
+
+        static string StripAndRemoveObscureWhitespace(string value)
+        {
+            if (value == "")
+            {
+                return "";
+            }
+
+            foreach (char character in ObscureZeroWidthWhitespace + ObscureFullWidthWhitespace)
+            {
+                value = value.Replace(character.ToString(), "");
+            }
+
+            return value.Trim();
+        }
+    }
+
+    public bool Equals(EmailAddress? other) => other is not null && _normalizedValue.Equals(other._normalizedValue);
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is EmailAddress other && Equals(other);
+
+    public override int GetHashCode() => _normalizedValue.GetHashCode();
+
+    public override string ToString() => _normalizedValue;
+
+    public static bool operator ==(EmailAddress left, EmailAddress right) =>
+        (left is null && right is null) ||
+        (left is not null && right is not null && left.Equals(right));
+
+    public static bool operator !=(EmailAddress left, EmailAddress right) => !(left == right);
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -11,5 +11,11 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.GotoAsync("/request-trn");
         await page.ClickButton("Start now");
         await page.WaitForUrlPathAsync("/request-trn/email");
+
+        var email = Faker.Internet.Email();
+        await page.FillAsync("input[name=Email]", email);
+        await page.ClickButton("Continue");
+
+        await page.WaitForUrlPathAsync("/request-trn/name");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/EmailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/EmailTests.cs
@@ -1,0 +1,107 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class EmailTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponse(response);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+        var state = CreateNewState(email);
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(email, doc.GetElementById("Email")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_EmptyEmailAddressEntered_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter your email address");
+    }
+
+    [Fact]
+    public async Task Post_InvalidFormatEmailAddress_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+        var invalidEmail = "invalid-email";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "Email", invalidEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a valid email address");
+    }
+
+
+    [Fact]
+    public async Task Post_ValidRequestWithValidData_RedirectsToNamePage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var email = Faker.Internet.Email();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "Email", email }
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/TestBase.cs
@@ -65,7 +65,7 @@ public abstract class TestBase : IDisposable
         return (JourneyInstance<RequestTrnJourneyState>)reloadedInstance!;
     }
 
-    public RequestTrnJourneyState CreateNewState() => new RequestTrnJourneyState();
+    public RequestTrnJourneyState CreateNewState(string? email = null) => new RequestTrnJourneyState() { Email = email };
 
     public virtual void Dispose()
     {


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

Add an email address page following the designs [Request a TRN] under /request-trn/email

When a valid email is entered and Continue is clicked, store the email address on the FormFlow instance and redirect to /request-trn/name (a new page).

If no email is entered show an error Enter your email address.

If the email isn’t valid (i.e. doesn’t contain an @) show an error Enter a valid email address.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
