### PR TITLE
Amend API responses for TRS alerts data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # API Changelog
 
+## Unreleased
+
+All references to `sanctions` have been removed and replaced with `alerts`; the following endpoints are affected:
+- `GET /v3/persons/<trn>`
+- `GET /v3/person`
+- `GET /v3/persons`
+- `GET /v3/persons/find`
+
+
 ## 20240814
 
 ### `POST /v3/persons/find`
@@ -9,6 +18,7 @@ New endpoint added for bulk person lookup by TRN and date of birth.
 ### `GET /v3/persons?findBy=LastNameAndDateOfBirth&lastName={lastName}&dateOfBirth={dateOfBirth}`
 
 `inductionStatus`, `qts` and `eyts` members have been added to align with the bulk `POST` endpoint.
+
 
 ## 20240606
 
@@ -26,6 +36,7 @@ The `person` property has been removed from the response.
 ### `GET /v3/trn-requests`
 
 The `person` property has been removed from the response.
+
 
 ## 20240416
 

--- a/TeachingRecordSystem/gen/TeachingRecordSystem.Api.Generator/VersionedDtoGenerator.cs
+++ b/TeachingRecordSystem/gen/TeachingRecordSystem.Api.Generator/VersionedDtoGenerator.cs
@@ -201,6 +201,11 @@ public class VersionedDtoGenerator : ISourceGenerator
 
                 foreach (var (property, propertyType) in referenceGeneratedTypeInfo.Properties)
                 {
+                    if (excludeMembers.Contains(property.Identifier.ValueText))
+                    {
+                        continue;
+                    }
+
                     AddProperty(property, propertyType);
                 }
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/GlobalUsings.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using AutoMapper;
+global using PostgresModels = TeachingRecordSystem.Core.DataStore.Postgres.Models;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -166,13 +166,17 @@ public class Program
             {
                 cfg.AddMaps(typeof(Program).Assembly);
                 cfg.CreateMap(typeof(Option<>), typeof(Option<>)).ConvertUsing(typeof(OptionMapper<,>));
-            })
-            .AddTransient(typeof(OptionMapper<,>));
+            });
 
         services.Scan(scan =>
         {
             scan.FromAssemblyOf<Program>()
                 .AddClasses(filter => filter.InNamespaces("TeachingRecordSystem.Api.V3.Core.Operations").Where(type => type.Name.EndsWith("Handler")))
+                    .AsSelf()
+                    .WithTransientLifetime();
+
+            scan.FromAssemblyOf<Program>()
+                .AddClasses(filter => filter.AssignableTo(typeof(ITypeConverter<,>)))
                     .AsSelf()
                     .WithTransientLifetime();
         });

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Constants.cs
@@ -2,7 +2,7 @@ namespace TeachingRecordSystem.Api.V3;
 
 public static class Constants
 {
-    public static IReadOnlyCollection<string> ExposableSanctionCodes { get; } = new[]
+    public static IReadOnlyCollection<string> LegacyExposableSanctionCodes { get; } = new[]
     {
         "G1",
         "A18",
@@ -37,7 +37,7 @@ public static class Constants
         "A23",
     };
 
-    public static IReadOnlyCollection<string> ProhibitionSanctionCodes { get; } = new[]
+    public static IReadOnlyCollection<string> LegacyProhibitionSanctionCodes { get; } = new[]
     {
         "G1",
         "B1",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonsByTrnAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonsByTrnAndDateOfBirth.cs
@@ -19,6 +19,7 @@ public record FindPersonsByTrnAndDateOfBirthResultItem
     public required string MiddleName { get; init; }
     public required string LastName { get; init; }
     public required IReadOnlyCollection<SanctionInfo> Sanctions { get; init; }
+    public required IReadOnlyCollection<Alert> Alerts { get; init; }
     public required IReadOnlyCollection<NameInfo> PreviousNames { get; init; }
     public required InductionStatusInfo? InductionStatus { get; init; }
     public required QtsInfo? Qts { get; init; }
@@ -60,7 +61,7 @@ public class FindPersonsByTrnAndDateOfBirthHandler(
             new GetSanctionsByContactIdsQuery(
                 contactsById.Keys,
                 ActiveOnly: true,
-                new()));
+                new(dfeta_sanction.Fields.dfeta_StartDate, dfeta_sanction.Fields.dfeta_EndDate)));
 
         var getPreviousNamesTask = crmQueryDispatcher.ExecuteQuery(new GetPreviousNamesByContactIdsQuery(contactsById.Keys));
 
