### PR TITLE
Split previous name and name into separate pages in request a TRN journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -44,6 +44,9 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrnName(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/Name", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrnPreviousName(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/PreviousName", journeyInstanceId: journeyInstanceId);
+
     public string RequestTrnDateOfBirth(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/DateOfBirth", journeyInstanceId: journeyInstanceId);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@LinkGenerator.RequestTrnPreviousName(Model.JourneyInstance!.InstanceId)" />
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
@@ -30,9 +30,9 @@ public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator) : Page
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.Name is null)
+        if (JourneyInstance!.State.PreviousName is null)
         {
-            context.Result = Redirect(linkGenerator.RequestTrnName(JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.RequestTrnPreviousName(JourneyInstance.InstanceId));
             return;
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.FormFlow;
+using EmailAddress = TeachingRecordSystem.AuthorizeAccess.DataAnnotations.EmailAddressAttribute;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
@@ -14,7 +15,7 @@ public class EmailModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
     [BindProperty]
     [Display(Name = "What is your email address?", Description = "We’ll only use this to send you your TRN if you’re eligible for one.")]
     [Required(ErrorMessage = "Enter your email address")]
-    [EmailAddress(ErrorMessage = "Enter a valid email address")]
+    [@EmailAddress(ErrorMessage = "Enter a valid email address")]
     public string? Email { get; set; }
 
     public async Task<IActionResult> OnPost()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
@@ -15,18 +15,6 @@
                 <govuk-input-label is-page-heading="true" class="govuk-label--l" />
             </govuk-input>
 
-            <govuk-radios asp-for="HasPreviousName">
-                <govuk-radios-fieldset>
-                    <govuk-radios-item value="@true">
-                        Yes
-                        <govuk-radios-item-conditional>
-                            <govuk-input asp-for="PreviousName" spellcheck="false"/>
-                        </govuk-radios-item-conditional>
-                    </govuk-radios-item>
-                    <govuk-radios-item value="@false">No</govuk-radios-item>
-                </govuk-radios-fieldset>
-            </govuk-radios>
-
             <govuk-button type="submit">Continue</govuk-button>
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
 using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
@@ -15,17 +14,8 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
     [BindProperty]
     [Display(Name = "What is your name?", Description = "Full name")]
     [Required(ErrorMessage = "Enter your name")]
+    [MaxLength(200, ErrorMessage = "Name must be 200 characters or less")]
     public string? Name { get; set; }
-
-    [BindProperty]
-    [Display(Name = "Do you have a previous name?")]
-    [Required(ErrorMessage = "Tell us if you have a previous name")]
-    public bool? HasPreviousName { get; set; }
-
-    [BindProperty]
-    [Display(Name = "Previous full name")]
-    [RequiredIfOtherPropertyEquals(nameof(HasPreviousName), ErrorMessage = "Tell us your previous name")]
-    public string? PreviousName { get; set; }
 
     public async Task<IActionResult> OnPost()
     {
@@ -37,11 +27,9 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.Name = Name;
-            state.HasPreviousName = HasPreviousName;
-            state.PreviousName = HasPreviousName!.Value ? PreviousName : null;
         });
 
-        return Redirect(linkGenerator.RequestTrnDateOfBirth(JourneyInstance!.InstanceId));
+        return Redirect(linkGenerator.RequestTrnPreviousName(JourneyInstance!.InstanceId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -53,7 +41,5 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
         }
 
         Name ??= JourneyInstance!.State.Name;
-        HasPreviousName ??= JourneyInstance!.State.HasPreviousName;
-        PreviousName ??= JourneyInstance!.State.PreviousName;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
@@ -17,7 +17,7 @@ public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGener
     public bool? HasNationalInsuranceNumber { get; set; }
 
     [BindProperty]
-    [Display(Name = "National Insurance number")]
+    [Display(Name = "National Insurance number", Description = "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.")]
     [Required(ErrorMessage = "Enter your National Insurance number")]
     public string? NationalInsuranceNumber { get; set; }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml
@@ -1,23 +1,23 @@
-@page "/request-trn/national-insurance-number"
-@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.NationalInsuranceNumberModel
+@page "/request-trn/previous-name"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.PreviousNameModel
 @{
-    ViewBag.Title = Html.DisplayNameFor(m => m.HasNationalInsuranceNumber);
+    ViewBag.Title = Html.DisplayNameFor(m => m.HasPreviousName);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId)" method="post">            
-            <govuk-radios asp-for="HasNationalInsuranceNumber">
+        <form action="@LinkGenerator.RequestTrnPreviousName(Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-radios asp-for="HasPreviousName">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-input asp-for="NationalInsuranceNumber" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false" />
+                            <govuk-input asp-for="PreviousName" spellcheck="false" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">No</govuk-radios-item>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.AuthorizeAccess.DataAnnotations;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class PreviousNameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Have you ever changed your name?")]
+    [Required(ErrorMessage = "Tell us if you have ever changed your name")]
+    public bool? HasPreviousName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Previous full name")]
+    [RequiredIfOtherPropertyEquals(nameof(HasPreviousName), ErrorMessage = "Tell us your previous name")]
+    [MaxLength(200, ErrorMessage = "Previous name must be 200 characters or less")]
+    public string? PreviousName { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.HasPreviousName = HasPreviousName;
+            state.PreviousName = HasPreviousName!.Value ? PreviousName : null;
+        });
+
+        return Redirect(linkGenerator.RequestTrnDateOfBirth(JourneyInstance!.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.Name is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnName(JourneyInstance.InstanceId));
+            return;
+        }
+
+        HasPreviousName ??= JourneyInstance!.State.HasPreviousName;
+        PreviousName ??= JourneyInstance!.State.PreviousName;
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -25,6 +25,10 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var name = Faker.Name.FullName();
         var previousName = Faker.Name.FullName();
         await page.FillAsync("input[name=Name]", name);
