### PR TITLE
Implemented Edit an alert start date journey + tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
@@ -11,9 +11,9 @@ public class Alert
     public required Guid AlertTypeId { get; init; }
     public required Guid PersonId { get; init; }
     public required string? Details { get; init; }
-    public required string? ExternalLink { get; init; }
-    public required DateOnly? StartDate { get; init; }
-    public required DateOnly? EndDate { get; init; }
+    public required string? ExternalLink { get; set; }
+    public required DateOnly? StartDate { get; set; }
+    public required DateOnly? EndDate { get; set; }
     public required DateTime CreatedOn { get; init; }
     public required DateTime UpdatedOn { get; set; }
     public DateTime? DeletedOn { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.Core.Events.Models;
+using File = TeachingRecordSystem.Core.Events.Models.File;
 
 namespace TeachingRecordSystem.Core.Events;
 
@@ -7,5 +8,5 @@ public record class AlertCreatedEvent : EventBase, IEventWithPersonId, IEventWit
     public required Guid PersonId { get; init; }
     public required Alert Alert { get; init; }
     public required string? Reason { get; init; }
-    public required Models.File? EvidenceFile { get; init; }
+    public required File? EvidenceFile { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
@@ -1,0 +1,24 @@
+using TeachingRecordSystem.Core.Events.Models;
+using File = TeachingRecordSystem.Core.Events.Models.File;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record class AlertUpdatedEvent : EventBase, IEventWithPersonId, IEventWithAlert
+{
+    public required Guid PersonId { get; init; }
+    public required Alert Alert { get; init; }
+    public required Alert OldAlert { get; init; }
+    public required string? ChangeReason { get; init; }
+    public required File? EvidenceFile { get; init; }
+    public required AlertUpdatedEventChanges Changes { get; init; }
+}
+
+[Flags]
+public enum AlertUpdatedEventChanges
+{
+    None = 0,
+    Details = 1 << 0,
+    ExternalLink = 1 << 2,
+    StartDate = 1 << 3,
+    EndDate = 1 << 4,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+/// <summary>
+/// Checks that an Alert exists with the ID specified by the alertId route value.
+/// </summary>
+/// <remarks>
+/// <para>Returns a <see cref="StatusCodes.Status400BadRequest"/> response if the request is missing the alertId route value.</para>
+/// <para>Returns a <see cref="StatusCodes.Status404NotFound"/> response if no alert with the specified ID exists.</para>
+/// <para>Assigns the <see cref="CurrentMandatoryQualificationFeature"/> and <see cref="CurrentPersonFeature"/> on success.</para>
+/// </remarks>
+public class CheckAlertExistsFilter(TrsDbContext dbContext, ICrmQueryDispatcher crmQueryDispatcher) :
+    AssignCurrentPersonInfoFilterBase(crmQueryDispatcher), IAsyncResourceFilter
+{
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        if (context.RouteData.Values["alertId"] is not string alertIdParam ||
+            !Guid.TryParse(alertIdParam, out Guid alertId))
+        {
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        var currentAlert = await dbContext.Alerts
+            .SingleOrDefaultAsync(a => a.AlertId == alertId);
+
+        if (currentAlert is null)
+        {
+            context.Result = new NotFoundResult();
+            return;
+        }
+
+        context.HttpContext.SetCurrentAlertFeature(new(currentAlert));
+
+        await TryAssignCurrentPersonInfo(currentAlert.PersonId, context.HttpContext);
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -11,4 +11,5 @@ public static class JourneyNames
     public const string EditMqStatus = nameof(EditMqStatus);
     public const string DeleteMq = nameof(DeleteMq);
     public const string AddAlert = nameof(AddAlert);
+    public const string EditAlertStartDate = nameof(EditAlertStartDate);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
@@ -32,6 +32,12 @@ public static class HttpContextExtensions
 
     public static void SetCurrentSupportTaskFeature(this HttpContext context, CurrentSupportTaskFeature currentSupportTaskFeature) =>
         context.Features.Set(currentSupportTaskFeature);
+
+    public static CurrentAlertFeature GetCurrentAlertFeature(this HttpContext context) =>
+        context.Features.GetRequiredFeature<CurrentAlertFeature>();
+
+    public static void SetCurrentAlertFeature(this HttpContext context, CurrentAlertFeature currentAlertFeature) =>
+        context.Features.Set(currentAlertFeature);
 }
 
 public record CurrentPersonFeature(Guid PersonId, string FirstName, string MiddleName, string LastName)
@@ -42,3 +48,5 @@ public record CurrentPersonFeature(Guid PersonId, string FirstName, string Middl
 public record CurrentMandatoryQualificationFeature(MandatoryQualification MandatoryQualification);
 
 public record CurrentSupportTaskFeature(SupportTask SupportTask);
+
+public record CurrentAlertFeature(Alert Alert);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/EndDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/EndDate.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.UiCommon.DataAnnotations;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
 
@@ -26,8 +25,9 @@ public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
 
     [BindProperty]
     [Display(Name = "End date")]
-    [RequiredIfOtherPropertyEquals(nameof(HasEndDate), ErrorMessage = "Enter an end date")]
     public DateOnly? EndDate { get; set; }
+
+    public DateOnly? StartDate { get; set; }
 
     public void OnGet()
     {
@@ -36,6 +36,17 @@ public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        if (HasEndDate == true && EndDate is null)
+        {
+            ModelState.AddModelError(nameof(EndDate), "Enter an end date");
+        }
+        else
+
+        if (StartDate >= EndDate)
+        {
+            ModelState.AddModelError(nameof(EndDate), "End date must be after start date");
+        }
+
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();
@@ -69,5 +80,6 @@ public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
+        StartDate = JourneyInstance!.State.StartDate;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/StartDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/StartDate.cshtml.cs
@@ -23,6 +23,8 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
     [Display(Name = "Enter start date")]
     public DateOnly? StartDate { get; set; }
 
+    public DateOnly? EndDate { get; set; }
+
     public void OnGet()
     {
         StartDate = JourneyInstance!.State.StartDate;
@@ -30,6 +32,11 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public async Task<IActionResult> OnPost()
     {
+        if (StartDate >= EndDate)
+        {
+            ModelState.AddModelError(nameof(StartDate), "Start date must be before end date");
+        }
+
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();
@@ -62,5 +69,6 @@ public class StartDateModel(TrsLinkGenerator linkGenerator) : PageModel
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
+        EndDate = JourneyInstance!.State.EndDate;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/AlertChangeStartDateReasonOption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/AlertChangeStartDateReasonOption.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+public enum AlertChangeStartDateReasonOption
+{
+    [Display(Name = "Incorrect start date")]
+    IncorrectStartDate,
+    [Display(Name = "Change of start date")]
+    ChangeOfStartDate,
+    [Display(Name = "Another reason")]
+    AnotherReason
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml
@@ -1,0 +1,60 @@
+@page "/alerts/{alertId}/start-date/check-answers/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate.CheckAnswersModel
+@{
+    ViewBag.Title = "Check details and confirm change";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.AlertEditStartDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-from-desktop">
+        <form action="@LinkGenerator.AlertEditStartDateCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
+            <govuk-summary-list data-testid="change-summary">
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>New start date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="new-start-date">@Model.NewStartDate!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditStartDate(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Current start date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="current-start-date" use-empty-fallback>@Model.CurrentStartDate?.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>                
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value><multi-line-text text="@Model.ChangeReason" data-testid="change-reason" /></govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditStartDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Evidence</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="evidence">
+                        @if (Model.UploadedEvidenceFileUrl is not null)
+                        {
+                            <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} (opens in new tab)")</a>
+                        }
+                        else
+                        {
+                            <span data-testid="uploaded-evidence-link" use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditStartDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Confirm change</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertEditStartDateCheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
@@ -1,0 +1,121 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+[Journey(JourneyNames.EditAlertStartDate), RequireJourneyInstance]
+public class CheckAnswersModel(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService,
+    IClock clock) : PageModel
+{
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    public JourneyInstance<EditAlertStartDateState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public DateOnly? NewStartDate { get; set; }
+
+    public DateOnly? CurrentStartDate { get; set; }
+
+    public string? ChangeReason { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        var now = clock.UtcNow;
+
+        var alert = await dbContext.Alerts
+            .SingleAsync(a => a.AlertId == AlertId);
+
+        var changes = NewStartDate != alert.StartDate ?
+            AlertUpdatedEventChanges.StartDate :
+            AlertUpdatedEventChanges.None;
+
+        if (changes != AlertUpdatedEventChanges.None)
+        {
+            var oldAlertEventModel = EventModels.Alert.FromModel(alert);
+
+            alert.StartDate = NewStartDate;
+            alert.UpdatedOn = now;
+
+            var updatedEvent = new AlertUpdatedEvent()
+            {
+                EventId = Guid.NewGuid(),
+                CreatedUtc = now,
+                RaisedBy = User.GetUserId(),
+                PersonId = PersonId,
+                Alert = EventModels.Alert.FromModel(alert),
+                OldAlert = oldAlertEventModel,
+                ChangeReason = ChangeReason,
+                EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
+                new EventModels.File()
+                {
+                    FileId = fileId,
+                    Name = JourneyInstance.State.EvidenceFileName!
+                } :
+                null,
+                Changes = changes
+            };
+
+            dbContext.AddEvent(updatedEvent);
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        await JourneyInstance!.CompleteAsync();
+        TempData.SetFlashSuccess("Alert changed");
+
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (!JourneyInstance!.State.IsComplete)
+        {
+            context.Result = Redirect(linkGenerator.AlertEditStartDate(AlertId, JourneyInstance.InstanceId));
+            return;
+        }
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+        var alertInfo = context.HttpContext.GetCurrentAlertFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+        NewStartDate = JourneyInstance!.State.StartDate;
+        CurrentStartDate = alertInfo.Alert.StartDate;
+        ChangeReason = JourneyInstance.State.ChangeReason != AlertChangeStartDateReasonOption.AnotherReason ?
+            JourneyInstance.State.ChangeReason!.GetDisplayName() :
+            JourneyInstance!.State.ChangeReasonDetail;
+        EvidenceFileName = JourneyInstance.State.EvidenceFileName;
+        UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance!.State.EvidenceFileId!.Value, _fileUrlExpiresAfter) :
+            null;
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateState.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+public class EditAlertStartDateState
+{
+    public bool Initialized { get; set; }
+
+    public DateOnly? CurrentStartDate { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public AlertChangeStartDateReasonOption? ChangeReason { get; set; }
+
+    public string? ChangeReasonDetail { get; set; }
+
+    public bool? UploadEvidence { get; set; }
+
+    public Guid? EvidenceFileId { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    [JsonIgnore]
+    [MemberNotNullWhen(true, nameof(StartDate), nameof(ChangeReason), nameof(UploadEvidence), nameof(EvidenceFileId))]
+    public bool IsComplete => StartDate is not null &&
+        ChangeReason.HasValue &&
+        (ChangeReason.Value == AlertChangeStartDateReasonOption.AnotherReason ? !string.IsNullOrWhiteSpace(ChangeReasonDetail) : true) &&
+        UploadEvidence.HasValue &&
+        (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
+
+    public void EnsureInitialized(CurrentAlertFeature alertInfo)
+    {
+        if (Initialized)
+        {
+            return;
+        }
+
+        StartDate = CurrentStartDate = alertInfo.Alert.StartDate;
+        Initialized = true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml
@@ -1,0 +1,28 @@
+@page "/alerts/{alertId}/start-date/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate.IndexModel
+@{
+    ViewBag.Title = "Change start date";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.AlertEditStartDateCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.PersonAlerts(Model.PersonId))">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AlertEditStartDate(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
+            <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
+
+            <govuk-date-input asp-for="StartDate">
+                <govuk-date-input-fieldset>
+                    <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
+                </govuk-date-input-fieldset>
+            </govuk-date-input>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertEditStartDateCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </<div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+[Journey(JourneyNames.EditAlertStartDate), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<EditAlertStartDateState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Start date")]
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? CurrentStartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+
+    public void OnGet()
+    {
+        StartDate = JourneyInstance!.State.StartDate;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (StartDate is null)
+        {
+            ModelState.AddModelError(nameof(StartDate), "Enter a start date");
+        }
+        else if (StartDate >= EndDate)
+        {
+            ModelState.AddModelError(nameof(StartDate), "Start date must be before end date");
+        }
+        else if (StartDate == CurrentStartDate)
+        {
+            ModelState.AddModelError(nameof(StartDate), "Enter a different start date");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state => state.StartDate = StartDate);
+
+        return Redirect(FromCheckAnswers
+            ? linkGenerator.AlertEditStartDateCheckAnswers(AlertId, JourneyInstance.InstanceId)
+            : linkGenerator.AlertEditStartDateReason(AlertId, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var alertInfo = context.HttpContext.GetCurrentAlertFeature();
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        JourneyInstance!.State.EnsureInitialized(alertInfo);
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+        CurrentStartDate = alertInfo.Alert.StartDate;
+        EndDate = alertInfo.Alert.EndDate;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml
@@ -1,0 +1,65 @@
+@page "/alerts/{alertId}/start-date/change-reason/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate.ReasonModel
+@{
+    ViewBag.Title = "Why are you changing the start date?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.AlertEditStartDateCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.AlertEditStartDate(Model.AlertId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AlertEditStartDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
+            <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@AlertChangeStartDateReasonOption.IncorrectStartDate">
+                        @AlertChangeStartDateReasonOption.IncorrectStartDate.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@AlertChangeStartDateReasonOption.ChangeOfStartDate">
+                        @AlertChangeStartDateReasonOption.ChangeOfStartDate.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@AlertChangeStartDateReasonOption.AnotherReason">
+                        @AlertChangeStartDateReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional>
+                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="4000" />
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-radios asp-for="UploadEvidence" data-testid="upload-evidence-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@true">
+                        Yes
+                        <govuk-radios-item-conditional>
+                            @if (Model.EvidenceFileId is not null)
+                            {
+                                <span class="govuk-caption-m">Currently uploaded file</span>
+                                <p class="govuk-body">
+                                    <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} ({Model.EvidenceFileSizeDescription})")</a>
+                                </p>
+                            }
+                            <govuk-file-upload asp-for="EvidenceFile" input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+                                <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+                            </govuk-file-upload>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertEditStartDateReasonCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
@@ -1,0 +1,146 @@
+using System.ComponentModel.DataAnnotations;
+using Humanizer;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.DataAnnotations;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+[Journey(JourneyNames.EditAlertStartDate), RequireJourneyInstance]
+public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileService) : PageModel
+{
+    public const int MaxFileSizeMb = 50;
+
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    public JourneyInstance<EditAlertStartDateState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Select a reason")]
+    [Required(ErrorMessage = "Select a reason")]
+    public AlertChangeStartDateReasonOption? ChangeReason { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Enter details")]
+    public string? ChangeReasonDetail { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Upload evidence")]
+    [Required(ErrorMessage = "Select yes if you want to upload evidence")]
+    public bool? UploadEvidence { get; set; }
+
+    [BindProperty]
+    [EvidenceFile]
+    [FileSize(MaxFileSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    public IFormFile? EvidenceFile { get; set; }
+
+    public Guid? EvidenceFileId { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public async Task OnGet()
+    {
+        ChangeReason = JourneyInstance!.State.ChangeReason;
+        ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
+        UploadEvidence = JourneyInstance?.State.UploadEvidence;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
+        UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
+            null;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (ChangeReason == AlertChangeStartDateReasonOption.AnotherReason && string.IsNullOrWhiteSpace(ChangeReasonDetail))
+        {
+            ModelState.AddModelError(nameof(ChangeReasonDetail), "Enter details");
+        }
+
+        if (UploadEvidence == true && EvidenceFileId is null && EvidenceFile is null)
+        {
+            ModelState.AddModelError(nameof(EvidenceFile), "Select a file");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        if (UploadEvidence == true)
+        {
+            if (EvidenceFile is not null)
+            {
+                if (EvidenceFileId is not null)
+                {
+                    await fileService.DeleteFile(EvidenceFileId.Value);
+                }
+
+                using var stream = EvidenceFile.OpenReadStream();
+                var evidenceFileId = await fileService.UploadFile(stream, EvidenceFile.ContentType);
+                await JourneyInstance!.UpdateStateAsync(state =>
+                {
+                    state.EvidenceFileId = evidenceFileId;
+                    state.EvidenceFileName = EvidenceFile.FileName;
+                    state.EvidenceFileSizeDescription = EvidenceFile.Length.Bytes().Humanize();
+                });
+            }
+        }
+        else if (EvidenceFileId is not null)
+        {
+            await fileService.DeleteFile(EvidenceFileId.Value);
+            await JourneyInstance!.UpdateStateAsync(state =>
+            {
+                state.EvidenceFileId = null;
+                state.EvidenceFileName = null;
+                state.EvidenceFileSizeDescription = null;
+            });
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.ChangeReason = ChangeReason;
+            state.ChangeReasonDetail = ChangeReasonDetail;
+            state.UploadEvidence = UploadEvidence;
+        });
+
+        return Redirect(linkGenerator.AlertEditStartDateCheckAnswers(AlertId, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.StartDate is null)
+        {
+            context.Result = Redirect(linkGenerator.AlertEditStartDate(AlertId, JourneyInstance.InstanceId));
+            return;
+        }
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -99,11 +99,24 @@ builder.Services
             });
 
         options.Conventions.AddFolderApplicationModelConvention(
-            "/Alerts/AddAlert",
+            "/Alerts",
             model =>
             {
                 model.Filters.Add(new RequireFeatureEnabledFilterFactory("Alerts"));
+            });
+
+        options.Conventions.AddFolderApplicationModelConvention(
+            "/Alerts/AddAlert",
+            model =>
+            {
                 model.Filters.Add(new CheckPersonExistsFilterFactory());
+            });
+
+        options.Conventions.AddFolderApplicationModelConvention(
+            "/Alerts/EditAlert",
+            model =>
+            {
+                model.Filters.Add(new ServiceFilterAttribute<CheckAlertExistsFilter>());
             });
 
         options.Conventions.AddFolderApplicationModelConvention(
@@ -205,6 +218,7 @@ builder.Services
     .AddTrsBaseServices()
     .AddTransient<ICurrentUserIdProvider, HttpContextCurrentUserIdProvider>()
     .AddTransient<CheckMandatoryQualificationExistsFilter>()
+    .AddTransient<CheckAlertExistsFilter>()
     .AddFormFlow(options =>
     {
         options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
@@ -223,6 +237,12 @@ builder.Services
             JourneyNames.AddAlert,
             typeof(TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert.AddAlertState),
             requestDataKeys: ["personId"],
+            appendUniqueKey: true));
+
+        options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
+            JourneyNames.EditAlertStartDate,
+            typeof(TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate.EditAlertStartDateState),
+            requestDataKeys: ["alertId"],
             appendUniqueKey: true));
 
         options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -61,6 +61,24 @@ public class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string AlertAddConfirmCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/Alerts/AddAlert/CheckAnswers", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
+    public string AlertEditStartDate(Guid alertId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertEditStartDateCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertEditStartDateReason(Guid alertId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Reason", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertEditStartDateReasonCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Reason", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertEditStartDateCheckAnswers(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/EditAlert/StartDate/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertEditStartDateCheckAnswersCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/EditAlert/StartDate/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
     public string AlertClose(Guid alertId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/Alerts/CloseAlert/Index", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
@@ -99,7 +99,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditAlertStartDatePage(alertId);
 
-        await page.FillDateInput(startDate);
+        await page.FillDateInput(newStartDate);
 
         await page.ClickContinueButton();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -36,6 +36,11 @@ public static class PageExtensions
         await page.GotoAsync($"/alerts/add?personId={personId}");
     }
 
+    public static async Task GoToEditAlertStartDatePage(this IPage page, Guid alertId)
+    {
+        await page.GotoAsync($"/alerts/{alertId}/start-date");
+    }
+
     public static async Task GoToAddMqPage(this IPage page, Guid personId)
     {
         await page.GotoAsync($"/mqs/add?personId={personId}");
@@ -155,6 +160,21 @@ public static class PageExtensions
     public static async Task AssertOnAddAlertCheckAnswersPage(this IPage page)
     {
         await page.WaitForUrlPathAsync($"/alerts/add/check-answers");
+    }
+
+    public static async Task AssertOnEditAlertStartDatePage(this IPage page, Guid alertId)
+    {
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/start-date");
+    }
+
+    public static async Task AssertOnEditAlertStartDateChangeReasonPage(this IPage page, Guid alertId)
+    {
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/start-date/change-reason");
+    }
+
+    public static async Task AssertOnEditAlertStartDateCheckAnswersPage(this IPage page, Guid alertId)
+    {
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/start-date/check-answers");
     }
 
     public static async Task AssertOnAlertDetailPage(this IPage page, Guid alertId)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/EndDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/EndDateTests.cs
@@ -200,6 +200,37 @@ public class EndDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
+    public async Task Post_WhenEndDateIsBeforeStartDate_ReturnsError()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+
+        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState
+        {
+            AlertTypeId = Guid.NewGuid(),
+            Details = "Details",
+            StartDate = new DateOnly(2022, 2, 3)
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/end-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["HasEndDate"] = "True",
+                ["EndDate.Day"] = "1",
+                ["EndDate.Month"] = "2",
+                ["EndDate.Year"] = "2022"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EndDate", "End date must be after start date");
+    }
+
+    [Fact]
     public async Task Post_WithValidInput_RedirectsToReasonPage()
     {
         // Arrange

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
@@ -172,6 +172,36 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
+    public async Task Post_WhenStartDateIsAfterEndDate_RendersError()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+
+        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState
+        {
+            AlertTypeId = Guid.NewGuid(),
+            Details = "Details",
+            EndDate = new DateOnly(2021, 1, 1)
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["StartDate.Day"] = "2",
+                ["StartDate.Month"] = "1",
+                ["StartDate.Year"] = "2021"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StartDate", "Start date must be before end date");
+    }
+
+    [Fact]
     public async Task Post_WithValidInput_RedirectsToEndDatePage()
     {
         // Arrange

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
@@ -1,0 +1,261 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.StartDate;
+
+public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/start-date", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_WithValidJourneyState_ReturnsOk(bool populateOptional)
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var changeReason = populateOptional ? AlertChangeStartDateReasonOption.AnotherReason : AlertChangeStartDateReasonOption.IncorrectStartDate;
+        var changeReasonDetail = populateOptional ? "Some details" : null;
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate,
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = populateOptional ? true : false,
+                EvidenceFileId = populateOptional ? evidenceFileId : null,
+                EvidenceFileName = populateOptional ? evidenceFileName : null
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(journeyStartDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("new-start-date")!.TextContent);
+        Assert.Equal(databaseStartDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("current-start-date")!.TextContent);
+        if (changeReason == AlertChangeStartDateReasonOption.AnotherReason)
+        {
+            Assert.Equal(changeReasonDetail, doc.GetElementByTestId("change-reason")!.TextContent);
+        }
+        else
+        {
+            Assert.Equal(changeReason.GetDisplayName(), doc.GetElementByTestId("change-reason")!.TextContent);
+        }
+        Assert.Equal(populateOptional ? $"{evidenceFileName} (opens in new tab)" : "-", doc.GetElementByTestId("uploaded-evidence-link")!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/start-date", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(AlertChangeStartDateReasonOption.IncorrectStartDate)]
+    [InlineData(AlertChangeStartDateReasonOption.ChangeOfStartDate)]
+    [InlineData(AlertChangeStartDateReasonOption.AnotherReason)]
+    public async Task Post_Confirm_UpdatesAlertCreatesEventCompletesJourneyAndRedirectsWithFlashMessage(AlertChangeStartDateReasonOption changeReason)
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var changeReasonDetail = "Some reason or other";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var originalAlert = person.Alerts.Single();
+        var alertId = originalAlert.AlertId;
+
+        EventPublisher.Clear();
+
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate,
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "Alert changed");
+
+        await WithDbContext(async dbContext =>
+        {
+            var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alertId);
+            Assert.Equal(journeyStartDate, updatedAlert!.StartDate);
+        });
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var expectedAlertUpdatedEvent = new AlertUpdatedEvent()
+            {
+                EventId = Guid.Empty,
+                CreatedUtc = Clock.UtcNow,
+                RaisedBy = GetCurrentUserId(),
+                PersonId = person.PersonId,
+                Alert = new()
+                {
+                    AlertId = alertId,
+                    AlertTypeId = originalAlert.AlertTypeId,
+                    Details = originalAlert.Details,
+                    ExternalLink = originalAlert.ExternalLink,
+                    StartDate = journeyStartDate,
+                    EndDate = originalAlert.EndDate
+                },
+                OldAlert = new()
+                {
+                    AlertId = alertId,
+                    AlertTypeId = originalAlert.AlertTypeId,
+                    Details = originalAlert.Details,
+                    ExternalLink = originalAlert.ExternalLink,
+                    StartDate = databaseStartDate,
+                    EndDate = originalAlert.EndDate
+                },
+                ChangeReason = changeReason == AlertChangeStartDateReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                EvidenceFile = new()
+                {
+                    FileId = evidenceFileId,
+                    Name = evidenceFileName
+                },
+                Changes = AlertUpdatedEventChanges.StartDate
+            };
+
+            var actualAlertUpdatedEvent = Assert.IsType<AlertUpdatedEvent>(e);
+            Assert.Equivalent(expectedAlertUpdatedEvent with { EventId = actualAlertUpdatedEvent.EventId }, actualAlertUpdatedEvent);
+        });
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.True(journeyInstance.Completed);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var changeReason = AlertChangeStartDateReasonOption.IncorrectStartDate;
+        var changeReasonDetail = "Some reason or other";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate,
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private async Task<JourneyInstance<EditAlertStartDateState>> CreateJourneyInstance(Guid alertId, EditAlertStartDateState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.EditAlertStartDate,
+            state ?? new EditAlertStartDateState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
@@ -1,0 +1,213 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.StartDate;
+
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal($"{databaseStartDate:%d}", doc.GetElementById("StartDate.Day")?.GetAttribute("value"));
+        Assert.Equal($"{databaseStartDate:%M}", doc.GetElementById("StartDate.Month")?.GetAttribute("value"));
+        Assert.Equal($"{databaseStartDate:yyyy}", doc.GetElementById("StartDate.Year")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithInitializedJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal($"{journeyStartDate:%d}", doc.GetElementById("StartDate.Day")?.GetAttribute("value"));
+        Assert.Equal($"{journeyStartDate:%M}", doc.GetElementById("StartDate.Month")?.GetAttribute("value"));
+        Assert.Equal($"{journeyStartDate:yyyy}", doc.GetElementById("StartDate.Year")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoStartDateIsEntered_ReturnsError()
+    {
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StartDate", "Enter a start date");
+    }
+
+    [Fact]
+    public async Task Post_WhenStartDateIsAfterEndDate_RendersError()
+    {
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var databaseEndDate = new DateOnly(2022, 11, 6);
+        var newStartDate = databaseEndDate.AddDays(1);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate).WithEndDate(databaseEndDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "StartDate.Day", $"{newStartDate:%d}" },
+                { "StartDate.Month", $"{newStartDate:%M}" },
+                { "StartDate.Year", $"{newStartDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StartDate", "Start date must be before end date");
+    }
+
+    [Fact]
+    public async Task Post_WhenStartDateIsUnchanged_RendersError()
+    {
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var newStartDate = databaseStartDate;
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "StartDate.Day", $"{newStartDate:%d}" },
+                { "StartDate.Month", $"{newStartDate:%M}" },
+                { "StartDate.Year", $"{newStartDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StartDate", "Enter a different start date");
+    }
+
+    [Fact]
+    public async Task Post_WhenStartDateIsEntered_RedirectsToChangeReasonPage()
+    {
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var newStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "StartDate.Day", $"{newStartDate:%d}" },
+                { "StartDate.Month", $"{newStartDate:%M}" },
+                { "StartDate.Year", $"{newStartDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/start-date/change-reason", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private async Task<JourneyInstance<EditAlertStartDateState>> CreateJourneyInstance(Guid alertId, EditAlertStartDateState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.EditAlertStartDate,
+            state ?? new EditAlertStartDateState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/ReasonTests.cs
@@ -1,0 +1,283 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.StartDate;
+
+public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithAlert());
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_ReturnsOK()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithAlert());
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoChangeReasonIsSelected_ReturnsError()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["UploadEvidence"] = "False"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "ChangeReason", "Select a reason");
+    }
+
+    [Fact]
+    public async Task Post_WhenChangeReasonAnotherReasonIsSelectedAndDetailsAreEmpty_ReturnsError()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["ChangeReason"] = "AnotherReason",
+                ["ChangeReasonDetail"] = "",
+                ["UploadEvidence"] = "False"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "ChangeReasonDetail", "Enter details");
+    }
+
+    [Fact]
+    public async Task Post_WhenUploadEvidenceOptionIsYesAndNoFileIsSelected_ReturnsError()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["ChangeReason"] = "AnotherReason",
+                ["ChangeReasonDetail"] = "Some details",
+                ["UploadEvidence"] = "True"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "Select a file");
+    }
+
+    [Fact]
+    public async Task Post_WhenEvidenceFileIsInvalidType_ReturnsError()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate
+            });
+
+        var multipartContent = CreateFormFileUpload(".cs");
+        multipartContent.Add(new StringContent(AlertChangeStartDateReasonOption.AnotherReason.ToString()), "ChangeReason");
+        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
+        multipartContent.Add(new StringContent("True"), "UploadEvidence");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX");
+    }
+
+    [Fact]
+    public async Task Post_WhenValidInput_RedirectsToCheckAnswersPage()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var journeyStartDate = new DateOnly(2021, 10, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new EditAlertStartDateState()
+            {
+                Initialized = true,
+                StartDate = journeyStartDate
+            });
+
+        var multipartContent = CreateFormFileUpload(".pdf");
+        multipartContent.Add(new StringContent(AlertChangeStartDateReasonOption.AnotherReason.ToString()), "ChangeReason");
+        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
+        multipartContent.Add(new StringContent("True"), "UploadEvidence");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/start-date/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    private MultipartFormDataContent CreateFormFileUpload(string fileExtension)
+    {
+        var byteArrayContent = new ByteArrayContent(new byte[] { });
+        byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
+
+        var multipartContent = new MultipartFormDataContent
+        {
+            { byteArrayContent, "EvidenceFile", $"evidence{fileExtension}" }
+        };
+
+        return multipartContent;
+    }
+    private async Task<JourneyInstance<EditAlertStartDateState>> CreateJourneyInstance(Guid alertId, EditAlertStartDateState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.EditAlertStartDate,
+            state ?? new EditAlertStartDateState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}


### PR DESCRIPTION
### Context

We need to build out the front end of the TRS console to enable users to interact with Alerts data through the TRS console.

### Changes proposed in this pull request

Build out the TRS console as per the Figma designs, ensuring that an AlertUpdatedEvent is created with the original and changed start date.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
