### PR TITLE
Add workload identity federation to TRA namespaces

### DIFF
--- a/terraform/aks/app.tf
+++ b/terraform/aks/app.tf
@@ -242,9 +242,10 @@ module "worker_application" {
   kubernetes_config_map_name = module.worker_application_configuration.kubernetes_config_map_name
   kubernetes_secret_name     = module.worker_application_configuration.kubernetes_secret_name
 
-  docker_image = var.docker_image
-  command      = ["/bin/ash", "-c", "cd /Apps/Worker/; dotnet TeachingRecordSystem.Worker.dll;"]
-  replicas     = var.worker_replicas
-  max_memory   = var.worker_max_memory
-  enable_logit = var.enable_logit
+  docker_image   = var.docker_image
+  command        = ["/bin/ash", "-c", "cd /Apps/Worker/; dotnet TeachingRecordSystem.Worker.dll;"]
+  replicas       = var.worker_replicas
+  max_memory     = var.worker_max_memory
+  enable_logit   = var.enable_logit
+  enable_gcp_wif = var.enable_gcp_wif
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -47,6 +47,8 @@ variable "enable_monitoring" {
 
 variable "enable_logit" { default = false }
 
+variable "enable_gcp_wif" { default = true }
+
 variable "deploy_azure_backing_services" {
   type    = string
   default = true

--- a/terraform/aks/workspace_variables/dev.tfvars.json
+++ b/terraform/aks/workspace_variables/dev.tfvars.json
@@ -7,5 +7,6 @@
   "deploy_dqt_reporting_server": true,
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": false,
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_gcp_wif": true
 }

--- a/terraform/aks/workspace_variables/dv_review.tfvars.json
+++ b/terraform/aks/workspace_variables/dv_review.tfvars.json
@@ -7,5 +7,6 @@
   "run_dqt_reporting_service": false,
   "run_recurring_jobs": false,
   "enable_logit": true,
+  "enable_gcp_wif": true,
   "deploy_azure_backing_services": false
 }

--- a/terraform/aks/workspace_variables/pre-production.tfvars.json
+++ b/terraform/aks/workspace_variables/pre-production.tfvars.json
@@ -7,5 +7,6 @@
   "deploy_dqt_reporting_server": false,
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": true,
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_gcp_wif": true
 }

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -8,6 +8,7 @@
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": true,
   "enable_logit": true,
+  "enable_gcp_wif": true,
   "api_replicas": 2,
   "api_max_memory": "4Gi",
   "authz_replicas": 2,

--- a/terraform/aks/workspace_variables/test.tfvars.json
+++ b/terraform/aks/workspace_variables/test.tfvars.json
@@ -8,5 +8,6 @@
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": false,
   "postgres_server_version": "15",
-  "enable_logit": true
+  "enable_logit": true,
+  "enable_gcp_wif": true
 }


### PR DESCRIPTION
### Context

WIF is live in the BAT apps. We can start migrating TRA apps now, especially TRS as it's the first dotnet app.

### Changes proposed in this pull request

Add Google WIF to all TRA namespaces

### Guidance to review


### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
