### PR TITLE
Rename teacher endpoints to person

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 20240606
 
+All endpoints under `/teacher` and `/teachers` have been moved to `/person` and `/persons`, respectively.
+
+The `email` property on the response from `/teacher` (now `/person`) and `/teachers/<trn>` (now `/persons/<trn>`) has been renamed to `emailAddress`.
+
+The `email` property on the request to `/teacher/name-changes` (now `/person/name-changes`) and `/teacher/date-of-birth-changes` (now `/person/date-of-birth-changes`) has been renamed to `emailAddress`.
+
 ### `PUT /v3/trn-requests`
 
 The scalar `email` property in the request has been replaced with an `emailAddresses` collection property so that multiple email addresses can be provided to match on.

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersons.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersons.cs
@@ -7,11 +7,11 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Api.V3.Core.Operations;
 
-public record FindTeachersCommand(string LastName, DateOnly? DateOfBirth);
+public record FindPersonsCommand(string LastName, DateOnly? DateOfBirth);
 
-public record FindTeachersResult(int Total, IReadOnlyCollection<FindTeachersResultItem> Items);
+public record FindPersonsResult(int Total, IReadOnlyCollection<FindPersonsResultItem> Items);
 
-public record FindTeachersResultItem
+public record FindPersonsResultItem
 {
     public required string Trn { get; init; }
     public required DateOnly DateOfBirth { get; init; }
@@ -22,11 +22,11 @@ public record FindTeachersResultItem
     public required IReadOnlyCollection<NameInfo> PreviousNames { get; init; }
 }
 
