### PR TITLE
Release pending API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,19 @@
 # API Changelog
 
-## Unreleased
+## 20240920
 
 All references to `sanctions` have been removed and replaced with `alerts`; the following endpoints are affected:
 - `GET /v3/persons/<trn>`
 - `GET /v3/person`
-- `GET /v3/persons`
+- `GET /v3/persons?findBy=LastNameAndDateOfBirth`
 - `GET /v3/persons/find`
+
+An endpoint has been added to mark a person as deceased: `PUT /v3/persons/deceased/<trn>`.
 
 
 ## 20240912
 
-Endpoints have been added for setting and retrieving QTS via QTLS date.
+Endpoints have been added for setting and retrieving the QTS via QTLS date.
 - `GET /v3/persons/<trn>/qtls`
 - `PUT /v3/persons/<trn>/qtls`
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/Alert.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+namespace TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
 [AutoMap(typeof(Core.SharedModels.Alert))]
 public record Alert

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/AlertCategory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/AlertCategory.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+namespace TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
 [AutoMap(typeof(Core.SharedModels.AlertCategory))]
 public record AlertCategory

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/AlertType.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+namespace TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
 [AutoMap(typeof(Core.SharedModels.AlertType))]
 public record AlertType

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/PersonInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/ApiModels/PersonInfo.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.V3.VNext.ApiModels;
+namespace TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
 public record PersonInfo
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/AlertsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/AlertsController.cs
@@ -2,10 +2,10 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using TeachingRecordSystem.Api.Infrastructure.Security;
-using TeachingRecordSystem.Api.V3.VNext.Requests;
-using TeachingRecordSystem.Api.V3.VNext.Responses;
+using TeachingRecordSystem.Api.V3.V20240920.Requests;
+using TeachingRecordSystem.Api.V3.V20240920.Responses;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
+namespace TeachingRecordSystem.Api.V3.V20240920.Controllers;
 
 [Route("alerts")]
 [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = $"{ApiRoles.UpdateRole}")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
@@ -5,10 +5,10 @@ using Swashbuckle.AspNetCore.Annotations;
 using TeachingRecordSystem.Api.Infrastructure.ModelBinding;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using TeachingRecordSystem.Api.V3.VNext.Requests;
-using TeachingRecordSystem.Api.V3.VNext.Responses;
+using TeachingRecordSystem.Api.V3.V20240920.Requests;
+using TeachingRecordSystem.Api.V3.V20240920.Responses;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
+namespace TeachingRecordSystem.Api.V3.V20240920.Controllers;
 
 [Route("person")]
 public class PersonController(IMapper mapper) : ControllerBase

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
@@ -4,10 +4,10 @@ using Swashbuckle.AspNetCore.Annotations;
 using TeachingRecordSystem.Api.Infrastructure.ModelBinding;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using TeachingRecordSystem.Api.V3.VNext.Requests;
-using TeachingRecordSystem.Api.V3.VNext.Responses;
+using TeachingRecordSystem.Api.V3.V20240920.Requests;
+using TeachingRecordSystem.Api.V3.V20240920.Responses;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
+namespace TeachingRecordSystem.Api.V3.V20240920.Controllers;
 
 [Route("persons")]
 public class PersonsController(IMapper mapper) : ControllerBase
