### PR TITLE
Added job to export Workforce Data to GCS

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Faker.Net" Version="2.0.154" />
     <PackageVersion Include="FakeXrmEasy.v9" Version="3.5.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.10.0" />
     <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.3.1" />
     <PackageVersion Include="GovukNotify" Version="6.1.0" />
     <PackageVersion Include="GovUk.Frontend.AspNetCore" Version="2.0.1" />
@@ -67,6 +68,7 @@
     <PackageVersion Include="OpenIddict.AspNetCore" Version="5.2.0" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="5.2.0" />
     <PackageVersion Include="Optional" Version="4.0.0" />
+    <PackageVersion Include="Parquet.Net" Version="4.24.0" />
     <PackageVersion Include="PdfSharpCore" Version="1.3.62" />
     <PackageVersion Include="Polly.Core" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ExportWorkforceDataJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ExportWorkforceDataJob.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.Services.WorkforceData;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class ExportWorkforceDataJob(WorkforceDataExporter workforceDataExporter)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        await workforceDataExporter.Export(cancellationToken);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -148,6 +148,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<ExportWorkforceDataJob>(
+                    nameof(ExportWorkforceDataJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/Google/IStorageClientProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/Google/IStorageClientProvider.cs
@@ -1,0 +1,8 @@
+using Google.Cloud.Storage.V1;
+
+namespace TeachingRecordSystem.Core.Services.WorkforceData.Google;
+
+public interface IStorageClientProvider
+{
+    ValueTask<StorageClient> GetStorageClientAsync();
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/Google/OptionsStorageClientProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/Google/OptionsStorageClientProvider.cs
@@ -1,0 +1,23 @@
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Options;
+
+namespace TeachingRecordSystem.Core.Services.WorkforceData.Google;
+
+public class OptionsStorageClientProvider : IStorageClientProvider
+{
+    private readonly IOptions<WorkforceDataExportOptions> _optionsAccessor;
+
+    public OptionsStorageClientProvider(IOptions<WorkforceDataExportOptions> optionsAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(optionsAccessor);
+        _optionsAccessor = optionsAccessor;
+    }
+
+    public ValueTask<StorageClient> GetStorageClientAsync()
+    {
+        var configuredClient = _optionsAccessor.Value.StorageClient ??
+            throw new InvalidOperationException($"No {nameof(WorkforceDataExportOptions.StorageClient)} has been configured.");
+
+        return new ValueTask<StorageClient>(configuredClient);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<TpsEstablishmentRefresher>();
         services.AddSingleton<IConfigureOptions<WorkforceDataExportOptions>, WorkforceDataExportConfigureOptions>();
         services.AddSingleton<IStorageClientProvider, OptionsStorageClientProvider>();
+        services.AddSingleton<WorkforceDataExporter>();
 
         return services;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using TeachingRecordSystem.Core.Services.Establishments.Tps;
+using TeachingRecordSystem.Core.Services.WorkforceData.Google;
 
 namespace TeachingRecordSystem.Core.Services.WorkforceData;
 
@@ -11,6 +13,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<TpsCsvExtractFileImporter>();
         services.AddSingleton<TpsCsvExtractProcessor>();
         services.AddSingleton<TpsEstablishmentRefresher>();
+        services.AddSingleton<IConfigureOptions<WorkforceDataExportOptions>, WorkforceDataExportConfigureOptions>();
+        services.AddSingleton<IStorageClientProvider, OptionsStorageClientProvider>();
 
         return services;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExportConfigureOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExportConfigureOptions.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace TeachingRecordSystem.Core.Services.WorkforceData;
+
+internal class WorkforceDataExportConfigureOptions : IConfigureOptions<WorkforceDataExportOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public WorkforceDataExportConfigureOptions(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public void Configure(WorkforceDataExportOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var section = _configuration.GetSection("WorkforceDataExport");
+
+        options.BucketName = section["BucketName"]!;
+        var credentialsJson = section["CredentialsJson"];
+
+        if (!string.IsNullOrEmpty(credentialsJson))
+        {
+            var credentialsJsonDoc = JsonDocument.Parse(credentialsJson);
+
+            if (credentialsJsonDoc.RootElement.TryGetProperty("private_key", out _))
+            {
+                var creds = GoogleCredential.FromJson(credentialsJson);
+                options.StorageClient = StorageClient.Create(creds);
+            }
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExportItem.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExportItem.cs
@@ -1,0 +1,25 @@
+namespace TeachingRecordSystem.Core.Services.WorkforceData;
+
+public record WorkforceDataExportItem
+{
+    public required Guid TpsEmploymentId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string Trn { get; init; }
+    public required Guid EstablishmentId { get; init; }
+    public required string EstablishmentSource { get; init; }
+    public required int? EstablishmentUrn { get; init; }
+    public required string LocalAuthorityCode { get; init; }
+    public required string? EstablishmentNumber { get; init; }
+    public required string EstablishmentName { get; init; }
+    public required DateOnly StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+    public required DateOnly LastKnownTpsEmployedDate { get; init; }
+    public required string EmploymentType { get; init; }
+    public required bool WithdrawalConfirmed { get; init; }
+    public required DateOnly LastExtractDate { get; init; }
+    public required string Key { get; init; }
+    public required string NationalInsuranceNumber { get; init; }
+    public required string? PersonPostcode { get; init; }
+    public required DateTime CreatedOn { get; init; }
+    public required DateTime UpdatedOn { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExportOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExportOptions.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using Google.Cloud.Storage.V1;
+
+namespace TeachingRecordSystem.Core.Services.WorkforceData;
+
+public class WorkforceDataExportOptions
+{
+    public StorageClient? StorageClient { get; set; }
+    [DisallowNull]
+    public string? BucketName { get; set; }
+
+    [MemberNotNull(nameof(BucketName))]
+    internal void ValidateOptions()
+    {
+        if (BucketName is null)
+        {
+            throw new InvalidOperationException($"{nameof(BucketName)} has not been configured.");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExporter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/WorkforceDataExporter.cs
@@ -1,0 +1,100 @@
+using Microsoft.Extensions.Options;
+using Parquet.Serialization;
+using Parquet.Utils;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.WorkforceData.Google;
+
+namespace TeachingRecordSystem.Core.Services.WorkforceData;
+
+public class WorkforceDataExporter(
+    IClock clock,
+    IDbContextFactory<TrsDbContext> dbContextFactory,
+    IOptions<WorkforceDataExportOptions> optionsAccessor,
+    IStorageClientProvider storageClientProvider)
+{
+    public async Task Export(CancellationToken cancellationToken)
+    {
+        using var dbContext = dbContextFactory.CreateDbContext();
+        dbContext.Database.SetCommandTimeout(300);
+
+        FormattableString querySql =
+            $"""
+            SELECT
+            	t.tps_employment_id,
+            	t.person_id,
+            	p.trn,
+            	e.establishment_id,
+            	s.name establishment_source,
+            	e.urn establishment_urn,
+            	e.la_code local_authority_code,
+            	e.establishment_number,
+            	e.establishment_name,
+            	t.start_date,
+            	t.end_date,
+            	t.last_known_tps_employed_date,
+            	CASE
+            		WHEN t.employment_type = 0 THEN 'FT'
+            		WHEN t.employment_type = 1 THEN 'PTR'
+            		WHEN t.employment_type = 2 THEN 'PTI'
+            		WHEN t.employment_type = 3 THEN 'PT'
+            	END employment_type,
+            	t.withdrawal_confirmed,
+            	t.last_extract_date,
+            	t.key,
+            	t.national_insurance_number,
+            	t.person_postcode,
+            	t.created_on,
+            	t.updated_on
+            FROM
+            		tps_employments t
+            	JOIN		
+            		persons p ON p.person_id = t.person_id
+            	JOIN
+            		establishments e ON e.establishment_id = t.establishment_id
+            	JOIN
+            		establishment_sources s ON s.establishment_source_id = e.establishment_source_id
+            """;
+
+        var fileDateTime = clock.UtcNow.ToString("yyyyMMddHHmm");
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"workforce_data_{fileDateTime}");
+        Directory.CreateDirectory(tempDirectory);
+
+        var i = 0;
+        var fileNumber = 0;
+        var itemsToExport = new List<WorkforceDataExportItem>();
+        await foreach (var item in dbContext.Database.SqlQuery<WorkforceDataExportItem>(querySql).AsAsyncEnumerable())
+        {
+            i++;
+            itemsToExport.Add(item);
+
+            if (i % 50000 == 0)
+            {
+                fileNumber++;
+                await ParquetSerializer.SerializeAsync(itemsToExport, Path.Combine(tempDirectory, $"workforce_data_{fileDateTime}_{fileNumber}.parquet"));
+                itemsToExport.Clear();
+            }
+        }
+
+        if (itemsToExport.Count > 0)
+        {
+            fileNumber++;
+            await ParquetSerializer.SerializeAsync(itemsToExport, Path.Combine(tempDirectory, $"workforce_data_{fileDateTime}_{fileNumber}.parquet"));
+            itemsToExport.Clear();
+        }
+
+        using var stream = new MemoryStream();
+        var merger = new FileMerger(new DirectoryInfo(tempDirectory));
+        await merger.MergeFilesAsync(stream);
+        await UploadFile(stream, $"workforce_data_{clock.UtcNow:yyyyMMddHHmm}.parquet", cancellationToken);
+        Directory.Delete(tempDirectory, true);
+    }
+
+    private async Task UploadFile(Stream stream, string fileName, CancellationToken cancellationToken)
+    {
+        var storageClient = await storageClientProvider.GetStorageClientAsync();
+        var options = optionsAccessor.Value;
+        options.ValidateOptions();
+
+        await storageClient.UploadObjectAsync(options.BucketName, fileName, null, stream, cancellationToken: cancellationToken);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -132,6 +132,7 @@
     <PackageReference Include="DistributedLock.Azure" />
     <PackageReference Include="DistributedLock.FileSystem" />
     <PackageReference Include="EFCore.NamingConventions" />
+    <PackageReference Include="Google.Cloud.Storage.V1" />
     <PackageReference Include="GovukNotify" />
     <PackageReference Include="Hangfire.Core" />
     <PackageReference Include="Hangfire.NetCore" />
@@ -159,6 +160,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" />
     <PackageReference Include="Optional" />
+    <PackageReference Include="Parquet.Net" />
     <PackageReference Include="PdfSharpCore" />
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="Scrutor" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.Core.Services.WorkforceData;
 
 namespace TeachingRecordSystem.Core.Tests.Services.WorkforceData;
 
-public class TpsCsvExtractProcessorTests
+public class TpsCsvExtractProcessorTests : IAsyncLifetime
 {
     public TpsCsvExtractProcessorTests(
         DbFixture dbFixture,
@@ -514,6 +514,10 @@ public class TpsCsvExtractProcessorTests
         Assert.Equal(nationalInsuranceNumber, updatedPersonEmployment.NationalInsuranceNumber);
         Assert.Equal(memberPostcode, updatedPersonEmployment.PersonPostcode);
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => DbFixture.DbHelper.ClearData();
 
     private DbFixture DbFixture { get; }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -1,0 +1,112 @@
+using Google.Apis.Upload;
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Options;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Parquet.Serialization;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+using TeachingRecordSystem.Core.Services.WorkforceData;
+using TeachingRecordSystem.Core.Services.WorkforceData.Google;
+
+namespace TeachingRecordSystem.Core.Tests.Services.WorkforceData;
+
+public class WorkforceDataExporterTests
+{
+    public WorkforceDataExporterTests(
+        DbFixture dbFixture,
+        IOrganizationServiceAsync2 organizationService,
+        ReferenceDataCache referenceDataCache,
+        FakeTrnGenerator trnGenerator)
+    {
+        DbFixture = dbFixture;
+        Clock = new();
+
+        Helper = new TrsDataSyncHelper(
+            dbFixture.GetDataSource(),
+            organizationService,
+            referenceDataCache,
+            Clock);
+
+        TestData = new TestData(
+            dbFixture.GetDbContextFactory(),
+            organizationService,
+            referenceDataCache,
+            Clock,
+            trnGenerator,
+            TestDataSyncConfiguration.Sync(Helper));
+    }
+
+    [Fact]
+    public async Task Export_WhenCalled_ExportsDataToParquetFileAndUploadsToGcs()
+    {
+        // Arrange
+        var optionsAccessor = Mock.Of<IOptions<WorkforceDataExportOptions>>();
+        var storageClientProvider = Mock.Of<IStorageClientProvider>();
+        var storageClient = Mock.Of<StorageClient>();
+        var person = await TestData.CreatePerson();
+        var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
+        var personPostcode = Faker.Address.UkPostCode();
+        var personEmployment = await TestData.CreateTpsEmployment(person, establishment1, new DateOnly(2023, 02, 02), new DateOnly(2024, 02, 29), EmploymentType.FullTime, new DateOnly(2024, 03, 25), nationalInsuranceNumber, personPostcode);
+
+        Mock.Get(optionsAccessor)
+            .Setup(o => o.Value)
+            .Returns(new WorkforceDataExportOptions
+            {
+                BucketName = "bucket-name",
+                StorageClient = storageClient
+            });
+        Mock.Get(storageClientProvider)
+            .Setup(s => s.GetStorageClientAsync())
+            .ReturnsAsync(storageClient);
+
+        ParquetSerializer.UntypedResult? deserializedExport = null;
+        Mock.Get(storageClient)
+            .Setup(s => s.UploadObjectAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<UploadObjectOptions>(), It.IsAny<CancellationToken>(), It.IsAny<IProgress<IUploadProgress>>()))
+            .Callback<string, string, string, Stream, UploadObjectOptions, CancellationToken, IProgress<IUploadProgress>>(
+            async (bucketName, objectName, contentType, stream, options, cancellationToken, progress) =>
+            {
+                deserializedExport = await ParquetSerializer.DeserializeAsync(stream, options: null, CancellationToken.None);
+            })
+            .ReturnsAsync(new Google.Apis.Storage.v1.Data.Object());
+
+        // Act
+        var workforceDataExporter = new WorkforceDataExporter(
+            TestData.Clock,
+            TestData.DbContextFactory,
+            optionsAccessor,
+            storageClientProvider);
+
+        await workforceDataExporter.Export(CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(deserializedExport);
+        Assert.Single(deserializedExport.Data);
+        var exportItem = deserializedExport.Data[0];
+        Assert.Equal(personEmployment.TpsEmploymentId, exportItem[nameof(WorkforceDataExportItem.TpsEmploymentId)]);
+        Assert.Equal(personEmployment.PersonId, exportItem[nameof(WorkforceDataExportItem.PersonId)]);
+        Assert.Equal(person.Trn, exportItem[nameof(WorkforceDataExportItem.Trn)]);
+        Assert.Equal(establishment1.EstablishmentId, exportItem[nameof(WorkforceDataExportItem.EstablishmentId)]);
+        Assert.Equal("GIAS", exportItem[nameof(WorkforceDataExportItem.EstablishmentSource)]);
+        Assert.Equal(establishment1.Urn, exportItem[nameof(WorkforceDataExportItem.EstablishmentUrn)]);
+        Assert.Equal(establishment1.EstablishmentName, exportItem[nameof(WorkforceDataExportItem.EstablishmentName)]);
+        Assert.Equal(personEmployment.StartDate, DateOnly.FromDateTime((DateTime)exportItem[nameof(WorkforceDataExportItem.StartDate)]));
+        Assert.Equal(personEmployment.LastKnownTpsEmployedDate, DateOnly.FromDateTime((DateTime)exportItem[nameof(WorkforceDataExportItem.LastKnownTpsEmployedDate)]));
+        Assert.Equal("FT", exportItem[nameof(WorkforceDataExportItem.EmploymentType)]);
+        Assert.False((bool)exportItem[nameof(WorkforceDataExportItem.WithdrawalConfirmed)]);
+        Assert.Equal(personEmployment.LastExtractDate, DateOnly.FromDateTime((DateTime)exportItem[nameof(WorkforceDataExportItem.LastExtractDate)]));
+        Assert.Equal(personEmployment.Key, exportItem[nameof(WorkforceDataExportItem.Key)]);
+        Assert.Equal(nationalInsuranceNumber, exportItem[nameof(WorkforceDataExportItem.NationalInsuranceNumber)]);
+        Assert.Equal(personPostcode, exportItem[nameof(WorkforceDataExportItem.PersonPostcode)]);
+        Assert.Equal(personEmployment.CreatedOn, (DateTime)exportItem[nameof(WorkforceDataExportItem.CreatedOn)]);
+        Assert.Equal(personEmployment.UpdatedOn, (DateTime)exportItem[nameof(WorkforceDataExportItem.UpdatedOn)]);
+    }
+
+    private DbFixture DbFixture { get; }
+
+    private TestData TestData { get; }
+
+    private TestableClock Clock { get; }
+
+    private TrsDataSyncHelper Helper { get; }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -10,7 +10,7 @@ using TeachingRecordSystem.Core.Services.WorkforceData.Google;
 
 namespace TeachingRecordSystem.Core.Tests.Services.WorkforceData;
 
-public class WorkforceDataExporterTests
+public class WorkforceDataExporterTests : IAsyncLifetime
 {
     public WorkforceDataExporterTests(
         DbFixture dbFixture,
@@ -101,6 +101,10 @@ public class WorkforceDataExporterTests
         Assert.Equal(personEmployment.CreatedOn, (DateTime)exportItem[nameof(WorkforceDataExportItem.CreatedOn)]);
         Assert.Equal(personEmployment.UpdatedOn, (DateTime)exportItem[nameof(WorkforceDataExportItem.UpdatedOn)]);
     }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => DbFixture.DbHelper.ClearData();
 
     private DbFixture DbFixture { get; }
 


### PR DESCRIPTION
### Context

We want to get workforce data into BigQuery but we don’t yet have support for database syncs in the .NET DfE Analytics port. We’ve agreed to push a file into BQ for the D&I team to consume for now.

### Changes proposed in this pull request

Create a job that pushes an Avro or Parquet file containing the contents of our tps_employments table into an encrypted GCS bucket (details TBD).

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
