### PR TITLE
Ensure we don't miss events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/PublishEventsBackgroundService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/PublishEventsBackgroundService.cs
@@ -59,7 +59,7 @@ public class PublishEventsBackgroundService : BackgroundService
                 .FromSql($"""
                     select * from events
                     where published is false
-                    and inserted > {lastProcessedEventTimestamp}
+                    and inserted >= {lastProcessedEventTimestamp}
                     and event_id != {lastProcessedEventId}
                     order by inserted, created
                     for update skip locked


### PR DESCRIPTION
The query that returns events could miss an event if it shares an `inserted` timestamp with the last inserted event from the previous batch. This fixes that.