### PR TITLE
Added DOB page for request a TRN journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -47,6 +47,9 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrnDateOfBirth(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/DateOfBirth", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrnIdentity(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/Identity", journeyInstanceId: journeyInstanceId);
+
     protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
         var url = GetRequiredPathByPage(page, handler, routeValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
@@ -1,5 +1,23 @@
 @page "/request-trn/date-of-birth"
 @model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.DateOfBirthModel
 @{
-    ViewBag.Title = "What is your date of birth?";
+    ViewBag.Title = Html.DisplayNameFor(m => m.DateOfBirth);
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RequestTrnDateOfBirth(Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-date-input asp-for="DateOfBirth">
+                <govuk-date-input-fieldset>
+                    <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
+                </govuk-date-input-fieldset>
+            </govuk-date-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
@@ -14,6 +14,9 @@
             <govuk-date-input asp-for="DateOfBirth">
                 <govuk-date-input-fieldset>
                     <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
+                    <govuk-date-input-day autocomplete="bday-day" />
+                    <govuk-date-input-month autocomplete="bday-month" />
+                    <govuk-date-input-year autocomplete="bday-year" />
                 </govuk-date-input-fieldset>
             </govuk-date-input>
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
@@ -1,7 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class DateOfBirthModel : PageModel
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
 {
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    [BindProperty]
+    [Display(Name = "What is your date of birth?")]
+    [Required(ErrorMessage = "Enter your date of birth")]
+    public DateOnly? DateOfBirth { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state => state.DateOfBirth = DateOfBirth);
+
+        return Redirect(linkGenerator.RequestTrnIdentity(JourneyInstance!.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.Name is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnName(JourneyInstance.InstanceId));
+            return;
+        }
+
+        DateOfBirth ??= JourneyInstance!.State.DateOfBirth;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
@@ -1,0 +1,5 @@
+@page "/request-trn/identity"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.IdentityModel
+@{
+    ViewBag.Title = "Upload proof of your identity";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class IdentityModel : PageModel
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -13,4 +13,5 @@ public class RequestTrnJourneyState()
     public string? Name { get; set; }
     public bool? HasPreviousName { get; set; }
     public string? PreviousName { get; set; }
+    public DateOnly? DateOfBirth { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/PageExtensions.cs
@@ -25,6 +25,13 @@ public static class PageExtensions
         Assert.Equal(trn, await page.GetByTestId("trn").InnerTextAsync());
     }
 
+    public static async Task FillDateInput(this IPage page, DateOnly date)
+    {
+        await page.FillAsync("label:text-is('Day')", date.Day.ToString());
+        await page.FillAsync("label:text-is('Month')", date.Month.ToString());
+        await page.FillAsync("label:text-is('Year')", date.Year.ToString());
+    }
+
     public static Task ClickButton(this IPage page, string text) =>
         page.ClickAsync($".govuk-button:text-is('{text}')");
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -26,5 +26,11 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.ClickButton("Continue");
 
         await page.WaitForUrlPathAsync("/request-trn/date-of-birth");
+
+        var dateOfBirth = new DateOnly(1980, 3, 1);
+        await page.FillDateInput(dateOfBirth);
+        await page.ClickButton("Continue");
+
+        await page.WaitForUrlPathAsync("/request-trn/identity");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
@@ -1,0 +1,126 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_NameMissingFromState_RedirectsToName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        var dateOfBirth = new DateOnly(1980, 1, 1);
+        state.DateOfBirth = dateOfBirth;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal($"{dateOfBirth:%d}", doc.GetElementById("DateOfBirth.Day")?.GetAttribute("value"));
+        Assert.Equal($"{dateOfBirth:%M}", doc.GetElementById("DateOfBirth.Month")?.GetAttribute("value"));
+        Assert.Equal($"{dateOfBirth:yyyy}", doc.GetElementById("DateOfBirth.Year")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_WhenNoDateOfBirthIsEntered_ReturnsError()
+    {
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Enter your date of birth");
+    }
+
+    [Fact]
+    public async Task Post_NameMissingFromState_RedirectsToName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var dateOfBirth = new DateOnly(1980, 3, 1);
+        state.DateOfBirth = dateOfBirth;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "DateOfBirth.Day", $"{dateOfBirth:%d}" },
+                { "DateOfBirth.Month", $"{dateOfBirth:%M}" },
+                { "DateOfBirth.Year", $"{dateOfBirth:yyyy}" }
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesStateAndRedirectsToNextPage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        var dateOfBirth = new DateOnly(1980, 3, 1);
+        state.DateOfBirth = dateOfBirth;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "DateOfBirth.Day", $"{dateOfBirth:%d}" },
+                { "DateOfBirth.Month", $"{dateOfBirth:%M}" },
+                { "DateOfBirth.Year", $"{dateOfBirth:yyyy}" }
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+}


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

If no DOB is entered show an error Enter your date of birth.

When a valid DOB is entered and Continue is clicked, store the DOB on the FormFlow instance and redirect to /request-trn/identity

If the name question has not yet been answered, redirect to /request-trn/name

### Guidance to review

Page + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
