### PR TITLE
Amend background service retry backoff type to linear

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/DqtReportingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/DqtReportingService.cs
@@ -31,9 +31,9 @@ public partial class DqtReportingService : BackgroundService
     private static readonly ResiliencePipeline _resiliencePipeline = new ResiliencePipelineBuilder()
         .AddRetry(new Polly.Retry.RetryStrategyOptions()
         {
-            BackoffType = DelayBackoffType.Exponential,
+            BackoffType = DelayBackoffType.Linear,
             Delay = TimeSpan.FromSeconds(30),
-            MaxRetryAttempts = 3
+            MaxRetryAttempts = 10
         })
         .Build();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -21,7 +21,7 @@ public class TrsDataSyncService(
     private static readonly ResiliencePipeline _resiliencePipeline = new ResiliencePipelineBuilder()
         .AddRetry(new Polly.Retry.RetryStrategyOptions()
         {
-            BackoffType = DelayBackoffType.Exponential,
+            BackoffType = DelayBackoffType.Linear,
             Delay = TimeSpan.FromSeconds(30),
             MaxRetryAttempts = 10
         })


### PR DESCRIPTION
The `TrsDataSyncService` is waiting too long between retries in some cases. This amends the backoff type to linear to hopefully solve that problem. I've mirrored the policy into `DqtReportingService` too.