### PR TITLE
Add NINO and postcode from workforce data into person_search_attributes

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonEmploymentMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonEmploymentMapping.cs
@@ -14,8 +14,10 @@ public class PersonEmploymentMapping : IEntityTypeConfiguration<PersonEmployment
         builder.Property(e => e.EmploymentType).IsRequired();
         builder.Property(e => e.CreatedOn).IsRequired();
         builder.Property(e => e.UpdatedOn).IsRequired();
-        builder.Property(x => x.Key).HasMaxLength(50).IsRequired();
-        builder.HasIndex(x => x.Key).HasDatabaseName(PersonEmployment.KeyIndexName);
+        builder.Property(e => e.Key).HasMaxLength(50).IsRequired();
+        builder.Property(e => e.NationalInsuranceNumber).HasMaxLength(9).IsFixedLength();
+        builder.Property(e => e.PersonPostcode).HasMaxLength(10);
+        builder.HasIndex(e => e.Key).HasDatabaseName(PersonEmployment.KeyIndexName);
         builder.HasIndex(e => e.PersonId).HasDatabaseName(PersonEmployment.PersonIdIndexName);
         builder.HasIndex(e => e.EstablishmentId).HasDatabaseName(PersonEmployment.EstablishmentIdIndexName);
         builder.HasOne<Person>().WithMany().HasForeignKey(e => e.PersonId).HasConstraintName("fk_person_employments_person_id");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240611134629_PersonEmploymentsAddNinoAndPostcode.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240611134629_PersonEmploymentsAddNinoAndPostcode.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240611134629_PersonEmploymentsAddNinoAndPostcode")]
+    partial class PersonEmploymentsAddNinoAndPostcode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240611134629_PersonEmploymentsAddNinoAndPostcode.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240611134629_PersonEmploymentsAddNinoAndPostcode.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersonEmploymentsAddNinoAndPostcode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "national_insurance_number",
+                table: "person_employments",
+                type: "character(9)",
+                fixedLength: true,
+                maxLength: 9,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "person_postcode",
+                table: "person_employments",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+
+            migrationBuilder.Procedure("p_refresh_person_employments_person_search_attributes_v1.sql");
+            migrationBuilder.Procedure("fn_delete_person_employments_person_search_attributes_v1.sql");
+            migrationBuilder.Procedure("fn_insert_person_employments_person_search_attributes_v1.sql");
+            migrationBuilder.Procedure("fn_update_person_employments_person_search_attributes_v1.sql");
+            migrationBuilder.Procedure("p_refresh_person_search_attributes_v3.sql");
+            migrationBuilder.Trigger("trg_delete_person_employments_person_search_attributes_v1.sql");
+            migrationBuilder.Trigger("trg_insert_person_employments_person_search_attributes_v1.sql");
+            migrationBuilder.Trigger("trg_update_person_employments_person_search_attributes_v1.sql");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Procedure("p_refresh_person_search_attributes_v2.sql");
+            migrationBuilder.Sql("drop trigger trg_delete_person_employments_person_search_attributes on person_employments");
+            migrationBuilder.Sql("drop trigger trg_insert_person_employments_person_search_attributes on person_employments");
+            migrationBuilder.Sql("drop trigger trg_update_person_employments_person_search_attributes on person_employments");
+            migrationBuilder.Sql("drop function fn_delete_person_employments_person_search_attributes");
+            migrationBuilder.Sql("drop function fn_insert_person_employments_person_search_attributes");
+            migrationBuilder.Sql("drop function fn_update_person_employments_person_search_attributes");
+            migrationBuilder.Sql("drop procedure p_refresh_person_employments_person_search_attributes");
+
+            migrationBuilder.DropColumn(
+                name: "national_insurance_number",
+                table: "person_employments");
+
+            migrationBuilder.DropColumn(
+                name: "person_postcode",
+                table: "person_employments");
+
+
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonEmployment.cs
@@ -17,4 +17,6 @@ public class PersonEmployment
     public required DateTime CreatedOn { get; set; }
     public required DateTime UpdatedOn { get; set; }
     public required string Key { get; set; }
