### PR TITLE
Add check to see if user requesting a TRN is intending to do an NPQ

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/AuthorizeAccessLinkGenerator.cs
@@ -38,6 +38,12 @@ public abstract class AuthorizeAccessLinkGenerator
     public string RequestTrn(JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RequestTrn/Index", journeyInstanceId: journeyInstanceId);
 
+    public string RequestTrnNpqCheck(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/NpqCheck", journeyInstanceId: journeyInstanceId);
+
+    public string RequestTrnNotEligible(JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RequestTrn/NotEligible", journeyInstanceId: journeyInstanceId);
+
     public string RequestTrnEmail(JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RequestTrn/Email", routeValues: new { fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrn(Model.JourneyInstance!.InstanceId))" />
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RequestTrnCheckAnswers(Model.JourneyInstance!.InstanceId) : LinkGenerator.RequestTrnNpqCheck(Model.JourneyInstance!.InstanceId))" />
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
@@ -24,4 +24,4 @@
     </div>
 </div>
 
-<govuk-button-link href="@LinkGenerator.RequestTrnEmail(Model.JourneyInstance!.InstanceId)" is-start-button="true">Start now</govuk-button-link>
+<govuk-button-link href="@LinkGenerator.RequestTrnNpqCheck(Model.JourneyInstance!.InstanceId)" is-start-button="true">Start now</govuk-button-link>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NotEligible.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NotEligible.cshtml
@@ -9,7 +9,17 @@
 }
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-grid-column-full-from-desktop">
         <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+        <p class="govuk-body">You can only use this service if you need a TRN to register for an NPQ.</p>
+        <p class="govuk-body">
+            Find out how to <a class="govuk-link" href="https://www.gov.uk/guidance/teacher-reference-number-trn#if-youre-a-mentor-for-a-trainee-or-early-career-teacher">get a TRN if you’re a mentor for a trainee or early career teacher</a>.
+        </p>
+        <p class="govuk-body">If you’ve forgotten your TRN, you can:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>check your payslip or pension statement</li>
+            <li>use the <a class="govuk-link" href="https://find-a-lost-trn.education.gov.uk/start">Find a lost TRN service</a> to check if you have a TRN or to find your TRN</li>
+        </ul>
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NotEligible.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NotEligible.cshtml
@@ -1,0 +1,15 @@
+@page "/request-trn/not-eligible"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.NotEligibleModel
+@{
+    ViewBag.Title = "You cannot use this service to get a TRN";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrnNpqCheck(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NotEligible.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NotEligible.cshtml.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.UiCommon.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class NotEligibleModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var state = JourneyInstance!.State;
+        if (state.HasPendingTrnRequest)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+        }
+        else if (state.IsPlanningToTakeAnNpq is null)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnNpqCheck(JourneyInstance!.InstanceId));
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NpqCheck.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NpqCheck.cshtml
@@ -1,0 +1,25 @@
+@page "/request-trn/npq-check"
+@model TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn.NpqCheckModel
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.IsPlanningToTakeAnNpq);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RequestTrn(Model.JourneyInstance!.InstanceId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RequestTrnNpqCheck(Model.JourneyInstance!.InstanceId)" method="post">
+            <govuk-radios asp-for="IsPlanningToTakeAnNpq">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
+                    <govuk-radios-item value="@true">Yes</govuk-radios-item>
+                    <govuk-radios-item value="@false">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NpqCheck.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NpqCheck.cshtml.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.UiCommon.FormFlow;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Pages.RequestTrn;
+
+[Journey(RequestTrnJourneyState.JourneyName), RequireJourneyInstance]
+public class NpqCheckModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<RequestTrnJourneyState>? JourneyInstance { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Do you plan on taking a national professional qualification (NPQ)?")]
+    [Required(ErrorMessage = "Tell us whether you plan on taking a national professional qualification (NPQ)")]
+    public bool? IsPlanningToTakeAnNpq { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state => state.IsPlanningToTakeAnNpq = IsPlanningToTakeAnNpq);
+
+        return IsPlanningToTakeAnNpq == true ?
+            Redirect(linkGenerator.RequestTrnEmail(JourneyInstance!.InstanceId)) :
+            Redirect(linkGenerator.RequestTrnNotEligible(JourneyInstance.InstanceId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var state = JourneyInstance!.State;
+        if (state.HasPendingTrnRequest)
+        {
+            context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+            return;
+        }
+
+        IsPlanningToTakeAnNpq ??= JourneyInstance!.State.IsPlanningToTakeAnNpq;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/RequestTrnJourneyState.cs
@@ -9,6 +9,7 @@ public class RequestTrnJourneyState()
     public static JourneyDescriptor JourneyDescriptor { get; } =
         new JourneyDescriptor(JourneyName, typeof(RequestTrnJourneyState), requestDataKeys: [], appendUniqueKey: true);
 
+    public bool? IsPlanningToTakeAnNpq { get; set; }
     public string? Email { get; set; }
     public string? Name { get; set; }
     public bool? HasPreviousName { get; set; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/RequestTrnTests.cs
@@ -5,88 +5,104 @@ namespace TeachingRecordSystem.AuthorizeAccess.EndToEndTests;
 public class RequestTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task RequestTrn(bool hasNationalInsuranceNumber)
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public async Task RequestTrn(bool isPlanningToTakeAnNpq, bool hasNationalInsuranceNumber)
     {
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
         await page.GotoAsync("/request-trn");
         await page.ClickButton("Start now");
-        await page.WaitForUrlPathAsync("/request-trn/email");
+        await page.WaitForUrlPathAsync("/request-trn/npq-check");
 
-        var email = Faker.Internet.Email();
-        await page.FillAsync("input[name=Email]", email);
-        await page.ClickButton("Continue");
-
-        await page.WaitForUrlPathAsync("/request-trn/name");
-
-        var name = Faker.Name.FullName();
-        var previousName = Faker.Name.FullName();
-        await page.FillAsync("input[name=Name]", name);
-        await page.ClickButton("Continue");
-
-        await page.WaitForUrlPathAsync("/request-trn/previous-name");
-
-        await page.CheckAsync("text=Yes");
-        await page.FillAsync("input[name=PreviousName]", previousName);
-        await page.ClickButton("Continue");
-
-        await page.WaitForUrlPathAsync("/request-trn/date-of-birth");
-
-        var dateOfBirth = new DateOnly(1980, 10, 12);
-        await page.FillDateInput(dateOfBirth);
-        await page.ClickButton("Continue");
-
-        await page.WaitForUrlPathAsync("/request-trn/identity");
-
-        await page
-                .GetByLabel("Upload file")
-                .SetInputFilesAsync(
-                    new FilePayload()
-                    {
-                        Name = "evidence.jpg",
-                        MimeType = "image/jpeg",
-                        Buffer = TestData.JpegImage
-                    });
-        await page.ClickButton("Continue");
-
-        await page.WaitForUrlPathAsync("/request-trn/national-insurance-number");
-
-        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
-        if (hasNationalInsuranceNumber)
+        if (isPlanningToTakeAnNpq)
         {
             await page.CheckAsync("text=Yes");
-            await page.FillAsync("input[name=NationalInsuranceNumber]", nationalInsuranceNumber);
             await page.ClickButton("Continue");
 
-            await page.WaitForUrlPathAsync("/request-trn/check-answers");
+            await page.WaitForUrlPathAsync("/request-trn/email");
+
+            var email = Faker.Internet.Email();
+            await page.FillAsync("input[name=Email]", email);
+            await page.ClickButton("Continue");
+
+            await page.WaitForUrlPathAsync("/request-trn/name");
+
+            var name = Faker.Name.FullName();
+            var previousName = Faker.Name.FullName();
+            await page.FillAsync("input[name=Name]", name);
+            await page.ClickButton("Continue");
+
+            await page.WaitForUrlPathAsync("/request-trn/previous-name");
+
+            await page.CheckAsync("text=Yes");
+            await page.FillAsync("input[name=PreviousName]", previousName);
+            await page.ClickButton("Continue");
+
+            await page.WaitForUrlPathAsync("/request-trn/date-of-birth");
+
+            var dateOfBirth = new DateOnly(1980, 10, 12);
+            await page.FillDateInput(dateOfBirth);
+            await page.ClickButton("Continue");
+
+            await page.WaitForUrlPathAsync("/request-trn/identity");
+
+            await page
+                    .GetByLabel("Upload file")
+                    .SetInputFilesAsync(
+                        new FilePayload()
+                        {
+                            Name = "evidence.jpg",
+                            MimeType = "image/jpeg",
+                            Buffer = TestData.JpegImage
+                        });
+            await page.ClickButton("Continue");
+
+            await page.WaitForUrlPathAsync("/request-trn/national-insurance-number");
+
+            var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
+            if (hasNationalInsuranceNumber)
+            {
+                await page.CheckAsync("text=Yes");
+                await page.FillAsync("input[name=NationalInsuranceNumber]", nationalInsuranceNumber);
+                await page.ClickButton("Continue");
+
+                await page.WaitForUrlPathAsync("/request-trn/check-answers");
+            }
+            else
+            {
+                await page.CheckAsync("text=No");
+                await page.ClickButton("Continue");
+                await page.WaitForUrlPathAsync("/request-trn/address");
+
+                var addressLine1 = Faker.Address.StreetAddress();
+                var addressLine2 = Faker.Address.SecondaryAddress();
+                var townOrCity = Faker.Address.City();
+                var postalCode = Faker.Address.ZipCode();
+                var country = Faker.Address.Country();
+
+                await page.FillAsync("input[name=AddressLine1]", addressLine1);
+                await page.FillAsync("input[name=AddressLine2]", addressLine2);
+                await page.FillAsync("input[name=TownOrCity]", townOrCity);
+                await page.FillAsync("input[name=PostalCode]", postalCode);
+                await page.FillAsync("input[name=Country]", country);
+                await page.ClickButton("Continue");
+
+                await page.WaitForUrlPathAsync("/request-trn/check-answers");
+            }
+
+            await page.ClickButton("Submit request");
+
+            await page.WaitForUrlPathAsync("/request-trn/submitted");
         }
         else
         {
             await page.CheckAsync("text=No");
             await page.ClickButton("Continue");
-            await page.WaitForUrlPathAsync("/request-trn/address");
 
-            var addressLine1 = Faker.Address.StreetAddress();
-            var addressLine2 = Faker.Address.SecondaryAddress();
-            var townOrCity = Faker.Address.City();
-            var postalCode = Faker.Address.ZipCode();
-            var country = Faker.Address.Country();
-
-            await page.FillAsync("input[name=AddressLine1]", addressLine1);
-            await page.FillAsync("input[name=AddressLine2]", addressLine2);
-            await page.FillAsync("input[name=TownOrCity]", townOrCity);
-            await page.FillAsync("input[name=PostalCode]", postalCode);
-            await page.FillAsync("input[name=Country]", country);
-            await page.ClickButton("Continue");
-
-            await page.WaitForUrlPathAsync("/request-trn/check-answers");
+            await page.WaitForUrlPathAsync("/request-trn/not-eligible");
         }
-
-        await page.ClickButton("Submit request");
-
-        await page.WaitForUrlPathAsync("/request-trn/submitted");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NotEligibleTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NotEligibleTests.cs
@@ -1,0 +1,91 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class NotEligibleTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/not-eligible?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasIsPlanningToTakeAnNpqMissingFromState_RedirectsToNpqCheck()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/not-eligible?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.IsPlanningToTakeAnNpq = false;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/not-eligible?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponse(response);
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/not-eligible?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_HasIsPlanningToTakeAnNpqMissingFromState_RedirectsToNpqCheck()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/not-eligible?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NpqCheckTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/NpqCheckTests.cs
@@ -1,0 +1,130 @@
+namespace TeachingRecordSystem.AuthorizeAccess.Tests.PageTests.RequestTrn;
+
+public class NpqCheckTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponse(response);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.IsPlanningToTakeAnNpq = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var radioButtons = doc.GetElementsByName("IsPlanningToTakeAnNpq");
+        var selectedRadioButton = radioButtons.Single(r => r.HasAttribute("checked"));
+        Assert.Equal("True", selectedRadioButton.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_HasPendingTrnRequestSetTrue_RedirectsToSubmitted()
+    {
+        // Arrange
+        var state = CreateNewState();
+        state.HasPendingTrnRequest = true;
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["IsPlanningToTakeAnNpq"] = "true"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenIsPlanningToTakeAnNpqHasNoSelection_ReturnsError()
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "IsPlanningToTakeAnNpq", "Tell us whether you plan on taking a national professional qualification (NPQ)");
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("false")]
+    public async Task Post_ValidRequest_UpdatesJourneyStateAndRedirects(string isPlanningToTakeAnNpq)
+    {
+        // Arrange
+        var state = CreateNewState();
+        var journeyInstance = await CreateJourneyInstance(state);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/npq-check?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["IsPlanningToTakeAnNpq"] = isPlanningToTakeAnNpq
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        if (isPlanningToTakeAnNpq == "true")
+        {
+            Assert.Equal($"/request-trn/email?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+        }
+        else
+        {
+            Assert.Equal($"/request-trn/not-eligible?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+        }
+    }
+}


### PR DESCRIPTION
### Context

Some people are using the request TRN journey even though they’re not registering for an NPQ.

### Changes proposed in this pull request

Add the ‘Do you plan on taking a national professional qualification (NPQ)?’ question to the beginning of the journey as shown in the Request a TRN Figma designs.

If ‘No’ is selected then show an error as per the designs.

If ‘Yes’ is selected, proceed to the email address page.

If no option is selected, show an error ‘Tell us whether you plan on taking a national professional qualification (NPQ)’.

### Guidance to review

Page changes + tests

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
