### PR TITLE
Amended DB health checks to use NpgsqlDataSource

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/Extensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Npgsql;
 using Prometheus;
 using TeachingRecordSystem.Core.Infrastructure.Configuration;
 using TeachingRecordSystem.ServiceDefaults.Infrastructure.Logging;
@@ -23,7 +24,7 @@ public static class Extensions
         builder.AddHangfire();
         builder.AddBackgroundWorkScheduler();
 
-        builder.Services.AddHealthChecks().AddNpgSql(builder.Configuration.GetPostgresConnectionString());
+        builder.Services.AddHealthChecks().AddNpgSql(sp => sp.GetRequiredService<NpgsqlDataSource>());
         builder.Services.AddDatabaseDeveloperPageExceptionFilter();
         builder.Services.AddSingleton<UrlRedactor>();
 


### PR DESCRIPTION
### Context

The /metrics endpoint published database-related metrics with a pool-name that matches the connection string (minus the password).

James has done some work to fix this but it seems that something is still exposing the connection string minus password in the metrics.

### Changes proposed in this pull request

The issue was tracked down to the DB health checks using a connection string
