### PR TITLE
Set AllowPiiUpdatesFromRegister  when creating name/DOB change requests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateDateOfBirthChangeIncidentHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateDateOfBirthChangeIncidentHandler.cs
@@ -60,6 +60,7 @@ public class CreateDateOfBirthChangeIncidentHandler : ICrmQueryHandler<CreateDat
                 Target = incident.Id.ToEntityReference(Incident.EntityLogicalName),
                 ColumnSet = new(Incident.Fields.TicketNumber)
             });
+        requestBuilder.AddRequest(new UpdateRequest() { Target = new Contact() { Id = query.ContactId, dfeta_AllowPiiUpdatesFromRegister = false } });
         await requestBuilder.Execute();
 
         var ticketNumber = getIncidentResponse.GetResponse().Entity.ToEntity<Incident>().TicketNumber;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateNameChangeIncidentHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateNameChangeIncidentHandler.cs
@@ -65,6 +65,7 @@ public class CreateNameChangeIncidentHandler : ICrmQueryHandler<CreateNameChange
                 Target = incident.Id.ToEntityReference(Incident.EntityLogicalName),
                 ColumnSet = new(Incident.Fields.TicketNumber)
             });
+        requestBuilder.AddRequest(new UpdateRequest() { Target = new Contact() { Id = query.ContactId, dfeta_AllowPiiUpdatesFromRegister = false } });
         await requestBuilder.Execute();
 
         var ticketNumber = getIncidentResponse.GetResponse().Entity.ToEntity<Incident>().TicketNumber;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateDateOfBirthChangeIncidentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateDateOfBirthChangeIncidentTests.cs
@@ -61,5 +61,8 @@ public class CreateDateOfBirthChangeIncidentTests : IAsyncLifetime
         Assert.NotNull(createdAnnotation);
         Assert.Equal(createdDocument.Id, createdAnnotation.ObjectId.Id);
         Assert.Equal(dfeta_document.EntityLogicalName, createdAnnotation.ObjectTypeCode);
+
+        var contact = ctx.ContactSet.Single(c => c.Id == createPersonResult.ContactId);
+        Assert.False(contact.dfeta_AllowPiiUpdatesFromRegister);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateNameChangeIncidentTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateNameChangeIncidentTests.cs
@@ -73,5 +73,8 @@ public class CreateNameChangeIncidentTests : IAsyncLifetime
         Assert.NotNull(createdAnnotation);
         Assert.Equal(createdDocument.Id, createdAnnotation.ObjectId.Id);
         Assert.Equal(dfeta_document.EntityLogicalName, createdAnnotation.ObjectTypeCode);
+
+        var contact = ctx.ContactSet.Single(c => c.Id == createPersonResult.ContactId);
+        Assert.False(contact.dfeta_AllowPiiUpdatesFromRegister);
     }
 }


### PR DESCRIPTION
Currently a plugin sets this to `false` when PII is updated on the `contact` record (and that update hasn't come from the API). That's arguably too late. This change sets this value to `false` as soon as a change of name/DOB request is created.