### PR TITLE
Add manual deploy to workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -7,6 +7,12 @@ on:
         type: string
         required: true
 
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        required: true
+        type: string
+
 concurrency: deploy_dev
 jobs:
   deploy_aks:
@@ -25,4 +31,3 @@ jobs:
         environment_name: dev
         docker_image: ${{ inputs.docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -6,7 +6,11 @@ on:
       docker_image:
         type: string
         required: true
+
   workflow_dispatch:
+    inputs:
+      docker_image:
+        type: string
 
 concurrency: deploy_preprod
 jobs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,6 +7,12 @@ on:
         type: string
         required: true
 
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        required: true
+        type: string
+
 concurrency: deploy_prod
 jobs:
   deploy_aks:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -7,6 +7,12 @@ on:
         type: string
         required: true
 
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        required: true
+        type: string
+
 concurrency: deploy_test
 jobs:
   deploy_aks:
@@ -25,4 +31,3 @@ jobs:
         environment_name: test
         docker_image: ${{ inputs.docker_image }}
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-


### PR DESCRIPTION
### Context

As per [teacher-services-cloud/documentation/disaster-recovery-testing.md at main · DFE-Digital/teacher-services-cloud](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/disaster-recovery-testing.md#prerequisites) we require a manual deploy workflow for DR

### Changes proposed in this pull request

Add manual deploy to workflows

https://trello.com/c/m7VgZ94r/2033-trs-dr-deploy-workflow-setup

### Guidance to review

Workflows can be deployed manually and existing workflows continue working fine

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