+    public required string? NationalInsuranceNumber { get; set; }
+    public required string? PersonPostcode { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_delete_person_employments_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_delete_person_employments_person_search_attributes_v1.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION fn_delete_person_employments_person_search_attributes()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    DELETE FROM
+        person_search_attributes psa
+    USING
+        old_person_employments o
+    WHERE
+        psa.attribute_key = o.person_employment_id::text;
+    
+    RETURN NULL;
+END;
+$BODY$

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_insert_person_employments_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_insert_person_employments_person_search_attributes_v1.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION fn_insert_person_employments_person_search_attributes()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE person_employment_ids uuid[];
+BEGIN
+
+    person_employment_ids := ARRAY(SELECT person_employment_id FROM new_person_employments);
+
+    CALL p_refresh_person_employments_person_search_attributes(person_employment_ids);
+    
+    RETURN NULL;
+END;
+$BODY$

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_update_person_employments_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/fn_update_person_employments_person_search_attributes_v1.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION fn_update_person_employments_person_search_attributes()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE person_employment_ids uuid[];
+BEGIN
+
+    person_employment_ids := ARRAY(
+        SELECT o.person_employment_id FROM old_person_employments o
+        JOIN new_person_employments n ON o.person_employment_id = n.person_employment_id
+        WHERE n.national_insurance_number != o.national_insurance_number
+        OR n.person_postcode != o.person_postcode
+        );
+
+    IF (array_length(person_employment_ids, 1) > 0) THEN
+        CALL p_refresh_person_employments_person_search_attributes(person_employment_ids);
+    END IF;
+    
+    RETURN NULL;
+END;
+$BODY$

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_person_employments_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_person_employments_person_search_attributes_v1.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE PROCEDURE public.p_refresh_person_employments_person_search_attributes(
+	IN p_person_employment_ids uuid[])
+LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+    DELETE FROM person_search_attributes WHERE attribute_key = ANY(p_person_employment_ids::text[]);
+    
+    INSERT INTO person_search_attributes (person_id, attribute_type, attribute_value, tags, attribute_key)
+	WITH person_employments_data AS (
+		SELECT
+		    person_id,
+		    national_insurance_number,
+		    person_postcode,
+            person_employment_id
+		FROM
+		    person_employments pe
+		WHERE
+		    pe.person_employment_id = ANY(p_person_employment_ids)
+	),
+	attribs AS (
+		SELECT
+			pe.person_id,
+			unnest(ARRAY['NationalInsuranceNumber', 'Postcode']) attribute_type,
+			unnest(ARRAY[pe.national_insurance_number, pe.person_postcode]) attribute_value,        
+			ARRAY['data_source:person_employments'] tags,
+            pe.person_employment_id attribute_key
+		FROM
+			person_employments_data pe
+	)
+	SELECT
+	    *
+	FROM
+	    attribs
+    WHERE
+        attribs.attribute_value IS NOT NULL;
+END;
+$BODY$;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_person_search_attributes_v3.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Procedures/p_refresh_person_search_attributes_v3.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE PROCEDURE public.p_refresh_person_search_attributes(
+    IN p_person_ids uuid[])
+LANGUAGE 'plpgsql'
+AS $BODY$
+BEGIN
+
+DELETE FROM person_search_attributes WHERE person_id = ANY(p_person_ids);
+
+INSERT INTO person_search_attributes (person_id, attribute_type, attribute_value, tags, attribute_key)
+WITH person_data AS (
+	SELECT p.person_id, p.first_name, p.last_name, p.date_of_birth, p.national_insurance_number, p.trn
+	FROM persons p
+	WHERE p.person_id = ANY(p_person_ids)
+),
+attrs AS (
+    SELECT
+	    x.person_id,
+	    unnest(ARRAY['DateOfBirth', 'NationalInsuranceNumber', 'Trn', 'LastName', 'FirstName', 'FullName']) attribute_type,
+	    unnest(ARRAY[to_char(x.date_of_birth, 'yyyy-mm-dd'), x.national_insurance_number, x.trn, x.last_name, x.first_name, CONCAT(x.first_name, ' ', x.last_name)]) attribute_value,
+	    ARRAY['data_source:persons'] tags,
+	    NULL attribute_key
+    FROM person_data x
+    UNION SELECT
+	    n.person_id,
+	    unnest(ARRAY['FirstName', 'FullName']) attribute_key,
+	    unnest(ARRAY[n.synonym, CONCAT(n.synonym, ' ', n.last_name)]) attribute_value,
+	    ARRAY['data_source:persons', CONCAT('Synonym:', n.first_name)] tags,
+	    NULL attribute_key
+	    FROM (
+		    SELECT x.person_id, x.first_name, x.last_name, unnest(synonyms) synonym
+		    FROM person_data x
+		    JOIN name_synonyms n ON x.first_name = n.name) n
+)
+SELECT * FROM attrs WHERE attribute_value IS NOT NULL;
+		
+END;
+$BODY$;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_delete_person_employments_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_delete_person_employments_person_search_attributes_v1.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE TRIGGER trg_delete_person_employments_person_search_attributes
+    AFTER DELETE
+    ON person_employments
+    REFERENCING OLD TABLE AS old_person_employments
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION fn_delete_person_employments_person_search_attributes();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_insert_person_employments_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_insert_person_employments_person_search_attributes_v1.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE TRIGGER trg_insert_person_employments_person_search_attributes
+    AFTER INSERT
+    ON person_employments
+    REFERENCING NEW TABLE AS new_person_employments
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION fn_insert_person_employments_person_search_attributes();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_update_person_employments_person_search_attributes_v1.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Triggers/trg_update_person_employments_person_search_attributes_v1.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE TRIGGER trg_update_person_employments_person_search_attributes
+    AFTER UPDATE
+    ON person_employments
+    REFERENCING OLD TABLE AS old_person_employments NEW TABLE AS new_person_employments
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION fn_update_person_employments_person_search_attributes();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/PersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/PersonEmployment.cs
@@ -9,7 +9,9 @@ public record PersonEmployment
     public required DateOnly? EndDate { get; init; }
     public required EmploymentType EmploymentType { get; init; }
     public required DateOnly LastKnownEmployedDate { get; init; }
-    public required DateOnly LastExtractDate { get; set; }
+    public required DateOnly LastExtractDate { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
+    public required string? PersonPostcode { get; init; }
     public required string Key { get; init; }
 
     public static PersonEmployment FromModel(DataStore.Postgres.Models.PersonEmployment model) => new()
@@ -22,6 +24,8 @@ public record PersonEmployment
         EmploymentType = model.EmploymentType,
         LastKnownEmployedDate = model.LastKnownEmployedDate,
         LastExtractDate = model.LastExtractDate,
+        NationalInsuranceNumber = model.NationalInsuranceNumber,
+        PersonPostcode = model.PersonPostcode,
         Key = model.Key
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonEmploymentUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonEmploymentUpdatedEvent.cs
@@ -19,5 +19,7 @@ public enum PersonEmploymentUpdatedEventChanges
     EmploymentType = 1 << 2,
     EstablishmentId = 1 << 3,
     LastKnownEmployedDate = 1 << 4,
-    LastExtractDate = 1 << 5
+    LastExtractDate = 1 << 5,
+    NationalInsuranceNumber = 1 << 6,
+    PersonPostcode = 1 << 7
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewPersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewPersonEmployment.cs
@@ -10,6 +10,8 @@ public record NewPersonEmployment
     public required EmploymentType EmploymentType { get; init; }
     public required DateOnly LastExtractDate { get; init; }
     public required string Key { get; init; }
+    public required string NationalInsuranceNumber { get; init; }
+    public required string? PersonPostcode { get; init; }
     public required DateTime CreatedOn { get; init; }
     public required DateTime UpdatedOn { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmployment.cs
@@ -10,8 +10,12 @@ public record UpdatedPersonEmployment
     public required EmploymentType CurrentEmploymentType { get; init; }
     public required DateOnly CurrentLastKnownEmployedDate { get; init; }
     public required DateOnly CurrentLastExtractDate { get; init; }
+    public required string? CurrentNationalInsuranceNumber { get; init; }
+    public required string? CurrentPersonPostcode { get; init; }
     public required EmploymentType NewEmploymentType { get; init; }
     public required DateOnly NewLastKnownEmployedDate { get; init; }
     public required DateOnly NewLastExtractDate { get; init; }
+    public required string? NewNationalInsuranceNumber { get; init; }
+    public required string? NewPersonPostcode { get; init; }
     public required string Key { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEndDate.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEndDate.cs
@@ -10,6 +10,8 @@ public record UpdatedPersonEmploymentEndDate
     public required EmploymentType EmploymentType { get; init; }
     public required DateOnly LastKnownEmployedDate { get; init; }
     public required DateOnly LastExtractDate { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
+    public required string? PersonPostcode { get; init; }
     public required string Key { get; init; }
     public required DateOnly? NewEndDate { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
@@ -10,6 +10,8 @@ public record UpdatedPersonEmploymentEstablishment
     public required EmploymentType EmploymentType { get; init; }
     public required DateOnly LastKnownEmployedDate { get; init; }
     public required DateOnly LastExtractDate { get; init; }
+    public required string? NationalInsuranceNumber { get; set; }
+    public required string? PersonPostcode { get; set; }
     public required string Key { get; init; }
     public required Guid EstablishmentId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -5,15 +5,23 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="DataStore\Postgres\Procedures\fn_delete_person_employments_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Procedures\fn_delete_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Procedures\fn_insert_person_employments_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Procedures\fn_insert_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Procedures\fn_update_person_employments_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Procedures\fn_update_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Procedures\fn_update_person_search_attributes_v2.sql" />
     <None Remove="DataStore\Postgres\Procedures\p_refresh_name_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Procedures\p_refresh_person_employments_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v2.sql" />
+    <None Remove="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v3.sql" />
+    <None Remove="DataStore\Postgres\Triggers\trg_delete_person_employments_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Triggers\trg_delete_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Triggers\trg_insert_person_employments_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Triggers\trg_insert_person_search_attributes_v1.sql" />
+    <None Remove="DataStore\Postgres\Triggers\trg_update_person_employments_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Triggers\trg_update_person_search_attributes_v1.sql" />
     <None Remove="DataStore\Postgres\Triggers\trg_update_person_search_attributes_v2.sql" />
     <None Remove="Services\DqtReporting\Migrations\0001_Initial.sql" />
@@ -41,15 +49,23 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_delete_person_employments_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_delete_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_insert_person_employments_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_insert_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_update_person_employments_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_update_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Procedures\fn_update_person_search_attributes_v2.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Procedures\p_refresh_name_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\p_refresh_person_employments_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v2.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Procedures\p_refresh_person_search_attributes_v3.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_delete_person_employments_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_insert_person_employments_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_insert_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_delete_person_search_attributes_v1.sql" />
+    <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_update_person_employments_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_update_person_search_attributes_v1.sql" />
     <EmbeddedResource Include="DataStore\Postgres\Triggers\trg_update_person_search_attributes_v2.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0001_Initial.sql" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -187,7 +187,9 @@ public class TpsCsvExtractProcessorTests
         var person = await TestData.CreatePerson();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
-        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25));
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var personPostcode = Faker.Address.UkPostCode();
+        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25), nationalInsuranceNumber, personPostcode);
         var updatedEndDate = new DateOnly(2024, 03, 30);
         var updatedLastExtractDate = new DateOnly(2024, 04, 25);
         await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, new DateOnly(2023, 02, 02), updatedEndDate, updatedLastExtractDate));
