### PR TITLE
Reduce the console logs

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -77,6 +77,7 @@
     <PackageVersion Include="Sentry.Serilog" Version="3.41.3" />
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="2.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Production.json
@@ -10,5 +10,15 @@
     "IncludeActivityData": true,
     "MaxRequestBodySize": "None",
     "TracesSampleRate": 0
+  },
+  "Serilog": {
+    "Filter": [
+      {
+        "Name": "ByIncludingOnly",
+        "Args": {
+          "expression": "@l = 'Error' or StartsWith(@m, 'Request finished')"
+        }
+      }
+    ]
   }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.json
@@ -3,7 +3,8 @@
     "MinimumLevel": {
       "Default": "Information"
     },
-    "Enrich": [ "FromLogContext" ]
+    "Enrich": [ "FromLogContext" ],
+    "Using": [ "Serilog.Expressions" ]
   },
   "AllowedHosts": "*",
   "RecurringJobs": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.Production.json
@@ -4,5 +4,15 @@
     "IncludeActivityData": true,
     "MaxRequestBodySize": "None",
     "TracesSampleRate": 0
+  },
+  "Serilog": {
+    "Filter": [
+      {
+        "Name": "ByIncludingOnly",
+        "Args": {
+          "expression": "@l = 'Error' or StartsWith(@m, 'Request finished')"
+        }
+      }
+    ]
   }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
@@ -6,7 +6,8 @@
         "Microsoft.AspNetCore": "Warning"
       }
     },
-    "Enrich": [ "FromLogContext" ]
+    "Enrich": [ "FromLogContext" ],
+    "Using": [ "Serilog.Expressions" ]
   },
   "AllowedHosts": "*",
   "RequestTrnSupportEmail": "qts.enquiries@education.gov.uk"

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -139,6 +139,7 @@
     <PackageReference Include="PdfSharpCore" />
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="Scrutor" />
+    <PackageReference Include="Serilog.Expressions" />
     <PackageReference Include="System.Net.Http.Json" />
     <PackageReference Include="Sentry.Serilog" />
     <PackageReference Include="Serilog.Formatting.Compact" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Production.json
@@ -1,2 +1,12 @@
 {
+  "Serilog": {
+    "Filter": [
+      {
+        "Name": "ByIncludingOnly",
+        "Args": {
+          "expression": "@l = 'Error' or StartsWith(@m, 'Request finished')"
+        }
+      }
+    ]
+  }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
@@ -6,7 +6,8 @@
         "Microsoft.AspNetCore": "Warning"
       }
     },
-    "Enrich": [ "FromLogContext" ]
+    "Enrich": [ "FromLogContext" ],
+    "Using": [ "Serilog.Expressions" ]
   },
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Information"
+      "Default": "Error"
     },
     "Enrich": [ "FromLogContext" ]
   },


### PR DESCRIPTION
We went a little too far with increasing the log levels in https://github.com/DFE-Digital/teaching-record-system/pull/1381. This changes the minimum log level back to `Error` but includes a single `Information` `Request finished` entry per request for the web apps.