### PR TITLE
Use a non-privileged port

### DIFF
--- a/TeachingRecordSystem/Dockerfile
+++ b/TeachingRecordSystem/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine3.18
 ARG GIT_SHA
 ENV SENTRY_RELEASE ${GIT_SHA}
-ENV ASPNETCORE_HTTP_PORTS 80
+ENV ASPNETCORE_HTTP_PORTS 3000
 COPY src/TeachingRecordSystem.Api/bin/Release/net8.0/publish/ Apps/Api/
 COPY src/TeachingRecordSystem.Cli/bin/Release/net8.0/publish/ Apps/TrsCli/
 COPY src/TeachingRecordSystem.SupportUi/bin/Release/net8.0/publish/ Apps/SupportUi/

--- a/terraform/aks/app.tf
+++ b/terraform/aks/app.tf
@@ -93,7 +93,7 @@ module "api_application" {
 
   docker_image = var.docker_image
   command      = ["/bin/ash", "-c", "cd /Apps/Api/; dotnet TeachingRecordSystem.Api.dll;"]
-  web_port     = 80
+  web_port     = 3000
   probe_path   = "/health"
   replicas     = var.api_replicas
   max_memory   = var.api_max_memory
@@ -144,7 +144,7 @@ module "authz_application" {
 
   docker_image = var.docker_image
   command      = ["/bin/ash", "-c", "cd /Apps/AuthorizeAccess/; dotnet TeachingRecordSystem.AuthorizeAccess.dll;"]
-  web_port     = 80
+  web_port     = 3000
   probe_path   = "/health"
   replicas     = var.authz_replicas
   max_memory   = var.authz_max_memory
@@ -194,7 +194,7 @@ module "ui_application" {
 
   docker_image                 = var.docker_image
   command                      = ["/bin/ash", "-c", "cd /Apps/SupportUi/; dotnet TeachingRecordSystem.SupportUi.dll;"]
-  web_port                     = 80
+  web_port                     = 3000
   probe_path                   = "/health"
   replicas                     = var.ui_replicas
   enable_logit                 = var.enable_logit


### PR DESCRIPTION
We have a security recommendation to use a non-privileged port; this changes our web apps to use port 3000 instead of 80.