### PR TITLE
Rename IEventObserver and its method

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/IEventObserver.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/IEventObserver.cs
@@ -1,6 +1,0 @@
-namespace TeachingRecordSystem.Core.Events.Processing;
-
-public interface IEventObserver
-{
-    Task OnEventSaved(EventBase @event);
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/IEventPublisher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/IEventPublisher.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events.Processing;
+
+public interface IEventPublisher
+{
+    Task PublishEvent(EventBase @event);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/NoopEventObserver.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/NoopEventObserver.cs
@@ -1,6 +1,0 @@
-namespace TeachingRecordSystem.Core.Events.Processing;
-
-public class NoopEventObserver : IEventObserver
-{
-    public Task OnEventSaved(EventBase @event) => Task.CompletedTask;
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/NoopEventPublisher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/NoopEventPublisher.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events.Processing;
+
+public class NoopEventPublisher : IEventPublisher
+{
+    public Task PublishEvent(EventBase @event) => Task.CompletedTask;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/PublishEventsBackgroundService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/PublishEventsBackgroundService.cs
@@ -10,16 +10,16 @@ public class PublishEventsBackgroundService : BackgroundService
 
     private static readonly TimeSpan _pollInterval = TimeSpan.FromMinutes(1);
 
-    private readonly IEventObserver _eventObserver;
+    private readonly IEventPublisher _eventPublisher;
     private readonly IDbContextFactory<TrsDbContext> _dbContextFactory;
     private readonly ILogger<PublishEventsBackgroundService> _logger;
 
     public PublishEventsBackgroundService(
-        IEventObserver eventObserver,
+        IEventPublisher eventPublisher,
         IDbContextFactory<TrsDbContext> dbContextFactory,
         ILogger<PublishEventsBackgroundService> logger)
     {
-        _eventObserver = eventObserver;
+        _eventPublisher = eventPublisher;
         _dbContextFactory = dbContextFactory;
         _logger = logger;
     }
@@ -82,7 +82,7 @@ public class PublishEventsBackgroundService : BackgroundService
                 try
                 {
                     var eventBase = e.ToEventBase();
-                    await _eventObserver.OnEventSaved(eventBase);
+                    await _eventPublisher.PublishEvent(eventBase);
 
                     e.Published = true;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Processing/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<IHostedService, PublishEventsBackgroundService>();
         }
 
-        services.AddSingleton<IEventObserver, NoopEventObserver>();
+        services.AddSingleton<IEventPublisher, NoopEventPublisher>();
 
         return services;
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
@@ -52,7 +52,7 @@ public class HostFixture : WebApplicationFactory<Program>
             // Publish events synchronously
             PublishEventsDbCommandInterceptor.ConfigureServices(services);
 
-            services.AddSingleton<IEventObserver>(_ => new ForwardToTestScopedEventObserver());
+            services.AddSingleton<IEventPublisher>(_ => new ForwardToTestScopedEventPublisher());
             services.AddTestScoped<IClock>(tss => tss.Clock);
             services.AddSingleton<TestData>(
                 sp => ActivatorUtilities.CreateInstance<TestData>(
@@ -110,11 +110,11 @@ public class HostFixture : WebApplicationFactory<Program>
         }
     }
 
-    // IEventObserver needs to be a singleton but we want it to resolve to a test-scoped CaptureEventObserver.
-    // This provides a wrapper that can be registered as a singleon that delegates to the test-scoped IEventObserver instance.
-    private class ForwardToTestScopedEventObserver : IEventObserver
+    // IEventPublisher needs to be a singleton but we want it to resolve to a test-scoped CaptureEventPublisher.
+    // This provides a wrapper that can be registered as a singleon that delegates to the test-scoped IEventPublisher instance.
+    private class ForwardToTestScopedEventPublisher : IEventPublisher
     {
-        public Task OnEventSaved(EventBase @event) => TestScopedServices.GetCurrent().EventObserver.OnEventSaved(@event);
+        public Task PublishEvent(EventBase @event) => TestScopedServices.GetCurrent().EventPublisher.PublishEvent(@event);
     }
 
     private class ForwardToTestScopedClock : IClock

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
@@ -276,7 +276,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             state.SetTrn(true, trn);
         });
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -305,7 +305,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(trnToken.Trn, data.TrnTokenTrn);
         Assert.Equal(applicationUser.UserId, data.ClientApplicationUserId);
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var supportTaskCreatedEvent = Assert.IsType<SupportTaskCreatedEvent>(e);
             Assert.Equal(Clock.UtcNow, supportTaskCreatedEvent.CreatedUtc);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/TestBase.cs
@@ -26,7 +26,7 @@ public abstract class TestBase : IDisposable
 
     public HostFixture HostFixture { get; }
 
-    public CaptureEventObserver EventObserver => _testServices.EventObserver;
+    public CaptureEventPublisher EventPublisher => _testServices.EventPublisher;
 
     public TestableClock Clock => _testServices.Clock;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
@@ -36,14 +36,14 @@ public abstract class TestBase : IDisposable
                 var events = synced.OfType<EventBase>();
                 foreach (var e in events)
                 {
-                    TestScopedServices.GetCurrent().EventObserver.OnEventSaved(e);
+                    TestScopedServices.GetCurrent().EventPublisher.PublishEvent(e);
                 }
             });
     }
 
     public HostFixture HostFixture { get; }
 
