### PR TITLE
Shorten timeout and add retries to TrnGenerationApiClient

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnGenerationApi/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnGenerationApi/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
                 var options = sp.GetRequiredService<IOptions<TrnGenerationApiOptions>>();
                 httpClient.BaseAddress = new Uri(options.Value.BaseAddress);
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.Value.ApiKey);
+                httpClient.Timeout = TimeSpan.FromSeconds(5);
             });
 
         return services;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnGenerationApi/TrnGenerationApiClient.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnGenerationApi/TrnGenerationApiClient.cs
@@ -1,17 +1,29 @@
+using Polly;
+
 namespace TeachingRecordSystem.Core.Services.TrnGenerationApi;
 
 public class TrnGenerationApiClient : ITrnGenerationApiClient
 {
     private readonly HttpClient _httpClient;
+    private readonly ResiliencePipeline _resiliencePipeline;
 
     public TrnGenerationApiClient(HttpClient httpClient)
     {
         _httpClient = httpClient;
+
+        _resiliencePipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new Polly.Retry.RetryStrategyOptions()
+            {
+                BackoffType = DelayBackoffType.Constant,
+                Delay = TimeSpan.FromSeconds(0),
+                MaxRetryAttempts = 2
+            })
+            .Build();
     }
 
     public async Task<string> GenerateTrn()
     {
-        var response = await _httpClient.PostAsync("/api/v1/trn-requests", null);
+        var response = await _resiliencePipeline.ExecuteAsync(async _ => await _httpClient.PostAsync("/api/v1/trn-requests", null));
 
         if (!response.IsSuccessStatusCode)
         {


### PR DESCRIPTION
We've got a few timeout errors in Sentry that originate from `TrnGenerationApiClient.GenerateTrn()`. This adds retries and significantly reduces the request timeout from the default 100 seconds to 5.