@@ -93,13 +94,39 @@ public class FindPersonsByTrnAndDateOfBirthHandler(
                     MiddleName = r.ResolveMiddleName(),
                     LastName = r.ResolveLastName(),
                     Sanctions = sanctions[r.Id]
-                        .Where(s => Constants.ExposableSanctionCodes.Contains(s.SanctionCode))
+                        .Where(s => Constants.LegacyExposableSanctionCodes.Contains(s.SanctionCode))
                         .Select(s => new SanctionInfo()
                         {
                             Code = s.SanctionCode,
                             StartDate = s.Sanction.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true)
                         })
                         .AsReadOnly(),
+                    Alerts = await sanctions[r.Id]
+                        .ToAsyncEnumerable()
+                        .SelectAwait(async s =>
+                        {
+                            var alertType = await referenceDataCache.GetAlertTypeByDqtSanctionCode(s.SanctionCode);
+                            var alertCategory = await referenceDataCache.GetAlertCategoryById(alertType.AlertCategoryId);
+
+                            return new Alert()
+                            {
+                                AlertId = s.Sanction.Id,
+                                AlertType = new()
+                                {
+                                    AlertTypeId = alertType.AlertTypeId,
+                                    AlertCategory = new()
+                                    {
+                                        AlertCategoryId = alertCategory.AlertCategoryId,
+                                        Name = alertCategory.Name
+                                    },
+                                    Name = alertType.Name,
+                                    DqtSanctionCode = alertType.DqtSanctionCode!
+                                },
+                                StartDate = s.Sanction.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+                                EndDate = s.Sanction.dfeta_EndDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true)
+                            };
+                        })
+                        .AsReadOnlyAsync(),
                     PreviousNames = previousNameHelper.GetFullPreviousNames(previousNames[r.Id], contactsById[r.Id])
                         .Select(name => new NameInfo()
                         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/Alert.cs
@@ -1,9 +1,9 @@
 namespace TeachingRecordSystem.Api.V3.Core.SharedModels;
 
-public record AlertInfo
+public record Alert
 {
+    public required Guid AlertId { get; init; }
     public required AlertType AlertType { get; init; }
-    public required string DqtSanctionCode { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/AlertCategory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/AlertCategory.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Api.V3.Core.SharedModels;
+
+public record AlertCategory
+{
+    public required Guid AlertCategoryId { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/AlertType.cs
@@ -1,7 +1,9 @@
 namespace TeachingRecordSystem.Api.V3.Core.SharedModels;
 
-public enum AlertType
+public record AlertType
 {
-    Prohibition,
-    // Only exposing Prohibitions for now
+    public required Guid AlertTypeId { get; init; }
+    public required AlertCategory AlertCategory { get; init; }
+    public required string Name { get; init; }
+    public required string DqtSanctionCode { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/ApiModels/AlertInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/ApiModels/AlertInfo.cs
@@ -1,10 +1,24 @@
+using TeachingRecordSystem.Api.V3.Core.SharedModels;
+
 namespace TeachingRecordSystem.Api.V3.V20240101.ApiModels;
 
-[AutoMap(typeof(Core.SharedModels.AlertInfo))]
+[AutoMap(typeof(Alert), TypeConverter = typeof(AlertInfoTypeConverter))]
 public record AlertInfo
 {
     public required AlertType AlertType { get; init; }
     public required string DqtSanctionCode { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
+}
+
+public class AlertInfoTypeConverter : ITypeConverter<Alert, AlertInfo>
+{
+    public AlertInfo Convert(Alert source, AlertInfo destination, ResolutionContext context) =>
+        new()
+        {
+            AlertType = AlertType.Prohibition,
+            DqtSanctionCode = source.AlertType.DqtSanctionCode,
+            StartDate = source.StartDate,
+            EndDate = source.EndDate,
+        };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeacherController.cs
@@ -35,7 +35,8 @@ public class TeacherController(IMapper mapper) : ControllerBase
         var command = new GetPersonCommand(
             trn,
             include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
-            DateOfBirth: null);
+            DateOfBirth: null,
+            ApplyLegacyAlertsBehavior: true);
 
         var result = await handler.Handle(command);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
@@ -29,7 +29,8 @@ public class TeachersController(IMapper mapper) : ControllerBase
         var command = new GetPersonCommand(
             trn,
             include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
-            DateOfBirth: null);
+            DateOfBirth: null,
+            ApplyLegacyAlertsBehavior: true);
 
         var result = await handler.Handle(command);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeacherController.cs
@@ -35,7 +35,8 @@ public class TeacherController(IMapper mapper) : ControllerBase
         var command = new GetPersonCommand(
             trn,
             include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
-            DateOfBirth: null);
+            DateOfBirth: null,
+            ApplyLegacyAlertsBehavior: true);
 
         var result = await handler.Handle(command);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
@@ -30,7 +30,8 @@ public class TeachersController(IMapper mapper) : ControllerBase
         var command = new GetPersonCommand(
             trn,
             include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
-            dateOfBirth);
+            dateOfBirth,
+            ApplyLegacyAlertsBehavior: true);
 
         var result = await handler.Handle(command);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
@@ -28,11 +28,12 @@ public class PersonController(IMapper mapper) : ControllerBase
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
             include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
-            DateOfBirth: null);
+            DateOfBirth: null,
+            ApplyLegacyAlertsBehavior: true);
 
         var result = await handler.Handle(command);
         var response = mapper.Map<GetPersonResponse?>(result);
-        return response is null ? Forbid() : Ok(result);
+        return response is null ? Forbid() : Ok(response);
     }
 
     [HttpPost("name-changes")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
@@ -30,7 +30,8 @@ public class PersonsController(IMapper mapper) : ControllerBase
         var command = new GetPersonCommand(
             trn,
             include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
-            dateOfBirth);
+            dateOfBirth,
+            ApplyLegacyAlertsBehavior: true);
 
         var result = await handler.Handle(command);
 
@@ -51,7 +52,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindTeachers(
+    public async Task<IActionResult> FindPersons(
         FindPersonRequest request,
         [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
@@ -19,7 +19,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindTeachers(
+    public async Task<IActionResult> FindPersons(
         [FromBody] FindPersonsRequest request,
         [FromServices] FindPersonsByTrnAndDateOfBirthHandler handler)
     {
@@ -37,7 +37,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindTeachers(
+    public async Task<IActionResult> FindPersons(
         FindPersonRequest request,
         [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/Alert.cs
@@ -1,9 +1,10 @@
 namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
 
+[AutoMap(typeof(Core.SharedModels.Alert))]
 public record Alert
 {
     public required Guid AlertId { get; init; }
-    public required AlertTypeInfo AlertType { get; init; }
+    public required AlertType AlertType { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertCategory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertCategory.cs
@@ -1,6 +1,7 @@
 namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
 
-public record AlertCategoryInfo
+[AutoMap(typeof(Core.SharedModels.AlertCategory))]
+public record AlertCategory
 {
     public required Guid AlertCategoryId { get; init; }
     public required string Name { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/ApiModels/AlertType.cs
@@ -1,8 +1,9 @@
 namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
 
-public record AlertTypeInfo
+[AutoMap(typeof(Core.SharedModels.AlertType))]
+public record AlertType
 {
     public required Guid AlertTypeId { get; init; }
-    public required AlertCategoryInfo AlertCategory { get; init; }
+    public required AlertCategory AlertCategory { get; init; }
     public required string Name { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonController.cs
@@ -28,10 +28,11 @@ public class PersonController(IMapper mapper) : ControllerBase
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
             include is not null ? (GetPersonCommandIncludes)include : GetPersonCommandIncludes.None,
-            DateOfBirth: null);
+            DateOfBirth: null,
+            ApplyLegacyAlertsBehavior: false);
 
         var result = await handler.Handle(command);
         var response = mapper.Map<GetPersonResponse?>(result);
-        return response is null ? Forbid() : Ok(result);
+        return response is null ? Forbid() : Ok(response);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonRequest.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+
+public record FindPersonRequest
+{
+    [FromQuery(Name = "findBy")]
+    public FindPersonFindBy FindBy { get; init; }
+    [FromQuery(Name = "lastName")]
+    public string? LastName { get; init; }
+    [FromQuery(Name = "dateOfBirth")]
+    public DateOnly? DateOfBirth { get; init; }
+}
+
+public enum FindPersonFindBy
+{
+    LastNameAndDateOfBirth = 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonsRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonsRequest.cs
@@ -1,0 +1,12 @@
+namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+
+public record FindPersonsRequest
+{
+    public required IReadOnlyCollection<FindPersonsRequestPerson> Persons { get; init; }
+}
+
+public record FindPersonsRequestPerson
+{
+    public required string Trn { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonResponse.cs
@@ -1,0 +1,19 @@
+using TeachingRecordSystem.Api.V3.Core.Operations;
+using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+using TeachingRecordSystem.Api.V3.VNext.Requests;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+
+[GenerateVersionedDto(typeof(V20240814.Responses.FindPersonResponse), excludeMembers: ["Query", "Results"])]
+public partial record FindPersonResponse
+{
+    public required FindPersonRequest Query { get; init; }
+    public required IReadOnlyCollection<FindPersonResponseResult> Results { get; init; }
+}
+
+[AutoMap(typeof(FindPersonByLastNameAndDateOfBirthResultItem))]
+[GenerateVersionedDto(typeof(V20240814.Responses.FindPersonResponseResult), excludeMembers: ["Sanctions"])]
+public partial record FindPersonResponseResult
+{
+    public required IReadOnlyCollection<Alert> Alerts { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonsResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonsResponse.cs
@@ -1,0 +1,20 @@
+using AutoMapper.Configuration.Annotations;
+using TeachingRecordSystem.Api.V3.Core.Operations;
+using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+
+[AutoMap(typeof(FindPersonsByTrnAndDateOfBirthResult))]
+[GenerateVersionedDto(typeof(V20240814.Responses.FindPersonsResponse), excludeMembers: ["Results"])]
+public partial record FindPersonsResponse
+{
+    [SourceMember(nameof(FindPersonsByTrnAndDateOfBirthResult.Items))]
+    public required IReadOnlyCollection<FindPersonsResponseResult> Results { get; init; }
+}
+
+[AutoMap(typeof(FindPersonsByTrnAndDateOfBirthResultItem))]
+[GenerateVersionedDto(typeof(V20240814.Responses.FindPersonsResponseResult), excludeMembers: ["Sanctions"])]
+public partial record FindPersonsResponseResult
+{
+    public required IReadOnlyCollection<Alert> Alerts { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/GetPersonResponse.cs
@@ -1,7 +1,12 @@
+using Optional;
 using TeachingRecordSystem.Api.V3.Core.Operations;
+using TeachingRecordSystem.Api.V3.VNext.ApiModels;
 
 namespace TeachingRecordSystem.Api.V3.VNext.Responses;
 
 [AutoMap(typeof(GetPersonResult))]
-[GenerateVersionedDto(typeof(V20240606.Responses.GetPersonResponse))]
-public partial record GetPersonResponse;
+[GenerateVersionedDto(typeof(V20240606.Responses.GetPersonResponse), excludeMembers: ["Alerts", "Sanctions"])]
+public partial record GetPersonResponse
+{
+    public required Option<IReadOnlyCollection<Alert>> Alerts { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/AsyncEnumerableExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/AsyncEnumerableExtensions.cs
@@ -2,6 +2,8 @@ namespace TeachingRecordSystem.Core;
 
 public static class AsyncEnumerableExtensions
 {
+    public static async ValueTask<IReadOnlyCollection<T>> AsReadOnlyAsync<T>(this IAsyncEnumerable<T> enumerable) => await enumerable.ToArrayAsync();
+
     public static async IAsyncEnumerable<T[]> Chunk<T>(this IAsyncEnumerable<T> source, int size)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(size, 0);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
@@ -172,6 +172,12 @@ public class ReferenceDataCache(
         return alertTypes;
     }
 
+    public async Task<AlertType> GetAlertTypeByDqtSanctionCode(string dqtSanctionCode)
+    {
+        var alertTypes = await EnsureAlertTypes();
+        return alertTypes.Single(at => at.DqtSanctionCode == dqtSanctionCode, $"Could not find alert type with DQT sanction code: '{dqtSanctionCode}'.");
+    }
+
     private Task<dfeta_sanctioncode[]> EnsureSanctionCodes() =>
         LazyInitializer.EnsureInitialized(
             ref _getSanctionCodesTask,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestBase.cs
@@ -36,6 +36,8 @@ public abstract class TestBase
 
     public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock => _testServices.GetAnIdentityApiClientMock;
 
+    public ReferenceDataCache ReferenceDataCache => HostFixture.Services.GetRequiredService<ReferenceDataCache>();
+
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 
     public IXrmFakedContext XrmFakedContext => HostFixture.Services.GetRequiredService<IXrmFakedContext>();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/FindTeachersTests.cs
@@ -237,7 +237,7 @@ public class FindTeachersTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var sanctionCode = "A17";
-        Debug.Assert(!TeachingRecordSystem.Api.V3.Constants.ExposableSanctionCodes.Contains(sanctionCode));
+        Debug.Assert(!TeachingRecordSystem.Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
         var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
 
         var request = new HttpRequestMessage(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTestBase.cs
@@ -414,7 +414,7 @@ public abstract class GetTeacherTestBase(HostFixture hostFixture) : TestBase(hos
             new("A18", null),
             new("G1", new DateOnly(2022, 4, 1)),
         };
-        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(TeachingRecordSystem.Api.V3.Constants.ExposableSanctionCodes.Contains));
+        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(TeachingRecordSystem.Api.V3.Constants.LegacyExposableSanctionCodes.Contains));
 
         await ConfigureMocks(contact, sanctions: sanctions);
 
@@ -455,7 +455,7 @@ public abstract class GetTeacherTestBase(HostFixture hostFixture) : TestBase(hos
             new("B1", null),
             new("G1", new DateOnly(2022, 4, 1)),
         };
-        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(TeachingRecordSystem.Api.V3.Constants.ProhibitionSanctionCodes.Contains));
+        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(TeachingRecordSystem.Api.V3.Constants.LegacyProhibitionSanctionCodes.Contains));
 
         await ConfigureMocks(contact, sanctions: sanctions);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -237,7 +237,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var sanctionCode = "A17";
-        Debug.Assert(!Api.V3.Constants.ExposableSanctionCodes.Contains(sanctionCode));
+        Debug.Assert(!Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
         var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
 
         var request = new HttpRequestMessage(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTestBase.cs
@@ -414,7 +414,7 @@ public abstract class GetPersonTestBase(HostFixture hostFixture) : TestBase(host
             new("A18", null),
             new("G1", new DateOnly(2022, 4, 1)),
         };
-        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(Api.V3.Constants.ExposableSanctionCodes.Contains));
+        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(Api.V3.Constants.LegacyExposableSanctionCodes.Contains));
 
         await ConfigureMocks(contact, sanctions: sanctions);
 
@@ -455,7 +455,7 @@ public abstract class GetPersonTestBase(HostFixture hostFixture) : TestBase(host
             new("B1", null),
             new("G1", new DateOnly(2022, 4, 1)),
         };
-        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(Api.V3.Constants.ProhibitionSanctionCodes.Contains));
+        Debug.Assert(sanctions.Select(s => s.SanctionCode).All(Api.V3.Constants.LegacyProhibitionSanctionCodes.Contains));
 
         await ConfigureMocks(contact, sanctions: sanctions);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -229,7 +229,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var sanctionCode = "A17";
-        Debug.Assert(!Api.V3.Constants.ExposableSanctionCodes.Contains(sanctionCode));
+        Debug.Assert(!Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
         var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
 
         var request = new HttpRequestMessage(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -196,7 +196,7 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var sanctionCode = "A17";
-        Debug.Assert(!Api.V3.Constants.ExposableSanctionCodes.Contains(sanctionCode));
+        Debug.Assert(!Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
         var person = await TestData.CreatePerson(b => b
             .WithDateOfBirth(dateOfBirth)
             .WithSanction(sanctionCode));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -1,33 +1,55 @@
 namespace TeachingRecordSystem.Api.Tests.V3.VNext;
 
-public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
+[Collection(nameof(DisableParallelization))]
+public class FindPersonByLastNameAndDateOfBirthTests : TestBase
 {
+    public FindPersonByLastNameAndDateOfBirthTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        XrmFakedContext.DeleteAllEntities<Contact>();
+        SetCurrentApiClient([ApiRoles.GetPerson]);
+    }
+
     [Fact]
-    public async Task Get_ValidRequestWithAlerts_ReturnsExpectedAlertsContent()
+    public async Task Get_ValidRequestWithMatchOnPersonWithAlerts_ReturnsExpectedAlertsContent()
     {
         // Arrange
+        var lastName = "Smith";
+        var dateOfBirth = new DateOnly(1990, 1, 1);
+
         var sanctionCode = "G1";
         var startDate = new DateOnly(2022, 4, 1);
         var endDate = new DateOnly(2023, 1, 20);
         var alertType = await ReferenceDataCache.GetAlertTypeByDqtSanctionCode(sanctionCode);
         var alertCategory = await ReferenceDataCache.GetAlertCategoryById(alertType.AlertCategoryId);
 
-        var person = await TestData.CreatePerson(x => x
-            .WithTrn()
+        var person = await TestData.CreatePerson(b => b
+            .WithLastName(lastName)
+            .WithDateOfBirth(dateOfBirth)
             .WithSanction(sanctionCode, startDate, endDate));
 
         var sanction = person.Sanctions.Single();
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/person?include=Alerts");
-
-        var httpClient = GetHttpClientWithIdentityAccessToken(person.Trn!);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
+        {
+            Content = JsonContent.Create(new
+            {
+                persons = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth
+                    }
+                }
+            })
+        };
 
         // Act
-        var response = await httpClient.SendAsync(request);
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
 
         // Assert
         var jsonResponse = await AssertEx.JsonResponse(response);
-        var responseAlerts = jsonResponse.RootElement.GetProperty("alerts");
+        var responseAlerts = jsonResponse.RootElement.GetProperty("results").EnumerateArray().Single().GetProperty("alerts");
 
         AssertEx.JsonObjectEquals(
             new[]
@@ -46,7 +68,7 @@ public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
                         }
                     },
                     startDate = startDate,
-                    endDate = endDate
+                    endDate = endDate,
                 }
             },
             responseAlerts);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/GetPersonByTrnTests.cs
@@ -1,0 +1,137 @@
+using TeachingRecordSystem.Api.V3.VNext.Requests;
+
+namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+
+public class GetPersonByTrnTests : TestBase
+{
+    public GetPersonByTrnTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        SetCurrentApiClient(roles: [ApiRoles.GetPerson]);
+    }
+
+    [Theory, RoleNamesData(except: [ApiRoles.GetPerson, ApiRoles.AppropriateBody])]
+    public async Task Get_ClientDoesNotHavePermission_ReturnsForbidden(string[] roles)
+    {
+        // Arrange
+        SetCurrentApiClient(roles);
+
+        var person = await TestData.CreatePerson(x => x.WithTrn());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(GetPersonRequestIncludes.InitialTeacherTraining)]
+    [InlineData(GetPersonRequestIncludes.NpqQualifications)]
+    [InlineData(GetPersonRequestIncludes.MandatoryQualifications)]
+    [InlineData(GetPersonRequestIncludes.PendingDetailChanges)]
+    [InlineData(GetPersonRequestIncludes.HigherEducationQualifications)]
+    [InlineData(GetPersonRequestIncludes.PreviousNames)]
+    [InlineData(GetPersonRequestIncludes._AllowIdSignInWithProhibitions)]
+    public async Task Get_AsAppropriateBodyWithNotPermittedInclude_ReturnsForbidden(GetPersonRequestIncludes include)
+    {
+        // Arrange
+        SetCurrentApiClient(roles: [ApiRoles.AppropriateBody]);
+
+        var person = await TestData.CreatePerson(x => x.WithTrn());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}&include={Uri.EscapeDataString(include.ToString())}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(GetPersonRequestIncludes.Induction)]
+    [InlineData(GetPersonRequestIncludes.Alerts)]
+    public async Task Get_AsAppropriateBodyWithPermittedInclude_ReturnsOk(GetPersonRequestIncludes include)
+    {
+        // Arrange
+        SetCurrentApiClient(roles: [ApiRoles.AppropriateBody]);
+
+        var person = await TestData.CreatePerson(x => x.WithTrn());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}&include={Uri.EscapeDataString(include.ToString())}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AsAppropriateBodyWithoutDateOfBirth_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentApiClient(roles: [ApiRoles.AppropriateBody]);
+
+        var person = await TestData.CreatePerson(x => x.WithTrn());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsExpectedAlertsContent()
+    {
+        // Arrange
+        var sanctionCode = "G1";
+        var startDate = new DateOnly(2022, 4, 1);
+        var endDate = new DateOnly(2023, 1, 20);
+        var alertType = await ReferenceDataCache.GetAlertTypeByDqtSanctionCode(sanctionCode);
+        var alertCategory = await ReferenceDataCache.GetAlertCategoryById(alertType.AlertCategoryId);
+
+        var person = await TestData.CreatePerson(x => x
+            .WithTrn()
+            .WithSanction(sanctionCode, startDate, endDate));
+
+        var sanction = person.Sanctions.Single();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=Alerts");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        var responseAlerts = jsonResponse.RootElement.GetProperty("alerts");
+
+        AssertEx.JsonObjectEquals(
+            new[]
+            {
+                new
+                {
+                    alertId = sanction.SanctionId,
+                    alertType = new
+                    {
+                        alertTypeId = alertType.AlertTypeId,
+                        name = alertType.Name,
+                        alertCategory = new
+                        {
+                            alertCategoryId = alertCategory.AlertCategoryId,
+                            name = alertCategory.Name
+                        }
+                    },
+                    startDate = startDate,
+                    endDate = endDate,
+                }
+            },
+            responseAlerts);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/TestBase.cs
@@ -2,9 +2,15 @@ namespace TeachingRecordSystem.Api.Tests.V3.VNext;
 
 public abstract class TestBase : Tests.TestBase
 {
+    public const string Version = VersionRegistry.V3MinorVersions.VNext;
+
     protected TestBase(HostFixture hostFixture) : base(hostFixture)
     {
     }
 
-    public HttpClient GetHttpClientWithApiKey() => GetHttpClientWithApiKey(VersionRegistry.V3MinorVersions.VNext);
+    public HttpClient GetHttpClientWithApiKey() =>
+        GetHttpClientWithApiKey(Version);
+
+    public HttpClient GetHttpClientWithIdentityAccessToken(string trn, string scope = "dqt:read") =>
+        GetHttpClientWithIdentityAccessToken(trn, scope, Version);
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
@@ -101,6 +101,12 @@ public class DbHelper(IDbContextFactory<TrsDbContext> dbContextFactory)
             new RespawnerOptions()
             {
                 DbAdapter = DbAdapter.Postgres,
-                TablesToIgnore = ["mandatory_qualification_providers", "establishment_sources", "tps_establishment_types"]
+                TablesToIgnore = [
+                    "mandatory_qualification_providers",
+                    "establishment_sources",
+                    "tps_establishment_types",
+                    "alert_types",
+                    "alert_categories"
+                ]
             });
 }


### PR DESCRIPTION
This updates the `vNext` API version to include alerts with the TRS data model. It also removes any references to `sanctions`. We'll need to know the 'API visibility' for each alert type (and apply some filtering) before this can be released.