### PR TITLE
Simplify authorization policies & use roles

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/AddSecuritySchemeOperationFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/AddSecuritySchemeOperationFilter.cs
@@ -21,7 +21,7 @@ public class AddSecuritySchemeOperationFilter : IOperationFilter
         var authorizationPolicy = authorizeAttributes.Single().Policy;
         OpenApiSecurityRequirement? requirement;
 
-        if (AuthorizationPolicies.IsApiKeyAuthentication(authorizationPolicy!))
+        if (authorizationPolicy == AuthorizationPolicies.ApiKey)
         {
             requirement = new OpenApiSecurityRequirement()
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/AuthorizationPolicies.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/AuthorizationPolicies.cs
@@ -4,27 +4,4 @@ public static class AuthorizationPolicies
 {
     public const string ApiKey = nameof(ApiKey);
     public const string IdentityUserWithTrn = nameof(IdentityUserWithTrn);
-    public const string GetPerson = nameof(GetPerson);
-    public const string UpdatePerson = nameof(UpdatePerson);
-    public const string UpdateNpq = nameof(UpdateNpq);
-    public const string UnlockPerson = nameof(UnlockPerson);
-    public const string CreateTrn = nameof(CreateTrn);
-    public const string AssignQtls = nameof(AssignQtls);
-
-    public static bool IsApiKeyAuthentication(string policy)
-    {
-        switch (policy)
-        {
-            case AssignQtls:
-            case ApiKey:
-            case GetPerson:
-            case UpdatePerson:
-            case UpdateNpq:
-            case UnlockPerson:
-            case CreateTrn:
-                return true;
-            default:
-                return false;
-        }
-    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -116,42 +116,6 @@ public class Program
                         return scopes.Contains("dqt:read") || scopes.Contains("teaching_record");
                     })
                     .RequireClaim("trn"));
-
-            options.AddPolicy(
-                AuthorizationPolicies.GetPerson,
-                policy => policy
-                    .AddAuthenticationSchemes(ApiKeyAuthenticationHandler.AuthenticationScheme)
-                    .RequireRole([ApiRoles.GetPerson, ApiRoles.UpdatePerson]));
-
-            options.AddPolicy(
-                AuthorizationPolicies.UpdatePerson,
-                policy => policy
-                    .AddAuthenticationSchemes(ApiKeyAuthenticationHandler.AuthenticationScheme)
-                    .RequireRole([ApiRoles.UpdatePerson]));
-
-            options.AddPolicy(
-                AuthorizationPolicies.UpdateNpq,
-                policy => policy
-                    .AddAuthenticationSchemes(ApiKeyAuthenticationHandler.AuthenticationScheme)
-                    .RequireRole([ApiRoles.UpdateNpq]));
-
-            options.AddPolicy(
-                AuthorizationPolicies.UnlockPerson,
-                policy => policy
-                    .AddAuthenticationSchemes(ApiKeyAuthenticationHandler.AuthenticationScheme)
-                    .RequireRole([ApiRoles.UnlockPerson]));
-
-            options.AddPolicy(
-                AuthorizationPolicies.CreateTrn,
-                policy => policy
-                    .AddAuthenticationSchemes(ApiKeyAuthenticationHandler.AuthenticationScheme)
-                    .RequireRole([ApiRoles.CreateTrn]));
-
-            options.AddPolicy(
-                AuthorizationPolicies.AssignQtls,
-                policy => policy
-                    .AddAuthenticationSchemes(ApiKeyAuthenticationHandler.AuthenticationScheme)
-                    .RequireRole([ApiRoles.AssignQtls]));
         });
 
         services

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/IttOutcomeController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/IttOutcomeController.cs
@@ -9,7 +9,7 @@ using TeachingRecordSystem.Api.V2.Responses;
 namespace TeachingRecordSystem.Api.V2.Controllers;
 
 [Route("teachers/{trn}/itt-outcome")]
-[Authorize(Policy = AuthorizationPolicies.UpdatePerson)]
+[Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
 public class IttOutcomeController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/NpqQualificationsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/NpqQualificationsController.cs
@@ -8,7 +8,7 @@ using TeachingRecordSystem.Api.V2.Requests;
 namespace TeachingRecordSystem.Api.V2.Controllers;
 
 [Route("npq-qualifications")]
-[Authorize(Policy = AuthorizationPolicies.UpdateNpq)]
+[Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdateNpq)]
 public class NpqQualificationsController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/TeachersController.cs
