### PR TITLE
Move reporting DB migrations into Worker start up

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/HostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Dqt;
@@ -26,6 +27,15 @@ public static class HostApplicationBuilderExtensions
                 sp => new ServiceClient(sp.GetRequiredService<IOptions<DqtReportingOptions>>().Value.CrmConnectionString));
 
             builder.Services.AddCrmEntityChangesService(name: DqtReportingService.CrmClientName);
+
+            builder.Services.AddStartupTask(sp =>
+            {
+                var migrator = new Migrator(
+                    connectionString: sp.GetRequiredService<IOptions<DqtReportingOptions>>().Value.ReportingDbConnectionString,
+                    logger: sp.GetRequiredService<ILoggerFactory>().CreateLogger<Migrator>());
+                migrator.MigrateDb();
+                return Task.CompletedTask;
+            });
         }
 
         return builder;

--- a/terraform/aks/app.tf
+++ b/terraform/aks/app.tf
@@ -228,7 +228,7 @@ module "worker_application_configuration" {
 
 module "worker_application" {
   source     = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=testing"
-  depends_on = [kubernetes_job.migrations, kubernetes_job.reporting_migrations]
+  depends_on = [kubernetes_job.migrations]
 
   name   = "worker"
   is_web = false

--- a/terraform/aks/dqt-reporting.tf
+++ b/terraform/aks/dqt-reporting.tf
@@ -55,35 +55,3 @@ resource "azurerm_mssql_database" "reporting_db" {
     ]
   }
 }
-
-resource "kubernetes_job" "reporting_migrations" {
-  metadata {
-    name      = "${var.service_name}-${var.environment_name}-reporting-migrations"
-    namespace = var.namespace
-  }
-
-  spec {
-    template {
-      metadata {}
-      spec {
-        container {
-          name    = "cli"
-          image   = var.docker_image
-          command = ["trscli"]
-          args    = ["migrate-reporting-db", "--connection-string", "$(CONNECTION_STRING)"]
-
-          env {
-            name  = "CONNECTION_STRING"
-            value = local.reporting_db_connection_string
-          }
-        }
-
-        restart_policy = "Never"
-      }
-    }
-
-    backoff_limit = 1
-  }
-
-  wait_for_completion = true
-}


### PR DESCRIPTION
For review apps we won't have a reporting DB around so the k8s job to deploy migrations won't work. This moves migrations into the Worker app, guarded by the `DqtReportingService:RunService` configuration option, which will be `false` for review apps.