### PR TITLE
Aligned error messages for Request a TRN journey with final content design

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EvidenceFileAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DataAnnotations/EvidenceFileAttribute.cs
@@ -8,7 +8,7 @@ public class EvidenceFileAttribute : FileExtensionsAttribute
     {
         if (ErrorMessage == null)
         {
-            ErrorMessage = "The selected file must be a JPEG, JPG, PNG or PDF";
+            ErrorMessage = "The selected file must be a PDF, JPG, JPEG or PNG";
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
@@ -7,7 +7,7 @@ using TeachingRecordSystem.FormFlow;
 namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
 
 [Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
-public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
+public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator, IClock clock) : PageModel
 {
     public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
 
@@ -21,6 +21,11 @@ public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator) : Page
 
     public async Task<IActionResult> OnPost()
     {
+        if (DateOfBirth >= clock.Today)
+        {
+            ModelState.AddModelError(nameof(DateOfBirth), "Date of birth must be in the past");
+        }
+
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
@@ -18,7 +18,7 @@ public class EmailModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
     [BindProperty]
     [Display(Name = "What is your email address?", Description = "We’ll only use this to send you your TRN if you’re eligible for one.")]
     [Required(ErrorMessage = "Enter your email address")]
-    [@EmailAddress(ErrorMessage = "Enter a valid email address")]
+    [@EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@example.com")]
     public string? Email { get; set; }
 
     public async Task<IActionResult> OnPost()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
@@ -13,7 +13,7 @@ public class IdentityModel(AuthorizeAccessLinkGenerator linkGenerator, IFileServ
 {
     public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
 
-    public const int MaxFileSizeMb = 50;
+    public const int MaxFileSizeMb = 3;
 
     private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
 
@@ -22,7 +22,7 @@ public class IdentityModel(AuthorizeAccessLinkGenerator linkGenerator, IFileServ
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(MaxFileSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(MaxFileSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 3MB")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
@@ -16,7 +16,7 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
 
     [BindProperty]
     [Display(Name = "What is your name?", Description = "Full name")]
-    [Required(ErrorMessage = "Enter your name")]
+    [Required(ErrorMessage = "Enter your full name")]
     [MaxLength(200, ErrorMessage = "Name must be 200 characters or less")]
     public string? Name { get; set; }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
@@ -16,7 +16,7 @@ public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGener
 
     [BindProperty]
     [Display(Name = "Do you have a National Insurance number?")]
-    [Required(ErrorMessage = "Tell us if you have a National Insurance number")]
+    [Required(ErrorMessage = "Select yes if you have a National Insurance number")]
     public bool? HasNationalInsuranceNumber { get; set; }
 
     [BindProperty]
@@ -30,7 +30,7 @@ public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGener
         {
             if (!string.IsNullOrEmpty(NationalInsuranceNumber) && !NationalInsuranceNumberHelper.IsValid(NationalInsuranceNumber))
             {
-                ModelState.AddModelError(nameof(NationalInsuranceNumber), "Enter a valid National Insurance number");
+                ModelState.AddModelError(nameof(NationalInsuranceNumber), "Enter a National Insurance number in the correct format");
             }
         }
         else

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml.cs
@@ -17,7 +17,7 @@ public class PreviousNameModel(AuthorizeAccessLinkGenerator linkGenerator) : Pag
 
     [BindProperty]
     [Display(Name = "Have you ever changed your name?")]
-    [Required(ErrorMessage = "Tell us if you have ever changed your name")]
+    [Required(ErrorMessage = "Select yes if you’ve ever changed your name")]
     public bool? HasPreviousName { get; set; }
 
     [BindProperty]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/DateOfBirthTests.cs
@@ -103,6 +103,33 @@ public class DateOfBirthTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
+    public async Task Post_WhenDateOfBirthIsInTheFuture_ReturnsError()
+    {
+        var state = CreateNewState();
+        state.Email = Faker.Internet.Email();
+        state.Name = Faker.Name.FullName();
+        state.PreviousName = Faker.Name.FullName();
+        state.HasPreviousName = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/date-of-birth?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "DateOfBirth.Day", "1" },
+                { "DateOfBirth.Month", "3" },
+                { "DateOfBirth.Year", $"{Clock.Today.Year + 1}" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Date of birth must be in the past");
+    }
+
+    [Fact]
     public async Task Post_HasPreviousNameMissingFromState_RedirectsToPreviousName()
     {
         // Arrange

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/EmailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/EmailTests.cs
@@ -113,7 +113,7 @@ public class EmailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a valid email address");
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter an email address in the correct format, like name@example.com");
     }
 
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/IdentityTests.cs
@@ -143,7 +143,7 @@ public class IdentityTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a JPEG, JPG, PNG or PDF");
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a PDF, JPG, JPEG or PNG");
     }
 
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NameTests.cs
@@ -88,7 +88,7 @@ public class NameTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "Name", "Enter your name");
+        await AssertEx.HtmlResponseHasError(response, "Name", "Enter your full name");
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NationalInsuranceNumberTests.cs
@@ -124,7 +124,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "HasNationalInsuranceNumber", "Tell us if you have a National Insurance number");
+        await AssertEx.HtmlResponseHasError(response, "HasNationalInsuranceNumber", "Select yes if you have a National Insurance number");
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "NationalInsuranceNumber", "Enter a valid National Insurance number");
+        await AssertEx.HtmlResponseHasError(response, "NationalInsuranceNumber", "Enter a National Insurance number in the correct format");
     }
 
     [Theory]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PreviousNameTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PreviousNameTests.cs
@@ -117,7 +117,7 @@ public class PreviousNameTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "HasPreviousName", "Tell us if you have ever changed your name");
+        await AssertEx.HtmlResponseHasError(response, "HasPreviousName", "Select yes if you’ve ever changed your name");
     }
 
     [Fact]


### PR DESCRIPTION
### Context

The initial content for error messages for the Get a TRN was lifted from other pages or guesstimated by us developers. We now have ‘proper’ content.

### Changes proposed in this pull request

Update error message content to align with internal spreadsheet (checking in with content desginer for any additional scenarios).

### Guidance to review

Error messages on pages + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