@@ -24,7 +24,7 @@ public class TeachersController : ControllerBase
         Summary = "Find teachers",
         Description = "Returns teachers matching the specified criteria")]
     [ProducesResponseType(typeof(FindTeachersResponse), StatusCodes.Status200OK)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> FindTeachers(FindTeachersRequest request)
     {
         var response = await _mediator.Send(request);
@@ -37,7 +37,7 @@ public class TeachersController : ControllerBase
         Summary = "Get teacher",
         Description = "Gets an individual teacher by their TRN")]
     [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> GetTeacher([FromRoute] GetTeacherRequest request)
     {
         var response = await _mediator.Send(request);
@@ -52,7 +52,7 @@ public class TeachersController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [MapError(10001, statusCode: StatusCodes.Status404NotFound)]
     [MapError(10002, statusCode: StatusCodes.Status409Conflict)]
-    [Authorize(Policy = AuthorizationPolicies.UpdatePerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
     public async Task<IActionResult> Update([FromBody] UpdateTeacherRequest request)
     {
         await _mediator.Send(request);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/TrnRequestsController.cs
@@ -9,7 +9,7 @@ using TeachingRecordSystem.Api.V2.Responses;
 namespace TeachingRecordSystem.Api.V2.Controllers;
 
 [Route("trn-requests")]
-[Authorize(Policy = AuthorizationPolicies.UpdatePerson)]
+[Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
 public class TrnRequestsController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/UnlockTeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V2/Controllers/UnlockTeacherController.cs
@@ -9,7 +9,7 @@ using TeachingRecordSystem.Api.V2.Responses;
 namespace TeachingRecordSystem.Api.V2.Controllers;
 
 [Route("unlock-teacher")]
-[Authorize(Policy = AuthorizationPolicies.UnlockPerson)]
+[Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UnlockPerson)]
 public class UnlockTeacherController : ControllerBase
 {
     private readonly IMediator _mediator;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
@@ -20,7 +20,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> Get(
         [FromRoute] string trn,
         [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include,
@@ -49,7 +49,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
         Description = "Creates a name change request for the teacher with the given TRN.")]
     [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.UpdatePerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
     public async Task<IActionResult> CreateNameChange(
         [FromBody] CreateNameChangeRequestRequest request,
         [FromServices] CreateNameChangeRequestHandler handler)
@@ -76,7 +76,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
         Description = "Creates a date of birth change request for the teacher with the given TRN.")]
     [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.UpdatePerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
     public async Task<IActionResult> CreateDateOfBirthChange(
         [FromBody] CreateDateOfBirthChangeRequestRequest request,
         [FromServices] CreateDateOfBirthChangeRequestHandler handler)
@@ -101,7 +101,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
         Description = "Finds teachers with a TRN matching the specified criteria.")]
     [ProducesResponseType(typeof(FindTeachersResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> FindTeachers(
         FindTeachersRequest request,
         [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240307/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240307/Controllers/TrnRequestsController.cs
@@ -9,7 +9,7 @@ using TeachingRecordSystem.Api.V3.V20240307.Requests;
 namespace TeachingRecordSystem.Api.V3.V20240307.Controllers;
 
 [Route("trn-requests")]
-[Authorize(Policy = AuthorizationPolicies.CreateTrn)]
+[Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.CreateTrn)]
 public class TrnRequestsController(IMapper mapper) : ControllerBase
 {
     [HttpPost("")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
@@ -20,7 +20,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> Get(
         [FromRoute] string trn,
         [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
@@ -20,7 +20,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> Get(
         [FromRoute] string trn,
         [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
@@ -50,7 +50,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         Description = "Finds a person matching the specified criteria.")]
     [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> FindTeachers(
         FindPersonRequest request,
         [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TrnRequestsController.cs
@@ -9,7 +9,7 @@ using TeachingRecordSystem.Api.V3.V20240606.Requests;
 namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
 
 [Route("trn-requests")]
-[Authorize(Policy = AuthorizationPolicies.CreateTrn)]
+[Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.CreateTrn)]
 public class TrnRequestsController(IMapper mapper) : ControllerBase
 {
     [HttpPost("")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
@@ -18,7 +18,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         Description = "Finds persons matching the specified criteria.")]
     [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> FindTeachers(
         [FromBody] FindPersonsRequest request,
         [FromServices] FindPersonsByTrnAndDateOfBirthHandler handler)
@@ -36,7 +36,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         Description = "Finds a person matching the specified criteria.")]
     [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.GetPerson)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> FindTeachers(
         FindPersonRequest request,
         [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
@@ -19,7 +19,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(QtlsInfo), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status202Accepted)]
     [MapError(10001, statusCode: StatusCodes.Status404NotFound)]
-    [Authorize(Policy = AuthorizationPolicies.AssignQtls)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.AssignQtls)]
     public async Task<IActionResult> PutQtls(
         [FromRoute] string trn,
         [FromBody] SetQtlsRequest request,
@@ -36,7 +36,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         Summary = "Get QTLS status for a teacher",
         Description = "Gets the QTLS status for the teacher with the given TRN.")]
     [ProducesResponseType(typeof(QtlsInfo), StatusCodes.Status200OK)]
-    [Authorize(Policy = AuthorizationPolicies.AssignQtls)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.AssignQtls)]
     public async Task<IActionResult> GetQtls(
         [FromRoute] string trn,
         [FromServices] GetQtlsHandler handler)


### PR DESCRIPTION
Until now we've used authorization policies exclusively to add security to API endpoints. In practice we've ended up with a policy-per-role. This change moves to using roles; we keep two policies, one for each authentication mechanism (API key vs ID/Authorize access token). This simplifies the setup and makes imminent changes for new roles easier to implement.