### PR TITLE
Small content change to request a TRN journey check answers page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
@@ -51,7 +51,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "No")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "None")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.RequestTrnNationalInsuranceNumber(Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="national insurance number">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/CheckAnswersTests.cs
@@ -263,7 +263,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         }
         else
         {
-            Assert.Equal("No", doc.GetSummaryListValueForKey("National Insurance number"));
+            Assert.Equal("None", doc.GetSummaryListValueForKey("National Insurance number"));
             var address = doc.GetSummaryListValueForKey("Address");
             Assert.Contains(state.AddressLine1!, address);
             Assert.Contains(state.AddressLine2!, address);


### PR DESCRIPTION
Tiny change to display the word "None" rather than "No" next to the label National Insurance number if a user has said that they don't have a NINO