@@ -108,7 +108,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         Summary = "Mark person as deceased",
         Description = "Marks a person as deceased.")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = $"{ApiRoles.UpdatePerson}")]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
     public async Task<IActionResult> Deceased(
         [FromRoute] string trn,
         [FromBody] SetDeceasedRequest request,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/CreateAlertRequestBody.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/CreateAlertRequestBody.cs
@@ -1,6 +1,6 @@
 using Optional;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+namespace TeachingRecordSystem.Api.V3.V20240920.Requests;
 
 public record CreateAlertRequestBody
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/FindPersonRequest.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+namespace TeachingRecordSystem.Api.V3.V20240920.Requests;
 
 public record FindPersonRequest
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/FindPersonsRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/FindPersonsRequest.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+namespace TeachingRecordSystem.Api.V3.V20240920.Requests;
 
 public record FindPersonsRequest
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/GetPersonRequestIncludes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/GetPersonRequestIncludes.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+namespace TeachingRecordSystem.Api.V3.V20240920.Requests;
 
 [Flags]
 [Description("Comma-separated list of data to include in response.")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/SetDeceasedRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/SetDeceasedRequest.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+namespace TeachingRecordSystem.Api.V3.V20240920.Requests;
 
 public class SetDeceasedRequest
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/UpdateAlertRequestBody.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/UpdateAlertRequestBody.cs
@@ -1,6 +1,6 @@
 using Optional;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+namespace TeachingRecordSystem.Api.V3.V20240920.Requests;
 
 public record UpdateAlertRequestBody
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/AlertResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/AlertResponse.cs
@@ -1,0 +1,8 @@
+using TeachingRecordSystem.Api.V3.V20240920.ApiModels;
+
+namespace TeachingRecordSystem.Api.V3.V20240920.Responses;
+
+public record AlertResponse : Alert
+{
+    public required PersonInfo Person { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/FindPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/FindPersonResponse.cs
@@ -1,8 +1,8 @@
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using TeachingRecordSystem.Api.V3.VNext.ApiModels;
-using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Api.V3.V20240920.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240920.Requests;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+namespace TeachingRecordSystem.Api.V3.V20240920.Responses;
 
 [GenerateVersionedDto(typeof(V20240814.Responses.FindPersonResponse), excludeMembers: ["Query", "Results"])]
 public partial record FindPersonResponse

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/FindPersonsResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/FindPersonsResponse.cs
@@ -1,8 +1,8 @@
 using AutoMapper.Configuration.Annotations;
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+namespace TeachingRecordSystem.Api.V3.V20240920.Responses;
 
 [AutoMap(typeof(FindPersonsByTrnAndDateOfBirthResult))]
 [GenerateVersionedDto(typeof(V20240814.Responses.FindPersonsResponse), excludeMembers: ["Results"])]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/GetPersonResponse.cs
@@ -1,8 +1,8 @@
 using Optional;
 using TeachingRecordSystem.Api.V3.Core.Operations;
-using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+namespace TeachingRecordSystem.Api.V3.V20240920.Responses;
 
 [AutoMap(typeof(GetPersonResult))]
 [GenerateVersionedDto(typeof(V20240606.Responses.GetPersonResponse), excludeMembers: ["Alerts", "Sanctions", "Induction"])]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Validators/SetDeceasedRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Validators/SetDeceasedRequestValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
-using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Api.V3.V20240920.Requests;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Validators;
+namespace TeachingRecordSystem.Api.V3.V20240920.Validators;
 
 public class SetDeceasedRequestValidator : AbstractValidator<SetDeceasedRequest>
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Validators/SetQtlsRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Validators/SetQtlsRequestValidator.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
 using TeachingRecordSystem.Api.V3.V20240912.Requests;
 
-namespace TeachingRecordSystem.Api.V3.VNext.Validators;
+namespace TeachingRecordSystem.Api.V3.V20240920.Validators;
 
 public class SetQtlsRequestValidator : AbstractValidator<SetQtlsRequest>
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/AlertResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/AlertResponse.cs
@@ -1,8 +1,0 @@
-using TeachingRecordSystem.Api.V3.VNext.ApiModels;
-
-namespace TeachingRecordSystem.Api.V3.VNext.Responses;
-
-public record AlertResponse : Alert
-{
-    public required PersonInfo Person { get; init; }
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertCreatedNotification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertCreatedNotification.cs
@@ -1,4 +1,4 @@
-using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
 namespace TeachingRecordSystem.Api.V3.VNext.WebHookMessages;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertDeletedNotification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertDeletedNotification.cs
@@ -1,4 +1,4 @@
-using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
 namespace TeachingRecordSystem.Api.V3.VNext.WebHookMessages;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertUpdatedNotification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/WebHookMessages/AlertUpdatedNotification.cs
@@ -1,4 +1,4 @@
-using TeachingRecordSystem.Api.V3.VNext.ApiModels;
+using TeachingRecordSystem.Api.V3.V20240920.ApiModels;
 
 namespace TeachingRecordSystem.Api.V3.VNext.WebHookMessages;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/VersionRegistry.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/VersionRegistry.cs
@@ -16,6 +16,7 @@ public static class VersionRegistry
         V3MinorVersions.V20240606,
         V3MinorVersions.V20240814,
         V3MinorVersions.V20240912,
+        V3MinorVersions.V20240920,
         V3MinorVersions.VNext,
     ];
 
@@ -58,6 +59,7 @@ public static class VersionRegistry
         public const string V20240606 = "20240606";
         public const string V20240814 = "20240814";
         public const string V20240912 = "20240912";
+        public const string V20240920 = "20240920";
         public const string VNext = VNextVersion;
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -1,9 +1,9 @@
-namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+namespace TeachingRecordSystem.Api.Tests.V3.V20240920;
 
 [Collection(nameof(DisableParallelization))]
-public class FindPersonsByTrnAndDateOfBirthTests : TestBase
+public class FindPersonByLastNameAndDateOfBirthTests : TestBase
 {
-    public FindPersonsByTrnAndDateOfBirthTests(HostFixture hostFixture) : base(hostFixture)
+    public FindPersonByLastNameAndDateOfBirthTests(HostFixture hostFixture) : base(hostFixture)
     {
         XrmFakedContext.DeleteAllEntities<Contact>();
         SetCurrentApiClient([ApiRoles.GetPerson]);
@@ -13,7 +13,6 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
     public async Task Get_ValidRequestWithMatchOnPersonWithAlerts_ReturnsExpectedAlertsContent()
     {
         // Arrange
-        var findBy = "LastNameAndDateOfBirth";
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
@@ -30,9 +29,20 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
 
         var sanction = person.Sanctions.Single();
 
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
+        {
+            Content = JsonContent.Create(new
+            {
+                persons = new[]
+                {
+                    new
+                    {
+                        trn = person.Trn,
+                        dateOfBirth = person.DateOfBirth
+                    }
+                }
+            })
+        };
 
         // Act
         var response = await GetHttpClientWithApiKey().SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -1,9 +1,9 @@
-namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+namespace TeachingRecordSystem.Api.Tests.V3.V20240920;
 
 [Collection(nameof(DisableParallelization))]
-public class FindPersonByLastNameAndDateOfBirthTests : TestBase
+public class FindPersonsByTrnAndDateOfBirthTests : TestBase
 {
-    public FindPersonByLastNameAndDateOfBirthTests(HostFixture hostFixture) : base(hostFixture)
+    public FindPersonsByTrnAndDateOfBirthTests(HostFixture hostFixture) : base(hostFixture)
     {
         XrmFakedContext.DeleteAllEntities<Contact>();
         SetCurrentApiClient([ApiRoles.GetPerson]);
@@ -13,6 +13,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
     public async Task Get_ValidRequestWithMatchOnPersonWithAlerts_ReturnsExpectedAlertsContent()
     {
         // Arrange
+        var findBy = "LastNameAndDateOfBirth";
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
@@ -29,20 +30,9 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
 
         var sanction = person.Sanctions.Single();
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
-        {
-            Content = JsonContent.Create(new
-            {
-                persons = new[]
-                {
-                    new
-                    {
-                        trn = person.Trn,
-                        dateOfBirth = person.DateOfBirth
-                    }
-                }
-            })
-        };
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy={findBy}&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
 
         // Act
         var response = await GetHttpClientWithApiKey().SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/GetPersonByTrnTests.cs
@@ -1,6 +1,6 @@
-using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Api.V3.V20240920.Requests;
 
-namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+namespace TeachingRecordSystem.Api.Tests.V3.V20240920;
 
 public class GetPersonByTrnTests : TestBase
 {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/GetPersonTests.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+namespace TeachingRecordSystem.Api.Tests.V3.V20240920;
 
 public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
 {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/SetDeceasedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/SetDeceasedTests.cs
@@ -2,7 +2,7 @@ using System.Net;
 using TeachingRecordSystem.Api.V3.Core.Operations;
 using TeachingRecordSystem.Core.Dqt;
 
-namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+namespace TeachingRecordSystem.Api.Tests.V3.V20240920;
 
 [Collection(nameof(DisableParallelization))]
 public class SetDeceasedTests : TestBase

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/TestBase.cs
@@ -1,8 +1,8 @@
-namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+namespace TeachingRecordSystem.Api.Tests.V3.V20240920;
 
 public abstract class TestBase : Tests.TestBase
 {
-    public const string Version = VersionRegistry.V3MinorVersions.VNext;
+    public const string Version = VersionRegistry.V3MinorVersions.V20240920;
 
     protected TestBase(HostFixture hostFixture) : base(hostFixture)
     {


### PR DESCRIPTION
Moves all endpoints under `vNext` into a new API release - `20240920`.