### PR TITLE
Add a lock around applying migrations to reporting DB

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DistributedLockKeys.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DistributedLockKeys.cs
@@ -7,4 +7,5 @@ public static class DistributedLockKeys
     public static string Trn(string trn) => $"trn:{trn}";
     public static string TrnRequestId(string clientId, string requestId) => $"trn-request:{clientId}/{requestId}";
     public static string DqtReportingReplicationSlot() => nameof(DqtReportingReplicationSlot);
+    public static string DqtReportingMigrations() => nameof(DqtReportingMigrations);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
@@ -19,8 +19,6 @@ using TeachingRecordSystem.Worker.Infrastructure.Logging;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.Services.Configure<HostOptions>(o => o.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore);
-
 if (builder.Environment.IsProduction())
 {
     builder.Configuration


### PR DESCRIPTION
In production we have multiple worker instances and they're all trying to apply migrations at the same time. This adds a distributed lock check around applying migrations so that only once instance will run migrations.

I've also restored the default behaviour of stopping the app if a hosted service throws; we'd turned this off because of some early instability in `DqtReportingService` that's since been solved. Also, we definitely want the app to stop if any startup tasks fail (which are done via a hosted service) since important things (like these migrations) are done there.