### PR TITLE
Optimize job which updates person employments with latest establishment version

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Services.Establishments.Gias;
+using TeachingRecordSystem.Core.Services.WorkforceData;
 
 namespace TeachingRecordSystem.Core.Jobs;
 
@@ -8,8 +9,6 @@ public class RefreshEstablishmentsJob(IBackgroundJobScheduler backgroundJobSched
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         var refreshJobId = await backgroundJobScheduler.Enqueue<EstablishmentRefresher>(j => j.RefreshEstablishments(cancellationToken));
-
-        // The following is temporarily commented out as the current query was take over an hour to return and needs further investigation
-        // await backgroundJobScheduler.ContinueJobWith<TpsCsvExtractProcessor>(refreshJobId, j => j.UpdateLatestEstablishmentVersions(cancellationToken));
+        await backgroundJobScheduler.ContinueJobWith<TpsCsvExtractProcessor>(refreshJobId, j => j.UpdateLatestEstablishmentVersions(cancellationToken));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedPersonEmploymentEstablishment.cs
@@ -13,5 +13,5 @@ public record UpdatedPersonEmploymentEstablishment
     public required string? NationalInsuranceNumber { get; set; }
     public required string? PersonPostcode { get; set; }
     public required string Key { get; init; }
-    public required Guid EstablishmentId { get; init; }
+    public required Guid NewEstablishmentId { get; init; }
 }


### PR DESCRIPTION
### Context

We previously created a job to refresh the person_employments with the “most open” version of an establishment based on the establishments imported from GIAS.

However, this took ages to run in production so needs to be optimised.

### Changes proposed in this pull request

Optimise the code in the `UpdateLatestEstablishmentVersions` method in the `TpsCsvExtractProcessor` class to do an update in the database returning current and changed values, limiting changes to max 1000 records at a time (in a similar way to the other methods in that class).

### Guidance to review

Simplish change in the end.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
