### PR TITLE
Allow deserializing events with missing properties

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
@@ -1,11 +1,35 @@
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
 public abstract record EventBase
 {
-    public static JsonSerializerOptions JsonSerializerOptions { get; } = new();
+    public static JsonSerializerOptions JsonSerializerOptions { get; } = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        {
+            Modifiers =
+            {
+                // Remove any required constraints;
+                // we want to be able to evolve the events by adding new properties with the required modifier
+                // without breaking deserialization for older events.
+                static typeInfo =>
+                {
+                    if (typeInfo.Kind != JsonTypeInfoKind.Object)
+                    {
+                        return;
+                    }
+
+                    foreach (var propertyInfo in typeInfo.Properties)
+                    {
+                        propertyInfo.IsRequired = false;
+                    }
+                }
+            }
+        }
+    };
 
     public required Guid EventId { get; init; }
     public required DateTime CreatedUtc { get; init; }


### PR DESCRIPTION
We want to be able to evolve events by adding new properties with the required modifier (so that we can ensure they're initialized correctly everywhere) but we don't want to break deserialization for older events that are missing those new properties. This removes all required constraints from properties when deserializing events.