### PR TITLE
Change endpoints to return contact.inductionstatus

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V1/Handlers/GetTeacherHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V1/Handlers/GetTeacherHandler.cs
@@ -90,19 +90,24 @@ public class GetTeacherHandler : IRequestHandler<GetTeacherRequest, GetTeacherRe
         Induction MapInduction()
         {
             var induction = teacher.Extract<dfeta_induction>();
+            var inductionStatus = teacher.FormattedValues.ContainsKey(Contact.Fields.dfeta_InductionStatus) ? teacher.FormattedValues[Contact.Fields.dfeta_InductionStatus] : null;
 
             return induction != null ?
                 new Induction()
                 {
                     StartDate = induction.dfeta_StartDate,
                     CompletionDate = induction.dfeta_CompletionDate,
-                    InductionStatusName = induction.FormattedValues.ContainsKey(dfeta_induction.Fields.dfeta_InductionStatus) ?
-                        induction.FormattedValues[dfeta_induction.Fields.dfeta_InductionStatus] :
-                        null,
+                    InductionStatusName = inductionStatus,
                     State = induction.StateCode.Value,
                     StateName = induction.FormattedValues[dfeta_induction.Fields.StateCode]
                 } :
-                null;
+                !string.IsNullOrEmpty(inductionStatus) ?
+                    new Induction()
+                    {
+                        StartDate = null,
+                        CompletionDate = null,
+                        InductionStatusName = inductionStatus
+                    } : null;
         }
 
         QualifiedTeacherStatus MapQualifiedTeacherStatus()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataCollectionExtensions.cs
@@ -10,7 +10,7 @@ internal static class DataCollectionExtensions
     {
         var destinationCollection = new U();
 
-        foreach (var keyValuePair in sourceCollection.Where(kvp => kvp.Key.StartsWith(prefix)))
+        foreach (var keyValuePair in sourceCollection.Where(kvp => kvp.Key.StartsWith(prefix + ".")))
         {
             var newKey = keyValuePair.Key.Remove(0, prefix.Length + 1);
             destinationCollection.Add(newKey, getValue(keyValuePair));

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/DataverseAdapter.cs
@@ -416,7 +416,8 @@ public partial class DataverseAdapter : IDataverseAdapter
                 Contact.Fields.dfeta_TRN,
                 Contact.Fields.dfeta_NINumber,
                 Contact.Fields.BirthDate,
-                Contact.Fields.dfeta_ActiveSanctions
+                Contact.Fields.dfeta_ActiveSanctions,
+                Contact.Fields.dfeta_InductionStatus
             ),
             Criteria = filter
         };

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V1/UnitTests/GetTeacherHandlerTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V1/UnitTests/GetTeacherHandlerTests.cs
@@ -108,6 +108,7 @@ public class GetTeacherHandlerTests
             {
                 { Contact.Fields.StateCode, ContactState.Active.ToString() },
                 { $"{prefix}.{dfeta_induction.Fields.dfeta_InductionStatus}", inductionStatusName },
+                { $"{Contact.Fields.dfeta_InductionStatus}", inductionStatusName },
                 { $"{prefix}.{dfeta_induction.Fields.StateCode}", dfeta_inductionState.Active.ToString() }
             }
         };
@@ -283,5 +284,49 @@ public class GetTeacherHandlerTests
                 Assert.Equal("MandatoryQualification", qualification.Name);
                 Assert.Equal(new DateTime(2021, 12, 2), qualification.DateAwarded);
             });
+    }
+
+    [Theory]
+    [InlineData(dfeta_InductionStatus.Pass, dfeta_InductionStatus.Pass)]
+    [InlineData(dfeta_InductionStatus.Exempt, dfeta_InductionStatus.Exempt)]
+    public void Given_contact_has_induction_the_details_are_mapped(dfeta_InductionStatus inductionStatus, dfeta_InductionStatus expectedInductionStatus)
+    {
+        var completionDate = new DateTime(2021, 1, 1);
+        var inductionStatusName = inductionStatus.ToString();
+        var startDate = new DateTime(2020, 10, 1);
+
+        var prefix = nameof(dfeta_induction);
+
+        var contact = new Contact
+        {
+            dfeta_ActiveSanctions = false,
+            StateCode = ContactState.Active,
+            Attributes =
+            {
+                { $"{prefix}.{dfeta_induction.Fields.dfeta_CompletionDate}",
+                    new AliasedValue(dfeta_induction.EntityLogicalName, dfeta_induction.Fields.dfeta_CompletionDate, completionDate) },
+                { $"{prefix}.{dfeta_induction.Fields.dfeta_StartDate}",
+                    new AliasedValue(dfeta_induction.EntityLogicalName, dfeta_induction.Fields.dfeta_StartDate, startDate) },
+                { $"{prefix}.{dfeta_induction.Fields.StateCode}",
+                    new AliasedValue(dfeta_induction.EntityLogicalName, dfeta_induction.Fields.StateCode, new OptionSetValue((int)dfeta_inductionState.Active)) },
+                { $"{prefix}.{dfeta_induction.PrimaryIdAttribute}",
+                    new AliasedValue(dfeta_induction.EntityLogicalName, dfeta_induction.PrimaryIdAttribute, Guid.NewGuid())}
+            },
+            FormattedValues =
+            {
+                { Contact.Fields.StateCode, ContactState.Active.ToString() },
+                { $"{prefix}.{dfeta_induction.Fields.dfeta_InductionStatus}", inductionStatusName },
+                { $"{Contact.Fields.dfeta_InductionStatus}", inductionStatusName },
+                { $"{prefix}.{dfeta_induction.Fields.StateCode}", dfeta_inductionState.Active.ToString() }
+            }
+        };
+
+        var response = GetTeacherHandler.MapContactToResponse(contact);
+
+        var induction = response.Induction;
+
+        Assert.NotNull(induction);
+        Assert.Equal(completionDate, induction.CompletionDate);
+        Assert.Equal(expectedInductionStatus.ToString(), induction.InductionStatusName);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTestBase.cs
@@ -144,8 +144,8 @@ public abstract class GetTeacherTestBase(HostFixture hostFixture) : TestBase(hos
         {
             startDate = induction.dfeta_StartDate?.ToString("yyyy-MM-dd"),
             endDate = induction.dfeta_CompletionDate?.ToString("yyyy-MM-dd"),
-            status = induction.dfeta_InductionStatus?.ToString(),
-            statusDescription = induction.dfeta_InductionStatus?.GetDescription(),
+            status = contact.dfeta_InductionStatus?.ToString(),
+            statusDescription = contact.dfeta_InductionStatus?.GetDescription(),
             certificateUrl = "/v3/certificates/induction",
             periods = new[]
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTestBase.cs
@@ -144,8 +144,8 @@ public abstract class GetPersonTestBase(HostFixture hostFixture) : TestBase(host
         {
             startDate = induction.dfeta_StartDate?.ToString("yyyy-MM-dd"),
             endDate = induction.dfeta_CompletionDate?.ToString("yyyy-MM-dd"),
-            status = induction.dfeta_InductionStatus?.ToString(),
-            statusDescription = induction.dfeta_InductionStatus?.GetDescription(),
+            status = contact.dfeta_InductionStatus?.ToString(),
+            statusDescription = contact.dfeta_InductionStatus?.GetDescription(),
             certificateUrl = "/v3/certificates/induction",
             periods = new[]
             {


### PR DESCRIPTION
### Context

Update v1 & v3 getteacher endpoints to use contact.inductionstatus

https://trello.com/c/ek0fcrle/54-update-api-to-use-contact-level-induction-status

### Changes proposed in this pull request

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
