### PR TITLE
Added Name page to request a TRN journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -44,6 +44,9 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrnName(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/Name", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrnDateOfBirth(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/DateOfBirth", journeyInstanceId: journeyInstanceId);
+
     protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
         var url = GetRequiredPathByPage(page, handler, routeValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/RequiredIfOtherPropertyEqualsAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/RequiredIfOtherPropertyEqualsAttribute.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class RequiredIfOtherPropertyEqualsAttribute : RequiredAttribute
+{
+    private readonly string _propertyName;
+    private readonly string? _targetValue;
+
+    public RequiredIfOtherPropertyEqualsAttribute(string propertyName, string? targetValue = null)
+    {
+        _propertyName = propertyName;
+        _targetValue = targetValue;
+    }
+
+    protected override ValidationResult IsValid(object? value, ValidationContext context)
+    {
+        object instance = context.ObjectInstance;
+        Type type = instance.GetType();
+
+        var property = type.GetProperty(_propertyName);
+        if (property == null)
+        {
+            throw new ArgumentException($"Property {_propertyName} not found");
+        }
+
+        var propertyValue = property.GetValue(instance)?.ToString();
+        bool isRequired;
+
+        if (_targetValue is null)
+        {
+            bool.TryParse(propertyValue, out isRequired);
+        }
+        else
+        {
+            isRequired = propertyValue == _targetValue;
+        }
+
+        return isRequired && !base.IsValid(value) ? new ValidationResult(ErrorMessage) : ValidationResult.Success!;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
@@ -1,0 +1,5 @@
+@page "/request-trn/date-of-birth"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.DateOfBirthModel
+@{
+    ViewBag.Title = "What is your date of birth?";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class DateOfBirthModel : PageModel
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
@@ -1,5 +1,33 @@
 @page "/request-trn/name"
 @model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.NameModel
 @{
-    ViewBag.Title = "What is your name?";
+    ViewBag.Title = Html.DisplayNameFor(m => m.Name);
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-input asp-for="Name" spellcheck="false">
+                <govuk-input-label is-page-heading="true" class="govuk-label--l" />
+            </govuk-input>
+
+            <govuk-radios asp-for="HasPreviousName">
+                <govuk-radios-fieldset>
+                    <govuk-radios-item value="@true">
+                        Yes
+                        <govuk-radios-item-conditional>
+                            <govuk-input asp-for="PreviousName" spellcheck="false"/>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
@@ -1,7 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class NameModel : PageModel
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
 {
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    [BindProperty]
+    [Display(Name = "What is your name?", Description = "Full name")]
+    [Required(ErrorMessage = "Enter your name")]
+    public string? Name { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Do you have a previous name?")]
+    [Required(ErrorMessage = "Tell us if you have a previous name")]
+    public bool? HasPreviousName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Previous full name")]
+    [RequiredIfOtherPropertyEquals(nameof(HasPreviousName), ErrorMessage = "Tell us your previous name")]
+    public string? PreviousName { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.Name = Name;
+            state.HasPreviousName = HasPreviousName;
+            state.PreviousName = HasPreviousName!.Value ? PreviousName : null;
+        });
+
+        return Redirect(linkGenerator.RequestTrnDateOfBirth(JourneyInstance!.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.Email is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnEmail(JourneyInstance.InstanceId));
+            return;
+        }
+
+        Name ??= JourneyInstance!.State.Name;
+        HasPreviousName ??= JourneyInstance!.State.HasPreviousName;
+        PreviousName ??= JourneyInstance!.State.PreviousName;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -10,4 +10,7 @@ public class RequestTrnJourneyState()
         new JourneyDescriptor(JourneyName, typeof(RequestTrnJourneyState), requestDataKeys: [], appendUniqueKey: true);
 
     public string? Email { get; set; }
+    public string? Name { get; set; }
+    public bool? HasPreviousName { get; set; }
+    public string? PreviousName { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -17,5 +17,14 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.ClickButton("Continue");
 
         await page.WaitForUrlPathAsync("/request-trn/name");
+
+        var name = Faker.Name.FullName();
+        var previousName = Faker.Name.FullName();
+        await page.FillAsync("input[name=Name]", name);
+        await page.CheckAsync("text=Yes");
+        await page.FillAsync("input[name=PreviousName]", previousName);
+        await page.ClickButton("Continue");
+
+        await page.WaitForUrlPathAsync("/request-trn/date-of-birth");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NameTests.cs
@@ -1,0 +1,173 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class NameTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_EmailMissingFromState_RedirectsToEmail()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(state.Name, doc.GetElementById("Name")?.GetAttribute("value"));
+        var radioButtons = doc.GetElementsByName("HasPreviousName");
+        var selectedRadioButton = radioButtons.Single(r => r.HasAttribute("checked"));
+        Assert.Equal("True", selectedRadioButton.GetAttribute("value"));
+        Assert.Equal(state.PreviousName, doc.GetElementById("PreviousName")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_EmptyNameEntered_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["HasPreviousName"] = "False",
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Name", "Enter your name");
+    }
+
+    [Fact]
+    public async Task Post_WhenHasPreviousNameHasNoSelection_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["Name"] = Faker.Name.FullName(),
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasPreviousName", "Tell us if you have a previous name");
+    }
+
+    [Fact]
+    public async Task Post_WhenHasPreviousNameIsTrueAndPreviousNameIsEmpty_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["Name"] = Faker.Name.FullName(),
+                ["HasPreviousName"] = "True",
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreviousName", "Tell us your previous name");
+    }
+
+    [Fact]
+    public async Task Post_EmailMissingFromState_RedirectsToEmail()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["Name"] = Faker.Name.FullName(),
+                ["HasPreviousName"] = "False",
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesStateAndRedirectsToNextPage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var name = Faker.Name.FullName();
+        var previousName = Faker.Name.FullName();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["Name"] = name,
+                ["HasPreviousName"] = "True",
+                ["PreviousName"] = previousName,
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        var reloadedJourneyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(name, reloadedJourneyInstance.State.Name);
+        Assert.Equal(previousName, reloadedJourneyInstance.State.PreviousName);
+        Assert.True(reloadedJourneyInstance.State.HasPreviousName);
+    }
+}


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

Add a name page (following the Request a TRN designs in Figma) under /request-trn/name

When a non-empty full name is entered and Continue is clicked, store the name & previous name on the FormFlow instance and redirect to /request-trn/date-of-birth(a new page).

If no name is entered show an error Enter your name.

If the ‘Do you have a previous name’ question is not answered, show an error Tell us if you have a previous name.

If ‘Yes’ is answered to the ‘Do you have a previous name' but no previous name is entered, show an error 'Tell us your previous name’.

If the email question has not yet been answered, redirect to /request-trn/email.

### Guidance to review

new page in journey + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
