### PR TITLE
Try and match one login user to id user based on email and TRN

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/IdDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/IdDbContext.cs
@@ -1,14 +1,17 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using static TeachingRecordSystem.AuthorizeAccess.IdModelTypes;
 
 namespace TeachingRecordSystem.AuthorizeAccess;
 
 public class IdDbContext(DbContextOptions<IdDbContext> options) : DbContext(options)
 {
     public DbSet<IdTrnToken> TrnTokens => Set<IdTrnToken>();
+    public DbSet<User> Users => Set<User>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<IdTrnToken>().HasKey(t => t.TrnToken);
+        modelBuilder.Entity<User>().HasKey(u => u.UserId);
     }
 }
 
@@ -27,4 +30,58 @@ public class IdTrnToken
     public required DateTime ExpiresUtc { get; set; }
     [Column("user_id")]
     public Guid? UserId { get; set; }
+}
+
+[Table("users")]
+public class User
+{
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+    [Column("email_address")]
+    public required string EmailAddress { get; set; }
+    [Column("first_name")]
+    public required string FirstName { get; set; }
+    [Column("last_name")]
+    public required string LastName { get; set; }
+    [Column("created")]
+    public required DateTime Created { get; set; }
+    [Column("updated")]
+    public required DateTime Updated { get; set; }
+    [Column("user_type")]
+    public IdModelTypes.UserType UserType { get; set; }
+    [Column("trn")]
+    public string? Trn { get; set; }
+    [Column("trn_association_source")]
+    public TrnAssociationSource? TrnAssociationSource { get; set; }
+    [Column("is_deleted")]
+    public bool IsDeleted { get; set; }
+    [Column("trn_lookup_support_ticket_created")]
+    public bool TrnLookupSupportTicketCreated { get; set; }
+    [Column("trn_verification_level")]
+    public TrnVerificationLevel? TrnVerificationLevel { get; set; }
+}
+
+public static class IdModelTypes
+{
+    public enum UserType
+    {
+        Default = 0,
+        Teacher = 0,
+        Staff = 1
+    }
+
+    public enum TrnAssociationSource
+    {
+        Lookup = 0,
+        Api = 1,
+        SupportUi = 2,
+        UserImport = 3,
+        TrnToken = 4,
+    }
+
+    public enum TrnVerificationLevel
+    {
+        Low = 0,
+        Medium = 1
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchRoute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchRoute.cs
@@ -5,5 +5,6 @@ public enum OneLoginUserMatchRoute
     Automatic = 1,
     Interactive = 2,
     TrnToken = 3,
-    Support = 4
+    Support = 4,
+    GetAnIdentityUser = 5,
 }


### PR DESCRIPTION
### Context

When we migrate from ID to One Login and ‘Teacher auth’ for AYTQ, users will have to set up a new account. For those who were not matched automatically in ID and had to raise a support ticket there’s a fair chance they will have the same problem with Teacher auth. We’d like to relax the matching rules slightly for users who are coming from ID to reduce the chances of them needing to raise another support ticket.

### Changes proposed in this pull request

Modify the matching process in Teacher Auth to look for an existing user in ID that has the same email address as the One Login user and a TRN linked to their account with verification level `Medium`. If there is a match, check that the verified last name and DOB match the last name and DOB on the teaching record linked to the ID TRN. If they match, assign the TRN to the Teacher Auth user.

Note there is very similar logic in place for working with TRN tokens today; this can likely be extended to cover the scenario above.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
