### PR TITLE
Fix Sentry logging in Worker

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Production.json
@@ -1,4 +1,10 @@
 {
+  "Sentry": {
+    "SendDefaultPii": false,
+    "IncludeActivityData": true,
+    "MaxRequestBodySize": "None",
+    "TracesSampleRate": 0
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Error",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Infrastructure/Logging/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Infrastructure/Logging/HostApplicationBuilderExtensions.cs
@@ -12,7 +12,11 @@ public static class HostApplicationBuilderExtensions
     {
         if (builder.Environment.IsProduction())
         {
-            SentrySdk.Init(dsn: builder.Configuration.GetRequiredValue("Sentry:Dsn"));
+            SentrySdk.Init(options =>
+            {
+                options.Dsn = builder.Configuration.GetRequiredValue("Sentry:Dsn");
+                options.IsGlobalModeEnabled = true;
+            });
         }
 
         builder.Services.AddApplicationInsightsTelemetryWorkerService();


### PR DESCRIPTION
Also updates the Sentry config for the `AuthorizeAccess` project to (largely) mirror the API.