@@ -214,7 +216,9 @@ public class TpsCsvExtractProcessorTests
         var person = await TestData.CreatePerson();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
-        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25));
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var personPostcode = Faker.Address.UkPostCode();
+        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25), nationalInsuranceNumber, personPostcode);
         await TestData.CreateTpsCsvExtract(b => b.WithTpsCsvExtractId(tpsCsvExtractId).WithItem(person!.Trn!, establishment1.LaCode, establishment1.EstablishmentNumber, establishment1.Postcode!, existingPersonEmployment.StartDate, existingPersonEmployment.LastKnownEmployedDate, existingPersonEmployment.LastExtractDate, "FT"));
 
         // Act
@@ -236,7 +240,9 @@ public class TpsCsvExtractProcessorTests
         var person = await TestData.CreatePerson();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 2); // Closed
         var establishment2 = await TestData.CreateEstablishment(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 1); // Open
-        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25));
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var personPostcode = Faker.Address.UkPostCode();
+        var existingPersonEmployment = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25), nationalInsuranceNumber, personPostcode);
 
         // Act
         var processor = new TpsCsvExtractProcessor(
@@ -260,8 +266,10 @@ public class TpsCsvExtractProcessorTests
         var extractDate = new DateOnly(2024, 04, 25);
         var lastKnownEmployedDateWithinThreeMonthsOfExtractDate = new DateOnly(2024, 02, 29);
         var lastKnownEmployedDateOutsideThreeMonthsOfExtractDate = new DateOnly(2023, 09, 30);
-        var personEmploymentWhichHasEnded = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), lastKnownEmployedDateOutsideThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
-        var personEmploymentWhichHasNotEnded = await TestData.CreatePersonEmployment(person, establishment2, new DateOnly(2023, 02, 02), lastKnownEmployedDateWithinThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate);
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var personPostcode = Faker.Address.UkPostCode();
+        var personEmploymentWhichHasEnded = await TestData.CreatePersonEmployment(person, establishment1, new DateOnly(2023, 02, 02), lastKnownEmployedDateOutsideThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate, nationalInsuranceNumber, personPostcode);
+        var personEmploymentWhichHasNotEnded = await TestData.CreatePersonEmployment(person, establishment2, new DateOnly(2023, 02, 02), lastKnownEmployedDateWithinThreeMonthsOfExtractDate, EmploymentType.FullTime, extractDate, nationalInsuranceNumber, personPostcode);
 
         // Act
         var processor = new TpsCsvExtractProcessor(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
@@ -12,6 +12,8 @@ public partial class TestData
         DateOnly lastKnownEmployedDate,
         EmploymentType employmentType,
         DateOnly lastExtractDate,
+        string? nationalInsuranceNumber = null,
+        string? personPostcode = null,
         DateOnly? endDate = null)
     {
         var key = $"{person.Trn}.{establishment.LaCode}.{establishment.EstablishmentNumber}.{startDate:yyyyMMdd}";
@@ -28,6 +30,8 @@ public partial class TestData
                 EmploymentType = employmentType,
                 LastKnownEmployedDate = lastKnownEmployedDate,
                 LastExtractDate = lastExtractDate,
+                NationalInsuranceNumber = nationalInsuranceNumber ?? GenerateNationalInsuranceNumber(),
+                PersonPostcode = personPostcode,
                 CreatedOn = Clock.UtcNow,
                 UpdatedOn = Clock.UtcNow,
                 Key = key


### PR DESCRIPTION
### Context

The current person search used by the One Login integration uses the NINO from DQT/TRS only. Now that we have NINO from workforce data to we should include this to improve the chances of matching using NINO. We may use the person’s postcode to match on in future as well so we should populate this too.

### Changes proposed in this pull request

Amend the process that imports workforce data to populate person_search_attributes with the NINO and person’s postcode, where available.

N.B. a database trigger on the appropriate workforce data tables is probably the way to go for this, similar to what we’re doing with the person table.

### Guidance to review

DB migrations + code + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
