### PR TITLE
Added NINO page to request a TRN journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -53,6 +53,14 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrnNationalInsuranceNumber(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/NationalInsuranceNumber", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrnAddress(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/Address", journeyInstanceId: journeyInstanceId);
+
+    public string RequestTrnCheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/CheckAnswers", journeyInstanceId: journeyInstanceId);
+
+
+
     protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
         var url = GetRequiredPathByPage(page, handler, routeValues);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml
@@ -1,0 +1,5 @@
+@page "/request-trn/address"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.AddressModel
+@{
+    ViewBag.Title = "What is your current address?";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class AddressModel : PageModel
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
@@ -1,0 +1,5 @@
+@page "/request-trn/check-answers"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.CheckAnswersModel
+@{
+    ViewBag.Title = "Check your answers";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+public class CheckAnswersModel : PageModel
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml
@@ -1,5 +1,34 @@
 @page "/request-trn/national-insurance-number"
 @model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.NationalInsuranceNumberModel
 @{
-    ViewBag.Title = "Do you have a National Insurance number?";
+    ViewBag.Title = Html.DisplayNameFor(m => m.NationalInsuranceNumber);
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId)" method="post">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-radios asp-for="HasNationalInsuranceNumber">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend />
+                    <govuk-radios-item value="@true">
+                        Yes
+                        <govuk-radios-item-conditional>
+                            <govuk-input asp-for="NationalInsuranceNumber" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-hint>It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</govuk-input-hint>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
@@ -1,7 +1,68 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class NationalInsuranceNumberModel : PageModel
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
 {
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Do you have a National Insurance number?")]
+    [Required(ErrorMessage = "Tell us if you have a National Insurance number")]
+    public bool? HasNationalInsuranceNumber { get; set; }
+
+    [BindProperty]
+    [Display(Name = "National Insurance number")]
+    [Required(ErrorMessage = "Enter your National Insurance number")]
+    public string? NationalInsuranceNumber { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (HasNationalInsuranceNumber == true)
+        {
+            if (!string.IsNullOrEmpty(NationalInsuranceNumber) && !NationalInsuranceNumberHelper.IsValid(NationalInsuranceNumber))
+            {
+                ModelState.AddModelError(nameof(NationalInsuranceNumber), "Enter a valid National Insurance number");
+            }
+        }
+        else
+        {
+            ModelState.Remove(nameof(NationalInsuranceNumber));
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.HasNationalInsuranceNumber = HasNationalInsuranceNumber!.Value;
+            state.NationalInsuranceNumber = NationalInsuranceNumber;
+        });
+
+        if (HasNationalInsuranceNumber == false)
+        {
+            return Redirect(linkGenerator.RequestTrnAddress(JourneyInstance!.InstanceId));
+        }
+
+        return Redirect(linkGenerator.RequestTrnCheckAnswers(JourneyInstance.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.EvidenceFileId is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnIdentity(JourneyInstance.InstanceId));
+            return;
+        }
+
+        HasNationalInsuranceNumber ??= JourneyInstance?.State.HasNationalInsuranceNumber;
+        NationalInsuranceNumber ??= JourneyInstance?.State.NationalInsuranceNumber;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -17,4 +17,6 @@ public class RequestTrnJourneyState()
     public Guid? EvidenceFileId { get; set; }
     public string? EvidenceFileName { get; set; }
     public string? EvidenceFileSizeDescription { get; set; }
+    public bool? HasNationalInsuranceNumber { get; set; }
+    public string? NationalInsuranceNumber { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -4,8 +4,10 @@ namespace TeachingRecordSystem.AuthorizeAccess.EndToEndTests;
 
 public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    [Fact]
-    public async Task RequestTrn()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RequestTrn(bool hasNationalInsuranceNumber)
     {
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -47,5 +49,21 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.ClickButton("Continue");
 
         await page.WaitForUrlPathAsync("/request-trn/national-insurance-number");
+
+        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
+        if (hasNationalInsuranceNumber)
+        {
+            await page.CheckAsync("text=Yes");
+            await page.FillAsync("input[name=NationalInsuranceNumber]", nationalInsuranceNumber);
+            await page.ClickButton("Continue");
+
+            await page.WaitForUrlPathAsync("/request-trn/check-answers");
+        }
+        else
+        {
+            await page.CheckAsync("text=No");
+            await page.ClickButton("Continue");
+            await page.WaitForUrlPathAsync("/request-trn/address");
+        }
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NationalInsuranceNumberTests.cs
@@ -1,0 +1,199 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_ProofOfIdentityMissingFromState_RedirectsToIdentity()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        state.HasNationalInsuranceNumber = true;
+        state.NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(state.NationalInsuranceNumber, doc.GetElementById("NationalInsuranceNumber")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_ProofOfIdentityMissingFromState_RedirectsToIdentity()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenHasNationalInsuranceNumberHasNoSelection_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "NationalInsuranceNumber", Faker.Identification.UkNationalInsuranceNumber() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasNationalInsuranceNumber", "Tell us if you have a National Insurance number");
+    }
+
+    [Fact]
+    public async Task Post_WhenHasNationalInsuranceNumberIsTrueAndNationalInsuranceNumberIsEmpty_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "HasNationalInsuranceNumber", "True" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "NationalInsuranceNumber", "Enter your National Insurance number");
+    }
+
+    [Fact]
+    public async Task Post_WhenHasNationalInsuranceNumberIsTrueAndNationalInsuranceNumberIsInvalid_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "HasNationalInsuranceNumber", "True" },
+                { "NationalInsuranceNumber", "invalid-national-insurance-number" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "NationalInsuranceNumber", "Enter a valid National Insurance number");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidRequest_UpdatesStateAndRedirectsToNextPage(bool hasNationalInsuranceNumber)
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var content = new FormUrlEncodedContentBuilder();
+        if (hasNationalInsuranceNumber)
+        {
+            content.Add("HasNationalInsuranceNumber", "True");
+            content.Add("NationalInsuranceNumber", Faker.Identification.UkNationalInsuranceNumber());
+        }
+        else
+        {
+            content.Add("HasNationalInsuranceNumber", "False");
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = content
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        if (hasNationalInsuranceNumber)
+        {
+            Assert.Equal($"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+        }
+        else
+        {
+            Assert.Equal($"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+        }
+    }
+}


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Add a National Insurance number page (following the [Request a TRN] Figma designs) under /request-trn/national-insurance-number

If the question is not answered, show an error ‘Tell us if you have a National Insurance number’. If ‘Yes’ is answered but the entered NINO is empty, show an error ‘Enter your National Insurance number’. If the entered NINO is not valid, show an error ‘Enter a valid National Insurance number’.

When the form is valid and Continue is clicked, store the ‘has NINO’ and NINO on the FormFlow instance and redirect to /request-trn/address if no NINO was entered or /request-trn/check-answers otherwise.

If the evidence question has not yet been answered, redirect to /request-trn/identity.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
