### PR TITLE
Add calling application user ID to Teacher Auth analytics events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
@@ -1,4 +1,6 @@
 using System.Security.Claims;
+using Dfe.Analytics;
+using Dfe.Analytics.AspNetCore;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -39,6 +41,11 @@ public class OAuth2Controller(
 
         var clientId = request.ClientId!;
         var client = await dbContext.ApplicationUsers.SingleAsync(u => u.ClientId == clientId);
+
+        if (HttpContext.GetWebRequestEvent() is Event webRequestEvent)
+        {
+            webRequestEvent.Data[DfeAnalyticsEventDataKeys.ApplicationUserId] = [client.UserId.ToString()];
+        }
 
         var childAuthenticationScheme = AuthenticationSchemes.MatchToTeachingRecord;
         var authenticateResult = await HttpContext.AuthenticateAsync(childAuthenticationScheme);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DfeAnalyticsEventDataKeys.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/DfeAnalyticsEventDataKeys.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.AuthorizeAccess;
+
+public static class DfeAnalyticsEventDataKeys
+{
+    public const string ApplicationUserId = "application_user_id";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Middleware/AddAnalyticsDataMiddleware.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Middleware/AddAnalyticsDataMiddleware.cs
@@ -1,0 +1,20 @@
+using Dfe.Analytics;
+using Dfe.Analytics.AspNetCore;
+using TeachingRecordSystem.AuthorizeAccess.Infrastructure.FormFlow;
+using TeachingRecordSystem.UiCommon.FormFlow.State;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Infrastructure.Middleware;
+
+public class AddAnalyticsDataMiddleware(IUserInstanceStateProvider userInstanceStateProvider, RequestDelegate next)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        var journeyInstance = await userInstanceStateProvider.GetSignInJourneyInstanceAsync(context);
+        if (journeyInstance is not null && context.GetWebRequestEvent() is Event webRequestEvent)
+        {
+            webRequestEvent.Data[DfeAnalyticsEventDataKeys.ApplicationUserId] = [journeyInstance.State.ClientApplicationUserId.ToString()];
+        }
+
+        await next(context);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -17,6 +17,7 @@ using TeachingRecordSystem.AuthorizeAccess;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Filters;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.FormFlow;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Logging;
+using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Middleware;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Oidc;
 using TeachingRecordSystem.AuthorizeAccess.Infrastructure.Security;
 using TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
@@ -248,6 +249,8 @@ if (builder.Environment.IsProduction())
 {
     app.UseDfeAnalytics();
 }
+
+app.UseMiddleware<AddAnalyticsDataMiddleware>();
 
 app.UseRouting();
 


### PR DESCRIPTION
We need to know what the calling service is for analytics events coming from Teacher Auth so that we can get service-specific stats. This adds an `application_user_id` entry to each web request event's `data`.