-public class FindTeachersHandler(ICrmQueryDispatcher crmQueryDispatcher, IConfiguration configuration)
+public class FindPersonsHandler(ICrmQueryDispatcher crmQueryDispatcher, IConfiguration configuration)
 {
     private readonly TimeSpan _concurrentNameChangeWindow = TimeSpan.FromSeconds(configuration.GetValue("ConcurrentNameChangeWindowSeconds", 5));
 
-    public async Task<FindTeachersResult> Handle(FindTeachersCommand command)
+    public async Task<FindPersonsResult> Handle(FindPersonsCommand command)
     {
         var contacts = await crmQueryDispatcher.ExecuteQuery(
             new GetActiveContactsByLastNameAndDateOfBirthQuery(
@@ -55,9 +55,9 @@ public class FindTeachersHandler(ICrmQueryDispatcher crmQueryDispatcher, IConfig
                 kvp => kvp.Key,
                 kvp => PreviousNameHelper.GetFullPreviousNames(kvp.Value, contactsById[kvp.Key], _concurrentNameChangeWindow));
 
-        return new FindTeachersResult(
+        return new FindPersonsResult(
             Total: contacts.Length,
-            Items: contacts.Select(r => new FindTeachersResultItem()
+            Items: contacts.Select(r => new FindPersonsResultItem()
             {
                 Trn = r.dfeta_TRN,
                 DateOfBirth = r.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetPerson.cs
@@ -38,7 +38,7 @@ public record GetPersonResult
     public required string? NationalInsuranceNumber { get; init; }
     public required Option<bool> PendingNameChange { get; init; }
     public required Option<bool> PendingDateOfBirthChange { get; init; }
-    public required string? Email { get; set; }
+    public required string? EmailAddress { get; set; }
     public required GetPersonResultQts? Qts { get; init; }
     public required GetPersonResultEyts? Eyts { get; init; }
     public required Option<GetPersonResultInduction?> Induction { get; init; }
@@ -375,7 +375,7 @@ public class GetPersonHandler(
             PendingDateOfBirthChange = command.Include.HasFlag(GetPersonCommandIncludes.PendingDetailChanges) ? Option.Some((await getPendingDetailChangesTask!).PendingDateOfBirthRequest) : default,
             Qts = MapQts(qts?.dfeta_QTSDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), qtsStatus != null ? GetQtsStatusDescription(qtsStatus!.dfeta_Value!, qtsStatus.dfeta_name) : null),
             Eyts = MapEyts(eyts?.dfeta_EYTSDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), eytsTeacherStatus != null ? GetEytsStatusDescription(eytsTeacherStatus!.dfeta_Value!) : null),
-            Email = contact.EMailAddress1,
+            EmailAddress = contact.EMailAddress1,
             Induction = command.Include.HasFlag(GetPersonCommandIncludes.Induction) ?
                 Option.Some(MapInduction(await getInductionTask!)) :
                 default,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeacherController.cs
@@ -11,7 +11,7 @@ using TeachingRecordSystem.Api.V3.V20240101.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240101.Controllers;
 
 [Route("teacher")]
-public class TeacherController : ControllerBase
+public class TeacherController(IMapper mapper) : ControllerBase
 {
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
@@ -44,7 +44,8 @@ public class TeacherController : ControllerBase
             return MissingOrInvalidTrn();
         }
 
-        return Ok(result);
+        var response = mapper.Map<GetTeacherResponse>(result);
+        return Ok(response);
 
         IActionResult MissingOrInvalidTrn() => Forbid();
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
@@ -102,9 +102,9 @@ public class TeachersController(IMapper mapper) : ControllerBase
     [Authorize(Policy = AuthorizationPolicies.GetPerson)]
     public async Task<IActionResult> FindTeachers(
         FindTeachersRequest request,
-        [FromServices] FindTeachersHandler handler)
+        [FromServices] FindPersonsHandler handler)
     {
-        var command = new FindTeachersCommand(request.LastName!, request.DateOfBirth!.Value);
+        var command = new FindPersonsCommand(request.LastName!, request.DateOfBirth!.Value);
         var result = await handler.Handle(command);
 
         var response = new FindTeachersResponse()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
@@ -1,0 +1,90 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Api.Infrastructure.ModelBinding;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Api.V3.Core.Operations;
+using TeachingRecordSystem.Api.V3.V20240606.Requests;
+using TeachingRecordSystem.Api.V3.V20240606.Responses;
+using CreateDetailChangeResponseVersion = TeachingRecordSystem.Api.V3.V20240412;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
+
+[Route("person")]
+public class PersonController(IMapper mapper) : ControllerBase
+{
+    [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
+    [HttpGet]
+    [SwaggerOperation(
+        OperationId = "GetCurrentPerson",
+        Summary = "Get the authenticated person's details",
+        Description = "Gets the details for the authenticated person.")]
+    [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Get(
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
+        [FromServices] GetPersonHandler handler)
+    {
+        var command = new GetPersonCommand(
+            Trn: User.FindFirstValue("trn")!,
+            include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
+            DateOfBirth: null);
+
+        var result = await handler.Handle(command);
+        var response = mapper.Map<GetPersonResponse?>(result);
+        return response is null ? Forbid() : Ok(result);
+    }
+
+    [HttpPost("name-changes")]
+    [SwaggerOperation(
+        OperationId = "CreateNameChange",
+        Summary = "Create name change request",
+        Description = "Creates a name change request for the authenticated teacher.")]
+    [ProducesResponseType(typeof(CreateDetailChangeResponseVersion.Responses.CreateNameChangeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
+    public async Task<IActionResult> CreateNameChange(
+        [FromBody] CreateNameChangeRequestRequest request,
+        [FromServices] CreateNameChangeRequestHandler handler)
+    {
+        var command = new CreateNameChangeRequestCommand()
+        {
+            Trn = User.FindFirstValue("trn")!,
+            FirstName = request.FirstName,
+            MiddleName = request.MiddleName,
+            LastName = request.LastName,
+            EvidenceFileName = request.EvidenceFileName,
+            EvidenceFileUrl = request.EvidenceFileUrl,
+        };
+
+        var caseNumber = await handler.Handle(command);
+        var response = new CreateDetailChangeResponseVersion.Responses.CreateNameChangeResponse() { CaseNumber = caseNumber };
+        return Ok(response);
+    }
+
+    [HttpPost("date-of-birth-changes")]
+    [SwaggerOperation(
+        OperationId = "CreateDobChange",
+        Summary = "Create DOB change request",
+        Description = "Creates a date of birth change request for the authenticated teacher.")]
+    [ProducesResponseType(typeof(CreateDetailChangeResponseVersion.Responses.CreateDateOfBirthChangeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
+    public async Task<IActionResult> CreateDateOfBirthChange(
+        [FromBody] CreateDateOfBirthChangeRequestRequest request,
+        [FromServices] CreateDateOfBirthChangeRequestHandler handler)
+    {
+        var command = new CreateDateOfBirthChangeRequestCommand()
+        {
+            Trn = User.FindFirstValue("trn")!,
+            DateOfBirth = request.DateOfBirth,
+            EvidenceFileName = request.EvidenceFileName,
+            EvidenceFileUrl = request.EvidenceFileUrl,
+        };
+
+        var caseNumber = await handler.Handle(command);
+        var response = new CreateDetailChangeResponseVersion.Responses.CreateNameChangeResponse() { CaseNumber = caseNumber };
+        return Ok(response);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Api.Infrastructure.ModelBinding;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Api.V3.Core.Operations;
+using TeachingRecordSystem.Api.V3.V20240606.Requests;
+using TeachingRecordSystem.Api.V3.V20240606.Responses;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
+
+[Route("persons")]
+public class PersonsController(IMapper mapper) : ControllerBase
+{
+    [HttpGet("{trn}")]
+    [SwaggerOperation(
+        OperationId = "GetPersonByTrn",
+        Summary = "Get person details by TRN",
+        Description = "Gets the details of the person corresponding to the given TRN.")]
+    [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    public async Task<IActionResult> Get(
+        [FromRoute] string trn,
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
+        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth,
+        [FromServices] GetPersonHandler handler)
+    {
+        var command = new GetPersonCommand(
+            trn,
+            include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
+            dateOfBirth);
+
+        var result = await handler.Handle(command);
+
+        if (result is null)
+        {
+            return NotFound();
+        }
+
+        var response = mapper.Map<GetPersonResponse>(result);
+        return Ok(response);
+    }
+
+    [HttpGet("")]
+    [SwaggerOperation(
+        OperationId = "FindPersons",
+        Summary = "Find persons",
+        Description = "Finds persons with a TRN matching the specified criteria.")]
+    [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    public async Task<IActionResult> FindTeachers(
+        FindPersonsRequest request,
+        [FromServices] FindPersonsHandler handler)
+    {
+        var command = new FindPersonsCommand(request.LastName!, request.DateOfBirth!.Value);
+        var result = await handler.Handle(command);
+
+        var response = new FindPersonsResponse()
+        {
+            Total = result.Total,
+            Query = request,
+            Results = result.Items.Select(mapper.Map<FindPersonsResponseResult>).AsReadOnly()
+        };
+
+        return Ok(response);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TeacherController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
+
+[Route("teacher")]
+public class TeacherController : ControllerBase
+{
+    [HttpGet("")]
+    [RemovesFromApi]
+    public IActionResult Get() => throw null!;
+
+    [HttpPost("name-changes")]
+    [RemovesFromApi]
+    public IActionResult CreateNameChange() => throw null!;
+
+    [HttpPost("date-of-birth-changes")]
+    [RemovesFromApi]
+    public IActionResult CreateDateOfBirthChange() => throw null!;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TeachersController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
+
+[Route("teachers")]
+public class TeachersController : ControllerBase
+{
+    [HttpGet("{trn}")]
+    [RemovesFromApi]
+    public IActionResult GetTeacherByTrn() => throw null!;
+
+    [HttpGet("")]
+    [RemovesFromApi]
+    public IActionResult FindTeacher() => throw null!;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/CreateDateOfBirthChangeRequestRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/CreateDateOfBirthChangeRequestRequest.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.Requests;
+
+public record CreateDateOfBirthChangeRequestRequest
+{
+    public string? EmailAddress { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required string EvidenceFileUrl { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/CreateNameChangeRequestRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/CreateNameChangeRequestRequest.cs
@@ -1,0 +1,11 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.Requests;
+
+public record CreateNameChangeRequestRequest
+{
+    public string? EmailAddress { get; init; }
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required string EvidenceFileUrl { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/FindPersonsRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/FindPersonsRequest.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Requests;
+
+public record FindPersonsRequest
+{
+    [FromQuery(Name = "findBy")]
+    public FindPersonsFindBy FindBy { get; init; }
+    [FromQuery(Name = "lastName")]
+    public string? LastName { get; init; }
+    [FromQuery(Name = "dateOfBirth")]
+    public DateOnly? DateOfBirth { get; init; }
+}
+
+public enum FindPersonsFindBy
+{
+    LastNameAndDateOfBirth = 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/GetPersonRequestIncludes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/GetPersonRequestIncludes.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Requests;
+
+[Flags]
+[Description("Comma-separated list of data to include in response.")]
+public enum GetPersonRequestIncludes
+{
+    None = 0,
+
+    Induction = 1 << 0,
+    InitialTeacherTraining = 1 << 1,
+    NpqQualifications = 1 << 2,
+    MandatoryQualifications = 1 << 3,
+    PendingDetailChanges = 1 << 4,
+    HigherEducationQualifications = 1 << 5,
+    Sanctions = 1 << 6,
+    Alerts = 1 << 7,
+    PreviousNames = 1 << 8,
+
+    [ExcludeFromSchema]
+    _AllowIdSignInWithProhibitions = 1 << 9,
+
+    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges | HigherEducationQualifications | Sanctions | Alerts | PreviousNames
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/FindPersonsResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/FindPersonsResponse.cs
@@ -1,19 +1,19 @@
 using TeachingRecordSystem.Api.V3.Core.Operations;
 using TeachingRecordSystem.Api.V3.V20240101.ApiModels;
-using TeachingRecordSystem.Api.V3.V20240101.Requests;
+using TeachingRecordSystem.Api.V3.V20240606.Requests;
 
-namespace TeachingRecordSystem.Api.V3.V20240101.Responses;
+namespace TeachingRecordSystem.Api.V3.V20240606.Responses;
 
 [AutoMap(typeof(FindPersonsResult))]
-public record FindTeachersResponse
+public record FindPersonsResponse
 {
     public required int Total { get; init; }
-    public required FindTeachersRequest Query { get; init; }
-    public required IReadOnlyCollection<FindTeachersResponseResult> Results { get; init; }
+    public required FindPersonsRequest Query { get; init; }
+    public required IReadOnlyCollection<FindPersonsResponseResult> Results { get; init; }
 }
 
 [AutoMap(typeof(FindPersonsResultItem))]
-public record FindTeachersResponseResult
+public record FindPersonsResponseResult
 {
     public required string Trn { get; init; }
     public required DateOnly DateOfBirth { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/GetPersonResponse.cs
@@ -1,13 +1,12 @@
 using System.Text.Json.Serialization;
-using AutoMapper.Configuration.Annotations;
 using Optional;
 using TeachingRecordSystem.Api.V3.Core.Operations;
 using TeachingRecordSystem.Api.V3.V20240101.ApiModels;
 
-namespace TeachingRecordSystem.Api.V3.V20240101.Responses;
+namespace TeachingRecordSystem.Api.V3.V20240606.Responses;
 
 [AutoMap(typeof(GetPersonResult))]
-public record GetTeacherResponse
+public record GetPersonResponse
 {
     public required string Trn { get; init; }
     public required string FirstName { get; init; }
@@ -17,15 +16,14 @@ public record GetTeacherResponse
     public required string? NationalInsuranceNumber { get; init; }
     public required Option<bool> PendingNameChange { get; init; }
     public required Option<bool> PendingDateOfBirthChange { get; init; }
-    [SourceMember("EmailAddress")]
-    public required string? Email { get; set; }
-    public required GetTeacherResponseQts? Qts { get; init; }
-    public required GetTeacherResponseEyts? Eyts { get; init; }
-    public required Option<GetTeacherResponseInduction?> Induction { get; init; }
-    public required Option<IReadOnlyCollection<GetTeacherResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
-    public required Option<IReadOnlyCollection<GetTeacherResponseNpqQualification>> NpqQualifications { get; init; }
-    public required Option<IReadOnlyCollection<GetTeacherResponseMandatoryQualification>> MandatoryQualifications { get; init; }
-    public required Option<IReadOnlyCollection<GetTeacherResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
+    public required string? EmailAddress { get; set; }
+    public required GetPersonResponseQts? Qts { get; init; }
+    public required GetPersonResponseEyts? Eyts { get; init; }
+    public required Option<GetPersonResponseInduction?> Induction { get; init; }
+    public required Option<IReadOnlyCollection<GetPersonResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
+    public required Option<IReadOnlyCollection<GetPersonResponseNpqQualification>> NpqQualifications { get; init; }
+    public required Option<IReadOnlyCollection<GetPersonResponseMandatoryQualification>> MandatoryQualifications { get; init; }
+    public required Option<IReadOnlyCollection<GetPersonResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
     public required Option<IReadOnlyCollection<SanctionInfo>> Sanctions { get; init; }
     public required Option<IReadOnlyCollection<AlertInfo>> Alerts { get; init; }
     public required Option<IReadOnlyCollection<NameInfo>> PreviousNames { get; init; }
@@ -33,7 +31,7 @@ public record GetTeacherResponse
 }
 
 [AutoMap(typeof(GetPersonResultQts))]
-public record GetTeacherResponseQts
+public record GetPersonResponseQts
 {
     public required DateOnly? Awarded { get; init; }
     public required string CertificateUrl { get; init; }
@@ -41,7 +39,7 @@ public record GetTeacherResponseQts
 }
 
 [AutoMap(typeof(GetPersonResultEyts))]
-public record GetTeacherResponseEyts
+public record GetPersonResponseEyts
 {
     public required DateOnly? Awarded { get; init; }
     public required string CertificateUrl { get; init; }
@@ -49,7 +47,7 @@ public record GetTeacherResponseEyts
 }
 
 [AutoMap(typeof(GetPersonResultInduction))]
-public record GetTeacherResponseInduction
+public record GetPersonResponseInduction
 {
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
@@ -57,96 +55,96 @@ public record GetTeacherResponseInduction
     public required string? StatusDescription { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? CertificateUrl { get; init; }
-    public required IReadOnlyCollection<GetTeacherResponseInductionPeriod> Periods { get; init; }
+    public required IReadOnlyCollection<GetPersonResponseInductionPeriod> Periods { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInductionPeriod))]
-public record GetTeacherResponseInductionPeriod
+public record GetPersonResponseInductionPeriod
 {
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required int? Terms { get; init; }
-    public required GetTeacherResponseInductionPeriodAppropriateBody? AppropriateBody { get; init; }
+    public required GetPersonResponseInductionPeriodAppropriateBody? AppropriateBody { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInductionPeriodAppropriateBody))]
-public record GetTeacherResponseInductionPeriodAppropriateBody
+public record GetPersonResponseInductionPeriodAppropriateBody
 {
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTraining))]
-public record GetTeacherResponseInitialTeacherTraining
+public record GetPersonResponseInitialTeacherTraining
 {
-    public required GetTeacherResponseInitialTeacherTrainingQualification? Qualification { get; init; }
+    public required GetPersonResponseInitialTeacherTrainingQualification? Qualification { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required IttProgrammeType? ProgrammeType { get; init; }
     public required string? ProgrammeTypeDescription { get; init; }
     public required IttOutcome? Result { get; init; }
-    public required GetTeacherResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
-    public required GetTeacherResponseInitialTeacherTrainingProvider? Provider { get; init; }
-    public required IReadOnlyCollection<GetTeacherResponseInitialTeacherTrainingSubject> Subjects { get; init; }
+    public required GetPersonResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
+    public required GetPersonResponseInitialTeacherTrainingProvider? Provider { get; init; }
+    public required IReadOnlyCollection<GetPersonResponseInitialTeacherTrainingSubject> Subjects { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingQualification))]
-public record GetTeacherResponseInitialTeacherTrainingQualification
+public record GetPersonResponseInitialTeacherTrainingQualification
 {
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingAgeRange))]
-public record GetTeacherResponseInitialTeacherTrainingAgeRange
+public record GetPersonResponseInitialTeacherTrainingAgeRange
 {
     public required string Description { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingProvider))]
-public record GetTeacherResponseInitialTeacherTrainingProvider
+public record GetPersonResponseInitialTeacherTrainingProvider
 {
     public required string Name { get; init; }
     public required string Ukprn { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingSubject))]
-public record GetTeacherResponseInitialTeacherTrainingSubject
+public record GetPersonResponseInitialTeacherTrainingSubject
 {
     public required string Code { get; init; }
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultNpqQualification))]
-public record GetTeacherResponseNpqQualification
+public record GetPersonResponseNpqQualification
 {
     public required DateOnly Awarded { get; init; }
-    public required GetTeacherResponseNpqQualificationType Type { get; init; }
+    public required GetPersonResponseNpqQualificationType Type { get; init; }
     public required string CertificateUrl { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultNpqQualificationType))]
-public record GetTeacherResponseNpqQualificationType
+public record GetPersonResponseNpqQualificationType
 {
     public required NpqQualificationType Code { get; init; }
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultMandatoryQualification))]
-public record GetTeacherResponseMandatoryQualification
+public record GetPersonResponseMandatoryQualification
 {
     public required DateOnly Awarded { get; init; }
     public required string Specialism { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultHigherEducationQualification))]
-public record GetTeacherResponseHigherEducationQualification
+public record GetPersonResponseHigherEducationQualification
 {
     public required string? Name { get; init; }
     public required DateOnly? Awarded { get; init; }
-    public required IReadOnlyCollection<GetTeacherResponseHigherEducationQualificationSubject> Subjects { get; init; }
+    public required IReadOnlyCollection<GetPersonResponseHigherEducationQualificationSubject> Subjects { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultHigherEducationQualificationSubject))]
-public record GetTeacherResponseHigherEducationQualificationSubject
+public record GetPersonResponseHigherEducationQualificationSubject
 {
     public required string Code { get; init; }
     public required string Name { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/CreateDateOfBirthChangeRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/CreateDateOfBirthChangeRequestValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using TeachingRecordSystem.Api.V3.V20240606.Requests;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Validators;
+
+public class CreateDateOfBirthChangeRequestValidator : AbstractValidator<CreateDateOfBirthChangeRequestRequest>
+{
+    public CreateDateOfBirthChangeRequestValidator()
+    {
+        RuleFor(r => r.DateOfBirth)
+            .NotNull();
+
+        RuleFor(r => r.EvidenceFileName)
+            .NotEmpty();
+
+        RuleFor(r => r.EvidenceFileUrl)
+            .NotEmpty();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/CreateNameChangeRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/CreateNameChangeRequestValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using TeachingRecordSystem.Api.V3.V20240606.Requests;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Validators;
+
+public class CreateNameChangeRequestValidator : AbstractValidator<CreateNameChangeRequestRequest>
+{
+    public CreateNameChangeRequestValidator()
+    {
+        RuleFor(r => r.FirstName)
+            .NotEmpty();
+
+        RuleFor(r => r.LastName)
+            .NotEmpty();
+
+        RuleFor(r => r.EvidenceFileName)
+            .NotEmpty();
+
+        RuleFor(r => r.EvidenceFileUrl)
+            .NotEmpty();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/FindTeachersRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/FindTeachersRequestValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using TeachingRecordSystem.Api.V3.V20240606.Requests;
+
+namespace TeachingRecordSystem.Api.V3.V20240606.Validators;
+
+public class FindTeachersRequestValidator : AbstractValidator<FindPersonsRequest>
+{
+    public FindTeachersRequestValidator()
+    {
+        RuleFor(r => r.FindBy)
+            .IsInEnum()
+            .WithMessage("Invalid matching policy.");
+
+        RuleFor(r => r.DateOfBirth)
+            .NotNull()
+            .When(r => r.FindBy == FindPersonsFindBy.LastNameAndDateOfBirth)
+            .WithMessage($"A value is required when findBy is '{nameof(FindPersonsFindBy.LastNameAndDateOfBirth)}'.");
+
+        RuleFor(r => r.LastName)
+            .NotEmpty()
+            .When(r => r.FindBy == FindPersonsFindBy.LastNameAndDateOfBirth)
+            .WithMessage($"A value is required when findBy is '{nameof(FindPersonsFindBy.LastNameAndDateOfBirth)}'.");
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestBase.cs
@@ -43,16 +43,22 @@ public abstract class TestBase
     public JsonContent CreateJsonContent(object requestBody) =>
         JsonContent.Create(requestBody, options: new System.Text.Json.JsonSerializerOptions().Configure());
 
-    public virtual HttpClient GetHttpClientWithApiKey(string? version = null)
+    public virtual HttpClient GetHttpClient(string? version = null)
     {
         var client = HostFixture.CreateClient();
-        client.DefaultRequestHeaders.Add("X-Use-CurrentClientIdProvider", "true");  // Signal for TestAuthenticationHandler to run
 
         if (version is not null)
         {
             client.DefaultRequestHeaders.Add(VersionRegistry.MinorVersionHeaderName, version);
         }
 
+        return client;
+    }
+
+    public virtual HttpClient GetHttpClientWithApiKey(string? version = null)
+    {
+        var client = GetHttpClient(version);
+        client.DefaultRequestHeaders.Add("X-Use-CurrentClientIdProvider", "true");  // Signal for TestAuthenticationHandler to run
         return client;
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateDateOfBirthChangeTests.cs
@@ -1,0 +1,170 @@
+using System.Text;
+using JustEat.HttpClientInterception;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
+
+[Collection(nameof(DisableParallelization))]  // Configures EvidenceFilesHttpClient
+public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Theory]
+    [InlineData(null, "evidence.jpg", "https://place.com/evidence.jpg")]
+    [InlineData("1990-07-01", "evidence.jpg", "https://place.com/evidence.jpg")]
+    [InlineData("1990-07-01", null, "https://place.com/evidence.jpg")]
+    [InlineData("1990-07-01", "evidence.jpg", null)]
+    public async Task Post_InvalidRequest_ReturnsBadRequest(
+        string? newDateOfBirthString,
+        string? evidenceFileName,
+        string? evidenceFileUrl)
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePerson();
+
+        var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/date-of-birth-changes")
+        {
+            Content = CreateJsonContent(new
+            {
+                dateOfBirth = newDateOfBirth,
+                evidenceFileName,
+                evidenceFileUrl
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(createPersonResult.Trn!).SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_TeacherWithTrnDoesNotExist_ReturnsBadRequest()
+    {
+        // Arrange
+        var trn = await TestData.GenerateTrn();
+        var newDateOfBirth = TestData.GenerateDateOfBirth();
+
+        var evidenceFileName = "evidence.txt";
+        var evidenceFileUrl = Faker.Internet.SecureUrl();
+        var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
+
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
+        {
+            var builder = new HttpRequestInterceptionBuilder();
+
+            var evidenceFileUri = new Uri(evidenceFileUrl);
+
+            builder
+                .Requests()
+                .ForGet()
+                .ForHttps()
+                .ForHost(evidenceFileUri.Host)
+                .ForPath(evidenceFileUri.LocalPath.TrimStart('/'))
+                .Responds()
+                .WithContentStream(() => new MemoryStream(evidenceFileContent))
+                .RegisterWith(options);
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/date-of-birth-changes")
+        {
+            Content = CreateJsonContent(new
+            {
+                trn,
+                dateOfBirth = newDateOfBirth,
+                evidenceFileName,
+                evidenceFileUrl
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(trn).SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsError(response, 10001, StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePerson();
+        var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
+
+        var evidenceFileName = "evidence.txt";
+        var evidenceFileUrl = Faker.Internet.SecureUrl();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/date-of-birth-changes")
+        {
+            Content = CreateJsonContent(new
+            {
+                dateOfBirth = newDateOfBirth,
+                evidenceFileName,
+                evidenceFileUrl
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(createPersonResult.Trn!).SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsError(response, 10028, StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePerson();
+        var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
+
+        var evidenceFileName = "evidence.txt";
+        var evidenceFileUrl = Faker.Internet.SecureUrl();
+        var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
+
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
+        {
+            var builder = new HttpRequestInterceptionBuilder();
+
+            var evidenceFileUri = new Uri(evidenceFileUrl);
+
+            builder
+                .Requests()
+                .ForGet()
+                .ForHttps()
+                .ForHost(evidenceFileUri.Host)
+                .ForPath(evidenceFileUri.LocalPath.TrimStart('/'))
+                .Responds()
+                .WithContentStream(() => new MemoryStream(evidenceFileContent))
+                .RegisterWith(options);
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/date-of-birth-changes")
+        {
+            Content = CreateJsonContent(new
+            {
+                dateOfBirth = newDateOfBirth,
+                evidenceFileName,
+                evidenceFileUrl
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(createPersonResult.Trn!).SendAsync(request);
+
+        // Assert
+        var crmQuery = new QueryByAttribute(Incident.EntityLogicalName);
+        crmQuery.AddAttributeValue(Incident.Fields.CustomerId, new EntityReference(Contact.EntityLogicalName, createPersonResult.ContactId));
+        var crmResults = TestData.OrganizationService.RetrieveMultiple(crmQuery);
+        var incident = Assert.Single(crmResults.Entities).ToEntity<Incident>();
+
+        await AssertEx.JsonResponseEquals(
+            response,
+            expected: new
+            {
+                caseNumber = incident.TicketNumber
+            });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateNameChangeTests.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using JustEat.HttpClientInterception;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
+
+[Collection(nameof(DisableParallelization))]  // Configures EvidenceFilesHttpClient
+public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Theory]
+    [InlineData(null, "Middle", "Last", "evidence.jpg", "https://place.com/evidence.jpg")]
+    [InlineData("First", "Middle", null, "evidence.jpg", "https://place.com/evidence.jpg")]
+    [InlineData("First", "Middle", "Last", null, "https://place.com/evidence.jpg")]
+    [InlineData("First", "Middle", "Last", "evidence.jpg", null)]
+    public async Task Post_InvalidRequest_ReturnsBadRequest(
+        string? newFirstName,
+        string? newMiddleName,
+        string? newLastName,
+        string? evidenceFileName,
+        string? evidenceFileUrl)
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/name-changes")
+        {
+            Content = CreateJsonContent(new
+            {
+                firstName = newFirstName,
+                middleName = newMiddleName,
+                lastName = newLastName,
+                evidenceFileName,
+                evidenceFileUrl
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(createPersonResult.Trn!).SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var newFirstName = TestData.GenerateFirstName();
+        var newMiddleName = TestData.GenerateMiddleName();
+        var newLastName = TestData.GenerateLastName();
+
+        var evidenceFileName = "evidence.txt";
+        var evidenceFileUrl = Faker.Internet.SecureUrl();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/name-changes")
+        {
+            Content = CreateJsonContent(new
+            {
+                firstName = newFirstName,
+                middleName = newMiddleName,
+                lastName = newLastName,
+                evidenceFileName,
+                evidenceFileUrl
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(createPersonResult.Trn!).SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsError(response, 10028, StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var newFirstName = TestData.GenerateFirstName();
+        var newMiddleName = TestData.GenerateMiddleName();
+        var newLastName = TestData.GenerateLastName();
+
+        var evidenceFileName = "evidence.txt";
+        var evidenceFileUrl = Faker.Internet.SecureUrl();
+        var evidenceFileContent = Encoding.UTF8.GetBytes("Test file");
+
+        HostFixture.ConfigureEvidenceFilesHttpClient(options =>
+        {
+            var builder = new HttpRequestInterceptionBuilder();
+
+            var evidenceFileUri = new Uri(evidenceFileUrl);
+
+            builder
+                .Requests()
+                .ForGet()
+                .ForHttps()
+                .ForHost(evidenceFileUri.Host)
+                .ForPath(evidenceFileUri.LocalPath.TrimStart('/'))
+                .Responds()
+                .WithContentStream(() => new MemoryStream(evidenceFileContent))
+                .RegisterWith(options);
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/name-changes")
+        {
+            Content = CreateJsonContent(new
+            {
+                firstName = newFirstName,
+                middleName = newMiddleName,
+                lastName = newLastName,
+                evidenceFileName,
+                evidenceFileUrl
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(createPersonResult.Trn!).SendAsync(request);
+
+        // Assert
+        var crmQuery = new QueryByAttribute(Incident.EntityLogicalName);
+        crmQuery.AddAttributeValue(Incident.Fields.CustomerId, new EntityReference(Contact.EntityLogicalName, createPersonResult.ContactId));
+        var crmResults = TestData.OrganizationService.RetrieveMultiple(crmQuery);
+        var incident = Assert.Single(crmResults.Entities).ToEntity<Incident>();
+
+        await AssertEx.JsonResponseEquals(
+            response,
+            expected: new
+            {
+                caseNumber = incident.TicketNumber
+            });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/FindTeachersTests.cs
@@ -1,0 +1,277 @@
+using System.Diagnostics;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
+
+[Collection(nameof(DisableParallelization))]
+public class FindTeachersTests : TestBase
+{
+    public FindTeachersTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        XrmFakedContext.DeleteAllEntities<Contact>();
+        SetCurrentApiClient([ApiRoles.GetPerson]);
+    }
+
+    [Theory, RoleNamesData(except: [ApiRoles.GetPerson, ApiRoles.UpdatePerson])]
+    public async Task Get_ClientDoesNotHavePermission_ReturnsForbidden(string[] roles)
+    {
+        // Arrange
+        SetCurrentApiClient(roles);
+
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = "Smith";
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("", "Invalid matching policy.")]
+    [InlineData("BadFindBy", "The value 'BadFindBy' is not valid for FindBy.")]
+    public async Task Get_InvalidFindBy_ReturnsError(string findBy, string expectedErrorMessage)
+    {
+        // Arrange
+        var lastName = "Smith";
+        var dateOfBirth = "1990-01-01";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, "findBy", expectedErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("", "1990-01-01", "lastName", "A value is required when findBy is 'LastNameAndDateOfBirth'.")]
+    [InlineData("Smith", "", "dateOfBirth", "A value is required when findBy is 'LastNameAndDateOfBirth'.")]
+    public async Task Get_MissingPropertiesForFindBy_ReturnsError(
+        string lastName,
+        string dateOfBirth,
+        string expectedErrorPropertyName,
+        string expectedErrorMessage)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy=LastNameAndDateOfBirth&lastName={lastName}&dateOfBirth={dateOfBirth}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, expectedErrorPropertyName, expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithMatchesOnLastName_ReturnsMappedContacts()
+    {
+        // Arrange
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = "Smith";
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                total = 2,
+                query = new
+                {
+                    findBy,
+                    lastName,
+                    dateOfBirth
+                },
+                results = new[]
+                {
+                    new
+                    {
+                        trn = person1.Trn,
+                        dateOfBirth = person1.DateOfBirth,
+                        firstName = person1.FirstName,
+                        middleName = person1.MiddleName ?? "",
+                        lastName = person1.LastName,
+                        sanctions = new[]
+                        {
+                            new
+                            {
+                                code = person1.Sanctions.First().SanctionCode,
+                                startDate = person1.Sanctions.First().StartDate
+                            }
+                        },
+                        previousNames = Array.Empty<object>()
+                    },
+                    new
+                    {
+                        trn = person2.Trn,
+                        dateOfBirth = person2.DateOfBirth,
+                        firstName = person2.FirstName,
+                        middleName = person2.MiddleName,
+                        lastName = person2.LastName,
+                        sanctions = new[]
+                        {
+                            new
+                            {
+                                code = person2.Sanctions.First().SanctionCode,
+                                startDate = person2.Sanctions.First().StartDate
+                            }
+                        },
+                        previousNames = Array.Empty<object>()
+                    }
+                }
+            });
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithMatchOnPreviousName_ReturnsMappedContacts()
+    {
+        // Arrange
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = TestData.GenerateLastName();
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person3 = await TestData.CreatePerson(b => b.WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
+        var updatedLastName = TestData.GenerateChangedLastName(lastName);
+        await TestData.UpdatePerson(b => b.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                total = 2,
+                query = new
+                {
+                    findBy,
+                    lastName,
+                    dateOfBirth
+                },
+                results = new[]
+                {
+                    new
+                    {
+                        trn = person1.Trn,
+                        dateOfBirth = person1.DateOfBirth,
+                        firstName = person1.FirstName,
+                        middleName = person1.MiddleName ?? "",
+                        lastName = person1.LastName,
+                        sanctions = new[]
+                        {
+                            new
+                            {
+                                code = person1.Sanctions.First().SanctionCode,
+                                startDate = person1.Sanctions.First().StartDate
+                            }
+                        },
+                        previousNames = Array.Empty<object>()
+                    },
+                    new
+                    {
+                        trn = person2.Trn,
+                        dateOfBirth = person2.DateOfBirth,
+                        firstName = person2.FirstName,
+                        middleName = person2.MiddleName,
+                        lastName = updatedLastName,
+                        sanctions = new[]
+                        {
+                            new
+                            {
+                                code = person2.Sanctions.First().SanctionCode,
+                                startDate = person2.Sanctions.First().StartDate
+                            }
+                        },
+                        previousNames = new object[]
+                        {
+                            new
+                            {
+                                firstName = person2.FirstName,
+                                middleName = person2.MiddleName,
+                                lastName = person2.LastName
+                            }
+                        }
+                    }
+                }
+            });
+    }
+
+    [Fact]
+    public async Task Get_NonExposableSanctionCode_IsNotReturned()
+    {
+        // Arrange
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = "Smith";
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var sanctionCode = "A17";
+        Debug.Assert(!Api.V3.Constants.ExposableSanctionCodes.Contains(sanctionCode));
+        var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                total = 1,
+                query = new
+                {
+                    findBy,
+                    lastName,
+                    dateOfBirth
+                },
+                results = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth,
+                        firstName = person.FirstName,
+                        middleName = person.MiddleName ?? "",
+                        lastName = person.LastName,
+                        sanctions = Array.Empty<object>(),
+                        previousNames = Array.Empty<object>()
+                    }
+                }
+            });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonByTrnTests.cs
@@ -1,0 +1,261 @@
+using static TeachingRecordSystem.TestCommon.TestData;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
+
+public class GetPersonByTrnTests : GetPersonTestBase
+{
+    public GetPersonByTrnTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        SetCurrentApiClient([ApiRoles.GetPerson]);
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedRequest_ReturnsUnauthorized()
+    {
+        // Arrange
+        var trn = "1234567";
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{trn}");
+
+        // Act
+        var response = await GetHttpClient().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status401Unauthorized, (int)response.StatusCode);
+    }
+
+    [Theory, RoleNamesData(except: [ApiRoles.GetPerson, ApiRoles.UpdatePerson])]
+    public async Task GetTeacher_ClientDoesNotHavePermission_ReturnsForbidden(string[] roles)
+    {
+        // Arrange
+        SetCurrentApiClient(roles);
+        var trn = "1234567";
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_TrnNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var trn = "1234567";
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsExpectedResponse()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestForTeacher_ReturnsExpectedContent(GetHttpClientWithApiKey(), baseUrl, contact, qtsRegistrations: null, expectedQts: null, expectedEyts: null);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForContactWithMultiWordFirstName_ReturnsExpectedResponse()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(GetHttpClientWithApiKey(), baseUrl, contact, qtsRegistrations: null, expectedQts: null, expectedEyts: null);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestWithInduction_ReturnsExpectedInductionContent(GetHttpClientWithApiKey(), baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(GetHttpClientWithApiKey(), baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
+    {
+        var qualifications = new[]
+        {
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.NPQLL, null, IsActive:true),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.NPQSL, new DateOnly(2022, 5, 6), IsActive:false),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.NPQEYL, new DateOnly(2022, 3, 4), IsActive:true)
+        };
+
+        var contact = await CreateContact(qualifications: qualifications);
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(GetHttpClientWithApiKey(), baseUrl, contact, qualifications);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b
+            .WithTrn()
+            // MQ with no EndDate
+            .WithMandatoryQualification(b => b.WithStatus(MandatoryQualificationStatus.InProgress))
+            // MQ with no Specialism
+            .WithMandatoryQualification(b => b.WithSpecialism(null))
+            // MQ with EndDate and Specialism
+            .WithMandatoryQualification(b => b
+                .WithStatus(MandatoryQualificationStatus.Passed, endDate: new(2022, 9, 1))
+                .WithSpecialism(MandatoryQualificationSpecialism.Auditory)));
+
+        var validMq = person.MandatoryQualifications.Last();
+
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=MandatoryQualifications");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseMandatoryQualifications = jsonResponse.RootElement.GetProperty("mandatoryQualifications");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    awarded = validMq.EndDate?.ToString("yyyy-MM-dd"),
+                    specialism = validMq.Specialism?.GetTitle()
+                }
+            },
+            responseMandatoryQualifications);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
+    {
+        var qualifications = new[]
+        {
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 6), true,  "001", "001", "002", "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 2), true,  "002", "002"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, null, true,  "001", "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 8), false,  "001", "001", "002", "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, null, true,  null, "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 8), true),
+        };
+
+        var contact = await CreateContact(qualifications: qualifications);
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(GetHttpClientWithApiKey(), baseUrl, contact, qualifications);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(GetHttpClientWithApiKey(), baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(GetHttpClientWithApiKey(), baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithSanctions_ReturnsExpectedSanctionsContent()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(GetHttpClientWithApiKey(), baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(GetHttpClientWithApiKey(), baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent()
+    {
+        var contact = await CreateContact();
+        var baseUrl = $"/v3/persons/{contact.dfeta_TRN}";
+
+        await ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent(GetHttpClientWithApiKey(), baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_DateOfBirthDoesNotMatchTeachingRecord_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var dateOfBirth = person.DateOfBirth.AddDays(1);
+
+        var httpClient = GetHttpClientWithApiKey();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_DateOfBirthMatchesTeachingRecord_ReturnsOk()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithTrn());
+
+        var httpClient = GetHttpClientWithApiKey();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_DateOfBirthNotProvided_ReturnsOk()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithTrn());
+
+        var httpClient = GetHttpClientWithApiKey();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTestBase.cs
@@ -1,0 +1,825 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Xrm.Sdk;
+using TeachingRecordSystem.Api.V3.Core.SharedModels;
+using TeachingRecordSystem.Core.Dqt;
+using static TeachingRecordSystem.TestCommon.TestData;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
+
+public abstract class GetPersonTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    internal const string QualifiedTeacherTrainedTeacherStatusValue = "71";
+    internal const string QtsAwardedInWalesTeacherStatusValue = "213";
+
+    protected async Task ValidRequestForTeacher_ReturnsExpectedContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact,
+        QtsRegistration[]? qtsRegistrations,
+        (DateTime? QTSDate, string StatusDescription)? expectedQts,
+        (DateTime? EYTSDate, string StatusDescription)? expectedEyts)
+    {
+        // Arrange
+        await ConfigureMocks(contact, qtsRegistrations: qtsRegistrations);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, baseUrl);
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var expectedJson = JsonSerializer.SerializeToNode(new
+        {
+            firstName = contact.FirstName,
+            lastName = contact.LastName,
+            middleName = contact.MiddleName,
+            trn = contact.dfeta_TRN,
+            dateOfBirth = contact.BirthDate?.ToString("yyyy-MM-dd"),
+            nationalInsuranceNumber = contact.dfeta_NINumber,
+            qts = new
+            {
+                awarded = expectedQts?.QTSDate?.ToString("yyyy-MM-dd"),
+                certificateUrl = "/v3/certificates/qts",
+                statusDescription = expectedQts?.StatusDescription
+            },
+            eyts = new
+            {
+                awarded = expectedEyts?.EYTSDate?.ToString("yyyy-MM-dd"),
+                certificateUrl = "/v3/certificates/eyts",
+                statusDescription = expectedEyts?.StatusDescription
+            },
+            emailAddress = contact.EMailAddress1
+        })!;
+
+        if (expectedQts == null)
+        {
+            expectedJson["qts"] = null;
+        }
+
+        if (expectedEyts == null)
+        {
+            expectedJson["eyts"] = null;
+        }
+
+        await AssertEx.JsonResponseEquals(
+            response,
+            expectedJson,
+            StatusCodes.Status200OK);
+    }
+
+    protected async Task ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact,
+        QtsRegistration[]? qtsRegistrations,
+        (DateTime? QtsDate, string StatusDescription)? expectedQts,
+        (DateTime? EytsDate, string StatusDescription)? expectedEyts)
+    {
+        // Arrange
+        await ConfigureMocks(contact, qtsRegistrations: qtsRegistrations);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, baseUrl);
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var expectedJson = JsonSerializer.SerializeToNode(new
+        {
+            firstName = contact.dfeta_StatedFirstName,
+            lastName = contact.dfeta_StatedLastName,
+            middleName = contact.dfeta_StatedMiddleName,
+            trn = contact.dfeta_TRN,
+            dateOfBirth = contact.BirthDate?.ToString("yyyy-MM-dd"),
+            nationalInsuranceNumber = contact.dfeta_NINumber,
+            qts = new
+            {
+                awarded = expectedQts?.QtsDate?.ToString("yyyy-MM-dd"),
+                certificateUrl = "/v3/certificates/qts",
+                statusDescription = expectedQts?.StatusDescription
+            },
+            eyts = new
+            {
+                awarded = expectedEyts?.EytsDate?.ToString("yyyy-MM-dd"),
+                certificateUrl = "/v3/certificates/eyts",
+                statusDescription = expectedEyts?.StatusDescription
+            },
+            emailAddress = contact.EMailAddress1
+        })!;
+
+        if (expectedQts == null)
+        {
+            expectedJson["qts"] = null;
+        }
+        if (expectedEyts == null)
+        {
+            expectedJson["eyts"] = null;
+        }
+
+        await AssertEx.JsonResponseEquals(
+            response,
+            expectedJson,
+            StatusCodes.Status200OK);
+    }
+
+    protected async Task ValidRequestWithInduction_ReturnsExpectedInductionContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var induction = CreateInduction();
+        var inductionPeriods = CreateInductionPeriods();
+
+        await ConfigureMocks(contact, induction: induction, inductionPeriods: inductionPeriods);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=Induction");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var expectedJson = JsonSerializer.SerializeToNode(new
+        {
+            startDate = induction.dfeta_StartDate?.ToString("yyyy-MM-dd"),
+            endDate = induction.dfeta_CompletionDate?.ToString("yyyy-MM-dd"),
+            status = induction.dfeta_InductionStatus?.ToString(),
+            statusDescription = induction.dfeta_InductionStatus?.GetDescription(),
+            certificateUrl = "/v3/certificates/induction",
+            periods = new[]
+            {
+                new
+                {
+                    startDate = inductionPeriods[0].dfeta_StartDate?.ToString("yyyy-MM-dd"),
+                    endDate = inductionPeriods[0].dfeta_EndDate?.ToString("yyyy-MM-dd"),
+                    terms = inductionPeriods[0].dfeta_Numberofterms,
+                    appropriateBody = new
+                    {
+                        name = inductionPeriods[0].GetAttributeValue<AliasedValue>($"appropriatebody.{Account.Fields.Name}").Value
+                    }
+                }
+            }
+        })!;
+
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseInduction = jsonResponse.RootElement.GetProperty("induction");
+
+        AssertEx.JsonObjectEquals(expectedJson, responseInduction);
+    }
+
+    protected async Task ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var itt = CreateItt(contact);
+
+        await ConfigureMocks(contact, itt);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=InitialTeacherTraining");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseItt = jsonResponse.RootElement.GetProperty("initialTeacherTraining");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    qualification = new
+                    {
+                        name = itt.GetAttributeValue<AliasedValue>($"qualification.{dfeta_ittqualification.Fields.dfeta_name}").Value
+                    },
+                    programmeType = itt.dfeta_ProgrammeType.ToString(),
+                    programmeTypeDescription = itt.dfeta_ProgrammeType?.ConvertToEnumByValue<dfeta_ITTProgrammeType, IttProgrammeType>().GetDescription(),
+                    startDate = itt.dfeta_ProgrammeStartDate?.ToString("yyyy-MM-dd"),
+                    endDate = itt.dfeta_ProgrammeEndDate?.ToString("yyyy-MM-dd"),
+                    result = itt.dfeta_Result?.ToString(),
+                    ageRange = new
+                    {
+                        description = "11 to 16 years"
+                    },
+                    provider = new
+                    {
+                        name = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.Name}").Value,
+                        ukprn = itt.GetAttributeValue<AliasedValue>($"establishment.{Account.Fields.dfeta_UKPRN}").Value
+                    },
+                    subjects = new[]
+                    {
+                        new
+                        {
+                            code = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
+                            name = itt.GetAttributeValue<AliasedValue>($"subject1.{dfeta_ittsubject.Fields.dfeta_name}").Value
+                        },
+                        new
+                        {
+                            code = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
+                            name = itt.GetAttributeValue<AliasedValue>($"subject2.{dfeta_ittsubject.Fields.dfeta_name}").Value
+                        },
+                        new
+                        {
+                            code = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}").Value,
+                            name = itt.GetAttributeValue<AliasedValue>($"subject3.{dfeta_ittsubject.Fields.dfeta_name}").Value
+                        }
+                    }
+                }
+            },
+            responseItt);
+    }
+
+    protected async Task ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact,
+        Qualification[] qualifications)
+    {
+        // Arrange
+        var npqQualificationValid = qualifications[2];
+
+        await ConfigureMocks(contact);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=NpqQualifications");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var expectedJson = JsonSerializer.SerializeToNode(new[]
+        {
+            new
+            {
+                awarded = npqQualificationValid.CompletionOrAwardDate?.ToString("yyyy-MM-dd"),
+                type = new
+                {
+                    code = npqQualificationValid.Type.ToString(),
+                    name = npqQualificationValid.Type.GetName()
+                },
+                certificateUrl = $"/v3/certificates/npq/{npqQualificationValid.QualificationId}",
+            }
+        })!;
+
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseNpqQualifications = jsonResponse.RootElement.GetProperty("npqQualifications");
+
+        AssertEx.JsonObjectEquals(expectedJson, responseNpqQualifications);
+    }
+
+    protected async Task ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact,
+        Qualification[] qualifications)
+    {
+        // Arrange
+        await ConfigureMocks(contact);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=HigherEducationQualifications");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseHigherEducationQualifications = jsonResponse.RootElement.GetProperty("higherEducationQualifications");
+
+        var heQualification1 = await TestData.ReferenceDataCache.GetHeQualificationByValue(qualifications[0].HeQualificationValue!);
+        var heQualification1Subject1 = await TestData.ReferenceDataCache.GetHeSubjectByValue(qualifications[0].HeSubject1Value!);
+        var heQualification1Subject2 = await TestData.ReferenceDataCache.GetHeSubjectByValue(qualifications[0].HeSubject2Value!);
+        var heQualification1Subject3 = await TestData.ReferenceDataCache.GetHeSubjectByValue(qualifications[0].HeSubject3Value!);
+        var heQualification2 = await TestData.ReferenceDataCache.GetHeQualificationByValue(qualifications[1].HeQualificationValue!);
+        var heQualification2Subject1 = await TestData.ReferenceDataCache.GetHeSubjectByValue(qualifications[1].HeSubject1Value!);
+        var heQualification3 = await TestData.ReferenceDataCache.GetHeQualificationByValue(qualifications[2].HeQualificationValue!);
+        var heQualification3Subject1 = await TestData.ReferenceDataCache.GetHeSubjectByValue(qualifications[2].HeSubject1Value!);
+        var heQualification5Subject1 = await TestData.ReferenceDataCache.GetHeSubjectByValue(qualifications[4].HeSubject1Value!);
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    name = (string?)heQualification1.dfeta_name,
+                    awarded = qualifications[0].CompletionOrAwardDate?.ToString("yyyy-MM-dd"),
+                    subjects = (object[])new[]
+                    {
+                        new { code = heQualification1Subject1.dfeta_Value, name = heQualification1Subject1.dfeta_name },
+                        new { code = heQualification1Subject2.dfeta_Value, name = heQualification1Subject2.dfeta_name },
+                        new { code = heQualification1Subject3.dfeta_Value, name = heQualification1Subject3.dfeta_name },
+                    }
+                },
+                new
+                {
+                    name = (string?)heQualification2.dfeta_name,
+                    awarded = qualifications[1].CompletionOrAwardDate?.ToString("yyyy-MM-dd"),
+                    subjects = (object[])new[]
+                    {
+                        new { code = heQualification2Subject1.dfeta_Value, name = heQualification2Subject1.dfeta_name },
+                    }
+                },
+                new
+                {
+                    name =  (string?)heQualification3.dfeta_name,
+                    awarded = (string?)null,
+                    subjects = (object[])new[]
+                    {
+                        new { code = heQualification3Subject1.dfeta_Value, name = heQualification3Subject1.dfeta_name },
+                    }
+                },
+                new
+                {
+                    name = (string?)null,
+                    awarded = (string?)null,
+                    subjects = (object[])new[]
+                    {
+                        new { code = heQualification5Subject1.dfeta_Value, name = heQualification5Subject1.dfeta_name },
+                    }
+                }
+            },
+            responseHigherEducationQualifications);
+    }
+
+    protected async Task ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var changeOfNameSubject = await TestData.ReferenceDataCache.GetSubjectByTitle("Change of Name");
+
+        var incidents = new[]
+        {
+            new Incident()
+            {
+                CustomerId = contact.Id.ToEntityReference(Contact.EntityLogicalName),
+                Title = "Name change request",
+                SubjectId = changeOfNameSubject.Id.ToEntityReference(Subject.EntityLogicalName)
+            }
+        };
+
+        await ConfigureMocks(contact, incidents: incidents);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=PendingDetailChanges");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        Assert.True(jsonResponse.RootElement.GetProperty("pendingNameChange").GetBoolean());
+    }
+
+    protected async Task ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var changeOfDateOfBirthSubject = await TestData.ReferenceDataCache.GetSubjectByTitle("Change of Date of Birth");
+
+        var incidents = new[]
+        {
+            new Incident()
+            {
+                CustomerId = contact.Id.ToEntityReference(Contact.EntityLogicalName),
+                Title = "DOB change request",
+                SubjectId = changeOfDateOfBirthSubject.Id.ToEntityReference(Subject.EntityLogicalName)
+            }
+        };
+
+        await ConfigureMocks(contact, incidents: incidents);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=PendingDetailChanges");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        Assert.True(jsonResponse.RootElement.GetProperty("pendingDateOfBirthChange").GetBoolean());
+    }
+
+    protected async Task ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var sanctions = new (string SanctionCode, DateOnly? StartDate)[]
+        {
+            new("A18", null),
+            new("G1", new DateOnly(2022, 4, 1)),
+        };
+        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(Api.V3.Constants.ExposableSanctionCodes.Contains));
+
+        await ConfigureMocks(contact, sanctions: sanctions);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=Sanctions");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseSanctions = jsonResponse.RootElement.GetProperty("sanctions");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    code = sanctions[0].SanctionCode,
+                    startDate = sanctions[0].StartDate
+                },
+                new
+                {
+                    code = sanctions[1].SanctionCode,
+                    startDate = sanctions[1].StartDate
+                }
+            },
+            responseSanctions);
+    }
+
+    protected async Task ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var sanctions = new (string SanctionCode, DateOnly? StartDate)[]
+        {
+            new("B1", null),
+            new("G1", new DateOnly(2022, 4, 1)),
+        };
+        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(Api.V3.Constants.ProhibitionSanctionCodes.Contains));
+
+        await ConfigureMocks(contact, sanctions: sanctions);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=Alerts");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseAlerts = jsonResponse.RootElement.GetProperty("alerts");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    alertType = "Prohibition",
+                    dqtSanctionCode = sanctions[0].SanctionCode,
+                    startDate = sanctions[0].StartDate,
+                    endDate = (DateOnly?)null
+                },
+                new
+                {
+                    alertType = "Prohibition",
+                    dqtSanctionCode = sanctions[1].SanctionCode,
+                    startDate = sanctions[1].StartDate,
+                    endDate = (DateOnly?)null
+                }
+            },
+            responseAlerts);
+    }
+
+    protected async Task ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent(
+        HttpClient httpClient,
+        string baseUrl,
+        Contact contact)
+    {
+        // Arrange
+        var updatedFirstName = TestData.GenerateFirstName();
+        var updatedMiddleName = TestData.GenerateMiddleName();
+        var updatedLastName = TestData.GenerateLastName();
+        var updatedNames = new[]
+        {
+            (FirstName: updatedFirstName, MiddleName: updatedMiddleName, contact.LastName),
+            (FirstName: updatedFirstName, MiddleName: updatedMiddleName, LastName: updatedLastName)
+        };
+
+        await ConfigureMocks(contact, updatedNames: updatedNames!);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=PreviousNames");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responsePreviousNames = jsonResponse.RootElement.GetProperty("previousNames");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    firstName = updatedFirstName,
+                    middleName = updatedMiddleName,
+                    lastName = contact.LastName,
+                },
+                new
+                {
+                    firstName = contact.FirstName,
+                    middleName = contact.MiddleName,
+                    lastName = contact.LastName,
+                }
+            },
+            responsePreviousNames);
+    }
+
+    protected async Task<Contact> CreateContact(
+        QtsRegistration[]? qtsRegistrations = null,
+        Qualification[]? qualifications = null,
+        bool hasMultiWordFirstName = false)
+    {
+        var firstName = hasMultiWordFirstName ? $"{Faker.Name.First()} {Faker.Name.First()}" : Faker.Name.First();
+
+        var person = await TestData.CreatePerson(
+            b =>
+            {
+                b.WithFirstName(firstName).WithTrn();
+
+                foreach (var item in qtsRegistrations ?? Array.Empty<QtsRegistration>())
+                {
+                    b.WithQtsRegistration(item!.QtsDate, item!.TeacherStatusValue, item.CreatedOn, item!.EytsDate, item!.EytsStatusValue);
+                }
+
+                foreach (var item in qualifications ?? Array.Empty<Qualification>())
+                {
+                    b.WithQualification(item.QualificationId, item.Type, item.CompletionOrAwardDate, item.IsActive, item.HeQualificationValue, item.HeSubject1Value, item.HeSubject2Value, item.HeSubject3Value);
+                }
+            });
+
+        return person.Contact;
+    }
+
+    private async Task ConfigureMocks(
+        Contact contact,
+        dfeta_initialteachertraining? itt = null,
+        dfeta_induction? induction = null,
+        dfeta_inductionperiod[]? inductionPeriods = null,
+        dfeta_qualification[]? qualifications = null,
+        Incident[]? incidents = null,
+        (string FirstName, string? MiddleName, string LastName)[]? updatedNames = null,
+        (string SanctionCode, DateOnly? StartDate)[]? sanctions = null,
+        QtsRegistration[]? qtsRegistrations = null)
+    {
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacherByTrn(contact.dfeta_TRN, /* columnNames: */ It.IsAny<string[]>(), /* activeOnly: */ true))
+            .ReturnsAsync(contact);
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetInitialTeacherTrainingByTeacher(
+                contact.Id,
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                /*activeOnly: */true))
+            .ReturnsAsync(itt != null ? new[] { itt } : Array.Empty<dfeta_initialteachertraining>());
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetInductionByTeacher(
+                contact.Id,
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>(),
+                It.IsAny<string[]>()))
+            .ReturnsAsync((induction, inductionPeriods));
+
+        DataverseAdapterMock
+             .Setup(mock => mock.GetQualificationsForTeacher(
+                 contact.Id,
+                 It.IsAny<string[]>(),
+                 It.IsAny<string[]>(),
+                 It.IsAny<string[]>()))
+             .ReturnsAsync(qualifications ?? Array.Empty<dfeta_qualification>());
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetIncidentsByContactId(contact.Id, IncidentState.Active, It.IsAny<string[]>()))
+            .ReturnsAsync(incidents ?? Array.Empty<Incident>());
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetTeacherStatus(
+                It.Is<string>(s => s == QtsAwardedInWalesTeacherStatusValue),
+                It.IsAny<RequestBuilder>()))
+            .Returns(async (string s, RequestBuilder b) => await TestData.ReferenceDataCache.GetTeacherStatusByValue(s));
+
+        using var ctx = new DqtCrmServiceContext(TestData.OrganizationService);
+        var qtsRegs = ctx.dfeta_qtsregistrationSet
+            .Where(c => c.GetAttributeValue<Guid>(dfeta_qtsregistration.Fields.dfeta_PersonId) == contact.Id)
+            .ToArray();
+
+        DataverseAdapterMock
+            .Setup(mock => mock.GetQtsRegistrationsByTeacher(
+                contact.Id,
+                It.IsAny<string[]>()))
+            .ReturnsAsync(qtsRegs ?? Array.Empty<dfeta_qtsregistration>());
+
+        var allEytsStatuses = await TestData.ReferenceDataCache.GetEytsStatuses();
+        var distinctEyts = qtsRegistrations?.Where(x => !string.IsNullOrEmpty(x.EytsStatusValue)).Select(x => x.EytsStatusValue).Distinct().ToArray();
+        Array.ForEach(distinctEyts ?? Array.Empty<string>(), item =>
+        {
+            var eytsStatus = allEytsStatuses.Single(x => x.dfeta_Value == item);
+            DataverseAdapterMock
+                .Setup(mock => mock.GetEarlyYearsStatus(eytsStatus.Id))
+                .ReturnsAsync(eytsStatus);
+        });
+
+        foreach (var qtsRegistration in qtsRegistrations ?? Array.Empty<QtsRegistration>())
+        {
+            var teacherStatus = !string.IsNullOrEmpty(qtsRegistration.TeacherStatusValue) ? await TestData.ReferenceDataCache.GetTeacherStatusByValue(qtsRegistration.TeacherStatusValue) : null;
+            var eytsStatus = !string.IsNullOrEmpty(qtsRegistration.EytsStatusValue) ? await TestData.ReferenceDataCache.GetEarlyYearsStatusByValue(qtsRegistration.EytsStatusValue) : null;
+
+            await TestData.OrganizationService.CreateAsync(new dfeta_qtsregistration()
+            {
+                Id = Guid.NewGuid(),
+                dfeta_PersonId = contact.Id.ToEntityReference(Contact.EntityLogicalName),
+                dfeta_QTSDate = qtsRegistration.QtsDate?.ToDateTime(),
+                dfeta_EYTSDate = qtsRegistration.EytsDate?.ToDateTime(),
+                CreatedOn = qtsRegistration.CreatedOn,
+                dfeta_TeacherStatusId = teacherStatus?.Id.ToEntityReference(dfeta_teacherstatus.EntityLogicalName),
+                dfeta_EarlyYearsStatusId = eytsStatus?.Id.ToEntityReference(dfeta_earlyyearsstatus.EntityLogicalName),
+            });
+        }
+
+        foreach (var sanction in sanctions ?? Array.Empty<(string, DateOnly?)>())
+        {
+            var sanctionCode = await TestData.ReferenceDataCache.GetSanctionCodeByValue(sanction.SanctionCode);
+
+            await TestData.OrganizationService.CreateAsync(new dfeta_sanction()
+            {
+                Id = Guid.NewGuid(),
+                dfeta_PersonId = contact.Id.ToEntityReference(Contact.EntityLogicalName),
+                dfeta_SanctionCodeId = sanctionCode.Id.ToEntityReference(dfeta_sanctioncode.EntityLogicalName),
+                dfeta_Spent = false,
+                dfeta_StartDate = sanction.StartDate?.ToDateTimeWithDqtBstFix(isLocalTime: true)
+            });
+        }
+
+        foreach (var updatedName in updatedNames ?? Array.Empty<(string, string?, string)>())
+        {
+            await TestData.UpdatePerson(b => b.WithPersonId(contact.Id).WithUpdatedName(updatedName.FirstName, updatedName.MiddleName, updatedName.LastName));
+            await Task.Delay(2000);
+        }
+    }
+
+    private static dfeta_initialteachertraining CreateItt(Contact teacher)
+    {
+        var ittStartDate = new DateOnly(2021, 9, 7);
+        var ittEndDate = new DateOnly(2022, 7, 29);
+        var ittProgrammeType = Api.V3.V20240101.ApiModels.IttProgrammeType.EYITTGraduateEntry;
+        var ittResult = Api.V3.V20240101.ApiModels.IttOutcome.Pass;
+        var ittAgeRangeFrom = dfeta_AgeRange._11;
+        var ittAgeRangeTo = dfeta_AgeRange._16;
+        var ittProviderName = Faker.Company.Name();
+        var ittProviderUkprn = "12345";
+        var ittTraineeId = "54321";
+        var ittSubject1Value = "12345";
+        var ittSubject1Name = "Subject 1";
+        var ittSubject2Value = "23456";
+        var ittSubject2Name = "Subject 2";
+        var ittSubject3Value = "34567";
+        var ittSubject3Name = "Subject 3";
+        var ittQualificationName = "My test qualification 123";
+
+        var itt = new dfeta_initialteachertraining()
+        {
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, teacher.Id),
+            dfeta_ProgrammeStartDate = ittStartDate.ToDateTime(),
+            dfeta_ProgrammeEndDate = ittEndDate.ToDateTime(),
+            dfeta_ProgrammeType = Enum.Parse<IttProgrammeType>(ittProgrammeType.ToString()).ConvertToIttProgrammeType(),
+            dfeta_Result = Enum.Parse<IttOutcome>(ittResult.ToString()).ConvertToITTResult(),
+            dfeta_AgeRangeFrom = ittAgeRangeFrom,
+            dfeta_AgeRangeTo = ittAgeRangeTo,
+            dfeta_TraineeID = ittTraineeId,
+            StateCode = dfeta_initialteachertrainingState.Active
+        };
+
+        itt.Attributes.Add($"qualification.{dfeta_ittqualification.PrimaryIdAttribute}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"qualification.{dfeta_ittqualification.Fields.dfeta_name}", new AliasedValue(dfeta_ittqualification.EntityLogicalName, dfeta_ittqualification.Fields.dfeta_name, ittQualificationName));
+        itt.Attributes.Add($"establishment.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"establishment.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, ittProviderName));
+        itt.Attributes.Add($"establishment.{Account.Fields.dfeta_UKPRN}", new AliasedValue(Account.EntityLogicalName, Account.Fields.dfeta_UKPRN, ittProviderUkprn));
+        itt.Attributes.Add($"subject1.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject1Value));
+        itt.Attributes.Add($"subject1.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject1Name));
+        itt.Attributes.Add($"subject2.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject2Value));
+        itt.Attributes.Add($"subject2.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject2Name));
+        itt.Attributes.Add($"subject3.{dfeta_ittsubject.PrimaryIdAttribute}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.PrimaryIdAttribute, Guid.NewGuid()));
+        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_Value}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_Value, ittSubject3Value));
+        itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject3Name));
+
+        return itt;
+    }
+
+    private static dfeta_induction CreateInduction()
+    {
+        var inductionStartDate = new DateOnly(1996, 2, 3);
+        var inductionEndDate = new DateOnly(1996, 6, 7);
+        var inductionStatus = dfeta_InductionStatus.Pass;
+
+        return new dfeta_induction()
+        {
+            dfeta_StartDate = inductionStartDate.ToDateTime(),
+            dfeta_CompletionDate = inductionEndDate.ToDateTime(),
+            dfeta_InductionStatus = inductionStatus
+        };
+    }
+
+    private static dfeta_inductionperiod[] CreateInductionPeriods()
+    {
+        var inductionPeriodStartDate = new DateOnly(1996, 2, 3);
+        var inductionPeriodEndDate = new DateOnly(1996, 6, 7);
+        var inductionPeriodTerms = 3;
+        var inductionPeriodAppropriateBodyName = "My appropriate body";
+
+        var inductionPeriod = new dfeta_inductionperiod()
+        {
+            dfeta_StartDate = inductionPeriodStartDate.ToDateTime(),
+            dfeta_EndDate = inductionPeriodEndDate.ToDateTime(),
+            dfeta_Numberofterms = inductionPeriodTerms
+        };
+
+        inductionPeriod.Attributes.Add($"appropriatebody.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
+        inductionPeriod.Attributes.Add($"appropriatebody.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, inductionPeriodAppropriateBodyName));
+
+        return new[]
+        {
+            inductionPeriod
+        };
+    }
+
+    private static dfeta_qualification CreateQualification(
+        dfeta_qualification_dfeta_Type type,
+        DateTime? date,
+        dfeta_qualificationState state,
+        string? specialismName,
+        string? heName = null,
+        (string Code, string Name)? heSubject1 = null,
+        (string Code, string Name)? heSubject2 = null,
+        (string Code, string Name)? heSubject3 = null)
+    {
+        var qualification = new dfeta_qualification
+        {
+            Id = Guid.NewGuid(),
+            dfeta_Type = type,
+            StateCode = state
+        };
+
+        if (type == dfeta_qualification_dfeta_Type.MandatoryQualification)
+        {
+            qualification.dfeta_MQ_Date = date;
+        }
+        else
+        {
+            qualification.dfeta_CompletionorAwardDate = date;
+        }
+
+        if (type == dfeta_qualification_dfeta_Type.HigherEducation)
+        {
+            if (heName is not null)
+            {
+                qualification.Attributes.Add($"{nameof(dfeta_hequalification)}.{dfeta_hequalification.PrimaryIdAttribute}", new AliasedValue(dfeta_hequalification.EntityLogicalName, dfeta_hequalification.PrimaryIdAttribute, Guid.NewGuid()));
+                qualification.Attributes.Add($"{nameof(dfeta_hequalification)}.{dfeta_hequalification.Fields.dfeta_name}", new AliasedValue(dfeta_hequalification.EntityLogicalName, dfeta_hequalification.Fields.dfeta_name, heName));
+            }
+
+            if (heSubject1 != null)
+            {
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}1.{dfeta_hesubject.PrimaryIdAttribute}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.PrimaryIdAttribute, Guid.NewGuid()));
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}1.{dfeta_hesubject.Fields.dfeta_name}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.Fields.dfeta_name, heSubject1.Value.Name));
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}1.{dfeta_hesubject.Fields.dfeta_Value}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.Fields.dfeta_Value, heSubject1.Value.Code));
+            }
+
+            if (heSubject2 != null)
+            {
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}2.{dfeta_hesubject.PrimaryIdAttribute}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.PrimaryIdAttribute, Guid.NewGuid()));
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}2.{dfeta_hesubject.Fields.dfeta_name}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.Fields.dfeta_name, heSubject2.Value.Name));
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}2.{dfeta_hesubject.Fields.dfeta_Value}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.Fields.dfeta_Value, heSubject2.Value.Code));
+            }
+
+            if (heSubject3 != null)
+            {
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}3.{dfeta_hesubject.PrimaryIdAttribute}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.PrimaryIdAttribute, Guid.NewGuid()));
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}3.{dfeta_hesubject.Fields.dfeta_name}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.Fields.dfeta_name, heSubject3.Value.Name));
+                qualification.Attributes.Add($"{nameof(dfeta_hesubject)}3.{dfeta_hesubject.Fields.dfeta_Value}", new AliasedValue(dfeta_hesubject.EntityLogicalName, dfeta_hesubject.Fields.dfeta_Value, heSubject3.Value.Code));
+            }
+        }
+
+        if (specialismName is not null)
+        {
+            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.PrimaryIdAttribute}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.PrimaryIdAttribute, Guid.NewGuid()));
+            qualification.Attributes.Add($"{dfeta_specialism.EntityLogicalName}.{dfeta_specialism.Fields.dfeta_name}", new AliasedValue(dfeta_specialism.EntityLogicalName, dfeta_specialism.Fields.dfeta_name, specialismName));
+        }
+
+        return qualification;
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTests.cs
@@ -1,0 +1,297 @@
+using static TeachingRecordSystem.TestCommon.TestData;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
+
+public class GetPersonTests(HostFixture hostFixture) : GetPersonTestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_TeacherWithTrnDoesNotExist_ReturnsForbidden()
+    {
+        // Arrange
+        var trn = "1234567";
+        var httpClient = GetHttpClientWithIdentityAccessToken(trn);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person");
+
+        // Act
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("28", "Qualified")]
+    [InlineData("50", "Qualified")]
+    [InlineData("67", "Qualified")]
+    [InlineData("68", "Qualified")]
+    [InlineData("69", "Qualified")]
+    [InlineData("71", "Qualified")]
+    [InlineData("87", "Qualified")]
+    [InlineData("90", "Qualified")]
+    [InlineData("100", "Qualified")]
+    [InlineData("103", "Qualified")]
+    [InlineData("104", "Qualified")]
+    [InlineData("206", "Qualified")]
+    [InlineData("211", "Trainee teacher")]
+    [InlineData("212", "Assessment only route candidate")]
+    [InlineData("214", "Partial qualified teacher status")]
+    public async Task Get_ValidRequestWithSingleQts_ReturnsExpectedResponse(string qtsStatusValue, string qtsStatusDescription)
+    {
+        var qtsDate = new DateOnly(2021, 01, 01);
+        var qtsCreatedDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, qtsStatusValue, qtsCreatedDate, null, null)
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), qtsStatusDescription), expectedEyts: null);
+    }
+
+    [Theory]
+    [InlineData("220", "Early years trainee")]
+    [InlineData("221", "Qualified")]
+    [InlineData("222", "Early years professional status")]
+    public async Task Get_ValidRequestWithSingleEYTS_ReturnsExpectedResponse(string eytsStatusValue, string eytsStatusDescription)
+    {
+        var eytsDate = new DateOnly(2021, 01, 01);
+        var createdDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(null, null, createdDate, eytsDate, eytsStatusValue)
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qtsRegistrations: qts, expectedQts: null, expectedEyts: (eytsDate.ToDateTime(), eytsStatusDescription));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithoutEYTSorQTS_ReturnsExpectedResponse()
+    {
+        var contact = await CreateContact(null);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qtsRegistrations: null, expectedQts: null, expectedEyts: null);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithEYTSandQTS_ReturnsExpectedResponse()
+    {
+        var qtsDate = new DateOnly(2021, 05, 15);
+        var eytsDate = new DateOnly(2021, 01, 01);
+        var createdDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, "212", createdDate, eytsDate, "220")
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), "Assessment only route candidate"), expectedEyts: (eytsDate.ToDateTime(), "Early years trainee"));
+    }
+
+    [Fact]
+    public async Task Get_MultipleQTSRecords_ReturnsMostRecent()
+    {
+        var qtsDate1 = new DateOnly(2021, 05, 15);
+        var qtsDate2 = new DateOnly(2021, 06, 15);
+        var createdDate1 = new DateTime(2021, 05, 15);
+        var createdDate2 = new DateTime(2021, 06, 15);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate1, "212", createdDate1, null, null),
+            new QtsRegistration(qtsDate2, "212", createdDate2, null, null)
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qtsRegistrations: qts, expectedQts: (qtsDate2.ToDateTime(), "Assessment only route candidate"), expectedEyts: null);
+    }
+
+    [Fact]
+    public async Task Get_MultipleEYTSRecords_ReturnsMostRecent()
+    {
+        var eytsDate1 = new DateOnly(2021, 05, 15);
+        var eytsDate2 = new DateOnly(2021, 06, 15);
+        var createdDate1 = new DateTime(2021, 05, 15);
+        var createdDate2 = new DateTime(2021, 06, 15);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(null, null, createdDate1, eytsDate1, "220"),
+            new QtsRegistration(null, null, createdDate2, eytsDate2, "220")
+        };
+        var contact = await CreateContact(qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestForTeacher_ReturnsExpectedContent(httpClient, baseUrl, contact, qtsRegistrations: qts, expectedQts: null, expectedEyts: (eytsDate2.ToDateTime(), "Early years trainee"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForContactWithMultiWordFirstName_ReturnsExpectedResponse()
+    {
+        var qtsDate = new DateOnly(2021, 05, 15);
+        var eytsDate = new DateOnly(2021, 01, 01);
+        var createdDate = new DateTime(2021, 01, 01);
+        var qts = new QtsRegistration[]
+        {
+            new QtsRegistration(qtsDate, "212", createdDate, eytsDate, "220")
+        };
+        var contact = await CreateContact(hasMultiWordFirstName: true, qtsRegistrations: qts);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestForTeacherWithMultiWordFirstName_ReturnsExpectedContent(httpClient, baseUrl, contact, qtsRegistrations: qts, expectedQts: (qtsDate.ToDateTime(), "Assessment only route candidate"), expectedEyts: (eytsDate.ToDateTime(), "Early years trainee"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(httpClient, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent()
+    {
+        var qualifications = new[]
+{
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.NPQLL, null, IsActive:true),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.NPQSL, new DateOnly(2022, 5, 6), IsActive:false),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.NPQEYL, new DateOnly(2022, 3, 4), IsActive:true)
+        };
+
+        var contact = await CreateContact(qualifications: qualifications);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestWithNpqQualifications_ReturnsExpectedNpqQualificationsContent(httpClient, baseUrl, contact, qualifications);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b
+            .WithTrn()
+            // MQ with no EndDate
+            .WithMandatoryQualification(b => b.WithStatus(MandatoryQualificationStatus.InProgress))
+            // MQ with no Specialism
+            .WithMandatoryQualification(b => b.WithSpecialism(null))
+            // MQ with EndDate and Specialism
+            .WithMandatoryQualification(b => b
+                .WithStatus(MandatoryQualificationStatus.Passed, endDate: new(2022, 9, 1))
+                .WithSpecialism(MandatoryQualificationSpecialism.Auditory)));
+
+        var validMq = person.MandatoryQualifications.Last();
+
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person?include=MandatoryQualifications");
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(person.Trn!).SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseMandatoryQualifications = jsonResponse.RootElement.GetProperty("mandatoryQualifications");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    awarded = validMq.EndDate?.ToString("yyyy-MM-dd"),
+                    specialism = validMq.Specialism?.GetTitle()
+                }
+            },
+            responseMandatoryQualifications);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent()
+    {
+        var qualifications = new[]
+        {
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 6), true,  "001", "001", "002", "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 2), true,  "002", "002"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, null, true,  "001", "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 8), false,  "001", "001", "002", "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, null, true,  null, "003"),
+            new Qualification(Guid.NewGuid(), dfeta_qualification_dfeta_Type.HigherEducation, new DateOnly(2022, 4, 8), true),
+        };
+
+        var contact = await CreateContact(qualifications: qualifications);
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "/v3/person";
+
+        await ValidRequestWithHigherEducationQualifications_ReturnsExpectedHigherEducationQualificationsContent(httpClient, baseUrl, contact, qualifications);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "v3/person";
+
+        await ValidRequestForContactWithPendingNameChange_ReturnsPendingNameChangeTrue(httpClient, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "v3/person";
+
+        await ValidRequestForContactWithPendingDateOfBirthChange_ReturnsPendingDateOfBirthChangeTrue(httpClient, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithSanctions_ReturnsExpectedSanctionsContent()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "v3/person";
+
+        await ValidRequestWithSanctions_ReturnsExpectedSanctionsContent(httpClient, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithAlerts_ReturnsExpectedSanctionsContent()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "v3/person";
+
+        await ValidRequestWithAlerts_ReturnsExpectedSanctionsContent(httpClient, baseUrl, contact);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent()
+    {
+        var contact = await CreateContact();
+        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
+        var baseUrl = "v3/person";
+
+        await ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent(httpClient, baseUrl, contact);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/TestBase.cs
@@ -1,10 +1,12 @@
 namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
 
-public abstract class TestBase : Tests.TestBase
+public abstract class TestBase(HostFixture hostFixture) : Tests.TestBase(hostFixture)
 {
-    protected TestBase(HostFixture hostFixture) : base(hostFixture)
-    {
-    }
+    public const string Version = VersionRegistry.V3MinorVersions.V20240606;
 
-    public HttpClient GetHttpClientWithApiKey() => GetHttpClientWithApiKey(VersionRegistry.V3MinorVersions.V20240606);
+    public HttpClient GetHttpClient() => GetHttpClient(Version);
+
+    public HttpClient GetHttpClientWithApiKey() => GetHttpClientWithApiKey(Version);
+
+    public HttpClient GetHttpClientWithIdentityAccessToken(string trn) => GetHttpClientWithIdentityAccessToken(trn, version: Version);
 }


### PR DESCRIPTION
This moves all `/teacher` and `/teachers` endpoints to `/person` and `/persons`, respectively. The PR looks large but it's largely copy/paste.

I've also renamed `email` to `emailAddress`, to be consistent with what we're now doing on the TRN request endpoints.