### PR TITLE
Workaround partial stated name attributes

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/ContactExtensions.cs
@@ -45,6 +45,6 @@ public static class ContactExtensions
     }
 
     public static bool HasStatedNames(this Contact contact) =>
-        !string.IsNullOrEmpty(contact.dfeta_StatedFirstName) ||
+        !string.IsNullOrEmpty(contact.dfeta_StatedFirstName) &&
         !string.IsNullOrEmpty(contact.dfeta_StatedLastName);
 }


### PR DESCRIPTION
The `stated` `name` attributes should either be completely set or completely empty. For reasons yet unknown we have some records that have `stated` name attributes partially set; in these cases we're returning a half-empty name over the API. This amends the check for stated names to check that both stated first name *and* stated last name have been set.