### PR TITLE
Restore metrics endpoint

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -68,6 +68,7 @@
     <PackageVersion Include="Optional" Version="4.0.0" />
     <PackageVersion Include="PdfSharpCore" Version="1.3.62" />
     <PackageVersion Include="Polly.Core" Version="8.2.1" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageVersion Include="RedisRateLimiting.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="Respawn" Version="6.1.0" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/Extensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Prometheus;
 using TeachingRecordSystem.Core.Infrastructure.Configuration;
 
 namespace TeachingRecordSystem.ServiceDefaults;
@@ -68,6 +69,9 @@ public static class Extensions
         });
 
         app.UseHealthChecks("/status");
+
+        app.MapMetrics();
+        app.UseHttpMetrics();
 
         return app;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/TeachingRecordSystem.ServiceDefaults.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/TeachingRecordSystem.ServiceDefaults.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" />
     <PackageReference Include="Hangfire.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We removed this for the AKS migration but we're about to start collecting metrics again.