### PR TITLE
Fix date parsing on person search for deployment environments

### DIFF
--- a/TeachingRecordSystem/Directory.Build.props
+++ b/TeachingRecordSystem/Directory.Build.props
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Using Include="Microsoft.EntityFrameworkCore" />
     <Using Include="TeachingRecordSystem.Core" />
+    <Using Include="TeachingRecordSystem.Core.CoreConstants" Static="true" />
     <Using Include="TeachingRecordSystem.Core.Events" />
     <Using Include="TeachingRecordSystem.Core.Models" />
     <Using Include="System.Threading.Tasks.Task" Alias="Task" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/CoreConstants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/CoreConstants.cs
@@ -1,0 +1,8 @@
+using System.Globalization;
+
+namespace TeachingRecordSystem.Core;
+
+public static class CoreConstants
+{
+    public static readonly CultureInfo EnGbCulture = CultureInfo.GetCultureInfo("en-GB");
+}


### PR DESCRIPTION
Parsing a `dd/MM/yyyy`-style doesn't work on deployed environments since the culture is not set to en-gb. This explicitly passes that culture to the `Parse` method for the person search.