### PR TITLE
Add versioned ApiModel for QtlsInfo

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetQtls.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetQtls.cs
@@ -8,18 +8,16 @@ namespace TeachingRecordSystem.Api.V3.Core.Operations;
 
 public record GetQtlsCommand(string Trn);
 
-public class GetQtlsHandler(ICrmQueryDispatcher _crmQueryDispatcher)
+public class GetQtlsHandler(ICrmQueryDispatcher crmQueryDispatcher)
 {
     public async Task<QtlsInfo?> Handle(GetQtlsCommand command)
     {
-        var contact = (await _crmQueryDispatcher.ExecuteQuery(
+        var contact = (await crmQueryDispatcher.ExecuteQuery(
             new GetActiveContactByTrnQuery(
                 command.Trn,
                 new ColumnSet(
                     Contact.Fields.dfeta_TRN,
-                    Contact.Fields.dfeta_qtlsdate
-                    )
-                )
+                    Contact.Fields.dfeta_qtlsdate))
             ))!;
 
         if (contact is null)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/QtlsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/QtlsInfo.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.QtlsInfo))]
+public record QtlsInfo
+{
+    public required DateOnly? QtsDate { get; init; }
+    public required string Trn { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using TeachingRecordSystem.Api.V3.Core.SharedModels;
+using TeachingRecordSystem.Api.V3.VNext.ApiModels;
 using TeachingRecordSystem.Api.V3.VNext.Requests;
 
 namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
@@ -16,14 +16,16 @@ public class PersonsController(IMapper mapper) : ControllerBase
         OperationId = "PutQtls",
         Summary = "Set QTLS status for a teacher",
         Description = "Sets the QTLS status for the teacher with the given TRN.")]
+    [ProducesResponseType(typeof(QtlsInfo), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status202Accepted)]
     [MapError(10001, statusCode: StatusCodes.Status404NotFound)]
     [Authorize(Policy = AuthorizationPolicies.AssignQtls)]
     public async Task<IActionResult> Put(
+        [FromRoute] string trn,
         [FromBody] SetQtlsRequest request,
         [FromServices] SetQtlsHandler handler)
     {
-        var command = new SetQtlsCommand(request.Trn!, request.QtsDate);
+        var command = new SetQtlsCommand(trn, request.QtsDate);
         var result = await handler.Handle(command);
         return result is { Succeeded: true } ? Ok(result.QtlsInfo!) : Accepted();
     }
@@ -33,6 +35,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         OperationId = "GetQtls",
         Summary = "Get QTLS status for a teacher",
         Description = "Gets the QTLS status for the teacher with the given TRN.")]
+    [ProducesResponseType(typeof(QtlsInfo), StatusCodes.Status200OK)]
     [Authorize(Policy = AuthorizationPolicies.AssignQtls)]
     public async Task<IActionResult> Get(
         [FromRoute] string trn,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/SetQtlsRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/SetQtlsRequest.cs
@@ -1,11 +1,6 @@
-using Microsoft.AspNetCore.Mvc;
-
 namespace TeachingRecordSystem.Api.V3.VNext.Requests;
 
 public record SetQtlsRequest
 {
     public required DateOnly? QtsDate { get; init; }
-
-    [FromRoute]
-    public string? Trn { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/SetQtlsRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/SetQtlsRequestValidator.cs
@@ -7,10 +7,6 @@ public class SetQtlsRequestValidator : AbstractValidator<SetQtlsRequest>
 {
     public SetQtlsRequestValidator(IClock clock)
     {
-        RuleFor(x => x.Trn)
-            .Matches(@"^\d{7}$")
-            .WithMessage(Properties.StringResources.ErrorMessages_TRNMustBe7Digits);
-
         RuleFor(x => x.QtsDate)
             .LessThanOrEqualTo(clock.Today)
             .WithMessage($"Date cannot be in the future.");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/SetQtlsDateRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/SetQtlsDateRequestTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using TeachingRecordSystem.Api.Properties;
 using TeachingRecordSystem.Api.V3.VNext.Requests;
 using TeachingRecordSystem.Core.Dqt;
 
@@ -11,7 +10,7 @@ public class SetQtlsDateRequestTests : TestBase
     public SetQtlsDateRequestTests(HostFixture hostFixture)
         : base(hostFixture)
     {
-        SetCurrentApiClient(new[] { ApiRoles.AssignQtls });
+        SetCurrentApiClient([ApiRoles.AssignQtls]);
     }
 
     [Theory, RoleNamesData(except: ApiRoles.AssignQtls)]
@@ -31,26 +30,6 @@ public class SetQtlsDateRequestTests : TestBase
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
-    }
-
-    [Theory]
-    [InlineData("123456")]
-    [InlineData("12345678")]
-    [InlineData("xxx")]
-    public async Task Put_InvalidTrn_ReturnsErrror(string trn)
-    {
-        // Arrange
-        var requestBody = CreateJsonContent(new { qtsDate = new DateOnly(1990, 01, 01) });
-        var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{trn}/qtls")
-        {
-            Content = requestBody
-        };
-
-        // Act
-        var response = await GetHttpClientWithApiKey().SendAsync(request);
-
-        // Assert
-        await AssertEx.JsonResponseHasValidationErrorForProperty(response, "trn", expectedError: StringResources.ErrorMessages_TRNMustBe7Digits);
     }
 
     [Fact]


### PR DESCRIPTION
While working on DTO versioning I noticed the QTLS endpoints are using an `ApiModel` from `Core` rather than a versioned one - this fixes that.

I've also fixed up some Swagger annotations on the endpoints and removed a TRN validation test - we've moved away from that in the v3 endpoints.