### PR TITLE
Increase length of attribute_value field in person_search_attributes table to 1000 characters

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240617143745_PersonSearchAttributesAttributeValueIncreaseLength.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240617143745_PersonSearchAttributesAttributeValueIncreaseLength.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240617143745_PersonSearchAttributesAttributeValueIncreaseLength")]
+    partial class PersonSearchAttributesAttributeValueIncreaseLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240617143745_PersonSearchAttributesAttributeValueIncreaseLength.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20240617143745_PersonSearchAttributesAttributeValueIncreaseLength.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersonSearchAttributesAttributeValueIncreaseLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "attribute_value",
+                table: "person_search_attributes",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldCollation: "case_insensitive");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "attribute_value",
+                table: "person_search_attributes",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(1000)",
+                oldMaxLength: 1000,
+                oldCollation: "case_insensitive");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonSearchAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/PersonSearchAttribute.cs
@@ -3,7 +3,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 public class PersonSearchAttribute
 {
     public const int AttributeTypeMaxLength = 50;
-    public const int AttributeValueMaxLength = 100;
+    public const int AttributeValueMaxLength = 1000;
     public const int AttributeKeyMaxLength = 50;
     public const string PersonIdIndexName = "ix_person_search_attributes_person_id";
     public const string AttributeTypeAndValueIndexName = "ix_person_search_attributes_attribute_type_and_value";


### PR DESCRIPTION
### Context

The `attribute_value` field in the `person_search_attributes` table is currently set to 100 characters, however it can be used to populate concatenated first name and last name fields which themselves can be 100 characters max.

### Changes proposed in this pull request

Give ourselves some headroom for any future use of the `attribute_value` field in the `person_search_attributes` table and increase the field length to 1000 characters.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
