### PR TITLE
Add address page to request a TRN journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml
@@ -3,3 +3,27 @@
 @{
     ViewBag.Title = "What is your current address?";
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RequestTrnAddress(Model.JourneyInstance!.InstanceId)" method="post">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="AddressLine1" autocomplete="address-line1" spellcheck="false" />
+
+            <govuk-input asp-for="AddressLine2" autocomplete="address-line2" spellcheck="false" />
+
+            <govuk-input asp-for="TownOrCity" autocomplete="address-level2" spellcheck="false" />            
+
+            <govuk-input asp-for="PostalCode" input-class="govuk-input--width-20" autocomplete="postal-code" spellcheck="false" />
+
+            <govuk-input asp-for="Country" autocomplete="country-name" spellcheck="false" />
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
@@ -40,6 +40,15 @@ public class AddressModel(AuthorizeAccessLinkGenerator linkGenerator) : PageMode
     [MaxLength(200, ErrorMessage = "Country must be 200 characters or less")]
     public string? Country { get; set; }
 
+    public void OnGet()
+    {
+        AddressLine1 ??= JourneyInstance!.State.AddressLine1;
+        AddressLine2 ??= JourneyInstance!.State.AddressLine2;
+        TownOrCity ??= JourneyInstance!.State.TownOrCity;
+        PostalCode ??= JourneyInstance!.State.PostalCode;
+        Country ??= JourneyInstance!.State.Country;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -66,11 +75,5 @@ public class AddressModel(AuthorizeAccessLinkGenerator linkGenerator) : PageMode
             context.Result = Redirect(linkGenerator.RequestTrnNationalInsuranceNumber(JourneyInstance.InstanceId));
             return;
         }
-
-        AddressLine1 ??= JourneyInstance!.State.AddressLine1;
-        AddressLine2 ??= JourneyInstance!.State.AddressLine2;
-        TownOrCity ??= JourneyInstance!.State.TownOrCity;
-        PostalCode ??= JourneyInstance!.State.PostalCode;
-        Country ??= JourneyInstance!.State.Country;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
@@ -1,7 +1,76 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class AddressModel : PageModel
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class AddressModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
 {
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Address line 1")]
+    [Required(ErrorMessage = "Enter address line 1")]
+    [MaxLength(200, ErrorMessage = "Address line 1 must be 200 characters or less")]
+    public string? AddressLine1 { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Address line 2 (optional)")]
+    [MaxLength(200, ErrorMessage = "Address line 2 must be 200 characters or less")]
+    public string? AddressLine2 { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Town or city")]
+    [Required(ErrorMessage = "Enter town or city")]
+    [MaxLength(200, ErrorMessage = "Town or city must be 200 characters or less")]
+    public string? TownOrCity { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Postal code")]
+    [Required(ErrorMessage = "Enter postal code")]
+    [MaxLength(50, ErrorMessage = "Postal code must be 50 characters or less")]
+    public string? PostalCode { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Country")]
+    [Required(ErrorMessage = "Enter country")]
+    [MaxLength(200, ErrorMessage = "Country must be 200 characters or less")]
+    public string? Country { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.AddressLine1 = AddressLine1;
+            state.AddressLine2 = AddressLine2;
+            state.TownOrCity = TownOrCity;
+            state.Country = Country;
+            state.PostalCode = PostalCode;
+        });
+
+        return Redirect(linkGenerator.RequestTrnCheckAnswers(JourneyInstance!.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.HasNationalInsuranceNumber is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnNationalInsuranceNumber(JourneyInstance.InstanceId));
+            return;
+        }
+
+        AddressLine1 ??= JourneyInstance!.State.AddressLine1;
+        AddressLine2 ??= JourneyInstance!.State.AddressLine2;
+        TownOrCity ??= JourneyInstance!.State.TownOrCity;
+        PostalCode ??= JourneyInstance!.State.PostalCode;
+        Country ??= JourneyInstance!.State.Country;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
@@ -30,7 +30,7 @@ public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator) : Page
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.PreviousName is null)
+        if (JourneyInstance!.State.HasPreviousName is null)
         {
             context.Result = Redirect(linkGenerator.RequestTrnPreviousName(JourneyInstance.InstanceId));
             return;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -19,4 +19,9 @@ public class RequestTrnJourneyState()
     public string? EvidenceFileSizeDescription { get; set; }
     public bool? HasNationalInsuranceNumber { get; set; }
     public string? NationalInsuranceNumber { get; set; }
+    public string? AddressLine1 { get; set; }
+    public string? AddressLine2 { get; set; }
+    public string? TownOrCity { get; set; }
+    public string? Country { get; set; }
+    public string? PostalCode { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -68,6 +68,21 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
             await page.CheckAsync("text=No");
             await page.ClickButton("Continue");
             await page.WaitForUrlPathAsync("/request-trn/address");
+
+            var addressLine1 = Faker.Address.StreetAddress();
+            var addressLine2 = Faker.Address.SecondaryAddress();
+            var townOrCity = Faker.Address.City();
+            var postalCode = Faker.Address.ZipCode();
+            var country = Faker.Address.Country();
+
+            await page.FillAsync("input[name=AddressLine1]", addressLine1);
+            await page.FillAsync("input[name=AddressLine2]", addressLine2);
+            await page.FillAsync("input[name=TownOrCity]", townOrCity);
+            await page.FillAsync("input[name=PostalCode]", postalCode);
+            await page.FillAsync("input[name=Country]", country);
+            await page.ClickButton("Continue");
+
+            await page.WaitForUrlPathAsync("/request-trn/check-answers");
         }
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/AddressTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/AddressTests.cs
@@ -1,0 +1,224 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class AddressTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_HasNationalInsuranceNumberMissingFromState_RedirectsToNationalInsuranceNumber()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.DateOfBirth = new DateOnly(1980, 12, 13);
+        state.HasNationalInsuranceNumber = false;
+        state.AddressLine1 = Faker.Address.StreetAddress();
+        state.AddressLine2 = Faker.Address.SecondaryAddress();
+        state.TownOrCity = Faker.Address.City();
+        state.Country = Faker.Address.Country();
+        state.PostalCode = Faker.Address.ZipCode();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(state.AddressLine1, doc.GetElementById("AddressLine1")?.GetAttribute("value"));
+        Assert.Equal(state.AddressLine2, doc.GetElementById("AddressLine2")?.GetAttribute("value"));
+        Assert.Equal(state.TownOrCity, doc.GetElementById("TownOrCity")?.GetAttribute("value"));
+        Assert.Equal(state.PostalCode, doc.GetElementById("PostalCode")?.GetAttribute("value"));
+        Assert.Equal(state.Country, doc.GetElementById("Country")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasNationalInsuranceNumberMissingFromState_RedirectsToNationalInsuranceNumber()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(AddressLineType.AddressLine1, "Enter address line 1")]
+    [InlineData(AddressLineType.TownOrCity, "Enter town or city")]
+    [InlineData(AddressLineType.PostalCode, "Enter postal code")]
+    [InlineData(AddressLineType.Country, "Enter country")]
+    public async Task Post_EmptyMandatoryAddressLine_ReturnsError(AddressLineType emptyAddressLineType, string errorMessage)
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.DateOfBirth = new DateOnly(1980, 12, 13);
+        state.HasNationalInsuranceNumber = false;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var content = new FormUrlEncodedContentBuilder();
+        if (emptyAddressLineType != AddressLineType.AddressLine1)
+        {
+            content.Add("AddressLine1", Faker.Address.StreetAddress());
+        }
+
+        if (emptyAddressLineType != AddressLineType.AddressLine2)
+        {
+            content.Add("AddressLine2", Faker.Address.SecondaryAddress());
+        }
+
+        if (emptyAddressLineType != AddressLineType.TownOrCity)
+        {
+            content.Add("TownOrCity", Faker.Address.City());
+        }
+
+        if (emptyAddressLineType != AddressLineType.PostalCode)
+        {
+            content.Add("PostalCode", Faker.Address.ZipCode());
+        }
+
+        if (emptyAddressLineType != AddressLineType.Country)
+        {
+            content.Add("Country", Faker.Address.Country());
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = content
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, emptyAddressLineType.ToString(), errorMessage);
+    }
+
+    [Theory]
+    [InlineData(AddressLineType.AddressLine1, "Address line 1 must be 200 characters or less")]
+    [InlineData(AddressLineType.AddressLine2, "Address line 2 must be 200 characters or less")]
+    [InlineData(AddressLineType.TownOrCity, "Town or city must be 200 characters or less")]
+    [InlineData(AddressLineType.PostalCode, "Postal code must be 50 characters or less")]
+    [InlineData(AddressLineType.Country, "Country must be 200 characters or less")]
+    public async Task Post_AddressLinesTooManyCharacters_ReturnsError(AddressLineType overflowAddressLineType, string errorMessage)
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.DateOfBirth = new DateOnly(1980, 12, 13);
+        state.HasNationalInsuranceNumber = false;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var content = new FormUrlEncodedContentBuilder();
+        var addressLine1 = overflowAddressLineType == AddressLineType.AddressLine1 ? new string('a', 201) : Faker.Address.StreetAddress();
+        var addressLine2 = overflowAddressLineType == AddressLineType.AddressLine2 ? new string('a', 201) : Faker.Address.SecondaryAddress();
+        var townOrCity = overflowAddressLineType == AddressLineType.TownOrCity ? new string('a', 201) : Faker.Address.City();
+        var postalCode = overflowAddressLineType == AddressLineType.PostalCode ? new string('a', 51) : Faker.Address.ZipCode();
+        var country = overflowAddressLineType == AddressLineType.Country ? new string('a', 201) : Faker.Address.Country();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AddressLine1", addressLine1 },
+                { "AddressLine2", addressLine2 },
+                { "TownOrCity", townOrCity },
+                { "PostalCode", postalCode },
+                { "Country", country }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, overflowAddressLineType.ToString(), errorMessage);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesStateAndRedirectsToNextPage()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.DateOfBirth = new DateOnly(1980, 12, 13);
+        state.HasNationalInsuranceNumber = false;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var addressLine1 = Faker.Address.StreetAddress();
+        var addressLine2 = Faker.Address.SecondaryAddress();
+        var townOrCity = Faker.Address.City();
+        var postalCode = Faker.Address.ZipCode();
+        var country = Faker.Address.Country();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AddressLine1", addressLine1 },
+                { "AddressLine2", addressLine2 },
+                { "TownOrCity", townOrCity },
+                { "PostalCode", postalCode },
+                { "Country", country }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        var reloadedJourneyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(addressLine1, reloadedJourneyInstance.State.AddressLine1);
+        Assert.Equal(addressLine2, reloadedJourneyInstance.State.AddressLine2);
+        Assert.Equal(townOrCity, reloadedJourneyInstance.State.TownOrCity);
+        Assert.Equal(postalCode, reloadedJourneyInstance.State.PostalCode);
+        Assert.Equal(country, reloadedJourneyInstance.State.Country);
+    }
+
+    public enum AddressLineType
+    {
+        AddressLine1,
+        AddressLine2,
+        TownOrCity,
+        PostalCode,
+        Country
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
@@ -3,7 +3,7 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
-    public async Task Get__HasPreviousNameMissingFromState_RedirectsToPreviousName()
+    public async Task Get_HasPreviousNameMissingFromState_RedirectsToPreviousName()
     {
         // Arrange
         var state = CreateNewState();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
@@ -3,7 +3,7 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_NameMissingFromState_RedirectsToPreviousName()
+    public async Task Get__HasPreviousNameMissingFromState_RedirectsToPreviousName()
     {
         // Arrange
         var state = CreateNewState();
@@ -67,7 +67,7 @@ public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_NameMissingFromState_RedirectsToPreviousName()
+    public async Task Post_HasPreviousNameMissingFromState_RedirectsToPreviousName()
     {
         // Arrange
         var state = CreateNewState();


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

Add an address page following the [Request a TRN] designs inFigma under /request-trn/address

All fields are mandatory except address line 2. All fields should have a length limit of 200 except postcode which should have a limit of 50.

When the form is valid and Continue is clicked, store the address on the FormFlow instance and redirect to /request-trn/check-answers .

If the NINO question has not yet been answered, redirect to /request-trn/national-insurance-number.

### Guidance to review

Page + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
