### PR TITLE
Don't retry migrations job

### DIFF
--- a/terraform/aks/app.tf
+++ b/terraform/aks/app.tf
@@ -37,7 +37,7 @@ resource "kubernetes_job" "migrations" {
       }
     }
 
-    backoff_limit = 1
+    backoff_limit = 0
   }
 
   wait_for_completion = true


### PR DESCRIPTION
The `backoff_limit` of `1` means the migrations job will be retried once. We don't want to retry at all; if it fails the first time it will fail again.