### PR TITLE
Added backfill job to populate person_employments nino and person postcode

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BackfillNinoAndPersonPostcodeInEmploymentHistoryJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BackfillNinoAndPersonPostcodeInEmploymentHistoryJob.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.Services.WorkforceData;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class BackfillNinoAndPersonPostcodeInEmploymentHistoryJob(TpsCsvExtractProcessor tpsCsvExtractProcessor)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        await tpsCsvExtractProcessor.BackfillNinoAndPersonPostcodeInEmploymentHistory(cancellationToken);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -123,6 +123,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<BackfillNinoAndPersonPostcodeInEmploymentHistoryJob>(
+                    nameof(BackfillNinoAndPersonPostcodeInEmploymentHistoryJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentNationalInsuranceNumberAndPersonPostcode.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentNationalInsuranceNumberAndPersonPostcode.cs
@@ -1,0 +1,18 @@
+namespace TeachingRecordSystem.Core.Services.WorkforceData;
+
+public record UpdatedPersonEmploymentNationalInsuranceNumberAndPersonPostcode
+{
+    public required Guid PersonEmploymentId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required Guid EstablishmentId { get; init; }
+    public required DateOnly StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+    public required EmploymentType EmploymentType { get; init; }
+    public required DateOnly LastKnownEmployedDate { get; init; }
+    public required DateOnly LastExtractDate { get; init; }
+    public required string? CurrentNationalInsuranceNumber { get; init; }
+    public required string? CurrentPersonPostcode { get; init; }
+    public required string? NewNationalInsuranceNumber { get; init; }
+    public required string? NewPersonPostcode { get; init; }
+    public required string Key { get; init; }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
@@ -30,7 +30,7 @@ public partial class TestData
                 EmploymentType = employmentType,
                 LastKnownEmployedDate = lastKnownEmployedDate,
                 LastExtractDate = lastExtractDate,
-                NationalInsuranceNumber = nationalInsuranceNumber ?? GenerateNationalInsuranceNumber(),
+                NationalInsuranceNumber = nationalInsuranceNumber,
                 PersonPostcode = personPostcode,
                 CreatedOn = Clock.UtcNow,
                 UpdatedOn = Clock.UtcNow,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateTpsCsvExtract.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateTpsCsvExtract.cs
@@ -51,13 +51,14 @@ public partial class TestData
             DateOnly extractDate,
             string? fullOrPartTimeIndicator = null,
             string? nationalInsuranceNumber = null,
-            DateOnly? dateOfBirth = null)
+            DateOnly? dateOfBirth = null,
+            string? memberPostcode = null)
         {
             nationalInsuranceNumber ??= Faker.Identification.UkNationalInsuranceNumber();
             dateOfBirth ??= DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
             fullOrPartTimeIndicator ??= validFullOrPartTimeIndicatorValues[Faker.RandomNumber.Next(0, 2)];
 
-            _items.Add(new TpsCsvExtractItem(trn, nationalInsuranceNumber, dateOfBirth.Value, localAuthorityCode, establishmentPostcode, establishmentNumber, startDate, endDate, fullOrPartTimeIndicator, extractDate));
+            _items.Add(new TpsCsvExtractItem(trn, nationalInsuranceNumber, dateOfBirth.Value, localAuthorityCode, establishmentPostcode, establishmentNumber, startDate, endDate, fullOrPartTimeIndicator, extractDate, memberPostcode));
             return this;
         }
 
@@ -93,7 +94,7 @@ public partial class TestData
                         NationalInsuranceNumber = item.NationalInsuranceNumber,
                         DateOfBirth = item.DateOfBirth.ToString("dd/MM/yyyy"),
                         DateOfDeath = null,
-                        MemberPostcode = null,
+                        MemberPostcode = item.MemberPostcode,
                         MemberEmailAddress = null,
                         LocalAuthorityCode = item.LocalAuthorityCode,
                         EstablishmentNumber = item.EstablishmentNumber,
@@ -147,5 +148,5 @@ public partial class TestData
         }
     }
 
-    public record TpsCsvExtractItem(string Trn, string NationalInsuranceNumber, DateOnly DateOfBirth, string LocalAuthorityCode, string EstablishmentPostcode, string? EstablishmentNumber, DateOnly StartDate, DateOnly EndDate, string FullOrPartTimeIndicator, DateOnly ExtractDate);
+    public record TpsCsvExtractItem(string Trn, string NationalInsuranceNumber, DateOnly DateOfBirth, string LocalAuthorityCode, string EstablishmentPostcode, string? EstablishmentNumber, DateOnly StartDate, DateOnly EndDate, string FullOrPartTimeIndicator, DateOnly ExtractDate, string? MemberPostcode);
 }


### PR DESCRIPTION
### Context

We have added `national_insurance_number` and `person_postcode` fields to the `person_employments` table and amended the TPS import process to populated them (triggers on the table will also populate the `person_search_attributes` table with this attributes).

These fields need to be populated for existing records based on the last 3 months workforce data.

### Changes proposed in this pull request

Add an ad hoc job in Hangfire which populates the `national_insurance_number` and `person_postcode` fields in all existing `person_employments` records using the data in the `tps_csv_extract_items` table for previous imports.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
