### PR TITLE
Add support for creating alerts against a person in the TRS database to use in tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -1,4 +1,3 @@
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
@@ -1,0 +1,9 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record class AlertCreatedEvent : EventBase, IEventWithPersonId, IEventWithAlert
+{
+    public required Guid PersonId { get; init; }
+    public required Alert Alert { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithAlert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithAlert.cs
@@ -1,0 +1,8 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public interface IEventWithAlert
+{
+    Alert Alert { get; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Alert.cs
@@ -1,0 +1,21 @@
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record Alert
+{
+    public required Guid AlertId { get; init; }
+    public required Guid AlertTypeId { get; init; }
+    public required string? Details { get; init; }
+    public required string? ExternalLink { get; init; }
+    public required DateOnly? StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+
+    public static Alert FromModel(DataStore.Postgres.Models.Alert model) => new()
+    {
+        AlertId = model.AlertId,
+        AlertTypeId = model.AlertTypeId,
+        Details = model.Details,
+        ExternalLink = model.ExternalLink,
+        StartDate = model.StartDate,
+        EndDate = model.EndDate
+    };
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
@@ -33,8 +33,8 @@ public sealed class CrmClientFixture : IDisposable
         _memoryCache = memoryCache;
         _trnGenerationApiClient = GetTrnGenerationApiClient();
         _referenceDataCache = new ReferenceDataCache(
-            new CrmQueryDispatcher(CreateQueryServiceProvider(_baseServiceClient, referenceDataCache: null),
-            serviceClientName: null));
+            new CrmQueryDispatcher(CreateQueryServiceProvider(_baseServiceClient, referenceDataCache: null), serviceClientName: null),
+            dbFixture.GetDbContextFactory());
     }
 
     public IClock Clock { get; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.Establishments.Gias;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using Establishment = TeachingRecordSystem.Core.Models.Establishment;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.Establishments.Tps;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.Core.Services.WorkforceData;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.PersonMatching;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.Core.Tests.Services.TrsDataSync;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.Core.Tests.Services.TrsDataSync;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.Core.Services.WorkforceData;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -3,7 +3,6 @@ using Google.Cloud.Storage.V1;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Parquet.Serialization;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.Core.Services.WorkforceData;
 using TeachingRecordSystem.Core.Services.WorkforceData.Google;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 
@@ -257,6 +256,10 @@ public partial class TestData
     }
 
     public string GenerateNationalInsuranceNumber() => Faker.Identification.UkNationalInsuranceNumber();
+
+    public string GenerateLoremIpsum() => Faker.Lorem.Paragraph();
+
+    public string GenerateUrl() => Faker.Internet.Url();
 
     protected async Task<T> WithDbContext<T>(Func<TrsDbContext, Task<T>> action)
     {


### PR DESCRIPTION
### Context

Our tests currently create alerts using a DQT-like schema. This needs to be amended to use the new TRS schema.

### Changes proposed in this pull request

Add a `WithAlert()`  method on `CreatePersonBuilder` and use a builder type (like MQs).

All properties should be optional.

If the alert type is not specified, choose a random alert type.

If the details property is not specified, use some lorem ipsum (`Faker.Lorem.Paragraph()`)

If the external link property is not specified, generate a fake URL.

If start date is not specified, generate a random date (see MQs).

If end date is not specified, use `null`.

If end is specified but is before start date, throw an exception.

Leave the existing `WithSanction()` method for now until we have fully migrated alerts from DQT to TRS.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
