### PR TITLE
Amended so that workforce data tests run don't clash with each other

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
@@ -4,6 +4,7 @@ using TeachingRecordSystem.Core.Services.WorkforceData;
 
 namespace TeachingRecordSystem.Core.Tests.Services.WorkforceData;
 
+[Collection(nameof(WorkforceDataTestCollection))]
 public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
 {
     public static TheoryData<TpsCsvExtractFileImportTestScenarioData> GetImportFileTestScenarioData()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -6,6 +6,7 @@ using TeachingRecordSystem.Core.Services.WorkforceData;
 
 namespace TeachingRecordSystem.Core.Tests.Services.WorkforceData;
 
+[Collection(nameof(WorkforceDataTestCollection))]
 public class TpsCsvExtractProcessorTests : IAsyncLifetime
 {
     public TpsCsvExtractProcessorTests(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -10,6 +10,7 @@ using TeachingRecordSystem.Core.Services.WorkforceData.Google;
 
 namespace TeachingRecordSystem.Core.Tests.Services.WorkforceData;
 
+[Collection(nameof(WorkforceDataTestCollection))]
 public class WorkforceDataExporterTests : IAsyncLifetime
 {
     public WorkforceDataExporterTests(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataTestCollection.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataTestCollection.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Tests.Services.WorkforceData;
+
+[CollectionDefinition(nameof(WorkforceDataTestCollection), DisableParallelization = true)]
+public class WorkforceDataTestCollection
+{
+}


### PR DESCRIPTION
The workforce data tests can clash with each other as they are writing and deleting from the same tables in the database.
This ensures they run separately.