+        await page.ClickButton("Continue");
+
+        await page.WaitForUrlPathAsync("/request-trn/previous-name");
+
         await page.CheckAsync("text=Yes");
         await page.FillAsync("input[name=PreviousName]", previousName);
         await page.ClickButton("Continue");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
@@ -3,7 +3,7 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_NameMissingFromState_RedirectsToName()
+    public async Task Get_NameMissingFromState_RedirectsToPreviousName()
     {
         // Arrange
         var state = CreateNewState();
@@ -16,7 +16,7 @@ public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+        Assert.Equal($"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_NameMissingFromState_RedirectsToName()
+    public async Task Post_NameMissingFromState_RedirectsToPreviousName()
     {
         // Arrange
         var state = CreateNewState();
@@ -90,7 +90,7 @@ public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+        Assert.Equal($"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PreviousNameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PreviousNameTests.cs
@@ -1,0 +1,140 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class PreviousNameTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_NameMissingFromState_RedirectsToName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var radioButtons = doc.GetElementsByName("HasPreviousName");
+        var selectedRadioButton = radioButtons.Single(r => r.HasAttribute("checked"));
+        Assert.Equal("True", selectedRadioButton.GetAttribute("value"));
+        Assert.Equal(state.PreviousName, doc.GetElementById("PreviousName")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_NameMissingFromState_RedirectsToName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenHasPreviousNameHasNoSelection_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["PreviousName"] = Faker.Name.FullName(),
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasPreviousName", "Tell us if you have ever changed your name");
+    }
+
+    [Fact]
+    public async Task Post_WhenHasPreviousNameIsTrueAndPreviousNameIsEmpty_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["HasPreviousName"] = "True",
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreviousName", "Tell us your previous name");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesStateAndRedirectsToNextPage()
+    {
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var previousName = Faker.Name.FullName();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["HasPreviousName"] = "True",
+                ["PreviousName"] = previousName
+            }),
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        var reloadedJourneyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(previousName, reloadedJourneyInstance.State.PreviousName);
+        Assert.True(reloadedJourneyInstance.State.HasPreviousName);
+    }
+}


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants. The name page has been split such that previous name is now in its own page.

### Changes proposed in this pull request

Amend the name page following the changed [Request a TRN] designs in Figma.

Add a new page at /request-trn/previous-name.

If the ‘Have you ever changed your name?’ question is not answered, show an error ‘Tell us if you have ever changed your name’. If ‘Yes’ has been answered but ‘Previous full name’ is empty, show an error ‘Tell us your previous name’.

When the form is valid and Continue is clicked, store the ‘has previous name’ and previous name on the FormFlow instance and redirect to /request-trn/date-of-birth .

If the name question has not yet been answered, redirect to /request-trn/name.

Amend the date of birth page to check that the previous name page has been answered instead of name.

### Guidance to review

Page changes + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
