### PR TITLE
Added optional timeout when saving batches of events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/NpgsqlExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/NpgsqlExtensions.cs
@@ -32,7 +32,7 @@ public static class NpgsqlExtensions
         }
     }
 
-    public static async Task<int> SaveEvents(this NpgsqlTransaction transaction, IReadOnlyCollection<EventBase> events, string tempTableSuffix, IClock clock, CancellationToken cancellationToken)
+    public static async Task<int> SaveEvents(this NpgsqlTransaction transaction, IReadOnlyCollection<EventBase> events, string tempTableSuffix, IClock clock, CancellationToken cancellationToken, int? timeoutSeconds = null)
     {
         if (events.Count == 0)
         {
@@ -107,6 +107,10 @@ public static class NpgsqlExtensions
         using (var mergeCommand = transaction.Connection!.CreateCommand())
         {
             mergeCommand.CommandText = insertStatement;
+            if (timeoutSeconds.HasValue)
+            {
+                mergeCommand.CommandTimeout = timeoutSeconds.Value;
+            }
             mergeCommand.Parameters.Add(new NpgsqlParameter("@now", clock.UtcNow));
             mergeCommand.Transaction = transaction;
             await mergeCommand.ExecuteNonQueryAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
@@ -260,7 +260,7 @@ public class TpsCsvExtractProcessor(
                 events.Add(createdEvent);
             }
 
-            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken);
+            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken, 120);
             await transaction.CommitAsync(cancellationToken);
             events.Clear();
         }
@@ -415,7 +415,7 @@ public class TpsCsvExtractProcessor(
                 }
             }
 
-            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken);
+            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken, 120);
             await transaction.CommitAsync(cancellationToken);
             events.Clear();
         }
@@ -565,7 +565,7 @@ public class TpsCsvExtractProcessor(
                 events.Add(updatedEvent);
             }
 
-            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken);
+            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken, 120);
             await transaction.CommitAsync(cancellationToken);
             events.Clear();
         }
@@ -668,7 +668,7 @@ public class TpsCsvExtractProcessor(
                 events.Add(updatedEvent);
             }
 
-            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken);
+            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken, 120);
             await transaction.CommitAsync(cancellationToken);
             events.Clear();
         }
@@ -783,7 +783,7 @@ public class TpsCsvExtractProcessor(
                 }
             }
 
-            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken);
+            await transaction.SaveEvents(events, TempEventsTableSuffix, clock, cancellationToken, 120);
             await transaction.CommitAsync(cancellationToken);
             events.Clear();
         }


### PR DESCRIPTION
### Context

The TPS extract import job for June took a number of retry attempts due to timeouts when saving batches of TRS events relating to the updates.

### Changes proposed in this pull request

Add an optional timeout setting to the `SaveEvents` extension method in `NpgsqlExtensions` and set this to 120 seconds for within the calls in the `TpsCsvExtractProcessor` class.

### Guidance to review

Simple change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
