### PR TITLE
Add dry run support to TrsDataSyncHelper

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
@@ -52,7 +52,7 @@ public partial class Commands
                     return;
                 }
 
-                await syncHelper.SyncPerson(contact, ignoreInvalid: false);
+                await syncHelper.SyncPerson(contact, ignoreInvalid: false, dryRun: false);
                 //return 0;
             },
             connectionStringOption,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllMqsFromCrmJob.cs
@@ -80,6 +80,7 @@ public class SyncAllMqsFromCrmJob
                 result.Entities.Select(e => e.ToEntity<dfeta_qualification>()).ToArray(),
                 ignoreInvalid: _syncOptionsAccessor.Value.IgnoreInvalidData,
                 createMigratedEvent: true,
+                dryRun: false,
                 cancellationToken);
 
             if (result.MoreRecords)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
@@ -68,6 +68,7 @@ public class SyncAllPersonsFromCrmJob
             await _trsDataSyncHelper.SyncPersons(
                 result.Entities.Select(e => e.ToEntity<Contact>()).ToArray(),
                 ignoreInvalid: _syncOptionsAccessor.Value.IgnoreInvalidData,
+                dryRun: false,
                 cancellationToken);
 
             if (result.MoreRecords)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -130,6 +130,7 @@ public class TrsDataSyncService(
                 modelType,
                 newOrUpdatedItems.Select(i => i.NewOrUpdatedEntity).ToArray(),
                 optionsAccessor.Value.IgnoreInvalidData,
+                dryRun: false,
                 cancellationToken);
 
             await trsDataSyncHelper.DeleteRecords(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -65,7 +65,7 @@ public class CheckPersonExistsFilter(
         // Ensure we've synced this person into the TRS DB at least once
         if (!await dbContext.Persons.AnyAsync(p => p.PersonId == personId))
         {
-            await backgroundJobScheduler.Enqueue<TrsDataSyncHelper>(helper => helper.SyncPerson(personId, CancellationToken.None));
+            await backgroundJobScheduler.Enqueue<TrsDataSyncHelper>(helper => helper.SyncPerson(personId, /*dryRun:*/ false, CancellationToken.None));
         }
 
         await next();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -590,7 +590,7 @@ public partial class TestData
             contact = retrieveContactHandle.GetResponse().Entity.ToEntity<Contact>();
 
             await testData.SyncConfiguration.SyncIfEnabled(
-                helper => helper.SyncPerson(contact, ignoreInvalid: false, CancellationToken.None),
+                helper => helper.SyncPerson(contact, ignoreInvalid: false),
                 _syncEnabledOverride);
 
             var mqs = await Task.WhenAll(_mqBuilders.Select(mqb => mqb.Execute(this, testData)));


### PR DESCRIPTION
When run in 'dry run' mode, DB transactions are not committed.