-    public CaptureEventObserver EventObserver => _testServices.EventObserver;
+    public CaptureEventPublisher EventPublisher => _testServices.EventPublisher;
 
     public TestableClock Clock => _testServices.Clock;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestScopedServices.cs
@@ -7,7 +7,7 @@ public class TestScopedServices
     public TestScopedServices()
     {
         Clock = new();
-        EventObserver = new();
+        EventPublisher = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -25,5 +25,5 @@ public class TestScopedServices
 
     public TestableClock Clock { get; }
 
-    public CaptureEventObserver EventObserver { get; }
+    public CaptureEventPublisher EventPublisher { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -49,7 +49,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<CurrentUserProvider>();
             services.AddStartupTask<TestUsers.CreateUsersStartupTask>();
 
-            services.AddSingleton<IEventObserver>(_ => new ForwardToTestScopedEventObserver());
+            services.AddSingleton<IEventPublisher>(_ => new ForwardToTestScopedEventPublisher());
             services.AddTestScoped<IClock>(tss => tss.Clock);
             services.AddTestScoped<IDataverseAdapter>(tss => tss.DataverseAdapterMock.Object);
             services.AddTestScoped<IAadUserService>(tss => tss.AzureActiveDirectoryUserServiceMock.Object);
@@ -106,11 +106,11 @@ public class HostFixture : WebApplicationFactory<Program>
         }
     }
 
-    // IEventObserver needs to be a singleton but we want it to resolve to a test-scoped CaptureEventObserver.
-    // This provides a wrapper that can be registered as a singleon that delegates to the test-scoped IEventObserver instance.
-    private class ForwardToTestScopedEventObserver : IEventObserver
+    // IEventPublisher needs to be a singleton but we want it to resolve to a test-scoped CaptureEventPublisher.
+    // This provides a wrapper that can be registered as a singleon that delegates to the test-scoped IEventPublisher instance.
+    private class ForwardToTestScopedEventPublisher : IEventPublisher
     {
-        public Task OnEventSaved(EventBase @event) => TestScopedServices.GetCurrent().EventObserver.OnEventSaved(@event);
+        public Task PublishEvent(EventBase @event) => TestScopedServices.GetCurrent().EventPublisher.PublishEvent(@event);
     }
 
     private class ForwardToTestScopedClock : IClock

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKeyTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKeyTests.cs
@@ -183,7 +183,7 @@ public class AddApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
             }
         };
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -203,7 +203,7 @@ public class AddApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
             return apiKey;
         });
 
