### PR TITLE
Increase production postgres DB size to 64GB

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -36,6 +36,7 @@ module "postgres" {
   server_version                 = var.postgres_server_version
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_enable_high_availability = var.postgres_enable_high_availability
+  azure_storage_mb               = var.postgres_azure_storage_mb
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "wal_level" {

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -124,6 +124,11 @@ variable "postgres_server_version" {
   default = "14"
 }
 
+variable "postgres_azure_storage_mb" {
+  type    = number
+  default = 32768
+}
+
 variable "redis_capacity" {
   type    = number
   default = 1

--- a/terraform/aks/workspace_variables/production.tfvars.json
+++ b/terraform/aks/workspace_variables/production.tfvars.json
@@ -15,6 +15,7 @@
   "ui_replicas": 2,
   "worker_replicas": 2,
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
+  "postgres_azure_storage_mb": 65536,
   "postgres_enable_high_availability": true,
   "redis_capacity": 1,
   "redis_family": "P",


### PR DESCRIPTION
We're nearing capacity on our production postgres DB's storage. This doubles the size to 64GB.