### PR TITLE
Remove induction periods from the latest API version

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/GetPersonResponse.cs
@@ -5,8 +5,13 @@ using TeachingRecordSystem.Api.V3.VNext.ApiModels;
 namespace TeachingRecordSystem.Api.V3.VNext.Responses;
 
 [AutoMap(typeof(GetPersonResult))]
-[GenerateVersionedDto(typeof(V20240606.Responses.GetPersonResponse), excludeMembers: ["Alerts", "Sanctions"])]
+[GenerateVersionedDto(typeof(V20240606.Responses.GetPersonResponse), excludeMembers: ["Alerts", "Sanctions", "Induction"])]
 public partial record GetPersonResponse
 {
     public required Option<IReadOnlyCollection<Alert>> Alerts { get; init; }
+    public required Option<GetPersonResponseInduction?> Induction { get; init; }
 }
+
+[AutoMap(typeof(GetPersonResultInduction))]
+[GenerateVersionedDto(typeof(V20240606.Responses.GetPersonResponseInduction), excludeMembers: ["Periods"])]
+public partial record GetPersonResponseInduction;


### PR DESCRIPTION
We won't be storing this in TRS.