### PR TITLE
Assign initial state in Get handlers

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Address.cshtml.cs
@@ -45,11 +45,11 @@ public class AddressModel(AuthorizeAccessLinkGenerator linkGenerator) : PageMode
 
     public void OnGet()
     {
-        AddressLine1 ??= JourneyInstance!.State.AddressLine1;
-        AddressLine2 ??= JourneyInstance!.State.AddressLine2;
-        TownOrCity ??= JourneyInstance!.State.TownOrCity;
-        PostalCode ??= JourneyInstance!.State.PostalCode;
-        Country ??= JourneyInstance!.State.Country;
+        AddressLine1 = JourneyInstance!.State.AddressLine1;
+        AddressLine2 = JourneyInstance!.State.AddressLine2;
+        TownOrCity = JourneyInstance!.State.TownOrCity;
+        PostalCode = JourneyInstance!.State.PostalCode;
+        Country = JourneyInstance!.State.Country;
     }
 
     public async Task<IActionResult> OnPost()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/DateOfBirth.cshtml.cs
@@ -19,6 +19,11 @@ public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator, IClock
     [Required(ErrorMessage = "Enter your date of birth")]
     public DateOnly? DateOfBirth { get; set; }
 
+    public void OnGet()
+    {
+        DateOfBirth = JourneyInstance!.State.DateOfBirth;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (DateOfBirth >= clock.Today)
@@ -48,9 +53,6 @@ public class DateOfBirthModel(AuthorizeAccessLinkGenerator linkGenerator, IClock
         else if (state.HasPreviousName is null)
         {
             context.Result = Redirect(linkGenerator.RequestTrnPreviousName(JourneyInstance.InstanceId));
-            return;
         }
-
-        DateOfBirth ??= JourneyInstance!.State.DateOfBirth;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Email.cshtml.cs
@@ -23,6 +23,11 @@ public class EmailModel(AuthorizeAccessLinkGenerator linkGenerator, ICrmQueryDis
     [@EmailAddress(ErrorMessage = "Enter an email address in the correct format, like name@example.com")]
     public string? Email { get; set; }
 
+    public void OnGet()
+    {
+        Email = JourneyInstance!.State.Email;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -53,7 +58,5 @@ public class EmailModel(AuthorizeAccessLinkGenerator linkGenerator, ICrmQueryDis
             context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
             return;
         }
-
-        Email ??= JourneyInstance!.State.Email;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Identity.cshtml.cs
@@ -35,7 +35,7 @@ public class IdentityModel(AuthorizeAccessLinkGenerator linkGenerator, IFileServ
 
     public async Task OnGet()
     {
-        UploadedEvidenceFileUrl ??= JourneyInstance?.State.EvidenceFileId is not null ?
+        UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Name.cshtml.cs
@@ -20,6 +20,11 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
     [MaxLength(200, ErrorMessage = "Name must be 200 characters or less")]
     public string? Name { get; set; }
 
+    public void OnGet()
+    {
+        Name = JourneyInstance!.State.Name;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -47,11 +52,6 @@ public class NameModel(AuthorizeAccessLinkGenerator linkGenerator) : PageModel
         else if (state.Email is null)
         {
             context.Result = Redirect(linkGenerator.RequestTrnEmail(JourneyInstance.InstanceId));
-        }
-
-        if (context.Result is null)
-        {
-            Name ??= JourneyInstance!.State.Name;
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NationalInsuranceNumber.cshtml.cs
@@ -24,6 +24,12 @@ public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGener
     [Required(ErrorMessage = "Enter your National Insurance number")]
     public string? NationalInsuranceNumber { get; set; }
 
+    public void OnGet()
+    {
+        HasNationalInsuranceNumber = JourneyInstance?.State.HasNationalInsuranceNumber;
+        NationalInsuranceNumber = JourneyInstance?.State.NationalInsuranceNumber;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (HasNationalInsuranceNumber == true)
@@ -68,12 +74,6 @@ public class NationalInsuranceNumberModel(AuthorizeAccessLinkGenerator linkGener
         else if (state.EvidenceFileId is null)
         {
             context.Result = Redirect(linkGenerator.RequestTrnIdentity(JourneyInstance.InstanceId));
-        }
-
-        if (context.Result is null)
-        {
-            HasNationalInsuranceNumber ??= JourneyInstance?.State.HasNationalInsuranceNumber;
-            NationalInsuranceNumber ??= JourneyInstance?.State.NationalInsuranceNumber;
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NpqCheck.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/NpqCheck.cshtml.cs
@@ -16,6 +16,11 @@ public class NpqCheckModel(AuthorizeAccessLinkGenerator linkGenerator) : PageMod
     [Required(ErrorMessage = "Tell us whether you plan on taking a national professional qualification (NPQ)")]
     public bool? IsPlanningToTakeAnNpq { get; set; }
 
+    public void OnGet()
+    {
+        IsPlanningToTakeAnNpq = JourneyInstance!.State.IsPlanningToTakeAnNpq;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -36,9 +41,6 @@ public class NpqCheckModel(AuthorizeAccessLinkGenerator linkGenerator) : PageMod
         if (state.HasPendingTrnRequest)
         {
             context.Result = Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
-            return;
         }
-
-        IsPlanningToTakeAnNpq ??= JourneyInstance!.State.IsPlanningToTakeAnNpq;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PreviousName.cshtml.cs
@@ -26,6 +26,12 @@ public class PreviousNameModel(AuthorizeAccessLinkGenerator linkGenerator) : Pag
     [MaxLength(200, ErrorMessage = "Previous name must be 200 characters or less")]
     public string? PreviousName { get; set; }
 
+    public void OnGet()
+    {
+        HasPreviousName = JourneyInstance!.State.HasPreviousName;
+        PreviousName = JourneyInstance!.State.PreviousName;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -55,12 +61,6 @@ public class PreviousNameModel(AuthorizeAccessLinkGenerator linkGenerator) : Pag
         {
             context.Result = Redirect(linkGenerator.RequestTrnName(JourneyInstance.InstanceId));
             return;
-        }
-
-        if (context.Result is null)
-        {
-            HasPreviousName ??= JourneyInstance!.State.HasPreviousName;
-            PreviousName ??= JourneyInstance!.State.PreviousName;
         }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml.cs
@@ -23,6 +23,11 @@ public class DetailsModel(TrsLinkGenerator linkGenerator) : PageModel
     [Display(Name = "Enter details")]
     public string? Details { get; set; }
 
+    public void OnGet()
+    {
+        Details = JourneyInstance!.State.Details;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -57,6 +62,5 @@ public class DetailsModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        Details ??= JourneyInstance!.State.Details;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/EndDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/EndDate.cshtml.cs
@@ -29,6 +29,11 @@ public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
     [RequiredIfOtherPropertyEquals(nameof(HasEndDate), ErrorMessage = "Enter an end date")]
     public DateOnly? EndDate { get; set; }
 
+    public void OnGet()
+    {
+        EndDate = JourneyInstance!.State.EndDate;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -64,6 +69,5 @@ public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        EndDate ??= JourneyInstance!.State.EndDate;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Link.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Link.cshtml.cs
@@ -22,6 +22,11 @@ public class LinkModel(TrsLinkGenerator linkGenerator) : PageModel
     [Display(Name = "Enter link")]
     public string? Link { get; set; }
 
+    public void OnGet()
+    {
+        Link = JourneyInstance!.State.Link;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!string.IsNullOrEmpty(Link) &&
@@ -63,6 +68,5 @@ public class LinkModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        Link ??= JourneyInstance!.State.Link;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Reason.cshtml.cs
@@ -49,11 +49,11 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     public async Task OnGet()
     {
-        Detail ??= JourneyInstance!.State.Reason;
-        UploadedEvidenceFileUrl ??= JourneyInstance?.State.EvidenceFileId is not null ?
+        Detail = JourneyInstance!.State.Reason;
+        UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
-        UploadEvidence ??= JourneyInstance?.State.UploadEvidence;
+        UploadEvidence = JourneyInstance?.State.UploadEvidence;
     }
 
     public async Task<IActionResult> OnPost()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/StartDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/StartDate.cshtml.cs
@@ -23,6 +23,11 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
     [Display(Name = "Enter start date")]
     public DateOnly? StartDate { get; set; }
 
+    public void OnGet()
+    {
+        StartDate = JourneyInstance!.State.StartDate;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -57,6 +62,5 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        StartDate ??= JourneyInstance!.State.StartDate;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Type.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Type.cshtml.cs
@@ -29,6 +29,11 @@ public class TypeModel(
 
     public AlertTypeInfo[]? AlertTypes { get; set; }
 
+    public void OnGet()
+    {
+        AlertTypeId = JourneyInstance!.State.AlertTypeId;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -61,7 +66,6 @@ public class TypeModel(
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        AlertTypeId ??= JourneyInstance!.State.AlertTypeId;
 
         var alertTypes = await referenceDataCache.GetAlertTypes(activeOnly: true);
         AlertTypes = alertTypes.Select(t => new AlertTypeInfo(t.AlertTypeId, t.Name)).ToArray();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml.cs
@@ -26,6 +26,11 @@ public class ProviderModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public ProviderInfo[]? Providers { get; set; }
 
+    public void OnGet()
+    {
+        ProviderId = JourneyInstance!.State.ProviderId;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (!ModelState.IsValid)
@@ -51,7 +56,6 @@ public class ProviderModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        ProviderId ??= JourneyInstance!.State.ProviderId;
         Providers = MandatoryQualificationProvider.All.Select(p => new ProviderInfo(p.MandatoryQualificationProviderId, p.Name)).ToArray();
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
@@ -25,6 +25,11 @@ public class SpecialismModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public IReadOnlyCollection<MandatoryQualificationSpecialismInfo>? Specialisms { get; set; }
 
+    public void OnGet()
+    {
+        Specialism = JourneyInstance!.State.Specialism;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (Specialism is MandatoryQualificationSpecialism specialism && !Specialisms!.Any(s => s.Value == specialism))
@@ -63,6 +68,5 @@ public class SpecialismModel(TrsLinkGenerator linkGenerator) : PageModel
         Specialisms = MandatoryQualificationSpecialismRegistry.GetAll(includeLegacy: false);
 
         PersonName = personInfo.Name;
-        Specialism ??= JourneyInstance.State.Specialism;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
@@ -23,6 +23,11 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
     [Display(Name = "Start date")]
     public DateOnly? StartDate { get; set; }
 
+    public void OnGet()
+    {
+        StartDate = JourneyInstance!.State.StartDate;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (StartDate.HasValue && JourneyInstance!.State.EndDate is DateOnly endDate && StartDate >= endDate)
@@ -59,6 +64,5 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        StartDate ??= JourneyInstance.State.StartDate;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml.cs
@@ -28,6 +28,12 @@ public class StatusModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public DateOnly? StartDate { get; set; }
 
+    public void OnGet()
+    {
+        Status = JourneyInstance!.State.Status;
+        EndDate = JourneyInstance!.State.EndDate;
+    }
+
     public async Task<IActionResult> OnPost()
     {
         if (Status == MandatoryQualificationStatus.Passed)
@@ -77,7 +83,5 @@ public class StatusModel(TrsLinkGenerator linkGenerator) : PageModel
 
         PersonName = personInfo.Name;
         StartDate = JourneyInstance!.State.StartDate;
-        Status ??= JourneyInstance.State.Status;
-        EndDate ??= JourneyInstance.State.EndDate;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
@@ -55,12 +55,12 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
 
     public async Task OnGet()
     {
-        DeletionReason ??= JourneyInstance!.State.DeletionReason;
-        DeletionReasonDetail ??= JourneyInstance?.State.DeletionReasonDetail;
-        UploadedEvidenceFileUrl ??= JourneyInstance?.State.EvidenceFileId is not null ?
+        DeletionReason = JourneyInstance!.State.DeletionReason;
+        DeletionReasonDetail = JourneyInstance?.State.DeletionReasonDetail;
+        UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
-        UploadEvidence ??= JourneyInstance?.State.UploadEvidence;
+        UploadEvidence = JourneyInstance?.State.UploadEvidence;
     }
 
     public async Task<IActionResult> OnPost()


### PR DESCRIPTION
We have a pattern used in a few places of assigning model-bound properties from journey state in `OnPageHandlerExecuting` using `??=`. While this works fine in most places, as a general pattern it's not correct. Consider an 'edit' page that allows a field to be 'cleared' (i.e. set to `null`) but the journey state has non-`null`; if we use `??=` in `OnPageHandlerExecuting` we will incorrectly undo the assignment to `null` in `POST` requests.