### PR TITLE
Add workload identity federation to namespaces

### DIFF
--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -61,6 +61,12 @@ variable "deploy_dqt_reporting_server" {
   default = false
 }
 
+variable "gcp_wif_namespaces" {
+  description = "List of namespaces with Azure GCP Wokload Identity Federation enabled"
+  type        = list(string)
+  default     = []
+}
+
 variable "run_dqt_reporting_service" {
   type = bool
 }

--- a/terraform/aks/workspace_variables/dev.tfvars.json
+++ b/terraform/aks/workspace_variables/dev.tfvars.json
@@ -7,5 +7,6 @@
   "deploy_dqt_reporting_server": true,
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": false,
-  "enable_logit": true
+  "enable_logit": true,
+  "gcp_wif_namespaces": ["tra-development"]
 }

--- a/terraform/aks/workspace_variables/dv_review.tfvars.json
+++ b/terraform/aks/workspace_variables/dv_review.tfvars.json
@@ -7,5 +7,6 @@
   "run_dqt_reporting_service": false,
   "run_recurring_jobs": false,
   "enable_logit": true,
-  "deploy_azure_backing_services": false
+  "deploy_azure_backing_services": false,
+  "gcp_wif_namespaces": ["development"]
 }

--- a/terraform/aks/workspace_variables/pre-production.tfvars.json
+++ b/terraform/aks/workspace_variables/pre-production.tfvars.json
@@ -7,5 +7,6 @@
   "deploy_dqt_reporting_server": false,
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": true,
-  "enable_logit": true
+  "enable_logit": true,
+  "gcp_wif_namespaces": ["tra-test"]
 }

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -19,5 +19,6 @@
   "redis_family": "P",
   "redis_sku_name": "Premium",
   "statuscake_extra_urls": ["https://teacher-qualifications-api.education.gov.uk/health"],
-  "ssl_urls": ["https://teacher-qualifications-api.education.gov.uk/health"]
+  "ssl_urls": ["https://teacher-qualifications-api.education.gov.uk/health"],
+  "gcp_wif_namespaces": ["tra-production"]
 }

--- a/terraform/aks/workspace_variables/test.tfvars.json
+++ b/terraform/aks/workspace_variables/test.tfvars.json
@@ -8,5 +8,6 @@
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": false,
   "postgres_server_version": "15",
-  "enable_logit": true
+  "enable_logit": true,
+  "gcp_wif_namespaces": ["tra-test"]
 }


### PR DESCRIPTION
### Context

WIF is live in the BAT apps. We can start migrating TRA apps now, especially TRS as it's the first dotnet app.

### Changes proposed in this pull request

Add Google WIF to all TRA namespaces

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
