### PR TITLE
Handle 'redundant' alert types that are not being migrated

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonByLastNameAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonByLastNameAndDateOfBirth.cs
@@ -96,6 +96,7 @@ public class FindPersonByLastNameAndDateOfBirthHandler(
                         .AsReadOnly(),
                     Alerts = await sanctions[r.Id]
                         .ToAsyncEnumerable()
+                        .WhereAwait(async s => await referenceDataCache.HaveAlertTypeForDqtSanctionCode(s.SanctionCode))
                         .SelectAwait(async s =>
                         {
                             var alertType = await referenceDataCache.GetAlertTypeByDqtSanctionCode(s.SanctionCode);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonsByTrnAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonsByTrnAndDateOfBirth.cs
@@ -103,6 +103,7 @@ public class FindPersonsByTrnAndDateOfBirthHandler(
                         .AsReadOnly(),
                     Alerts = await sanctions[r.Id]
                         .ToAsyncEnumerable()
+                        .WhereAwait(async s => await referenceDataCache.HaveAlertTypeForDqtSanctionCode(s.SanctionCode))
                         .SelectAwait(async s =>
                         {
                             var alertType = await referenceDataCache.GetAlertTypeByDqtSanctionCode(s.SanctionCode);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetPerson.cs
@@ -404,7 +404,8 @@ public class GetPersonHandler(
                 Option.Some(await (await getSanctionsTask!)
                     .ToAsyncEnumerable()
                     // The Legacy behavior is to only return prohibition-type alerts
-                    .Where(s => !command.ApplyLegacyAlertsBehavior || Constants.LegacyProhibitionSanctionCodes.Contains(s.SanctionCode))
+                    .WhereAwait(async s => await referenceDataCache.HaveAlertTypeForDqtSanctionCode(s.SanctionCode) &&
+                        (!command.ApplyLegacyAlertsBehavior || Constants.LegacyProhibitionSanctionCodes.Contains(s.SanctionCode)))
                     .SelectAwait(async s =>
                     {
                         var alertType = await referenceDataCache.GetAlertTypeByDqtSanctionCode(s.SanctionCode);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
@@ -178,6 +178,12 @@ public class ReferenceDataCache(
         return alertTypes.Single(at => at.DqtSanctionCode == dqtSanctionCode, $"Could not find alert type with DQT sanction code: '{dqtSanctionCode}'.");
     }
 
+    public async Task<bool> HaveAlertTypeForDqtSanctionCode(string dqtSanctionCode)
+    {
+        var alertTypes = await EnsureAlertTypes();
+        return alertTypes.Any(at => at.DqtSanctionCode == dqtSanctionCode);
+    }
+
     private Task<dfeta_sanctioncode[]> EnsureSanctionCodes() =>
         LazyInitializer.EnsureInitialized(
             ref _getSanctionCodesTask,


### PR DESCRIPTION
Our API implementation assumed we have a mapping from every DQT sanction code to a TRS alert type - that's not the case. 