### PR TITLE
Don't share API models across versions

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/AlertInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/AlertInfo.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.AlertInfo))]
+public record AlertInfo
+{
+    public required AlertType AlertType { get; init; }
+    public required string DqtSanctionCode { get; init; }
+    public required DateOnly? StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/AlertType.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+public enum AlertType
+{
+    Prohibition,
+    // Only exposing Prohibitions for now
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/InductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/InductionStatus.cs
@@ -1,0 +1,14 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+public enum InductionStatus
+{
+    Exempt,
+    Fail,
+    FailedinWales,
+    InductionExtended,
+    InProgress,
+    NotYetCompleted,
+    Pass,
+    PassedinWales,
+    RequiredtoComplete,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/IttOutcome.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/IttOutcome.cs
@@ -1,0 +1,17 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+public enum IttOutcome
+{
+    Pass,
+    Fail,
+    Withdrawn,
+    Deferred,
+    DeferredForSkillsTests,
+    ApplicationReceived,
+    ApplicationUnsuccessful,
+    Approved,
+    Info,
+    InTraining,
+    NoResultSubmitted,
+    UnderAssessment,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/IttProgrammeType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/IttProgrammeType.cs
@@ -1,0 +1,30 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+public enum IttProgrammeType
+{
+    Apprenticeship,
+    AssessmentOnlyRoute,
+    Core,
+    CoreFlexible,
+    EYITTAssessmentOnly,
+    EYITTGraduateEmploymentBased,
+    EYITTGraduateEntry,
+    EYITTSchoolDirectEarlyYears,
+    EYITTUndergraduate,
+    FutureTeachingScholars,
+    GraduateTeacherProgramme,
+    HEI,
+    LicensedTeacherProgramme,
+    OverseasTrainedTeacherProgramme,
+    RegisteredTeacherProgramme,
+    SchoolDirectTrainingProgramme,
+    SchoolDirectTrainingProgrammeSalaried,
+    SchoolDirectTrainingProgrammeSelfFunded,
+    TeachFirstProgramme,
+    TeachFirstProgrammeCC,
+    UndergraduateOptIn,
+    ProviderLedPostgrad,
+    ProviderLedUndergrad,
+    InternationalQualifiedTeacherStatus,
+    HighPotentialITT
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/NameInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/NameInfo.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.NameInfo))]
+public record NameInfo
+{
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/NpqQualificationType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/NpqQualificationType.cs
@@ -1,0 +1,14 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+public enum NpqQualificationType
+{
+    NPQEL,
+    NPQEYL,
+    NPQH,
+    NPQLBC,
+    NPQLL,
+    NPQLT,
+    NPQLTD,
+    NPQML,
+    NPQSL,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/SanctionInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/ApiModels/SanctionInfo.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Api.V3.V20240416.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.SanctionInfo))]
+public record SanctionInfo
+{
+    public required string Code { get; init; }
+    public required DateOnly? StartDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
@@ -4,7 +4,8 @@ using Swashbuckle.AspNetCore.Annotations;
 using TeachingRecordSystem.Api.Infrastructure.ModelBinding;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using GetTeacherDtoVersion = TeachingRecordSystem.Api.V3.V20240101;
+using TeachingRecordSystem.Api.V3.V20240416.Requests;
+using TeachingRecordSystem.Api.V3.V20240416.Responses;
 
 namespace TeachingRecordSystem.Api.V3.V20240416.Controllers;
 
@@ -16,13 +17,13 @@ public class TeachersController(IMapper mapper) : ControllerBase
         OperationId = "GetTeacherByTrn",
         Summary = "Get teacher details by TRN",
         Description = "Gets the details of the teacher corresponding to the given TRN.")]
