### PR TITLE
Automatically add missing columns into reporting DB

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/EntityTableMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/EntityTableMapping.cs
@@ -229,6 +229,18 @@ public class EntityTableMapping
 
         return command;
     }
+
+    public string GetAddAttributeColumnsSql(AttributeColumnMapping attribute)
+    {
+        var sqlBuilder = new StringBuilder();
+
+        foreach (var column in attribute.ColumnDefinitions)
+        {
+            sqlBuilder.AppendLine($"alter table [{TableName}] add [{column.ColumnName}] {column.ColumnDefinition}");
+        }
+
+        return sqlBuilder.ToString();
+    }
 }
 
 [DebuggerDisplay("{AttributeName,nq}")]


### PR DESCRIPTION
Currently whenever we (or Microsoft) add attributes to CRM entities we need to add a migration to add the corresponding columns to the reporting DB. This change catches the error caused when columns are missing and adds the columns automatically.