### PR TITLE
Amend non-prod postgres instances to support replication

### DIFF
--- a/terraform/aks/workspace_variables/dev.tfvars.json
+++ b/terraform/aks/workspace_variables/dev.tfvars.json
@@ -8,5 +8,6 @@
   "deploy_dqt_reporting_server": true,
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": false,
-  "enable_logit": true
+  "enable_logit": true,
+  "postgres_flexible_server_sku": "GP_Standard_D2ads_v5"
 }

--- a/terraform/aks/workspace_variables/pre-production.tfvars.json
+++ b/terraform/aks/workspace_variables/pre-production.tfvars.json
@@ -8,5 +8,6 @@
   "deploy_dqt_reporting_server": false,
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": true,
-  "enable_logit": true
+  "enable_logit": true,
+  "postgres_flexible_server_sku": "GP_Standard_D2ads_v5"
 }

--- a/terraform/aks/workspace_variables/test.tfvars.json
+++ b/terraform/aks/workspace_variables/test.tfvars.json
@@ -9,5 +9,6 @@
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": false,
   "postgres_server_version": "15",
-  "enable_logit": true
+  "enable_logit": true,
+  "postgres_flexible_server_sku": "GP_Standard_D2ads_v5"
 }


### PR DESCRIPTION
For syncing data from TRS into the DQT reporting DB we're relying on postgres' replication feature but that's not available in Burstable SKUs. This moves to the smallest General Purpose SKU.

Once data has been fully migrated from DQT these instances can be reverted to the Burstable SKU.