-    [ProducesResponseType(typeof(GetTeacherDtoVersion.Responses.GetTeacherResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
     [Authorize(Policy = AuthorizationPolicies.GetPerson)]
     public async Task<IActionResult> Get(
         [FromRoute] string trn,
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherDtoVersion.Requests.GetTeacherRequestIncludes? include,
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include,
         [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth,
         [FromServices] GetPersonHandler handler)
     {
@@ -38,7 +39,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
             return NotFound();
         }
 
-        var response = mapper.Map<GetTeacherDtoVersion.Responses.GetTeacherResponse>(result);
+        var response = mapper.Map<GetTeacherResponse>(result);
         return Ok(response);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Requests/GetTeacherRequestIncludes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Requests/GetTeacherRequestIncludes.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+
+namespace TeachingRecordSystem.Api.V3.V20240416.Requests;
+
+[Flags]
+[Description("Comma-separated list of data to include in response.")]
+public enum GetTeacherRequestIncludes
+{
+    None = 0,
+
+    Induction = 1 << 0,
+    InitialTeacherTraining = 1 << 1,
+    NpqQualifications = 1 << 2,
+    MandatoryQualifications = 1 << 3,
+    PendingDetailChanges = 1 << 4,
+    HigherEducationQualifications = 1 << 5,
+    Sanctions = 1 << 6,
+    Alerts = 1 << 7,
+    PreviousNames = 1 << 8,
+
+    [ExcludeFromSchema]
+    _AllowIdSignInWithProhibitions = 1 << 9,
+
+    All = Induction | InitialTeacherTraining | NpqQualifications | MandatoryQualifications | PendingDetailChanges | HigherEducationQualifications | Sanctions | Alerts | PreviousNames
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Responses/GetTeacherResponse.cs
@@ -1,12 +1,13 @@
 using System.Text.Json.Serialization;
+using AutoMapper.Configuration.Annotations;
 using Optional;
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240416.ApiModels;
 
-namespace TeachingRecordSystem.Api.V3.V20240606.Responses;
+namespace TeachingRecordSystem.Api.V3.V20240416.Responses;
 
 [AutoMap(typeof(GetPersonResult))]
-public record GetPersonResponse
+public record GetTeacherResponse
 {
     public required string Trn { get; init; }
     public required string FirstName { get; init; }
@@ -16,14 +17,15 @@ public record GetPersonResponse
     public required string? NationalInsuranceNumber { get; init; }
     public required Option<bool> PendingNameChange { get; init; }
     public required Option<bool> PendingDateOfBirthChange { get; init; }
-    public required string? EmailAddress { get; set; }
-    public required GetPersonResponseQts? Qts { get; init; }
-    public required GetPersonResponseEyts? Eyts { get; init; }
-    public required Option<GetPersonResponseInduction?> Induction { get; init; }
-    public required Option<IReadOnlyCollection<GetPersonResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
-    public required Option<IReadOnlyCollection<GetPersonResponseNpqQualification>> NpqQualifications { get; init; }
-    public required Option<IReadOnlyCollection<GetPersonResponseMandatoryQualification>> MandatoryQualifications { get; init; }
-    public required Option<IReadOnlyCollection<GetPersonResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
+    [SourceMember("EmailAddress")]
+    public required string? Email { get; set; }
+    public required GetTeacherResponseQts? Qts { get; init; }
+    public required GetTeacherResponseEyts? Eyts { get; init; }
+    public required Option<GetTeacherResponseInduction?> Induction { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseNpqQualification>> NpqQualifications { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseMandatoryQualification>> MandatoryQualifications { get; init; }
+    public required Option<IReadOnlyCollection<GetTeacherResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
     public required Option<IReadOnlyCollection<SanctionInfo>> Sanctions { get; init; }
     public required Option<IReadOnlyCollection<AlertInfo>> Alerts { get; init; }
     public required Option<IReadOnlyCollection<NameInfo>> PreviousNames { get; init; }
@@ -31,7 +33,7 @@ public record GetPersonResponse
 }
 
 [AutoMap(typeof(GetPersonResultQts))]
-public record GetPersonResponseQts
+public record GetTeacherResponseQts
 {
     public required DateOnly? Awarded { get; init; }
     public required string CertificateUrl { get; init; }
@@ -39,7 +41,7 @@ public record GetPersonResponseQts
 }
 
 [AutoMap(typeof(GetPersonResultEyts))]
-public record GetPersonResponseEyts
+public record GetTeacherResponseEyts
 {
     public required DateOnly? Awarded { get; init; }
     public required string CertificateUrl { get; init; }
@@ -47,7 +49,7 @@ public record GetPersonResponseEyts
 }
 
 [AutoMap(typeof(GetPersonResultInduction))]
-public record GetPersonResponseInduction
+public record GetTeacherResponseInduction
 {
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
@@ -55,96 +57,96 @@ public record GetPersonResponseInduction
     public required string? StatusDescription { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? CertificateUrl { get; init; }
-    public required IReadOnlyCollection<GetPersonResponseInductionPeriod> Periods { get; init; }
+    public required IReadOnlyCollection<GetTeacherResponseInductionPeriod> Periods { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInductionPeriod))]
-public record GetPersonResponseInductionPeriod
+public record GetTeacherResponseInductionPeriod
 {
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required int? Terms { get; init; }
-    public required GetPersonResponseInductionPeriodAppropriateBody? AppropriateBody { get; init; }
+    public required GetTeacherResponseInductionPeriodAppropriateBody? AppropriateBody { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInductionPeriodAppropriateBody))]
-public record GetPersonResponseInductionPeriodAppropriateBody
+public record GetTeacherResponseInductionPeriodAppropriateBody
 {
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTraining))]
-public record GetPersonResponseInitialTeacherTraining
+public record GetTeacherResponseInitialTeacherTraining
 {
-    public required GetPersonResponseInitialTeacherTrainingQualification? Qualification { get; init; }
+    public required GetTeacherResponseInitialTeacherTrainingQualification? Qualification { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required IttProgrammeType? ProgrammeType { get; init; }
     public required string? ProgrammeTypeDescription { get; init; }
     public required IttOutcome? Result { get; init; }
-    public required GetPersonResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
-    public required GetPersonResponseInitialTeacherTrainingProvider? Provider { get; init; }
-    public required IReadOnlyCollection<GetPersonResponseInitialTeacherTrainingSubject> Subjects { get; init; }
+    public required GetTeacherResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
+    public required GetTeacherResponseInitialTeacherTrainingProvider? Provider { get; init; }
+    public required IReadOnlyCollection<GetTeacherResponseInitialTeacherTrainingSubject> Subjects { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingQualification))]
-public record GetPersonResponseInitialTeacherTrainingQualification
+public record GetTeacherResponseInitialTeacherTrainingQualification
 {
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingAgeRange))]
-public record GetPersonResponseInitialTeacherTrainingAgeRange
+public record GetTeacherResponseInitialTeacherTrainingAgeRange
 {
     public required string Description { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingProvider))]
-public record GetPersonResponseInitialTeacherTrainingProvider
+public record GetTeacherResponseInitialTeacherTrainingProvider
 {
     public required string Name { get; init; }
     public required string Ukprn { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingSubject))]
