### PR TITLE
Increase the Console log level to Information

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
@@ -2,14 +2,6 @@
   "AllowVNextEndpoints": true,
   "AuthorizeAccessIssuer": "https://localhost:7236",
   "DetailedErrors": true,
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft.AspNetCore": "Warning"
-      }
-    }
-  },
   "ApiClients": {
     "developer": {
       "ApiKey": [ "developer" ]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Production.json
@@ -10,13 +10,5 @@
     "IncludeActivityData": true,
     "MaxRequestBodySize": "None",
     "TracesSampleRate": 0
-  },
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Error",
-      "Override": {
-        "TeachingRecordSystem.Api": "Warning"
-      }
-    }
   }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.json
@@ -1,10 +1,7 @@
 {
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft.AspNetCore": "Warning"
-      }
+      "Default": "Information"
     },
     "Enrich": [ "FromLogContext" ]
   },

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Development.json
@@ -1,13 +1,5 @@
 {
   "AuthorizeAccessIssuer": "https://localhost:7236",
   "DetailedErrors": true,
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft.AspNetCore": "Warning"
-      }
-    }
-  },
   "ShowDebugPages": true
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Production.json
@@ -4,13 +4,5 @@
     "IncludeActivityData": true,
     "MaxRequestBodySize": "None",
     "TracesSampleRate": 0
-  },
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Error",
-      "Override": {
-        "TeachingRecordSystem.AuthorizeAccess": "Warning"
-      }
-    }
   }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
@@ -1,11 +1,3 @@
 {
-  "DetailedErrors": true,
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft.AspNetCore": "Warning"
-      }
-    }
-  }
+  "DetailedErrors": true
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Production.json
@@ -1,10 +1,2 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Error",
-      "Override": {
-        "TeachingRecordSystem.SupportUi": "Warning"
-      }
-    }
-  }
 }


### PR DESCRIPTION
We're not getting many logs in logit currently because of the `Error` minimum log level. This ups the level to `Information`.