### PR TITLE
Add bulk person search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # API Changelog
 
+## 20240814
+
+### `POST /v3/persons/find`
+
+New endpoint added for bulk person lookup by TRN and date of birth.
+
+### `GET /v3/persons?findBy=LastNameAndDateOfBirth&lastName={lastName}&dateOfBirth={dateOfBirth}`
+
+`inductionStatus`, `qts` and `eyts` members have been added to align with the bulk `POST` endpoint.
+
 ## 20240606
 
 All endpoints under `/teacher` and `/teachers` have been moved to `/person` and `/persons`, respectively.

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -215,7 +215,6 @@ public class Program
 
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<Program>());
         services.AddSingleton<ICurrentClientProvider, ClaimsPrincipalCurrentClientProvider>();
-        services.AddSingleton<IClock, Clock>();
         services.AddMemoryCache();
         services.AddSingleton<AddTrnToSentryScopeResourceFilter>();
         services.AddTransient<TrnRequestHelper>();
@@ -241,7 +240,7 @@ public class Program
 
         services.AddAccessYourTeachingQualificationsOptions(configuration, env);
         services.AddCertificateGeneration();
-        services.AddCrmQueries();
+        services.AddTrsBaseServices();
 
         if (!env.IsUnitTests())
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/EytsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/EytsInfo.cs
@@ -1,0 +1,43 @@
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Dqt.Models;
+
+namespace TeachingRecordSystem.Api.V3.Core.SharedModels;
+
+public record EytsInfo
+{
+    public required DateOnly Awarded { get; init; }
+    public required string CertificateUrl { get; init; }
+    public required string StatusDescription { get; init; }
+
+    public static async Task<EytsInfo?> Create(dfeta_qtsregistration? qtsRegistration, ReferenceDataCache referenceDataCache)
+    {
+        if (qtsRegistration is null)
+        {
+            return null;
+        }
+
+        var awardedDate = qtsRegistration.dfeta_EYTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);
+        if (awardedDate is null)
+        {
+            return null;
+        }
+
+        var earlyYearsStatus = await referenceDataCache.GetEarlyYearsStatusById(qtsRegistration.dfeta_EarlyYearsStatusId.Id);
+        var statusDescription = GetStatusDescription(earlyYearsStatus);
+
+        return new()
+        {
+            Awarded = awardedDate!.Value,
+            CertificateUrl = "/v3/certificates/eyts",
+            StatusDescription = statusDescription,
+        };
+    }
+
+    private static string GetStatusDescription(dfeta_earlyyearsstatus earlyYearsStatus) => earlyYearsStatus.dfeta_Value switch
+    {
+        "222" => "Early years professional status",
+        "221" => "Qualified",
+        "220" => "Early years trainee",
+        _ => throw new ArgumentException($"Unregonized EYTS status: '{earlyYearsStatus.dfeta_Value}'.", nameof(earlyYearsStatus))
+    };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/InductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/InductionStatus.cs
@@ -6,31 +6,44 @@ public enum InductionStatus
 {
     Exempt = 1,
     Fail = 2,
-    FailedinWales = 3,
+    FailedInWales = 3,
     InductionExtended = 4,
     InProgress = 5,
     NotYetCompleted = 6,
     Pass = 7,
-    PassedinWales = 8,
-    RequiredtoComplete = 9,
+    PassedInWales = 8,
+    RequiredToComplete = 9,
 }
 
 public static class InductionStatusExtensions
 {
-    public static InductionStatus ConvertToInductionStatus(this dfeta_InductionStatus input) =>
-        input.ConvertToEnumByName<dfeta_InductionStatus, InductionStatus>();
-
-    public static string GetDescription(this dfeta_InductionStatus input) => input switch
+    public static InductionStatus ConvertToInductionStatus(this dfeta_InductionStatus input) => input switch
     {
-        dfeta_InductionStatus.Exempt => "Exempt",
-        dfeta_InductionStatus.Fail => "Fail",
-        dfeta_InductionStatus.FailedinWales => "Failed in Wales",
-        dfeta_InductionStatus.InductionExtended => "Extended",
-        dfeta_InductionStatus.InProgress => "In progress",
-        dfeta_InductionStatus.NotYetCompleted => "Not yet completed",
-        dfeta_InductionStatus.Pass => "Pass",
-        dfeta_InductionStatus.PassedinWales => "Passed in Wales",
-        dfeta_InductionStatus.RequiredtoComplete => "Required to complete",
+        dfeta_InductionStatus.Exempt => InductionStatus.Exempt,
+        dfeta_InductionStatus.Fail => InductionStatus.Fail,
+        dfeta_InductionStatus.FailedinWales => InductionStatus.FailedInWales,
+        dfeta_InductionStatus.InductionExtended => InductionStatus.InductionExtended,
+        dfeta_InductionStatus.InProgress => InductionStatus.InProgress,
+        dfeta_InductionStatus.NotYetCompleted => InductionStatus.NotYetCompleted,
+        dfeta_InductionStatus.Pass => InductionStatus.Pass,
+        dfeta_InductionStatus.PassedinWales => InductionStatus.PassedInWales,
+        dfeta_InductionStatus.RequiredtoComplete => InductionStatus.RequiredToComplete,
+        _ => throw new ArgumentException($"Unknown {nameof(InductionStatus)}: '{input}'.")
+    };
+
+    public static string GetDescription(this dfeta_InductionStatus input) => ConvertToInductionStatus(input).GetDescription();
+
+    public static string GetDescription(this InductionStatus input) => input switch
+    {
+        InductionStatus.Exempt => "Exempt",
+        InductionStatus.Fail => "Fail",
+        InductionStatus.FailedInWales => "Failed in Wales",
+        InductionStatus.InductionExtended => "Extended",
+        InductionStatus.InProgress => "In progress",
+        InductionStatus.NotYetCompleted => "Not yet completed",
+        InductionStatus.Pass => "Pass",
+        InductionStatus.PassedInWales => "Passed in Wales",
+        InductionStatus.RequiredToComplete => "Required to complete",
         _ => throw new ArgumentException($"Unknown {nameof(InductionStatus)}: '{input}'.")
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/InductionStatusInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/InductionStatusInfo.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.Core.SharedModels;
+
+public record InductionStatusInfo
+{
+    public required InductionStatus Status { get; init; }
+    public required string StatusDescription { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/QtsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/QtsInfo.cs
@@ -1,0 +1,58 @@
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Dqt.Models;
+
+namespace TeachingRecordSystem.Api.V3.Core.SharedModels;
+
+public record QtsInfo
+{
+    public required DateOnly Awarded { get; init; }
+    public required string CertificateUrl { get; init; }
+    public required string StatusDescription { get; init; }
+
+    public static async Task<QtsInfo?> Create(dfeta_qtsregistration? qtsRegistration, ReferenceDataCache referenceDataCache)
+    {
+        if (qtsRegistration is null)
+        {
+            return null;
+        }
+
+        var awardedDate = qtsRegistration.dfeta_QTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true);
+        if (awardedDate is null)
+        {
+            return null;
+        }
+
+        var teacherStatus = await referenceDataCache.GetTeacherStatusById(qtsRegistration.dfeta_TeacherStatusId.Id);
+        var statusDescription = GetStatusDescription(teacherStatus);
+
+        return new()
+        {
+            Awarded = awardedDate!.Value,
+            CertificateUrl = "/v3/certificates/qts",
+            StatusDescription = statusDescription,
+        };
+    }
+
+    private static string GetStatusDescription(dfeta_teacherstatus teacherStatus) => teacherStatus.dfeta_Value switch
+    {
+        "28" => "Qualified",
+        "50" => "Qualified",
+        "67" => "Qualified",
+        "68" => "Qualified",
+        "69" => "Qualified",
+        "71" => "Qualified",
+        "87" => "Qualified",
+        "90" => "Qualified",
+        "100" => "Qualified",
+        "103" => "Qualified",
+        "104" => "Qualified",
+        "206" => "Qualified",
+        "211" => "Trainee teacher",
+        "212" => "Assessment only route candidate",
+        "213" => "Qualified",
+        "214" => "Partial qualified teacher status",
+        "223" => "Qualified",
+        _ when teacherStatus.dfeta_name.StartsWith("Qualified teacher", StringComparison.OrdinalIgnoreCase) => "Qualified",
+        _ => throw new ArgumentException($"Unregonized QTS status: '{teacherStatus.dfeta_Value}'.", nameof(teacherStatus))
+    };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Responses/GetTeacherResponse.cs
@@ -32,7 +32,7 @@ public record GetTeacherResponse
     public required Option<bool> AllowIdSignInWithProhibitions { get; init; }
 }
 
-[AutoMap(typeof(GetPersonResultQts))]
+[AutoMap(typeof(Core.SharedModels.QtsInfo))]
 public record GetTeacherResponseQts
 {
     public required DateOnly? Awarded { get; init; }
@@ -40,7 +40,7 @@ public record GetTeacherResponseQts
     public required string? StatusDescription { get; init; }
 }
 
-[AutoMap(typeof(GetPersonResultEyts))]
+[AutoMap(typeof(Core.SharedModels.EytsInfo))]
 public record GetTeacherResponseEyts
 {
     public required DateOnly? Awarded { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/GetPersonResponse.cs
@@ -29,11 +29,11 @@ public partial record GetPersonResponse
     public required Option<bool> AllowIdSignInWithProhibitions { get; init; }
 }
 
-[AutoMap(typeof(GetPersonResultQts))]
+[AutoMap(typeof(Core.SharedModels.QtsInfo))]
 [GenerateVersionedDto(typeof(V20240101.Responses.GetTeacherResponseQts))]
 public partial record GetPersonResponseQts;
 
-[AutoMap(typeof(GetPersonResultEyts))]
+[AutoMap(typeof(Core.SharedModels.EytsInfo))]
 [GenerateVersionedDto(typeof(V20240101.Responses.GetTeacherResponseEyts))]
 public partial record GetPersonResponseEyts;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/ApiModels/EytsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/ApiModels/EytsInfo.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Api.V3.V20240814.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.EytsInfo))]
+public record EytsInfo
+{
+    public required DateOnly Awarded { get; init; }
+    public required string StatusDescription { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/ApiModels/InductionStatusInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/ApiModels/InductionStatusInfo.cs
@@ -1,0 +1,10 @@
+using TeachingRecordSystem.Api.V3.V20240101.ApiModels;
+
+namespace TeachingRecordSystem.Api.V3.V20240814.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.InductionStatusInfo))]
+public record InductionStatusInfo
+{
+    public required InductionStatus Status { get; init; }
+    public required string StatusDescription { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/ApiModels/QtsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/ApiModels/QtsInfo.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Api.V3.V20240814.ApiModels;
+
+[AutoMap(typeof(Core.SharedModels.QtsInfo))]
+public record QtsInfo
+{
+    public required DateOnly Awarded { get; init; }
+    public required string StatusDescription { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Api.V3.Core.Operations;
+using TeachingRecordSystem.Api.V3.V20240814.Requests;
+using TeachingRecordSystem.Api.V3.V20240814.Responses;
+
+namespace TeachingRecordSystem.Api.V3.V20240814.Controllers;
+
+[Route("persons")]
+public class PersonsController(IMapper mapper) : ControllerBase
+{
+    [HttpPost("find")]
+    [SwaggerOperation(
+        OperationId = "FindPersons",
+        Summary = "Find persons",
+        Description = "Finds persons matching the specified criteria.")]
+    [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    public async Task<IActionResult> FindTeachers(
+        [FromBody] FindPersonsRequest request,
+        [FromServices] FindPersonsByTrnAndDateOfBirthHandler handler)
+    {
+        var command = new FindPersonsByTrnAndDateOfBirthCommand(request.Persons.Select(p => (p.Trn, p.DateOfBirth)));
+        var result = await handler.Handle(command);
+        var response = mapper.Map<FindPersonsResponse>(result);
+        return Ok(response);
+    }
+
+    [HttpGet("")]
+    [SwaggerOperation(
+        OperationId = "FindPerson",
+        Summary = "Find person",
+        Description = "Finds a person matching the specified criteria.")]
+    [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    public async Task<IActionResult> FindTeachers(
+        FindPersonRequest request,
+        [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)
+    {
+        var command = new FindPersonByLastNameAndDateOfBirthCommand(request.LastName!, request.DateOfBirth!.Value);
+        var result = await handler.Handle(command);
+
+        var response = new FindPersonResponse()
+        {
+            Total = result.Total,
+            Query = request,
+            Results = result.Items.Select(mapper.Map<FindPersonResponseResult>).AsReadOnly()
+        };
+
+        return Ok(response);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Requests/FindPersonRequest.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api.V3.V20240814.Requests;
+
+public record FindPersonRequest
+{
+    [FromQuery(Name = "findBy")]
+    public FindPersonFindBy FindBy { get; init; }
+    [FromQuery(Name = "lastName")]
+    public string? LastName { get; init; }
+    [FromQuery(Name = "dateOfBirth")]
+    public DateOnly? DateOfBirth { get; init; }
+}
+
+public enum FindPersonFindBy
+{
+    LastNameAndDateOfBirth = 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Requests/FindPersonsRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Requests/FindPersonsRequest.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+namespace TeachingRecordSystem.Api.V3.V20240814.Requests;
 
 public record FindPersonsRequest
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonResponse.cs
@@ -1,0 +1,21 @@
+using TeachingRecordSystem.Api.V3.Core.Operations;
+using TeachingRecordSystem.Api.V3.V20240814.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240814.Requests;
+
+namespace TeachingRecordSystem.Api.V3.V20240814.Responses;
+
+[GenerateVersionedDto(typeof(V20240101.Responses.FindTeachersResponse), excludeMembers: ["Query", "Results"])]
+public partial record FindPersonResponse
+{
+    public required FindPersonRequest Query { get; init; }
+    public required IReadOnlyCollection<FindPersonResponseResult> Results { get; init; }
+}
+
+[AutoMap(typeof(FindPersonByLastNameAndDateOfBirthResultItem))]
+[GenerateVersionedDto(typeof(V20240101.Responses.FindTeachersResponseResult))]
+public partial record FindPersonResponseResult
+{
+    public required InductionStatusInfo InductionStatus { get; init; }
+    public required QtsInfo? Qts { get; init; }
+    public required EytsInfo? Eyts { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonsResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonsResponse.cs
@@ -1,13 +1,19 @@
+using AutoMapper.Configuration.Annotations;
+using TeachingRecordSystem.Api.V3.Core.Operations;
 using TeachingRecordSystem.Api.V3.V20240101.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240814.ApiModels;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+namespace TeachingRecordSystem.Api.V3.V20240814.Responses;
 
+[AutoMap(typeof(FindPersonsByTrnAndDateOfBirthResult))]
 public record FindPersonsResponse
 {
     public required int Total { get; init; }
+    [SourceMember(nameof(FindPersonsByTrnAndDateOfBirthResult.Items))]
     public required IReadOnlyCollection<FindPersonsResponseResult> Results { get; init; }
 }
 
+[AutoMap(typeof(FindPersonsByTrnAndDateOfBirthResultItem))]
 public record FindPersonsResponseResult
 {
     public required string Trn { get; init; }
@@ -17,4 +23,7 @@ public record FindPersonsResponseResult
     public required string LastName { get; init; }
     public required IReadOnlyCollection<SanctionInfo> Sanctions { get; init; }
     public required IReadOnlyCollection<NameInfo> PreviousNames { get; init; }
+    public required InductionStatusInfo InductionStatus { get; init; }
+    public required QtsInfo? Qts { get; init; }
+    public required EytsInfo? Eyts { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Validators/FindTeacherRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Validators/FindTeacherRequestValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using TeachingRecordSystem.Api.V3.V20240606.Requests;
+using TeachingRecordSystem.Api.V3.V20240814.Requests;
 
-namespace TeachingRecordSystem.Api.V3.V20240606.Validators;
+namespace TeachingRecordSystem.Api.V3.V20240814.Validators;
 
 public class FindPersonRequestValidator : AbstractValidator<FindPersonRequest>
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Validators/FindTeachersRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Validators/FindTeachersRequestValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using TeachingRecordSystem.Api.V3.V20240814.Requests;
+
+namespace TeachingRecordSystem.Api.V3.V20240814.Validators;
+
+public class FindPersonsRequestValidator : AbstractValidator<FindPersonsRequest>
+{
+    public FindPersonsRequestValidator()
+    {
+        RuleFor(r => r.Persons.Count)
+            .LessThan(500)
+            .WithMessage("Only 500 persons or less can be specified.")
+            .OverridePropertyName("Persons");
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
@@ -5,7 +5,6 @@ using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Core.Operations;
 using TeachingRecordSystem.Api.V3.VNext.ApiModels;
 using TeachingRecordSystem.Api.V3.VNext.Requests;
-using TeachingRecordSystem.Api.V3.VNext.Responses;
 
 namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
 
@@ -46,18 +45,5 @@ public class PersonsController(IMapper mapper) : ControllerBase
         var result = await handler.Handle(command);
         var response = mapper.Map<QtlsInfo?>(result);
         return response is not null ? Ok(response) : NotFound();
-    }
-
-    [HttpPost("find")]
-    [SwaggerOperation(
-        OperationId = "FindPersons",
-        Summary = "Find persons",
-        Description = "Finds persons matching the specified criteria.")]
-    [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
-    public Task<IActionResult> FindTeachers([FromBody] FindPersonsRequest request)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/VersionRegistry.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/VersionRegistry.cs
@@ -14,6 +14,7 @@ public static class VersionRegistry
         V3MinorVersions.V20240412,
         V3MinorVersions.V20240416,
         V3MinorVersions.V20240606,
+        V3MinorVersions.V20240814,
         V3MinorVersions.VNext,
     ];
 
@@ -54,6 +55,7 @@ public static class VersionRegistry
         public const string V20240412 = "20240412";
         public const string V20240416 = "20240416";
         public const string V20240606 = "20240606";
+        public const string V20240814 = "20240814";
         public const string VNext = VNextVersion;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/PreviousNameHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/PreviousNameHelper.cs
@@ -1,13 +1,14 @@
-namespace TeachingRecordSystem.Core.Dqt.Models;
+using Microsoft.Extensions.Configuration;
 using FullName = (string FirstName, string MiddleName, string LastName);
 
-public static class PreviousNameHelper
+namespace TeachingRecordSystem.Core.Dqt.Models;
+
+public class PreviousNameHelper(IConfiguration configuration)
 {
-    public static FullName[] GetFullPreviousNames(
-        IEnumerable<dfeta_previousname> previousNames,
-        Contact contact,
-        TimeSpan concurrentNameChangeWindow)
+    public FullName[] GetFullPreviousNames(IEnumerable<dfeta_previousname> previousNames, Contact contact)
     {
+        var concurrentNameChangeWindow = TimeSpan.FromSeconds(configuration.GetValue("ConcurrentNameChangeWindowSeconds", 5));
+
         var result = new List<FullName>();
 
         var currentFirstName = contact.FirstName!;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByTrnsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactsByTrnsQuery.cs
@@ -1,0 +1,6 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveContactsByTrnsQuery(IEnumerable<string> Trns, ColumnSet ColumnSet) :
+    ICrmQuery<IDictionary<string, Contact?>>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveQtsRegistrationsByContactIdsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveQtsRegistrationsByContactIdsQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetActiveQtsRegistrationsByContactIdsQuery(IEnumerable<Guid> ContactIds, ColumnSet ColumnSet) : ICrmQuery<IDictionary<Guid, dfeta_qtsregistration[]>>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByTrnsHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByTrnsHandler.cs
@@ -1,0 +1,33 @@
+using AngleSharp.Common;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class GetActiveContactsByTrnsHandler :
+    ICrmQueryHandler<GetActiveContactsByTrnsQuery, IDictionary<string, Contact?>>
+{
+    public async Task<IDictionary<string, Contact?>> Execute(
+        GetActiveContactsByTrnsQuery query,
+        IOrganizationServiceAsync organizationService)
+    {
+        var queryExpression = new QueryExpression(Contact.EntityLogicalName)
+        {
+            ColumnSet = query.ColumnSet,
+            Criteria = new FilterExpression(LogicalOperator.And)
+            {
+                Conditions =
+                {
+                    new ConditionExpression(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active),
+                    new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.In, query.Trns.ToArray())
+                }
+            }
+        };
+
+        var response = await organizationService.RetrieveMultipleAsync(queryExpression);
+        var contacts = response.Entities.Select(e => e.ToEntity<Contact>()).ToDictionary(c => c.dfeta_TRN, c => c);
+
+        return query.Trns.ToDictionary(trn => trn, trn => contacts.GetValueOrDefault(trn));
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveQtsRegistrationsByContactIdsHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveQtsRegistrationsByContactIdsHandler.cs
@@ -1,0 +1,34 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
+
+public class GetActiveQtsRegistrationsByContactIdsHandler : ICrmQueryHandler<GetActiveQtsRegistrationsByContactIdsQuery, IDictionary<Guid, dfeta_qtsregistration[]>>
+{
+    public async Task<IDictionary<Guid, dfeta_qtsregistration[]>> Execute(GetActiveQtsRegistrationsByContactIdsQuery query, IOrganizationServiceAsync organizationService)
+    {
+        var queryExpression = new QueryExpression()
+        {
+            EntityName = dfeta_qtsregistration.EntityLogicalName,
+            ColumnSet = query.ColumnSet
+        };
+        queryExpression.Criteria.AddCondition(dfeta_qtsregistration.Fields.StateCode, ConditionOperator.Equal, (int)TaskState.Open);
+        queryExpression.Criteria.AddCondition(dfeta_qtsregistration.Fields.dfeta_PersonId, ConditionOperator.In, query.ContactIds.Cast<object>().ToArray());
+
+        var request = new RetrieveMultipleRequest()
+        {
+            Query = queryExpression
+        };
+
+        var response = await organizationService.RetrieveMultipleAsync(queryExpression);
+
+        var qtsRegistrationsByContactIds = response.Entities
+            .GroupBy(r => r.GetAttributeValue<EntityReference>(dfeta_qtsregistration.Fields.dfeta_PersonId).Id)
+            .ToDictionary(group => group.Key, group => group.Select(e => e.ToEntity<dfeta_qtsregistration>()).ToArray());
+
+        return query.ContactIds.ToDictionary(id => id, id => qtsRegistrationsByContactIds.GetValueOrDefault(id, Array.Empty<dfeta_qtsregistration>()));
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ReferenceDataCache.cs
@@ -44,6 +44,12 @@ public class ReferenceDataCache : IStartupTask
         return subjects.Single(s => s.Title == title, $"Could not find subject with title: '{title}'.");
     }
 
+    public async Task<dfeta_teacherstatus> GetTeacherStatusById(Guid id)
+    {
+        var teacherStatuses = await EnsureTeacherStatuses();
+        return teacherStatuses.Single(ts => ts.Id == id, $"Could not find teacher status with ID: '{id}'.");
+    }
+
     public async Task<dfeta_teacherstatus> GetTeacherStatusByValue(string value)
     {
         var teacherStatuses = await EnsureTeacherStatuses();
@@ -60,6 +66,12 @@ public class ReferenceDataCache : IStartupTask
     {
         var earlyyearStatuses = await EnsureEarlyYearsStatuses();
         return earlyyearStatuses;
+    }
+
+    public async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatusById(Guid id)
+    {
+        var earlyYearsStatuses = await EnsureEarlyYearsStatuses();
+        return earlyYearsStatuses.Single(ey => ey.Id == id, $"Could not find early years teacher status with ID: '{id}'.");
     }
 
     public async Task<dfeta_earlyyearsstatus> GetEarlyYearsStatusByValue(string value)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ServiceCollectionExtensions.cs
@@ -11,7 +11,8 @@ public static partial class ServiceCollectionExtensions
     {
         return services
             .AddSingleton<IClock, Clock>()
-            .AddCrmQueries();
+            .AddCrmQueries()
+            .AddSingleton<PreviousNameHelper>();
     }
 
     public static IServiceCollection AddAccessYourTeachingQualificationsOptions(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -8,10 +8,8 @@ namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
 public class IndexModel(
     ICrmQueryDispatcher crmQueryDispatcher,
-    IConfiguration configuration) : PageModel
+    PreviousNameHelper previousNameHelper) : PageModel
 {
-    private readonly TimeSpan _concurrentNameChangeWindow = TimeSpan.FromSeconds(configuration.GetValue<int>("ConcurrentNameChangeWindowSeconds", 5));
-
     [FromRoute]
     public Guid PersonId { get; set; }
 
@@ -48,7 +46,7 @@ public class IndexModel(
                     Contact.Fields.dfeta_ActiveSanctions)));
 
         var contact = contactDetail!.Contact;
-        var previousNames = PreviousNameHelper.GetFullPreviousNames(contactDetail.PreviousNames, contactDetail.Contact, _concurrentNameChangeWindow);
+        var previousNames = previousNameHelper.GetFullPreviousNames(contactDetail.PreviousNames, contactDetail.Contact);
 
         Person = new PersonInfo()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -194,6 +194,7 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
 }
 
 builder.Services
+    .AddTrsBaseServices()
     .AddTransient<ICurrentUserIdProvider, HttpContextCurrentUserIdProvider>()
     .AddTransient<CheckMandatoryQualificationExistsFilter>()
     .AddFormFlow(options =>
@@ -252,7 +253,6 @@ builder.AddBlobStorage();
 builder.Services
     .AddTransient<TrsLinkGenerator>()
     .AddTransient<CheckUserExistsFilter>()
-    .AddSingleton<IClock, Clock>()
     .AddSupportUiServices(builder.Configuration, builder.Environment)
     .AddSingleton<ReferenceDataCache>()
     .AddSingleton<SanctionTextLookup>()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/ServiceCollectionExtensions.cs
@@ -10,7 +10,6 @@ public static class ServiceCollectionExtensions
         IHostEnvironment environment)
     {
         services.AddAzureActiveDirectory(environment);
-        services.AddCrmQueries();
 
         return services;
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -1,0 +1,247 @@
+using System.Diagnostics;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240814;
+
+[Collection(nameof(DisableParallelization))]
+public class FindPersonByLastNameAndDateOfBirthTests : TestBase
+{
+    public FindPersonByLastNameAndDateOfBirthTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        XrmFakedContext.DeleteAllEntities<Contact>();
+        SetCurrentApiClient([ApiRoles.GetPerson]);
+    }
+
+    [Theory, RoleNamesData(except: [ApiRoles.GetPerson, ApiRoles.UpdatePerson])]
+    public async Task Get_ClientDoesNotHavePermission_ReturnsForbidden(string[] roles)
+    {
+        // Arrange
+        SetCurrentApiClient(roles);
+
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = "Smith";
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("", "Invalid matching policy.")]
+    [InlineData("BadFindBy", "The value 'BadFindBy' is not valid for FindBy.")]
+    public async Task Get_InvalidFindBy_ReturnsError(string findBy, string expectedErrorMessage)
+    {
+        // Arrange
+        var lastName = "Smith";
+        var dateOfBirth = "1990-01-01";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, "findBy", expectedErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("", "1990-01-01", "lastName", "A value is required when findBy is 'LastNameAndDateOfBirth'.")]
+    [InlineData("Smith", "", "dateOfBirth", "A value is required when findBy is 'LastNameAndDateOfBirth'.")]
+    public async Task Get_MissingPropertiesForFindBy_ReturnsError(
+        string lastName,
+        string dateOfBirth,
+        string expectedErrorPropertyName,
+        string expectedErrorMessage)
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy=LastNameAndDateOfBirth&lastName={lastName}&dateOfBirth={dateOfBirth}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, expectedErrorPropertyName, expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithMatchesOnLastName_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = "Smith";
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person1 = await TestData.CreatePerson(b => b
+            .WithLastName(lastName)
+            .WithDateOfBirth(dateOfBirth)
+            .WithSanction("G1")
+            .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
+            .WithQts(qtsDate: new(2021, 7, 1))
+            .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
+
+        var person2 = await TestData.CreatePerson(b => b
+            .WithLastName(lastName)
+            .WithDateOfBirth(dateOfBirth)
+            .WithSanction("G1"));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                total = 2,
+                query = new
+                {
+                    findBy,
+                    lastName,
+                    dateOfBirth
+                },
+                results = new[]
+                {
+                    new
+                    {
+                        trn = person1.Trn,
+                        dateOfBirth = person1.DateOfBirth,
+                        firstName = person1.FirstName,
+                        middleName = person1.MiddleName ?? "",
+                        lastName = person1.LastName,
+                        sanctions = new[]
+                        {
+                            new
+                            {
+                                code = person1.Sanctions.First().SanctionCode,
+                                startDate = person1.Sanctions.First().StartDate
+                            }
+                        },
+                        previousNames = Array.Empty<object>(),
+                        inductionStatus = (object?)new
+                        {
+                            status = "Pass",
+                            statusDescription = "Pass"
+                        },
+                        qts = (object?)new
+                        {
+                            awarded = person1.QtsDate,
+                            statusDescription = "Qualified"
+                        },
+                        eyts = (object?)new
+                        {
+                            awarded = person1.EytsDate,
+                            statusDescription = "Early years professional status"
+                        }
+                    },
+                    new
+                    {
+                        trn = person2.Trn,
+                        dateOfBirth = person2.DateOfBirth,
+                        firstName = person2.FirstName,
+                        middleName = person2.MiddleName,
+                        lastName = person2.LastName,
+                        sanctions = new[]
+                        {
+                            new
+                            {
+                                code = person2.Sanctions.First().SanctionCode,
+                                startDate = person2.Sanctions.First().StartDate
+                            }
+                        },
+                        previousNames = Array.Empty<object>(),
+                        inductionStatus = (object?)null,
+                        qts = (object?)null,
+                        eyts = (object?)null,
+                    }
+                }
+            });
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithMatchOnPreviousName_ReturnsExpectedPersons()
+    {
+        // Arrange
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = TestData.GenerateLastName();
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var updatedLastName = TestData.GenerateChangedLastName(lastName);
+        await TestData.UpdatePerson(b => b.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var results = jsonResponse.RootElement.GetProperty("results").EnumerateArray();
+        Assert.Collection(
+            results,
+            person =>
+            {
+                Assert.Equal(person1.Trn, person.GetProperty("trn").GetString());
+            },
+            person =>
+            {
+                Assert.Equal(person2.Trn, person.GetProperty("trn").GetString());
+                Assert.Equal(updatedLastName, person.GetProperty("lastName").GetString());
+                var previousNames = person.GetProperty("previousNames").EnumerateArray();
+                Assert.Collection(
+                    previousNames,
+                    pn =>
+                    {
+                        Assert.Equal(person2.FirstName, pn.GetProperty("firstName").GetString());
+                        Assert.Equal(person2.MiddleName, pn.GetProperty("middleName").GetString());
+                        Assert.Equal(person2.LastName, pn.GetProperty("lastName").GetString());
+                    });
+            });
+    }
+
+    [Fact]
+    public async Task Get_NonExposableSanctionCode_IsNotReturned()
+    {
+        // Arrange
+        var findBy = "LastNameAndDateOfBirth";
+        var lastName = "Smith";
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var sanctionCode = "A17";
+        Debug.Assert(!Api.V3.Constants.ExposableSanctionCodes.Contains(sanctionCode));
+        var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseSanctions = jsonResponse.RootElement.GetProperty("results").EnumerateArray().First().GetProperty("sanctions").EnumerateArray();
+        Assert.Empty(responseSanctions);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -1,0 +1,227 @@
+using System.Diagnostics;
+
+namespace TeachingRecordSystem.Api.Tests.V3.V20240814;
+
+[Collection(nameof(DisableParallelization))]
+public class FindPersonsByTrnAndDateOfBirthTests : TestBase
+{
+    public FindPersonsByTrnAndDateOfBirthTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        XrmFakedContext.DeleteAllEntities<Contact>();
+        SetCurrentApiClient([ApiRoles.GetPerson]);
+    }
+
+    [Theory, RoleNamesData(except: [ApiRoles.GetPerson, ApiRoles.UpdatePerson])]
+    public async Task Get_ClientDoesNotHavePermission_ReturnsForbidden(string[] roles)
+    {
+        // Arrange
+        SetCurrentApiClient(roles);
+
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person = await TestData.CreatePerson(b => b
+            .WithDateOfBirth(dateOfBirth));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
+        {
+            Content = JsonContent.Create(new
+            {
+                persons = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth
+                    }
+                }
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_TooManyPeopleRequested_ReturnsError()
+    {
+        // Arrange
+        var limit = 500;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
+        {
+            Content = JsonContent.Create(new
+            {
+                persons = await Enumerable.Range(0, limit + 1)
+                    .ToAsyncEnumerable()
+                    .SelectAwait(async i => new
+                    {
+                        trn = await TestData.GenerateTrn(),
+                        dateOfBirth = new DateOnly(1990, 1, 1).AddDays(i)
+                    })
+                    .ToArrayAsync()
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseHasValidationErrorForProperty(response, "persons", "Only 500 persons or less can be specified.");
+    }
+
+    [Fact]
+    public async Task Get_IncorrectDateOfBirth_DoesNotReturnRecord()
+    {
+        // Arrange
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person = await TestData.CreatePerson(b => b
+            .WithDateOfBirth(dateOfBirth)
+            .WithSanction("G1")
+            .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
+            .WithQts(qtsDate: new(2021, 7, 1))
+            .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
+        {
+            Content = JsonContent.Create(new
+            {
+                persons = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth.AddDays(1)
+                    }
+                }
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                total = 0,
+                results = Array.Empty<object>()
+            });
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsMatchedRecord()
+    {
+        // Arrange
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var person = await TestData.CreatePerson(b => b
+            .WithDateOfBirth(dateOfBirth)
+            .WithSanction("G1")
+            .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
+            .WithQts(qtsDate: new(2021, 7, 1))
+            .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
+        {
+            Content = JsonContent.Create(new
+            {
+                persons = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth
+                    }
+                }
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseEquals(
+            response,
+            new
+            {
+                total = 1,
+                results = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth,
+                        firstName = person.FirstName,
+                        middleName = person.MiddleName ?? "",
+                        lastName = person.LastName,
+                        sanctions = new[]
+                        {
+                            new
+                            {
+                                code = person.Sanctions.First().SanctionCode,
+                                startDate = person.Sanctions.First().StartDate
+                            }
+                        },
+                        previousNames = Array.Empty<object>(),
+                        inductionStatus = (object?)new
+                        {
+                            status = "Pass",
+                            statusDescription = "Pass"
+                        },
+                        qts = (object?)new
+                        {
+                            awarded = person.QtsDate,
+                            statusDescription = "Qualified"
+                        },
+                        eyts = (object?)new
+                        {
+                            awarded = person.EytsDate,
+                            statusDescription = "Early years professional status"
+                        }
+                    }
+                }
+            });
+    }
+
+    [Fact]
+    public async Task Get_NonExposableSanctionCode_IsNotReturned()
+    {
+        // Arrange
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
+        var sanctionCode = "A17";
+        Debug.Assert(!Api.V3.Constants.ExposableSanctionCodes.Contains(sanctionCode));
+        var person = await TestData.CreatePerson(b => b
+            .WithDateOfBirth(dateOfBirth)
+            .WithSanction(sanctionCode));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
+        {
+            Content = JsonContent.Create(new
+            {
+                persons = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth
+                    }
+                }
+            })
+        };
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseSanctions = jsonResponse.RootElement.GetProperty("results").EnumerateArray().First().GetProperty("sanctions").EnumerateArray();
+        Assert.Empty(responseSanctions);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/TestBase.cs
@@ -1,0 +1,12 @@
+namespace TeachingRecordSystem.Api.Tests.V3.V20240814;
+
+public abstract class TestBase(HostFixture hostFixture) : Tests.TestBase(hostFixture)
+{
+    public const string Version = VersionRegistry.V3MinorVersions.V20240814;
+
+    public HttpClient GetHttpClient() => GetHttpClient(Version);
+
+    public HttpClient GetHttpClientWithApiKey() => GetHttpClientWithApiKey(Version);
+
+    public HttpClient GetHttpClientWithIdentityAccessToken(string trn) => GetHttpClientWithIdentityAccessToken(trn, version: Version);
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -106,7 +106,14 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithInduction(dfeta_InductionStatus inductionStatus, dfeta_InductionExemptionReason? inductionExemptionReason, DateOnly? inductionStartDate, DateOnly? completedDate, DateOnly? inductionPeriodStartDate, DateOnly? inductionPeriodEndDate, Guid? appropriateBodyOrgId)
+        public CreatePersonBuilder WithInduction(
+            dfeta_InductionStatus inductionStatus,
+            dfeta_InductionExemptionReason? inductionExemptionReason,
+            DateOnly? inductionStartDate,
+            DateOnly? completedDate,
+            DateOnly? inductionPeriodStartDate = null,
+            DateOnly? inductionPeriodEndDate = null,
+            Guid? appropriateBodyOrgId = null)
         {
             var inductionId = Guid.NewGuid();
             if (inductionStatus == dfeta_InductionStatus.Exempt && inductionExemptionReason == null)
@@ -253,7 +260,7 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithEyts(DateOnly? eytsDate, string? eytsStatusValue, DateTime? createdDate)
+        public CreatePersonBuilder WithEyts(DateOnly? eytsDate, string? eytsStatusValue, DateTime? createdDate = null)
         {
             _qtsRegistrations.Add(new QtsRegistration(null, null, createdDate, eytsDate, eytsStatusValue));
             return this;


### PR DESCRIPTION
This adds a POST API endpoint for bulk person lookup by TRN & DOB. Up to 500 people can be requested in one go. The singular find by last name and DOB operation has been amended to return induction status, QTS and EYTS as well so that both operations have the same response structure.

In doing this I've also refactored some of the `Get Person` operation so that some its response types can be re-used. Some of the mapping logic has moved into those types too instead of being baked into specific API operations.

I've also made `PreviousNameHelper` a non-`static` class so we don't have to use `IConfiguration` directly in all the places it's called from.