-public record GetPersonResponseInitialTeacherTrainingSubject
+public record GetTeacherResponseInitialTeacherTrainingSubject
 {
     public required string Code { get; init; }
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultNpqQualification))]
-public record GetPersonResponseNpqQualification
+public record GetTeacherResponseNpqQualification
 {
     public required DateOnly Awarded { get; init; }
-    public required GetPersonResponseNpqQualificationType Type { get; init; }
+    public required GetTeacherResponseNpqQualificationType Type { get; init; }
     public required string CertificateUrl { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultNpqQualificationType))]
-public record GetPersonResponseNpqQualificationType
+public record GetTeacherResponseNpqQualificationType
 {
     public required NpqQualificationType Code { get; init; }
     public required string Name { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultMandatoryQualification))]
-public record GetPersonResponseMandatoryQualification
+public record GetTeacherResponseMandatoryQualification
 {
     public required DateOnly Awarded { get; init; }
     public required string Specialism { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultHigherEducationQualification))]
-public record GetPersonResponseHigherEducationQualification
+public record GetTeacherResponseHigherEducationQualification
 {
     public required string? Name { get; init; }
     public required DateOnly? Awarded { get; init; }
-    public required IReadOnlyCollection<GetPersonResponseHigherEducationQualificationSubject> Subjects { get; init; }
+    public required IReadOnlyCollection<GetTeacherResponseHigherEducationQualificationSubject> Subjects { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultHigherEducationQualificationSubject))]
-public record GetPersonResponseHigherEducationQualificationSubject
+public record GetTeacherResponseHigherEducationQualificationSubject
 {
     public required string Code { get; init; }
     public required string Name { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/AlertInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/AlertInfo.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.AlertInfo))]
