### PR TITLE
Fix errors from bot traffic

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/FormFlowJourneySignInHandler.cs
@@ -29,9 +29,13 @@ public class FormFlowJourneySignInHandler(SignInJourneyHelper helper) : IAuthent
         return AuthenticateResult.Success(journeyInstance.State.OneLoginAuthenticationTicket);
     }
 
-    public Task ChallengeAsync(AuthenticationProperties? properties)
+    public async Task ChallengeAsync(AuthenticationProperties? properties)
     {
-        throw new NotSupportedException();
+        // We'll get here if an instance ID wasn't provided in the query string
+        // (and MissingInstanceFilter won't have executed yet since authorization runs before resource filters).
+        EnsureInitialized();
+        var result = Results.BadRequest();
+        await result.ExecuteAsync(_context);
     }
 
     public Task ForbidAsync(AuthenticationProperties? properties)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Test.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Test.cshtml.cs
@@ -18,6 +18,11 @@ public class TestModel : PageModel
 
     public IActionResult OnGet()
     {
+        if (string.IsNullOrEmpty(AuthenticationScheme))
+        {
+            return BadRequest();
+        }
+
         if (User.Identity?.IsAuthenticated != true)
         {
             return Challenge(


### PR DESCRIPTION
We've got some Sentry errors from bots hitting `/debug` and `/test`. Both are valid endpoints in `AuthorizeAccess` but they need a particular query parameter specifying to work correctly; when that's missing we get unhandled exceptions.

This changes both endpoints to return a `400 Bad request` response if the query parameter is missing (or invalid).