### PR TITLE
Add proof of identity page to request a TRN journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -50,6 +50,9 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrnIdentity(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/Identity", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrnNationalInsuranceNumber(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/NationalInsuranceNumber", journeyInstanceId: journeyInstanceId);
+
     protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
         var url = GetRequiredPathByPage(page, handler, routeValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EvidenceFileAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EvidenceFileAttribute.cs
@@ -1,0 +1,14 @@
+namespace TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class EvidenceFileAttribute : FileExtensionsAttribute
+{
+    public EvidenceFileAttribute()
+        : base(".bmp", ".csv", ".doc", ".docx", ".eml", ".jpeg", ".jpg", ".mbox", ".msg", ".ods", ".odt", ".pdf", ".png", ".tif", ".txt", ".xls", ".xlsx")
+    {
+        if (ErrorMessage == null)
+        {
+            ErrorMessage = "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX";
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EvidenceFileAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EvidenceFileAttribute.cs
@@ -4,11 +4,11 @@ namespace TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
 public class EvidenceFileAttribute : FileExtensionsAttribute
 {
     public EvidenceFileAttribute()
-        : base(".bmp", ".csv", ".doc", ".docx", ".eml", ".jpeg", ".jpg", ".mbox", ".msg", ".ods", ".odt", ".pdf", ".png", ".tif", ".txt", ".xls", ".xlsx")
+        : base(".jpeg", ".jpg", ".pdf", ".png")
     {
         if (ErrorMessage == null)
         {
-            ErrorMessage = "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX";
+            ErrorMessage = "The selected file must be a JPEG, JPG, PNG or PDF";
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileExtensionsAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileExtensionsAttribute.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class FileExtensionsAttribute : ValidationAttribute
+{
+    private List<string> AllowedExtensions { get; set; }
+
+    public FileExtensionsAttribute(params string[] fileExtensions)
+    {
+        AllowedExtensions = fileExtensions.ToList();
+    }
+
+    public override bool IsValid(object? value)
+    {
+        if (value is IFormFile file)
+        {
+            var fileName = file.FileName;
+
+            return AllowedExtensions.Any(extension => fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileExtensionsAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileExtensionsAttribute.cs
@@ -14,13 +14,13 @@ public class FileExtensionsAttribute : ValidationAttribute
 
     public override bool IsValid(object? value)
     {
-        if (value is IFormFile file)
+        var file = value as IFormFile;
+        if (file is null)
         {
-            var fileName = file.FileName;
-
-            return AllowedExtensions.Any(extension => fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+            throw new NotSupportedException("FileExtensionsAttribute can only be used on property of type IFormFile");
         }
 
-        return true;
+        var fileName = file.FileName;
+        return AllowedExtensions.Any(extension => fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileSizeAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileSizeAttribute.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class FileSizeAttribute : ValidationAttribute
+{
+    private readonly int _maxFileSize;
+
+    public FileSizeAttribute(int maxFileSize)
+    {
+        _maxFileSize = maxFileSize;
+    }
+
+    protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is IFormFile file && file.Length > _maxFileSize)
+        {
+            return new ValidationResult(ErrorMessage);
+        }
+
+        return ValidationResult.Success!;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileSizeAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/FileSizeAttribute.cs
@@ -14,7 +14,14 @@ public class FileSizeAttribute : ValidationAttribute
 
     protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
     {
-        if (value is IFormFile file && file.Length > _maxFileSize)
+        var file = value as IFormFile;
+        if (file is null)
+        {
+            throw new NotSupportedException("FileSizeAttribute can only be used on property of type IFormFile");
+
+        }
+
+        if (file.Length > _maxFileSize)
         {
             return new ValidationResult(ErrorMessage);
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
@@ -33,7 +33,7 @@
                 </p>
             }
 
-            <govuk-file-upload asp-for="EvidenceFile" input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+            <govuk-file-upload asp-for="EvidenceFile" input-accept=".jpeg, .jpg, .pdf, .png">
                 <govuk-file-upload-label>Upload file</govuk-file-upload-label>
             </govuk-file-upload>
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
@@ -3,3 +3,41 @@
 @{
     ViewBag.Title = "Upload proof of your identity";
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrnDateOfBirth(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-details open="true">
+                <govuk-details-summary>Documents we accept</govuk-details-summary>
+                <govuk-details-text>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>passport</li>
+                        <li>driving license</li>
+                        <li>birth certificate</li>
+                        <li>UK work permit</li>
+                    </ul>
+                </govuk-details-text>
+            </govuk-details>
+
+            @if (Model.EvidenceFileId is not null)
+            {
+                <span class="govuk-caption-m">Currently uploaded file</span>
+                <p class="govuk-body">
+                    <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} ({Model.EvidenceFileSizeDescription})")</a>
+                </p>
+            }
+
+            <govuk-file-upload asp-for="EvidenceFile" input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+                <govuk-file-upload-label>Upload file</govuk-file-upload-label>
+            </govuk-file-upload>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
@@ -1,7 +1,84 @@
+using Humanizer;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class IdentityModel : PageModel
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class IdentityModel(AuthorizeAccessLinkGenerator linkGenerator, IFileService fileService) : PageModel
 {
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    public const int MaxFileSizeMb = 50;
+
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    [BindProperty]
+    [EvidenceFile]
+    [FileSize(MaxFileSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    public IFormFile? EvidenceFile { get; set; }
+
+    public Guid? EvidenceFileId { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public async Task OnGet()
+    {
+        UploadedEvidenceFileUrl ??= JourneyInstance?.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
+            null;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (EvidenceFileId is null && EvidenceFile is null)
+        {
+            ModelState.AddModelError(nameof(EvidenceFile), "Select a file");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        if (EvidenceFile is not null)
+        {
+            if (EvidenceFileId is not null)
+            {
+                await fileService.DeleteFile(EvidenceFileId.Value);
+            }
+
+            using var stream = EvidenceFile.OpenReadStream();
+            var evidenceFileId = await fileService.UploadFile(stream, EvidenceFile.ContentType);
+            await JourneyInstance!.UpdateStateAsync(state =>
+            {
+                state.EvidenceFileId = evidenceFileId;
+                state.EvidenceFileName = EvidenceFile.FileName;
+                state.EvidenceFileSizeDescription = EvidenceFile.Length.Bytes().Humanize();
+            });
+        }
+
+        return Redirect(linkGenerator.RequestTrnNationalInsuranceNumber(JourneyInstance!.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.DateOfBirth is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnDateOfBirth(JourneyInstance.InstanceId));
+            return;
+        }
+
+        EvidenceFileId ??= JourneyInstance?.State.EvidenceFileId;
+        EvidenceFileName ??= JourneyInstance?.State.EvidenceFileName;
+        EvidenceFileSizeDescription ??= JourneyInstance?.State.EvidenceFileSizeDescription;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml
@@ -1,0 +1,5 @@
+@page "/request-trn/national-insurance-number"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.NationalInsuranceNumberModel
+@{
+    ViewBag.Title = "Do you have a National Insurance number?";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class NationalInsuranceNumberModel : PageModel
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -14,4 +14,7 @@ public class RequestTrnJourneyState()
     public bool? HasPreviousName { get; set; }
     public string? PreviousName { get; set; }
     public DateOnly? DateOfBirth { get; set; }
+    public Guid? EvidenceFileId { get; set; }
+    public string? EvidenceFileName { get; set; }
+    public string? EvidenceFileSizeDescription { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -20,6 +20,8 @@ using TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 using TeachingRecordSystem.AuthorizeAccess.TagHelpers;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Infrastructure;
+using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.PersonMatching;
 using TeachingRecordSystem.FormFlow;
 using TeachingRecordSystem.ServiceDefaults;
@@ -150,6 +152,8 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
     builder.Services.AddDbContext<IdDbContext>(options => options.UseNpgsql(builder.Configuration.GetRequiredConnectionString("Id")));
 }
 
+builder.AddBlobStorage();
+
 builder.Services
     .AddTrsBaseServices()
     .AddTransient<AuthorizeAccessLinkGenerator, RoutingAuthorizeAccessLinkGenerator>()
@@ -165,6 +169,7 @@ builder.Services
     .AddSingleton<ICurrentUserIdProvider, FormFlowSessionCurrentUserIdProvider>()
     .AddTransient<SignInJourneyHelper>()
     .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>()
+    .AddFileService()
     .AddPersonMatching();
 
 builder.Services.AddOptions<AuthorizeAccessOptions>()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="GovUk.Frontend.AspNetCore" />
     <PackageReference Include="GovUk.OneLogin.AspNetCore" />
+    <PackageReference Include="Humanizer.Core" />
     <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="OpenIddict.AspNetCore" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
@@ -8,6 +8,7 @@ using Microsoft.Playwright;
 using OpenIddict.Server.AspNetCore;
 using TeachingRecordSystem.AuthorizeAccess.EndToEndTests.Infrastructure.Security;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.FormFlow.State;
 using TeachingRecordSystem.UiTestCommon.Infrastructure.FormFlow;
@@ -89,6 +90,19 @@ public sealed class HostFixture(IConfiguration configuration) : IAsyncDisposable
                     services.AddSingleton<FakeTrnGenerator>();
                     services.AddSingleton<TrsDataSyncHelper>();
                     services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
+                    services.AddSingleton(GetMockFileService());
+
+                    IFileService GetMockFileService()
+                    {
+                        var fileService = new Mock<IFileService>();
+                        fileService
+                            .Setup(s => s.UploadFile(It.IsAny<Stream>(), It.IsAny<string?>()))
+                            .ReturnsAsync(Guid.NewGuid());
+                        fileService
+                            .Setup(s => s.GetFileUrl(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
+                            .ReturnsAsync("https://fake.blob.core.windows.net/fake");
+                        return fileService.Object;
+                    }
                 });
             });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Playwright;
+
 namespace TeachingRecordSystem.AuthorizeAccess.EndToEndTests;
 
 public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
@@ -27,10 +29,23 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.WaitForUrlPathAsync("/request-trn/date-of-birth");
 
-        var dateOfBirth = new DateOnly(1980, 3, 1);
+        var dateOfBirth = new DateOnly(1980, 10, 12);
         await page.FillDateInput(dateOfBirth);
         await page.ClickButton("Continue");
 
         await page.WaitForUrlPathAsync("/request-trn/identity");
+
+        await page
+                .GetByLabel("Upload file")
+                .SetInputFilesAsync(
+                    new FilePayload()
+                    {
+                        Name = "evidence.jpg",
+                        MimeType = "image/jpeg",
+                        Buffer = TestData.JpegImage
+                    });
+        await page.ClickButton("Continue");
+
+        await page.WaitForUrlPathAsync("/request-trn/national-insurance-number");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using TeachingRecordSystem.AuthorizeAccess.Tests.Infrastructure.Security;
 using TeachingRecordSystem.Core.Events.Processing;
+using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.FormFlow.State;
 using TeachingRecordSystem.TestCommon.Infrastructure;
@@ -62,6 +63,19 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
             services.AddSingleton<FakeTrnGenerator>();
             services.AddSingleton<TrsDataSyncHelper>();
+            services.AddSingleton(GetMockFileService());
+
+            IFileService GetMockFileService()
+            {
+                var fileService = new Mock<IFileService>();
+                fileService
+                    .Setup(s => s.UploadFile(It.IsAny<Stream>(), It.IsAny<string?>()))
+                    .ReturnsAsync(Guid.NewGuid());
+                fileService
+                    .Setup(s => s.GetFileUrl(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
+                    .ReturnsAsync("https://fake.blob.core.windows.net/fake");
+                return fileService.Object;
+            }
         });
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
@@ -1,0 +1,155 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class IdentityTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_DateOfBirthMissingFromState_RedirectsToDateOfBirth()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var uploadedEvidenceLink = doc.GetElementByTestId("uploaded-evidence-link");
+        Assert.NotNull(uploadedEvidenceLink);
+        Assert.Equal($"{state.EvidenceFileName} ({state.EvidenceFileSizeDescription})", uploadedEvidenceLink!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_DateOfBirthMissingFromState_RedirectsToDateOfBirth()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var multipartContent = CreateFormFileUpload(".png");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoEvidenceFileIsSelected_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "Select a file");
+    }
+
+    [Fact]
+    public async Task Post_WhenEvidenceFileIsInvalidType_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var multipartContent = CreateFormFileUpload(".cs");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX");
+    }
+
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesStateAndRedirectsToNextPage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var multipartContent = CreateFormFileUpload(".png");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        var reloadedJourneyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.NotNull(reloadedJourneyInstance.State.EvidenceFileId);
+        Assert.Equal("evidence.png", reloadedJourneyInstance.State.EvidenceFileName);
+    }
+
+    private MultipartFormDataContent CreateFormFileUpload(string fileExtension)
+    {
+        var byteArrayContent = new ByteArrayContent(new byte[] { });
+        byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
+
+        var multipartContent = new MultipartFormDataContent
+        {
+            { byteArrayContent, "EvidenceFile", $"evidence{fileExtension}" }
+        };
+
+        return multipartContent;
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
@@ -107,7 +107,7 @@ public class IdentityTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX");
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a JPEG, JPG, PNG or PDF");
     }
 
 


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

Add an evidence page following the [Request a TRN] Figma designs under /request-trn/identity

Create a blob storage container (with no public access) for storing the files; generate a random name and upload the file to the container on form submission. Update the journey state with the file’s ID so it can be retrieved when the journey is completed then redirect to /request-trn/national-insurance-number

If the date of birth question has not yet been answered, redirect to /request-trn/date-of-birth.

### Guidance to review

Pages + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