+public record AlertInfo
+{
+    public required AlertType AlertType { get; init; }
+    public required string DqtSanctionCode { get; init; }
+    public required DateOnly? StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/AlertType.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+public enum AlertType
+{
+    Prohibition,
+    // Only exposing Prohibitions for now
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/InductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/InductionStatus.cs
@@ -1,0 +1,14 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+public enum InductionStatus
+{
+    Exempt,
+    Fail,
+    FailedinWales,
+    InductionExtended,
+    InProgress,
+    NotYetCompleted,
+    Pass,
+    PassedinWales,
+    RequiredtoComplete,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/IttOutcome.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/IttOutcome.cs
@@ -1,0 +1,17 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+public enum IttOutcome
+{
+    Pass,
+    Fail,
+    Withdrawn,
+    Deferred,
+    DeferredForSkillsTests,
+    ApplicationReceived,
+    ApplicationUnsuccessful,
+    Approved,
+    Info,
+    InTraining,
+    NoResultSubmitted,
+    UnderAssessment,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/IttProgrammeType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/IttProgrammeType.cs
@@ -1,0 +1,30 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+public enum IttProgrammeType
+{
+    Apprenticeship,
+    AssessmentOnlyRoute,
+    Core,
+    CoreFlexible,
+    EYITTAssessmentOnly,
+    EYITTGraduateEmploymentBased,
+    EYITTGraduateEntry,
+    EYITTSchoolDirectEarlyYears,
+    EYITTUndergraduate,
+    FutureTeachingScholars,
+    GraduateTeacherProgramme,
+    HEI,
+    LicensedTeacherProgramme,
+    OverseasTrainedTeacherProgramme,
+    RegisteredTeacherProgramme,
+    SchoolDirectTrainingProgramme,
+    SchoolDirectTrainingProgrammeSalaried,
+    SchoolDirectTrainingProgrammeSelfFunded,
+    TeachFirstProgramme,
+    TeachFirstProgrammeCC,
+    UndergraduateOptIn,
+    ProviderLedPostgrad,
+    ProviderLedUndergrad,
+    InternationalQualifiedTeacherStatus,
+    HighPotentialITT
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/NameInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/NameInfo.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.NameInfo))]
+public record NameInfo
+{
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/NpqQualificationType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/NpqQualificationType.cs
@@ -1,0 +1,14 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+public enum NpqQualificationType
+{
+    NPQEL,
+    NPQEYL,
+    NPQH,
+    NPQLBC,
+    NPQLL,
+    NPQLT,
+    NPQLTD,
+    NPQML,
+    NPQSL,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/SanctionInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/ApiModels/SanctionInfo.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.SanctionInfo))]
+public record SanctionInfo
+{
+    public required string Code { get; init; }
+    public required DateOnly? StartDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
@@ -7,7 +7,6 @@ using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Core.Operations;
 using TeachingRecordSystem.Api.V3.V20240606.Requests;
 using TeachingRecordSystem.Api.V3.V20240606.Responses;
-using CreateDetailChangeResponseVersion = TeachingRecordSystem.Api.V3.V20240412;
 
 namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
 
@@ -41,7 +40,7 @@ public class PersonController(IMapper mapper) : ControllerBase
         OperationId = "CreateNameChange",
         Summary = "Create name change request",
         Description = "Creates a name change request for the authenticated teacher.")]
