### PR TITLE
Consider first name synonyms when checking for existing contact

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -23,6 +23,7 @@ using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Infrastructure;
 using TeachingRecordSystem.Core.Services.Certificates;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.NameSynonyms;
 using TeachingRecordSystem.Core.Services.TrnGenerationApi;
 using TeachingRecordSystem.ServiceDefaults;
 
@@ -224,7 +225,8 @@ public class Program
         builder
             .AddBlobStorage()
             .AddDistributedLocks()
-            .AddIdentityApi();
+            .AddIdentityApi()
+            .AddNameSynonyms();
 
         services.AddAccessYourTeachingQualificationsOptions(configuration, env);
         services.AddCertificateGeneration();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/FindPotentialDuplicateContactsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/FindPotentialDuplicateContactsQuery.cs
@@ -2,7 +2,7 @@ namespace TeachingRecordSystem.Core.Dqt.Queries;
 
 public record FindPotentialDuplicateContactsQuery : ICrmQuery<FindPotentialDuplicateContactsResult[]>
 {
-    public required string FirstName { get; init; }
+    public required IEnumerable<string> FirstNames { get; init; }
     public required string MiddleName { get; init; }
     public required string LastName { get; init; }
     public required DateOnly DateOfBirth { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulateNameSynonymsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/PopulateNameSynonymsJob.cs
@@ -1,44 +1,14 @@
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.NameSynonyms;
 
 namespace TeachingRecordSystem.Core.Jobs;
 
-public class PopulateNameSynonymsJob(TrsDbContext dbContext, HttpClient httpClient)
+public class PopulateNameSynonymsJob(TrsDbContext dbContext, INameSynonymProvider nameSynonymProvider)
 {
     public async Task Execute(CancellationToken cancellationToken)
     {
-        using var stream = await httpClient.GetStreamAsync("https://raw.githubusercontent.com/carltonnorthern/nicknames/master/names.csv");
-        using var reader = new StreamReader(stream);
-
-        var namesLookup = new Dictionary<string, HashSet<string>>();
-        string? line = null;
-        while ((line = reader.ReadLine()) != null)
-        {
-            if (line.Length == 0 || line[0] == '#')
-            {
-                continue; // ignore empty lines and comments
-            }
-
-            var names = line.Split(',');
-            foreach (var name in names)
-            {
-                HashSet<string>? synonyms;
-                if (!namesLookup.TryGetValue(name, out synonyms))
-                {
-                    synonyms = new HashSet<string>();
-                    namesLookup[name] = synonyms;
-                }
-
-                foreach (var altName in names)
-                {
-                    // Don't add anything as a synonym of itself
-                    if (altName != name)
-                    {
-                        synonyms.Add(altName);
-                    }
-                }
-            }
-        }
+        var namesLookup = await nameSynonymProvider.GetAllNameSynonyms();
 
         foreach (var (name, synonyms) in namesLookup)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/INameSynonymProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/INameSynonymProvider.cs
@@ -1,0 +1,7 @@
+﻿
+namespace TeachingRecordSystem.Core.Services.NameSynonyms;
+
+public interface INameSynonymProvider
+{
+    Task<IReadOnlyDictionary<string, IReadOnlyCollection<string>>> GetAllNameSynonyms();
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/INameSynonymProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/INameSynonymProvider.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace TeachingRecordSystem.Core.Services.NameSynonyms;
 
 public interface INameSynonymProvider

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/NameSynonymProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/NameSynonymProvider.cs
@@ -1,0 +1,47 @@
+namespace TeachingRecordSystem.Core.Services.NameSynonyms;
+
+public class NameSynonymProvider(HttpClient httpClient) : INameSynonymProvider
+{
+    private Task<IReadOnlyDictionary<string, IReadOnlyCollection<string>>>? _synonymsTask;
+
+    public Task<IReadOnlyDictionary<string, IReadOnlyCollection<string>>> GetAllNameSynonyms() =>
+        LazyInitializer.EnsureInitialized(ref _synonymsTask, () => DownloadAllNameSynonyms());
+
+    private async Task<IReadOnlyDictionary<string, IReadOnlyCollection<string>>> DownloadAllNameSynonyms()
+    {
+        using var stream = await httpClient.GetStreamAsync("https://raw.githubusercontent.com/carltonnorthern/nicknames/master/names.csv");
+        using var reader = new StreamReader(stream);
+
+        var namesLookup = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        string? line = null;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (line.Length == 0 || line[0] == '#')
+            {
+                continue;
+            }
+
+            var names = line.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var name in names)
+            {
+                if (!namesLookup.TryGetValue(name, out var synonyms))
+                {
+                    synonyms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    namesLookup[name] = synonyms;
+                }
+
+                foreach (var altName in names)
+                {
+                    if (altName != name)
+                    {
+                        synonyms.Add(altName);
+                    }
+                }
+            }
+        }
+
+        return namesLookup.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.AsReadOnly());
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace TeachingRecordSystem.Core.Services.NameSynonyms;
+
+public static class ServiceCollectionExtensions
+{
+    public static IHostApplicationBuilder AddNameSynonyms(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<INameSynonymProvider, NameSynonymProvider>();
+
+        return builder;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
@@ -10,6 +10,7 @@ using TeachingRecordSystem.Core.Jobs;
 using TeachingRecordSystem.Core.Services.DqtReporting;
 using TeachingRecordSystem.Core.Services.Establishments;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.NameSynonyms;
 using TeachingRecordSystem.Core.Services.Notify;
 using TeachingRecordSystem.Core.Services.TrnGenerationApi;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
@@ -41,7 +42,8 @@ builder
     .AddBackgroundJobs()
     .AddBackgroundWorkScheduler()
     .AddEmail()
-    .AddIdentityApi();
+    .AddIdentityApi()
+    .AddNameSynonyms();
 
 var crmServiceClient = new ServiceClient(builder.Configuration.GetRequiredValue("ConnectionStrings:Crm"))
 {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/FindPotentialDuplicateContactsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/FindPotentialDuplicateContactsTests.cs
@@ -20,22 +20,21 @@ public class FindPotentialDuplicateContactsTests : IAsyncLifetime
     {
         // Arrange
         var email = $"{Guid.NewGuid()}@test.com";
-        var firstName = Faker.Name.First();
+        var firstName = "Rob";
+        var firstNameSynonym = "Robert";
         var middleName = Faker.Name.Middle();
         var lastName = Faker.Name.Last();
         var dob = new DateTime(1987, 01, 01);
 
-        var person = await _dataScope.TestData.CreatePerson(b =>
-        {
-            b.WithFirstName(email);
-            b.WithLastName(lastName);
-            b.WithMiddleName(middleName);
-            b.WithDateOfBirth(dob.ToDateOnlyWithDqtBstFix(isLocalTime: false));
-        });
+        var person = await _dataScope.TestData.CreatePerson(b => b
+            .WithFirstName(firstNameSynonym)
+            .WithLastName(lastName)
+            .WithMiddleName(middleName)
+            .WithDateOfBirth(dob.ToDateOnlyWithDqtBstFix(isLocalTime: false)));
 
         var query = new FindPotentialDuplicateContactsQuery()
         {
-            FirstName = firstName,
+            FirstNames = [firstName, firstNameSynonym],
             MiddleName = middleName,
             LastName = lastName,
             DateOfBirth = dob.ToDateOnlyWithDqtBstFix(isLocalTime: false)


### PR DESCRIPTION
This extends first name synonym application to the duplicate detection used in the v3 TRN request endpoint.

As part of this I've moved the synonym download code out of the existing job (that populates the TRS DB) into its own service.