### PR TITLE
Added Check Answers and Submitted pages to Request a TRN journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -38,31 +38,32 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrn(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/Index", journeyInstanceId: journeyInstanceId);
 
-    public string RequestTrnEmail(JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/RequestTrn/Email", journeyInstanceId: journeyInstanceId);
+    public string RequestTrnEmail(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RequestTrn/Email", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
-    public string RequestTrnName(JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/RequestTrn/Name", journeyInstanceId: journeyInstanceId);
+    public string RequestTrnName(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RequestTrn/Name", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
-    public string RequestTrnPreviousName(JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/RequestTrn/PreviousName", journeyInstanceId: journeyInstanceId);
+    public string RequestTrnPreviousName(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RequestTrn/PreviousName", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
-    public string RequestTrnDateOfBirth(JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/RequestTrn/DateOfBirth", journeyInstanceId: journeyInstanceId);
+    public string RequestTrnDateOfBirth(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RequestTrn/DateOfBirth", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
-    public string RequestTrnIdentity(JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/RequestTrn/Identity", journeyInstanceId: journeyInstanceId);
+    public string RequestTrnIdentity(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RequestTrn/Identity", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
-    public string RequestTrnNationalInsuranceNumber(JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/RequestTrn/NationalInsuranceNumber", journeyInstanceId: journeyInstanceId);
+    public string RequestTrnNationalInsuranceNumber(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RequestTrn/NationalInsuranceNumber", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
-    public string RequestTrnAddress(JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/RequestTrn/Address", journeyInstanceId: journeyInstanceId);
+    public string RequestTrnAddress(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RequestTrn/Address", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
     public string RequestTrnCheckAnswers(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/CheckAnswers", journeyInstanceId: journeyInstanceId);
 
-
+    public string RequestTrnSubmitted(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/Submitted", journeyInstanceId: journeyInstanceId);
 
     protected virtual string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnAddress(Model.JourneyInstance!.InstanceId)" method="post">
+        <form action="@LinkGenerator.RequestTrnAddress(Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <govuk-input asp-for="AddressLine1" autocomplete="address-line1" spellcheck="false" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
@@ -11,6 +11,9 @@ public class AddressModel(AuthorizeAccessLinkGenerator linkGenerator) : PageMode
 {
     public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
 
+    [FromQuery]
+    public bool? FromCheckAnswers { get; set; }
+
     [BindProperty]
     [Display(Name = "Address line 1")]
     [Required(ErrorMessage = "Enter address line 1")]
@@ -70,10 +73,14 @@ public class AddressModel(AuthorizeAccessLinkGenerator linkGenerator) : PageMode
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.HasNationalInsuranceNumber is null)
+        var state = JourneyInstance!.State;
+        if (state.HasPendingTrnRequest)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+        }
+        else if (state.HasNationalInsuranceNumber is null)
         {
             context.Result = Redirect(linkGenerator.RequestTrnNationalInsuranceNumber(JourneyInstance.InstanceId));
-            return;
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
@@ -3,3 +3,81 @@
 @{
     ViewBag.Title = "Check your answers";
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@(Model.HasNationalInsuranceNumber == true ? LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnAddress(Model.JourneyInstance!.InstanceId))" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form action="@LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId)" method="post">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="email">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Previous name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.PreviousName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnPreviousName(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="previous name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DateOfBirth!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnDateOfBirth(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Proof of identity</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.EvidenceFileName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="proof of identity">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "No")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="national insurance number">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                @if (Model.HasNationalInsuranceNumber == false)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Address</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>
+                            @Model.AddressLine1<br />
+                            @if (!string.IsNullOrWhiteSpace(Model.AddressLine2))
+                            {
+                                @Model.AddressLine2<br />
+                            }
+                            @Model.TownOrCity<br />
+                            @Model.PostalCode<br />
+                            @Model.Country
+                        </govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnAddress(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="address">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Submit request</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml.cs
@@ -1,7 +1,151 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.StaticFiles;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.FormFlow;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
-public class CheckAnswersModel : PageModel
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class CheckAnswersModel(AuthorizeAccessLinkGenerator linkGenerator, ICrmQueryDispatcher crmQueryDispatcher, IFileService fileService) : PageModel
 {
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    public RequestTrnJourneyState? JourneyState { get; set; }
+
+    public string? Email { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? PreviousName { get; set; }
+
+    public DateOnly? DateOfBirth { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public bool? HasNationalInsuranceNumber { get; set; }
+
+    public string? NationalInsuranceNumber { get; set; }
+
+    public string? AddressLine1 { get; set; }
+
+    public string? AddressLine2 { get; set; }
+
+    public string? TownOrCity { get; set; }
+
+    public string? PostalCode { get; set; }
+
+    public string? Country { get; set; }
+
+    public async Task OnGet()
+    {
+        Email = JourneyInstance!.State.Email;
+        Name = JourneyInstance!.State.Name;
+        PreviousName = JourneyInstance!.State.PreviousName;
+        DateOfBirth = JourneyInstance!.State.DateOfBirth;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
+        UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance!.State.EvidenceFileId!.Value, _fileUrlExpiresAfter) :
+            null;
+        HasNationalInsuranceNumber = JourneyInstance!.State.HasNationalInsuranceNumber;
+        NationalInsuranceNumber = JourneyInstance!.State.NationalInsuranceNumber;
+        AddressLine1 = JourneyInstance!.State.AddressLine1;
+        AddressLine2 = JourneyInstance!.State.AddressLine2;
+        TownOrCity = JourneyInstance!.State.TownOrCity;
+        PostalCode = JourneyInstance!.State.PostalCode;
+        Country = JourneyInstance!.State.Country;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        var state = JourneyInstance!.State;
+
+        var description = $"""
+            Email: {state.Email}
+            Name: {state.Name}
+            Previous name: {state.PreviousName}
+            Date of birth: {state.DateOfBirth:dd/MM/yyyy}                
+            National Insurance number: {state.NationalInsuranceNumber}
+            """;
+        if (state.HasNationalInsuranceNumber == false)
+        {
+            description += $"""
+
+                Address line 1: {state.AddressLine1}
+                Address line 2: {state.AddressLine2}
+                Town or city: {state.TownOrCity}
+                Postal code: {state.PostalCode}
+                Country: {state.Country}
+                """;
+        }
+
+        var fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
+        if (!fileExtensionContentTypeProvider.TryGetContentType(JourneyInstance!.State.EvidenceFileName!, out var evidenceFileMimeType))
+        {
+            evidenceFileMimeType = "application/octet-stream";
+        }
+
+        using var stream = await fileService.OpenReadStream(JourneyInstance!.State.EvidenceFileId!.Value);
+
+        await crmQueryDispatcher.ExecuteQuery(
+            new CreateTrnRequestTaskQuery()
+            {
+                Description = description,
+                EvidenceFileName = JourneyInstance!.State.EvidenceFileName!,
+                EvidenceFileContent = stream,
+                EvidenceFileMimeType = evidenceFileMimeType
+            });
+
+        await JourneyInstance!.UpdateStateAsync(state => state.HasPendingTrnRequest = true);
+
+        return Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var state = JourneyInstance!.State;
+        if (state.HasPendingTrnRequest)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+        }
+        else if (state.Email is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnEmail(JourneyInstance.InstanceId));
+        }
+        else if (state.Name is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnName(JourneyInstance.InstanceId));
+        }
+        else if (state.HasPreviousName is null || (state.HasPreviousName == true && state.PreviousName is null))
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnPreviousName(JourneyInstance.InstanceId));
+        }
+        else if (state.DateOfBirth is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnDateOfBirth(JourneyInstance.InstanceId));
+        }
+        else if (state.EvidenceFileId is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnIdentity(JourneyInstance!.InstanceId));
+        }
+        else if (state.HasNationalInsuranceNumber is null || (state.HasNationalInsuranceNumber == true && state.NationalInsuranceNumber is null))
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnNationalInsuranceNumber(JourneyInstance.InstanceId));
+        }
+        else if (state.HasNationalInsuranceNumber == false &&
+            (state.AddressLine1 is null || state.TownOrCity is null || state.PostalCode is null || state.Country is null))
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnAddress(JourneyInstance.InstanceId));
+        }
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnPreviousName(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnPreviousName(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnDateOfBirth(Model.JourneyInstance!.InstanceId)" method="post">
+        <form action="@LinkGenerator.RequestTrnDateOfBirth(Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <govuk-date-input asp-for="DateOfBirth">
                 <govuk-date-input-fieldset>
                     <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrn(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrn(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId)" method="post">            
+        <form action="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
 
             <govuk-input asp-for="Email" type="email" autocomplete="email">
                 <govuk-input-label is-page-heading="true" class="govuk-label--l" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnDateOfBirth(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnDateOfBirth(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+        <form action="@LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <govuk-details open="true">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId)" method="post">
+        <form action="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <govuk-input asp-for="Name" spellcheck="false">
                 <govuk-input-label is-page-heading="true" class="govuk-label--l" />
             </govuk-input>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
@@ -11,6 +11,9 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
 {
     public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
 
+    [FromQuery]
+    public bool? FromCheckAnswers { get; set; }
+
     [BindProperty]
     [Display(Name = "What is your name?", Description = "Full name")]
     [Required(ErrorMessage = "Enter your name")]
@@ -29,17 +32,26 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
             state.Name = Name;
         });
 
-        return Redirect(linkGenerator.RequestTrnPreviousName(JourneyInstance!.InstanceId));
+        return FromCheckAnswers == true ?
+            Redirect(linkGenerator.RequestTrnCheckAnswers(JourneyInstance!.InstanceId)) :
+            Redirect(linkGenerator.RequestTrnPreviousName(JourneyInstance!.InstanceId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.Email is null)
+        var state = JourneyInstance!.State;
+        if (state.HasPendingTrnRequest)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+        }
+        else if (state.Email is null)
         {
             context.Result = Redirect(linkGenerator.RequestTrnEmail(JourneyInstance.InstanceId));
-            return;
         }
 
-        Name ??= JourneyInstance!.State.Name;
+        if (context.Result is null)
+        {
+            Name ??= JourneyInstance!.State.Name;
+        }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnIdentity(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId)" method="post">            
+        <form action="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <govuk-radios asp-for="HasNationalInsuranceNumber">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
@@ -11,6 +11,9 @@ public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGener
 {
     public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
 
+    [FromQuery]
+    public bool? FromCheckAnswers { get; set; }
+
     [BindProperty]
     [Display(Name = "Do you have a National Insurance number?")]
     [Required(ErrorMessage = "Tell us if you have a National Insurance number")]
@@ -56,13 +59,20 @@ public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGener
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.EvidenceFileId is null)
+        var state = JourneyInstance!.State;
+        if (state.HasPendingTrnRequest)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+        }
+        else if (state.EvidenceFileId is null)
         {
             context.Result = Redirect(linkGenerator.RequestTrnIdentity(JourneyInstance.InstanceId));
-            return;
         }
 
-        HasNationalInsuranceNumber ??= JourneyInstance?.State.HasNationalInsuranceNumber;
-        NationalInsuranceNumber ??= JourneyInstance?.State.NationalInsuranceNumber;
+        if (context.Result is null)
+        {
+            HasNationalInsuranceNumber ??= JourneyInstance?.State.HasNationalInsuranceNumber;
+            NationalInsuranceNumber ??= JourneyInstance?.State.NationalInsuranceNumber;
+        }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnName(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RequestTrnPreviousName(Model.JourneyInstance!.InstanceId)" method="post">
+        <form action="@LinkGenerator.RequestTrnPreviousName(Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <govuk-radios asp-for="HasPreviousName">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -24,4 +24,5 @@ public class RequestTrnJourneyState()
     public string? TownOrCity { get; set; }
     public string? Country { get; set; }
     public string? PostalCode { get; set; }
+    public bool HasPendingTrnRequest { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Submitted.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Submitted.cshtml
@@ -1,0 +1,16 @@
+@page "/request-trn/submitted"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.SubmittedModel
+@{
+    ViewBag.Title = "What happens next";
+}
+
+<govuk-panel>
+    <govuk-panel-title>Request submitted</govuk-panel-title>
+</govuk-panel>
+
+<h1 class="govuk-heading-m">@ViewBag.Title</h1>
+
+<p class="govuk-body">We’ll email you within 5 working days with your TRN if you’re eligible for one.</p>
+
+<a class="govuk-link" href="https://register-national-professional-qualifications.education.gov.uk/">Return to Register for a national professional qualification (NPQ)</a>
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Submitted.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Submitted.cshtml.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class SubmittedModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (!JourneyInstance!.State.HasPendingTrnRequest)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnCheckAnswers(JourneyInstance!.InstanceId));
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateTrnRequestTaskHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateTrnRequestTaskHandler.cs
@@ -11,7 +11,7 @@ public class CreateTrnRequestTaskHandler : ICrmQueryHandler<CreateTrnRequestTask
         var crmTask = new CrmTask()
         {
             Id = Guid.NewGuid(),
-            Subject = "TRN Request",
+            Subject = "Notification for TRA Support Team - TRN request",
             Description = query.Description
         };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Files/BlobStorageFileService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Files/BlobStorageFileService.cs
@@ -40,6 +40,13 @@ public class BlobStorageFileService : IFileService
         return blobClient.GenerateSasUri(sasBuilder).ToString();
     }
 
+    public async Task<Stream> OpenReadStream(Guid fileId)
+    {
+        var blobClient = await GetBlobClient(fileId);
+        var stream = await blobClient.OpenReadAsync();
+        return stream;
+    }
+
     public async Task DeleteFile(Guid fileId)
     {
         var blobClient = await GetBlobClient(fileId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Files/IFileService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Files/IFileService.cs
@@ -6,5 +6,7 @@ public interface IFileService
 
     Task<string> GetFileUrl(Guid fileId, TimeSpan expiresAfter);
 
+    Task<Stream> OpenReadStream(Guid fileId);
+
     Task DeleteFile(Guid fileId);
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
@@ -101,6 +101,9 @@ public sealed class HostFixture(IConfiguration configuration) : IAsyncDisposable
                         fileService
                             .Setup(s => s.GetFileUrl(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
                             .ReturnsAsync("https://fake.blob.core.windows.net/fake");
+                        fileService
+                            .Setup(s => s.OpenReadStream(It.IsAny<Guid>()))
+                            .ReturnsAsync(() => new MemoryStream(TestData.JpegImage));
                         return fileService.Object;
                     }
                 });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -84,5 +84,9 @@ public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 
             await page.WaitForUrlPathAsync("/request-trn/check-answers");
         }
+
+        await page.ClickButton("Submit request");
+
+        await page.WaitForUrlPathAsync("/request-trn/submitted");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
@@ -74,6 +74,9 @@ public class HostFixture : WebApplicationFactory<Program>
                 fileService
                     .Setup(s => s.GetFileUrl(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
                     .ReturnsAsync("https://fake.blob.core.windows.net/fake");
+                fileService
+                    .Setup(s => s.OpenReadStream(It.IsAny<Guid>()))
+                    .ReturnsAsync(() => new MemoryStream(TestData.JpegImage));
                 return fileService.Object;
             }
         });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/AddressTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/AddressTests.cs
@@ -3,6 +3,24 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class AddressTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_HasNationalInsuranceNumberMissingFromState_RedirectsToNationalInsuranceNumber()
     {
         // Arrange
@@ -49,6 +67,24 @@ public class AddressTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(state.TownOrCity, doc.GetElementById("TownOrCity")?.GetAttribute("value"));
         Assert.Equal(state.PostalCode, doc.GetElementById("PostalCode")?.GetAttribute("value"));
         Assert.Equal(state.Country, doc.GetElementById("Country")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/CheckAnswersTests.cs
@@ -1,0 +1,530 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasEmailMissingFromState_RedirectsToEmail()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasNameMissingFromState_RedirectsToName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasHasPreviousNameMissingFromState_RedirectsToPreviousName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasPreviousNameMissingFromState_RedirectsToPreviousName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasDateOfBirthMissingFromState_RedirectsToDateOfBirth()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasEvidenceFileIdMissingFromState_RedirectsToIdentity()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasHasNationalInsuranceNumberMissingFromState_RedirectsToNationalInsuranceNumber()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.HasNationalInsuranceNumber = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasNationalInsuranceNumberTrueAndNationalInsuranceNumberMissingFromState_RedirectsToNationalInsuranceNumber()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.HasNationalInsuranceNumber = true;
+        state.NationalInsuranceNumber = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasNationalInsuranceNumberFalseAndAddressLine1MissingFromState_RedirectsToAddress()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.HasNationalInsuranceNumber = false;
+        state.AddressLine1 = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_ValidRequest_PopulatesModelFromJourneyState(bool hasNationalInsuranceNumber)
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        state.HasNationalInsuranceNumber = hasNationalInsuranceNumber;
+        state.NationalInsuranceNumber = hasNationalInsuranceNumber ? Faker.Identification.UkNationalInsuranceNumber() : null;
+        if (!hasNationalInsuranceNumber)
+        {
+            state.AddressLine1 = Faker.Address.StreetAddress();
+            state.AddressLine2 = Faker.Address.SecondaryAddress();
+            state.TownOrCity = Faker.Address.City();
+            state.Country = Faker.Address.Country();
+            state.PostalCode = Faker.Address.ZipCode();
+        }
+        state.HasPendingTrnRequest = false;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(state.Email, doc.GetSummaryListValueForKey("Email"));
+        Assert.Equal(state.Name, doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal(state.PreviousName, doc.GetSummaryListValueForKey("Previous name"));
+        Assert.Equal(state.DateOfBirth?.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal(state.EvidenceFileName, doc.GetSummaryListValueForKey("Proof of identity"));
+        if (hasNationalInsuranceNumber)
+        {
+            Assert.Equal(state.NationalInsuranceNumber, doc.GetSummaryListValueForKey("National Insurance number"));
+        }
+        else
+        {
+            Assert.Equal("No", doc.GetSummaryListValueForKey("National Insurance number"));
+            var address = doc.GetSummaryListValueForKey("Address");
+            Assert.Contains(state.AddressLine1!, address);
+            Assert.Contains(state.AddressLine2!, address);
+            Assert.Contains(state.TownOrCity!, address);
+            Assert.Contains(state.PostalCode!, address);
+            Assert.Contains(state.Country!, address);
+        }
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasEmailMissingFromState_RedirectsToEmail()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasNameMissingFromState_RedirectsToName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasHasPreviousNameMissingFromState_RedirectsToPreviousName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasPreviousNameMissingFromState_RedirectsToPreviousName()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasDateOfBirthMissingFromState_RedirectsToDateOfBirth()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasEvidenceFileIdMissingFromState_RedirectsToIdentity()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasHasNationalInsuranceNumberMissingFromState_RedirectsToNationalInsuranceNumber()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.HasNationalInsuranceNumber = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasNationalInsuranceNumberTrueAndNationalInsuranceNumberMissingFromState_RedirectsToNationalInsuranceNumber()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.HasNationalInsuranceNumber = true;
+        state.NationalInsuranceNumber = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasNationalInsuranceNumberFalseAndAddressLine1MissingFromState_RedirectsToAddress()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        state.PreviousName = Faker.Name.FullName();
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.HasNationalInsuranceNumber = false;
+        state.AddressLine1 = null;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/address?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidRequest_UpdatesStateAndAndRedirectsToSubmitted(bool hasNationalInsuranceNumber)
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.HasPreviousName = false;
+        state.DateOfBirth = new DateOnly(1980, 3, 1);
+        state.EvidenceFileId = Guid.NewGuid();
+        state.EvidenceFileName = "evidence-file-name.jpg";
+        state.EvidenceFileSizeDescription = "1.2 MB";
+        state.HasNationalInsuranceNumber = hasNationalInsuranceNumber;
+        state.NationalInsuranceNumber = hasNationalInsuranceNumber ? Faker.Identification.UkNationalInsuranceNumber() : null;
+        if (!hasNationalInsuranceNumber)
+        {
+            state.AddressLine1 = Faker.Address.StreetAddress();
+            state.AddressLine2 = Faker.Address.SecondaryAddress();
+            state.TownOrCity = Faker.Address.City();
+            state.Country = Faker.Address.Country();
+            state.PostalCode = Faker.Address.ZipCode();
+        }
+        state.HasPendingTrnRequest = false;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        var reloadedJourneyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.True(reloadedJourneyInstance.State.HasPendingTrnRequest);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
@@ -3,6 +3,24 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_HasPreviousNameMissingFromState_RedirectsToPreviousName()
     {
         // Arrange
@@ -42,6 +60,24 @@ public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal($"{dateOfBirth:%d}", doc.GetElementById("DateOfBirth.Day")?.GetAttribute("value"));
         Assert.Equal($"{dateOfBirth:%M}", doc.GetElementById("DateOfBirth.Month")?.GetAttribute("value"));
         Assert.Equal($"{dateOfBirth:yyyy}", doc.GetElementById("DateOfBirth.Year")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/EmailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/EmailTests.cs
@@ -3,6 +3,24 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class EmailTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
@@ -34,6 +52,24 @@ public class EmailTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
         Assert.Equal(email, doc.GetElementById("Email")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
@@ -3,6 +3,24 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class IdentityTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_DateOfBirthMissingFromState_RedirectsToDateOfBirth()
     {
         // Arrange
@@ -43,6 +61,24 @@ public class IdentityTests(HostFixture hostFixture) : TestBase(hostFixture)
         var uploadedEvidenceLink = doc.GetElementByTestId("uploaded-evidence-link");
         Assert.NotNull(uploadedEvidenceLink);
         Assert.Equal($"{state.EvidenceFileName} ({state.EvidenceFileSizeDescription})", uploadedEvidenceLink!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/identity?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NameTests.cs
@@ -3,6 +3,24 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class NameTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_EmailMissingFromState_RedirectsToEmail()
     {
         // Arrange
@@ -36,6 +54,24 @@ public class NameTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
         Assert.Equal(state.Name, doc.GetElementById("Name")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NationalInsuranceNumberTests.cs
@@ -3,6 +3,24 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_ProofOfIdentityMissingFromState_RedirectsToIdentity()
     {
         // Arrange
@@ -43,6 +61,24 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
         Assert.Equal(state.NationalInsuranceNumber, doc.GetElementById("NationalInsuranceNumber")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/national-insurance-number?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PreviousNameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PreviousNameTests.cs
@@ -3,6 +3,24 @@ namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
 public class PreviousNameTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Get_NameMissingFromState_RedirectsToName()
     {
         // Arrange
@@ -41,6 +59,24 @@ public class PreviousNameTests(HostFixture hostFixture) : TestBase(hostFixture)
         var selectedRadioButton = radioButtons.Single(r => r.HasAttribute("checked"));
         Assert.Equal("True", selectedRadioButton.GetAttribute("value"));
         Assert.Equal(state.PreviousName, doc.GetElementById("PreviousName")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/previous-name?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/SubmittedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/SubmittedTests.cs
@@ -1,0 +1,38 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class SubmittedTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_HasPendingTrnRequestMissingFromState_RedirectsToCheckAnswers()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsOK()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateTrnRequestTaskTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateTrnRequestTaskTests.cs
@@ -41,7 +41,7 @@ public class CreateTrnRequestTaskTests : IAsyncLifetime
 
         var createdCrmTask = ctx.TaskSet.SingleOrDefault(i => i.GetAttributeValue<Guid>(CrmTask.PrimaryIdAttribute) == crmTaskId);
         Assert.NotNull(createdCrmTask);
-        Assert.Equal("TRN Request", createdCrmTask.Subject);
+        Assert.Equal("Notification for TRA Support Team - TRN request", createdCrmTask.Subject);
         Assert.Equal(description, createdCrmTask.Description);
 
         var createdAnnotation = ctx.AnnotationSet.SingleOrDefault(i => i.GetAttributeValue<string>(Annotation.Fields.FileName) == evidenceFileName);


### PR DESCRIPTION
### Context

We’re building an interim solution that replaces Galaxkey for requesting a TRN for NPQ participants.

### Changes proposed in this pull request

Add a Check answers page following the [Request a TRN]Figma designs under /request-trn/check-answers

Only show the address fields if the address page was shown to the user (i.e. they do not have a NINO).

Each change link should have ?fromCheckAnswers=true appended to the query string. Each page linked to should be changed such that if fromCheckAnswers is true it redirects to check answers after the page has been submitted. The only exception to this is the NINO page - if the answer there is changed to ‘No’ the next page should be the address page.

When Submit Request is pressed, create the task in CRM and redirect to /request-trn/submitted

### Guidance to review

Pages + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