-    [ProducesResponseType(typeof(CreateDetailChangeResponseVersion.Responses.CreateNameChangeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CreateNameChangeResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     public async Task<IActionResult> CreateNameChange(
@@ -60,7 +59,7 @@ public class PersonController(IMapper mapper) : ControllerBase
         };
 
         var caseNumber = await handler.Handle(command);
-        var response = new CreateDetailChangeResponseVersion.Responses.CreateNameChangeResponse() { CaseNumber = caseNumber };
+        var response = new CreateNameChangeResponse() { CaseNumber = caseNumber };
         return Ok(response);
     }
 
@@ -69,7 +68,7 @@ public class PersonController(IMapper mapper) : ControllerBase
         OperationId = "CreateDobChange",
         Summary = "Create DOB change request",
         Description = "Creates a date of birth change request for the authenticated teacher.")]
-    [ProducesResponseType(typeof(CreateDetailChangeResponseVersion.Responses.CreateDateOfBirthChangeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CreateDateOfBirthChangeResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     public async Task<IActionResult> CreateDateOfBirthChange(
@@ -86,7 +85,7 @@ public class PersonController(IMapper mapper) : ControllerBase
         };
 
         var caseNumber = await handler.Handle(command);
-        var response = new CreateDetailChangeResponseVersion.Responses.CreateNameChangeResponse() { CaseNumber = caseNumber };
+        var response = new CreateNameChangeResponse() { CaseNumber = caseNumber };
         return Ok(response);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateDateOfBirthChangeResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateDateOfBirthChangeResponse.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.Responses;
+
+public record CreateDateOfBirthChangeResponse
+{
+    public required string CaseNumber { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateNameChangeResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateNameChangeResponse.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Api.V3.V20240606.Responses;
+
+public record CreateNameChangeResponse
+{
+    public required string CaseNumber { get; init; }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/SchemaTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/SchemaTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api.Tests.V3;
+
+public class SchemaTests
+{
+    [Fact]
+    public void CheckApiVersionReferences()
+    {
+        // Check that each API version only references types from its own version
+
+        var allTypes = typeof(Api.V3.Constants).Assembly.GetTypes();
+
+        foreach (var version in VersionRegistry.AllV3MinorVersions)
+        {
+            var versionNamespace = $"{typeof(Api.V3.Constants).Namespace}.V{version}";
+            var versionTypes = allTypes.Where(t => t.Namespace?.StartsWith(versionNamespace) == true).ToArray();
+
+            foreach (var type in versionTypes)
+            {
+                var properties = type.GetProperties();
+
+                foreach (var property in properties)
+                {
+                    var propertyIsVersionedType = property.PropertyType.Namespace?.StartsWith($"{typeof(Api.V3.Constants).Namespace}.V") == true;
+
+                    if (propertyIsVersionedType && !property.PropertyType.Namespace!.StartsWith(versionNamespace))
+                    {
+                        Assert.Fail($"The '{property.Name}' property on {type.FullName} references a schema outside of its version ('{property.PropertyType.FullName}').");
+                    }
+                }
+
+                // If the type is a controller, check the responses it's sending are the correct version.
+                // The ProducesResponseTypeAttribute is the simplest way to check this.
+                if (type.Name.EndsWith("Controller"))
+                {
+                    var actions = type.GetMethods();
+
+                    foreach (var action in actions)
+                    {
+                        var producesResponseTypeAttrs = action.GetCustomAttributes<ProducesResponseTypeAttribute>();
+
+                        foreach (var attr in producesResponseTypeAttrs)
+                        {
+                            if (attr.Type.Namespace?.StartsWith($"{typeof(Api.V3.Constants).Namespace}.V") == true &&
+                                !attr.Type.Namespace!.StartsWith(versionNamespace))
+                            {
+                                Assert.Fail($"The '{action.Name}' method on {type.FullName} references a schema outside of its version ('{attr.Type.FullName}').");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Until now we've reused some model types from previous versions instead of duplicating them. The thinking behind this was to avoid duplication but it's becoming messy and difficult to get right for versions where we want to tweak the response just a little (e.g. the main 'get person' endpoint).

This PR moves removes the reuse and adds a test that checks versioned types cannot reference other versions.

I started a spike some time ago on a source generator that would generate these types itself for cases where types don't need to change across versions but that's not ready to go just yet.