-        EventObserver.AssertEventsSaved(
+        EventPublisher.AssertEventsSaved(
             e =>
             {
                 var apiKeyCreatedEvent = Assert.IsType<ApiKeyCreatedEvent>(e);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKeyTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKeyTests.cs
@@ -145,7 +145,7 @@ public class EditApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/api-keys/{apiKey.ApiKeyId}/Expire");
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -160,7 +160,7 @@ public class EditApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(Clock.UtcNow, apiKey.Expires);
         });
 
-        EventObserver.AssertEventsSaved(
+        EventPublisher.AssertEventsSaved(
             e =>
             {
                 var apiKeyUpdatedEvent = Assert.IsType<ApiKeyUpdatedEvent>(e);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUserTests.cs
@@ -127,7 +127,7 @@ public class AddApplicationUserTests(HostFixture hostFixture) : TestBase(hostFix
 
         Assert.Equal($"/application-users/{applicationUser.UserId}", response.Headers.Location?.OriginalString);
 
-        EventObserver.AssertEventsSaved(
+        EventPublisher.AssertEventsSaved(
             e =>
             {
                 var applicationUserCreatedEvent = Assert.IsType<ApplicationUserCreatedEvent>(e);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
@@ -248,7 +248,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
             }
         };
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -263,7 +263,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
             Assert.True(new HashSet<string>(applicationUser.ApiRoles ?? []).SetEquals(new HashSet<string>(newRoles)));
         });
 
-        EventObserver.AssertEventsSaved(
+        EventPublisher.AssertEventsSaved(
             e =>
             {
                 var applicationUserUpdatedEvent = Assert.IsType<ApplicationUserUpdatedEvent>(e);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -172,7 +172,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId = qualification.QualificationId;
         });
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var expectedMqCreatedEvent = new MandatoryQualificationCreatedEvent()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/ConfirmTests.cs
@@ -139,7 +139,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
             .WithStartDate(startDate)
             .WithStatus(status, endDate)));
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         var qualificationId = person.MandatoryQualifications!.Single().QualificationId;
 
@@ -170,7 +170,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var redirectDoc = await redirectResponse.GetDocument();
         AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "Mandatory qualification deleted");
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var expectedMqDeletedEvent = new MandatoryQualificationDeletedEvent()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ConfirmTests.cs
@@ -116,7 +116,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualification = person.MandatoryQualifications.First();
         var qualificationId = qualification.QualificationId;
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -153,7 +153,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(newProvider.MandatoryQualificationProviderId, qualification.ProviderId);
         });
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ConfirmTests.cs
@@ -120,7 +120,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var changeReason = MqChangeSpecialismReasonOption.ChangeOfSpecialism;
         var changeReasonDetail = "Some reason";
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -157,7 +157,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(newMqSpecialism, qualification.Specialism);
         });
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ConfirmTests.cs
@@ -120,7 +120,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var changeReason = MqChangeStartDateReasonOption.IncorrectStartDate;
         var changeReasonDetail = "Some reason";
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         var journeyInstance = await CreateJourneyInstance(
             qualificationId,
@@ -157,7 +157,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(newStartDate, qualification.StartDate);
         });
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ConfirmTests.cs
@@ -229,7 +229,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualificationId = qualification.QualificationId;
         var provider = MandatoryQualificationProvider.GetById(qualification.ProviderId!.Value);
 
-        EventObserver.Clear();
+        EventPublisher.Clear();
 
         Guid? evidenceFileId = uploadEvidence ? Guid.NewGuid() : null;
         string? evidenceFileName = uploadEvidence ? "test.pdf" : null;
@@ -276,7 +276,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(newEndDate, qualification.EndDate);
         });
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
@@ -299,7 +299,7 @@ public class ConfirmTests : TestBase
         Assert.Equal(userId, user.AzureAdUserId);
         Assert.Collection(user.Roles, r => Assert.Equal(role, r));
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserAddedEvent>(e);
             Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
