### PR TITLE
Move trigger and procedure definitions into their own files

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/EmbeddedSqlHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/EmbeddedSqlHelper.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres;
+
+internal static class EmbeddedSqlHelper
+{
+    public static string GetProcedureSql(string fileName) =>
+        GetEmbeddedSql($"Procedures.{fileName}", "procedure");
+
+    public static string GetTriggerSql(string fileName) =>
+        GetEmbeddedSql($"Triggers.{fileName}", "trigger");
+
+    public static void Procedure(this MigrationBuilder migrationBuilder, string fileName) =>
+        migrationBuilder.Sql(GetProcedureSql(fileName));
+
+    public static void Trigger(this MigrationBuilder migrationBuilder, string fileName) =>
+        migrationBuilder.Sql(GetTriggerSql(fileName));
+
+    private static string GetEmbeddedSql(string relativePath, string resourceType)
+    {
+        var resourceName = $"{typeof(TrsDbContext).Namespace}.{relativePath}";
+        using var resourceStream = typeof(TrsDbContext).Assembly.GetManifestResourceStream(resourceName) ??
+            throw new ArgumentException($"Could not find {resourceType} '{resourceName}'.");
+        using var reader = new StreamReader(resourceStream);
+        return reader.ReadToEnd();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_update_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_update_person_search_attributes_v1.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION fn_update_person_search_attributes()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    IF ((TG_OP = 'DELETE')) THEN
+        DELETE FROM
+            person_search_attributes
+        WHERE
+            person_id = OLD.person_id;
+    END IF;
+    
+    IF (((TG_OP = 'INSERT') OR (TG_OP = 'UPDATE')) AND NEW.deleted_on IS NULL) THEN
+        CALL p_refresh_person_search_attributes(
+            NEW.person_id,
+            NEW.first_name,
+            NEW.last_name,
+            NEW.date_of_birth,
+            NEW.national_insurance_number,
+            NEW.trn);
+    END IF;
+    
+    RETURN NULL; -- result is ignored since this is an AFTER trigger
+END;
+$BODY$

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_name_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_name_person_search_attributes_v1.sql
@@ -1,0 +1,83 @@
+CREATE OR REPLACE PROCEDURE public.p_refresh_name_person_search_attributes(
+    IN p_person_id uuid,
+    IN p_first_name character varying,
+    IN p_last_name character varying,
+    IN p_attribute_key character varying)
+LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    DELETE FROM
+        person_search_attributes
+    WHERE
+        person_id = p_person_id
+        AND attribute_key = p_attribute_key;
+
+    INSERT INTO
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags,
+            attribute_key
+        )
+    SELECT
+        p_person_id,
+        attribs.attribute_type,
+        attribs.attribute_value,
+        ARRAY[]::text[],
+        p_attribute_key
+    FROM
+        (VALUES
+         ('FirstName', p_first_name),
+         ('LastName', p_last_name)) AS attribs (attribute_type, attribute_value)
+    WHERE
+        attribs.attribute_value IS NOT NULL;
+    
+    -- Insert synonyms of first name
+    INSERT INTO
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags,
+            attribute_key
+        )
+    SELECT
+        p_person_id,
+        'FirstName',
+        UNNEST(synonyms),
+        ARRAY[CONCAT('Synonym:', p_first_name)],
+        p_attribute_key
+    FROM
+        name_synonyms
+    WHERE
+        name = p_first_name;
+        
+    -- Insert full name as a searchable attribute
+    INSERT INTO 
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags,
+            attribute_key
+        )
+    SELECT 
+        first_names.person_id, 
+        'FullName', 
+        first_names.attribute_value || ' ' || last_names.attribute_value, 
+        '{}',
+        first_names.attribute_key
+    FROM
+            person_search_attributes first_names
+        JOIN
+            person_search_attributes last_names ON first_names.person_id = last_names.person_id AND first_names.attribute_key = last_names.attribute_key
+    WHERE
+        first_names.person_id = p_person_id
+        AND first_names.attribute_type = 'FirstName'
+        AND last_names.attribute_type = 'LastName';
+END;
+$BODY$;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_person_search_attributes_v1.sql
@@ -1,0 +1,44 @@
+CREATE OR REPLACE PROCEDURE public.p_refresh_person_search_attributes(
+    IN p_person_id uuid,
+    IN p_first_name character varying(100),
+    IN p_last_name character varying(100),
+    IN p_date_of_birth date,
+    IN p_national_insurance_number character(9),
+    IN p_trn character(7))
+LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    DELETE FROM
+        person_search_attributes
+    WHERE
+        person_id = p_person_id
+        AND attribute_key IS NULL;
+    
+    INSERT INTO
+        person_search_attributes
+        (
+            person_id,
+            attribute_type,
+            attribute_value,
+            tags
+        )
+    SELECT
+        p_person_id,
+        attribs.attribute_type,
+        attribs.attribute_value,
+        '{}'
+    FROM
+        (VALUES 		 
+         ('DateOfBirth', CASE WHEN p_date_of_birth IS NULL THEN NULL ELSE to_char(p_date_of_birth, 'yyyy-mm-dd') END),
+         ('NationalInsuranceNumber', p_national_insurance_number),
+         ('Trn', p_trn)) AS attribs (attribute_type, attribute_value)
+    WHERE
+        attribs.attribute_value IS NOT NULL;
+
+    CALL p_refresh_name_person_search_attributes(
+        p_person_id,
+        p_first_name,
+        p_last_name,
+        '1');
+END;
+$BODY$;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_update_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_update_person_search_attributes_v1.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE TRIGGER trg_update_person_search_attributes
+    AFTER INSERT OR DELETE OR UPDATE OF first_name, last_name, date_of_birth, national_insurance_number, trn, deleted_on
+    ON persons
+    FOR EACH ROW
+    EXECUTE FUNCTION fn_update_person_search_attributes();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="DataStore\Postgres\Procedures\fn_update_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Procedures\p_refresh_name_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Triggers\trg_update_person_search_attributes_v1.sql" />
     <None Remove="Services\DqtReporting\Migrations\0001_Initial.sql" />
     <None Remove="Services\DqtReporting\Migrations\0002_TrackingColumns.sql" />
     <None Remove="Services\DqtReporting\Migrations\0003_ContactSentQtsAwardedEmail.sql" />
@@ -28,6 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_update_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\p_refresh_name_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_update_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0001_Initial.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0002_TrackingColumns.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0003_ContactSentQtsAwardedEmail.sql" />


### PR DESCRIPTION
We're starting to get more and more postgres triggers and procedures. This rearranges them such that each version of a trigger/procedure is in its own file. A couple of helper methods simplify adding them to migrations.