### PR TITLE
Better handle long-running Hangfire jobs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Extensions.cs
@@ -61,7 +61,12 @@ public static class Extensions
                 .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
                 .UseSimpleAssemblyNameTypeSerializer()
                 .UseRecommendedSerializerSettings()
-                .UsePostgreSqlStorage(o => o.UseConnectionFactory(new DbDataSourceConnectionFactory(sp.GetRequiredService<NpgsqlDataSource>()))));
+                .UsePostgreSqlStorage(o => o.UseConnectionFactory(
+                    new DbDataSourceConnectionFactory(sp.GetRequiredService<NpgsqlDataSource>())),
+                    new PostgreSqlStorageOptions()
+                    {
+                        UseSlidingInvisibilityTimeout = true
+                    }));
         }
 
         return builder;


### PR DESCRIPTION
We have a few jobs that run for longer than 30 minutes that are getting rescheduled even though they're still running. This change enables 'sliding invisibility timeout' which should fix that problem