### PR TITLE
Use NpgsqlDataSource

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -62,6 +62,7 @@
     <PackageVersion Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.27" />
     <PackageVersion Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="1.1.27" />
     <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="OpenIddict.AspNetCore" Version="5.2.0" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="5.2.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -80,7 +80,7 @@ public class TrsDbContext : DbContext
 
     public DbSet<TpsEstablishmentType> TpsEstablishmentTypes => Set<TpsEstablishmentType>();
 
-    public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string connectionString, int? commandTimeout = null)
+    public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string? connectionString = null, int? commandTimeout = null)
     {
         Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o.CommandTimeout(commandTimeout);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDesignTimeDbContextFactory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDesignTimeDbContextFactory.cs
@@ -11,7 +11,7 @@ public class TrsDesignTimeDbContextFactory : IDesignTimeDbContextFactory<TrsDbCo
             .AddUserSecrets<TrsDesignTimeDbContextFactory>(optional: true)  // Optional for CI
             .Build();
 
-        var connectionString = configuration.GetRequiredConnectionString("DefaultConnection");
+        var connectionString = configuration.GetPostgresConnectionString();
 
         var optionsBuilder = new DbContextOptionsBuilder<TrsDbContext>();
         TrsDbContext.ConfigureOptions(optionsBuilder, connectionString);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -133,6 +133,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" />
+    <PackageReference Include="Npgsql.DependencyInjection" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" />
     <PackageReference Include="Optional" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
@@ -17,16 +17,14 @@ public class EstablishmentRefresherTests
         DbFixture = dbFixture;
         Clock = new();
 
-        var dbContextFactory = dbFixture.GetDbContextFactory();
-
         Helper = new TrsDataSyncHelper(
-            dbContextFactory,
+            dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
             Clock);
 
         TestData = new TestData(
-            dbContextFactory,
+            dbFixture.GetDbContextFactory(),
             organizationService,
             referenceDataCache,
             Clock,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
@@ -34,16 +34,14 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
         DbFixture = dbFixture;
         Clock = new();
 
-        var dbContextFactory = dbFixture.GetDbContextFactory();
-
         Helper = new TrsDataSyncHelper(
-            dbContextFactory,
+            dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
             Clock);
 
         TestData = new TestData(
-            dbContextFactory,
+            dbFixture.GetDbContextFactory(),
             organizationService,
             referenceDataCache,
             Clock,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -18,16 +18,14 @@ public class PersonMatchingServiceTests : IAsyncLifetime
         DbFixture = dbFixture;
         Clock = new();
 
-        var dbContextFactory = dbFixture.GetDbContextFactory();
-
         var syncHelper = new TrsDataSyncHelper(
-            dbContextFactory,
+            dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
             Clock);
 
         TestData = new TestData(
-            dbContextFactory,
+            dbFixture.GetDbContextFactory(),
             organizationService,
             referenceDataCache,
             Clock,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
@@ -16,16 +16,14 @@ public partial class TrsDataSyncHelperTests
         DbFixture = dbFixture;
         Clock = new();
 
-        var dbContextFactory = dbFixture.GetDbContextFactory();
-
         Helper = new TrsDataSyncHelper(
-            dbContextFactory,
+            dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
             Clock);
 
         TestData = new TestData(
-            dbContextFactory,
+            dbFixture.GetDbContextFactory(),
             organizationService,
             referenceDataCache,
             Clock,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
@@ -18,16 +18,14 @@ public class TrsDataSyncServiceFixture : IAsyncLifetime
         DbFixture = dbFixture;
         Clock = new();
 
-        var dbContextFactory = dbFixture.GetDbContextFactory();
-
         Helper = new TrsDataSyncHelper(
-            dbContextFactory,
+            dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
             Clock);
 
         TestData = new TestData(
-            dbContextFactory,
+            dbFixture.GetDbContextFactory(),
             organizationService,
             referenceDataCache,
             Clock,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -17,16 +17,14 @@ public class TpsCsvExtractProcessorTests
         DbFixture = dbFixture;
         Clock = new();
 
-        var dbContextFactory = dbFixture.GetDbContextFactory();
-
         Helper = new TrsDataSyncHelper(
-            dbContextFactory,
+            dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
             Clock);
 
         TestData = new TestData(
-            dbContextFactory,
+            dbFixture.GetDbContextFactory(),
             organizationService,
             referenceDataCache,
             Clock,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbFixture.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.TestCommon;
@@ -8,6 +9,8 @@ public class DbFixture(DbHelper dbHelper, IServiceProvider serviceProvider)
     public DbHelper DbHelper { get; } = dbHelper;
 
     public IServiceProvider Services { get; } = serviceProvider;
+
+    public NpgsqlDataSource GetDataSource() => Services.GetRequiredService<NpgsqlDataSource>();
 
     public TrsDbContext GetDbContext() => Services.GetRequiredService<TrsDbContext>();
 


### PR DESCRIPTION
The `/metrics` endpoint published database-related metrics with a `pool-name` that matches the connection string (minus the password). We don't really want to be exposing that. This PR moves to using `NpgsqlDataSource` with a `Name` of `TrsDb`; this changes the `pool-name` on the metrics to `TrsDb`.

It turns out `NpgsqlDataSource` is quite a nice thing to be passing around so I've updated a few places to use it over `IDbContextFactory<TrsDbContext>` (or the plain connection string).