### PR TITLE
Add root redirect to AuthorizeAccess

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -253,6 +253,15 @@ app.UseAuthorization();
 app.MapRazorPages();
 app.MapControllers();
 
+if (builder.Configuration["RootRedirect"] is string rootRedirect)
+{
+    app.MapGet("/", ctx =>
+    {
+        ctx.Response.Redirect(rootRedirect);
+        return Task.CompletedTask;
+    });
+}
+
 app.Run();
 
 public partial class Program { }


### PR DESCRIPTION
We don't have anything at the root of AuthorizeAccess (it returns a 404 currently). This adds a config-driven redirect which will point to AYTQ for deployed environments.