### PR TITLE
Add pg_failover_slots extension to postgres

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -43,3 +43,15 @@ resource "azurerm_postgresql_flexible_server_configuration" "wal_level" {
   server_id = module.postgres.azure_server_id
   value     = "logical"
 }
+
+resource "azurerm_postgresql_flexible_server_configuration" "shared_preload_libraries" {
+  name      = "shared_preload_libraries"
+  server_id = module.postgres.azure_server_id
+  value     = "pg_cron,pg_stat_statements,pg_failover_slots"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "hot_standby_feedback" {
+  name      = "hot_standby_feedback"
+  server_id = module.postgres.azure_server_id
+  value     = "on"
+}


### PR DESCRIPTION
From the Azure docs:

> The PG Failover Slots extension enhances Azure Database for PostgreSQL flexible server when operating with both logical replication and high availability enabled servers. It effectively addresses the challenge within the standard PostgreSQL engine that doesn't preserve logical replication slots after a failover. Maintaining these slots is critical to prevent replication pauses or data mismatches during primary server role changes, ensuring operational continuity and data integrity.