@@ -248,7 +248,7 @@ public class EditUserTests : TestBase
 
         if (expectedEvent)
         {
-            EventObserver.AssertEventsSaved(e =>
+            EventPublisher.AssertEventsSaved(e =>
             {
                 var userCreatedEvent = Assert.IsType<UserUpdatedEvent>(e);
                 Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
@@ -300,7 +300,7 @@ public class EditUserTests : TestBase
 
         Assert.False(updatedUser.Active);
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
             Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
@@ -346,7 +346,7 @@ public class EditUserTests : TestBase
 
         Assert.True(updatedUser.Active);
 
-        EventObserver.AssertEventsSaved(e =>
+        EventPublisher.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserActivatedEvent>(e);
             Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -34,14 +34,14 @@ public abstract class TestBase : IDisposable
                 var events = synced.OfType<EventBase>();
                 foreach (var e in events)
                 {
-                    TestScopedServices.GetCurrent().EventObserver.OnEventSaved(e);
+                    TestScopedServices.GetCurrent().EventPublisher.PublishEvent(e);
                 }
             });
     }
 
     public HostFixture HostFixture { get; }
 
-    public CaptureEventObserver EventObserver => _testServices.EventObserver;
+    public CaptureEventPublisher EventPublisher => _testServices.EventPublisher;
 
     public Mock<IDataverseAdapter> DataverseAdapterMock => _testServices.DataverseAdapterMock;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
@@ -12,7 +12,7 @@ public class TestScopedServices
         Clock = new();
         DataverseAdapterMock = new();
         AzureActiveDirectoryUserServiceMock = new();
-        EventObserver = new();
+        EventPublisher = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -34,5 +34,5 @@ public class TestScopedServices
 
     public Mock<IAadUserService> AzureActiveDirectoryUserServiceMock { get; }
 
-    public CaptureEventObserver EventObserver { get; }
+    public CaptureEventPublisher EventPublisher { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CaptureEventPublisher.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CaptureEventPublisher.cs
@@ -4,13 +4,13 @@ using Xunit;
 
 namespace TeachingRecordSystem.TestCommon;
 
-public class CaptureEventObserver : IEventObserver
+public class CaptureEventPublisher : IEventPublisher
 {
     private readonly HashSet<EventBase> _events = new(new EventIdEqualityComparer());
 
     public void Clear() => _events.Clear();
 
-    public Task OnEventSaved(EventBase @event)
+    public Task PublishEvent(EventBase @event)
     {
         _events.Add(@event);
         return Task.CompletedTask;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/PublishEventsDbCommandInterceptor.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/PublishEventsDbCommandInterceptor.cs
@@ -9,11 +9,11 @@ namespace TeachingRecordSystem.TestCommon.Infrastructure;
 
 public class PublishEventsDbCommandInterceptor : SaveChangesInterceptor
 {
-    private readonly IEventObserver _eventObserver;
+    private readonly IEventPublisher _eventPublisher;
 
-    public PublishEventsDbCommandInterceptor(IEventObserver eventObserver)
+    public PublishEventsDbCommandInterceptor(IEventPublisher eventPublisher)
     {
-        _eventObserver = eventObserver;
+        _eventPublisher = eventPublisher;
     }
 
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
@@ -35,7 +35,7 @@ public class PublishEventsDbCommandInterceptor : SaveChangesInterceptor
 
                 void OnEventSaved(object? sender, SavedChangesEventArgs args)
                 {
-                    _eventObserver.OnEventSaved(e.Entity.ToEventBase()).GetAwaiter().GetResult();
+                    _eventPublisher.PublishEvent(e.Entity.ToEventBase()).GetAwaiter().GetResult();
                     eventData.Context.SavedChanges -= OnEventSaved;
                 }
             }


### PR DESCRIPTION
`OnEventSaved` is a bit of a misnomer as we don't call this when an event is saved, we call it to publish the event. As such rename the type to `IEventPublisher` and its method to `PublishEvent`.