### PR TITLE
Alert audit history to alert sync

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
@@ -3,8 +3,9 @@ using File = TeachingRecordSystem.Core.Events.Models.File;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record class AlertCreatedEvent : EventBase, IEventWithPersonId, IEventWithAlert
+public record class AlertCreatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
 {
+    public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required Alert Alert { get; init; }
     public required string? Reason { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDqtDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDqtDeactivatedEvent.cs
@@ -1,0 +1,10 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record AlertDqtDeactivatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
+{
+    public string? Key { get; init; }
+    public required Guid PersonId { get; init; }
+    public required Alert Alert { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDqtImportedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDqtImportedEvent.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record AlertDqtImportedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
+{
+    public string? Key { get; init; }
+    public required Guid PersonId { get; init; }
+    public required Alert Alert { get; init; }
+    public required int DqtState { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDqtReactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDqtReactivatedEvent.cs
@@ -1,0 +1,10 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record AlertDqtReactivatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
+{
+    public string? Key { get; init; }
+    public required Guid PersonId { get; init; }
+    public required Alert Alert { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertMigratedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertMigratedEvent.cs
@@ -1,0 +1,10 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record AlertMigratedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
+{
+    public string? Key { get; init; }
+    public required Guid PersonId { get; init; }
+    public required Alert Alert { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
@@ -3,8 +3,9 @@ using File = TeachingRecordSystem.Core.Events.Models.File;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record class AlertUpdatedEvent : EventBase, IEventWithPersonId, IEventWithAlert
+public record class AlertUpdatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
 {
+    public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required Alert Alert { get; init; }
     public required Alert OldAlert { get; init; }
@@ -21,4 +22,6 @@ public enum AlertUpdatedEventChanges
     ExternalLink = 1 << 2,
     StartDate = 1 << 3,
     EndDate = 1 << 4,
+    DqtSpent = 1 << 5,
+    DqtSanctionCode = 1 << 6,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Alert.cs
@@ -3,11 +3,14 @@ namespace TeachingRecordSystem.Core.Events.Models;
 public record Alert
 {
     public required Guid AlertId { get; init; }
-    public required Guid AlertTypeId { get; init; }
+    public required Guid? AlertTypeId { get; init; }  // Nullable as pre-migration audit records won't have an alert type
     public required string? Details { get; init; }
     public required string? ExternalLink { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
+
+    public bool? DqtSpent { get; init; }
+    public AlertDqtSanctionCode? DqtSanctionCode { get; init; }
 
     public static Alert FromModel(DataStore.Postgres.Models.Alert model) => new()
     {
@@ -18,4 +21,11 @@ public record Alert
         StartDate = model.StartDate,
         EndDate = model.EndDate
     };
+}
+
+public record AlertDqtSanctionCode
+{
+    public required Guid SanctionCodeId { get; init; }
+    public required string Name { get; init; }
+    public required string Value { get; init; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Alert.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Alert.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using FakeXrmEasy.Extensions;
 using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Models;
 
@@ -45,11 +47,287 @@ public partial class TrsDataSyncHelperTests
         });
     }
 
+    [Fact]
+    public async Task SyncAlert_WithDeactivatedEvent_SetsDeletedOnAttribute()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithSyncOverride(false));
+        var qualificationId = Guid.NewGuid();
+        var auditDetailCollection = new AuditDetailCollection();
+        var entity = await CreateNewAlertEntityVersion(qualificationId, person.ContactId, auditDetailCollection);
+
+        Clock.Advance();
+        var deactivatedVersion = await CreateDeactivatedEntityVersion(entity, dfeta_sanction.EntityLogicalName, auditDetailCollection);
+
+        // Act
+        await Helper.SyncAlert(deactivatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
+
+        // Assert
+        await DbFixture.WithDbContext(async dbContext =>
+        {
+            var mq = await dbContext.Alerts.IgnoreQueryFilters().SingleOrDefaultAsync(p => p.DqtSanctionId == qualificationId);
+            Assert.NotNull(mq);
+            Assert.Equal(Clock.UtcNow, mq.DeletedOn);
+        });
+    }
+
+    [Fact]
+    public async Task SyncAlert_WithDqtCreateAudit_CreatesExpectedEvents()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var qualificationId = Guid.NewGuid();
+        var auditDetailCollection = new AuditDetailCollection();
+        var initialVersion = await CreateNewAlertEntityVersion(qualificationId, person.ContactId, auditDetailCollection, addCreateAudit: true);
+
+        // Act
+        await Helper.SyncAlert(initialVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
+
+        // Assert
+        var events = await GetEventsForAlert(qualificationId);
+
+        await Assert.CollectionAsync(
+            events,
+            async e =>
+            {
+                var createdEvent = Assert.IsType<AlertCreatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, createdEvent.CreatedUtc);
+                Assert.Equal(await TestData.GetCurrentCrmUserId(), createdEvent.RaisedBy.DqtUserId);
+                Assert.Equal(person.PersonId, createdEvent.PersonId);
+                await AssertAlertEventMatchesEntity(initialVersion, createdEvent.Alert, expectMigrationMappingsApplied: false);
+            },
+            async e =>
+            {
+                var migratedEvent = Assert.IsType<AlertMigratedEvent>(e);
+                Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
+                Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
+                Assert.Equal(person.PersonId, migratedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(initialVersion, migratedEvent.Alert, expectMigrationMappingsApplied: true);
+            });
+    }
+
+    [Fact]
+    public async Task SyncAlert_WithNoDqtAudit_CreatesExpectedEvents()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var auditDetailCollection = new AuditDetailCollection();
+        var initialVersion = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection, addCreateAudit: false);
+
+        // Act
+        await Helper.SyncAlert(initialVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
+
+        // Assert
+        var events = await GetEventsForAlert(alertId);
+
+        await Assert.CollectionAsync(
+            events,
+            async e =>
+            {
+                var migatedEvent = Assert.IsType<AlertDqtImportedEvent>(e);
+                Assert.Equal(Clock.UtcNow, migatedEvent.CreatedUtc);
+                Assert.Equal(await TestData.GetCurrentCrmUserId(), migatedEvent.RaisedBy.DqtUserId);
+                Assert.Equal(person.PersonId, migatedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(initialVersion, migatedEvent.Alert, expectMigrationMappingsApplied: false);
+            },
+            async e =>
+            {
+                var migratedEvent = Assert.IsType<AlertMigratedEvent>(e);
+                Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
+                Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
+                Assert.Equal(person.PersonId, migratedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(initialVersion, migratedEvent.Alert, expectMigrationMappingsApplied: true);
+            });
+    }
+
+    [Fact]
+    public async Task SyncAlert_WithNoDqtCreateButWithUpdateAudits_CreatesExpectedEvents()
+    {
+        // Many migrated records in DQT don't have a 'Create' audit record, since auditing was turned on after migration.
+        // In that case, TrsDataSyncHelper will take the current version and 'un-apply' every Update audit in reverse,
+        // leaving the initial version at the end. From that an AlertDqtImported event is created.
+        // This test is exercising that scenario.
+        // The Updates created here are deliberately partial updates to verify that the original version of the entity can
+        // be reconstructed from multiple Update audits.
+
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var auditDetailCollection = new AuditDetailCollection();
+        var initialVersion = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection, addCreateAudit: false);
+        var created = Clock.UtcNow;
+
+        Clock.Advance();
+        var updatedVersion = await CreateUpdatedAlertEntityVersion(initialVersion, auditDetailCollection, changes: AlertUpdatedEventChanges.StartDate);
+
+        Clock.Advance();
+        updatedVersion = await CreateUpdatedAlertEntityVersion(updatedVersion, auditDetailCollection, changes: AlertUpdatedEventChanges.Details);
+
+        // Act
+        await Helper.SyncAlert(updatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
+
+        // Assert
+        var events = await GetEventsForAlert(alertId);
+
+        await Assert.CollectionAsync(
+            events,
+            async e =>
+            {
+                var importedEvent = Assert.IsType<AlertDqtImportedEvent>(e);
+                Assert.Equal(created, importedEvent.CreatedUtc);
+                Assert.Equal(await TestData.GetCurrentCrmUserId(), importedEvent.RaisedBy.DqtUserId);
+                Assert.Equal(person.PersonId, importedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(initialVersion, importedEvent.Alert, expectMigrationMappingsApplied: false);
+            },
+            e =>
+            {
+                // Checking UpdatedEvent details is covered elsewhere
+                Assert.IsType<AlertUpdatedEvent>(e);
+                return Task.CompletedTask;
+            },
+            e =>
+            {
+                // Checking UpdatedEvent details is covered elsewhere
+                Assert.IsType<AlertUpdatedEvent>(e);
+                return Task.CompletedTask;
+            },
+            async e =>
+            {
+                var migratedEvent = Assert.IsType<AlertMigratedEvent>(e);
+                Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
+                Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
+                Assert.Equal(person.PersonId, migratedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(updatedVersion, migratedEvent.Alert, expectMigrationMappingsApplied: true);
+            });
+    }
+
+    [Fact]
+    public async Task SyncAlert_WithDqtUpdateAudit_CreatesExpectedEvents()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var auditDetailCollection = new AuditDetailCollection();
+        var initialVersion = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection);
+
+        Clock.Advance();
+        var updatedVersion = await CreateUpdatedAlertEntityVersion(initialVersion, auditDetailCollection);
+
+        // Act
+        await Helper.SyncAlert(updatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
+
+        // Assert
+        var events = await GetEventsForAlert(alertId);
+
+        await Assert.CollectionAsync(
+            events,
+            e =>
+            {
+                // Checking CreatedEvent details is covered elsewhere
+                Assert.IsType<AlertCreatedEvent>(e);
+                return Task.CompletedTask;
+            },
+            async e =>
+            {
+                var updatedEvent = Assert.IsType<AlertUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
+                Assert.Equal(await TestData.GetCurrentCrmUserId(), updatedEvent.RaisedBy.DqtUserId);
+                Assert.Equal(person.PersonId, updatedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(updatedVersion, updatedEvent.Alert, expectMigrationMappingsApplied: false);
+                Assert.Equal(GetChanges(initialVersion, updatedVersion), updatedEvent.Changes);
+            },
+            async e =>
+            {
+                var migratedEvent = Assert.IsType<AlertMigratedEvent>(e);
+                Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
+                Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
+                Assert.Equal(person.PersonId, migratedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(updatedVersion, migratedEvent.Alert, expectMigrationMappingsApplied: true);
+            });
+    }
+
+    [Fact]
+    public async Task SyncAlert_WithDqtDeactivatedAudit_CreatesExpectedEvent()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var auditDetailCollection = new AuditDetailCollection();
+        var entity = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection);
+
+        Clock.Advance();
+        var deactivatedVersion = await CreateDeactivatedEntityVersion(entity, dfeta_sanction.EntityLogicalName, auditDetailCollection);
+
+        // Act
+        await Helper.SyncAlert(deactivatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
+
+        // Assert
+        await DbFixture.WithDbContext(async dbContext =>
+        {
+            var alert = await dbContext.Alerts.IgnoreQueryFilters().SingleOrDefaultAsync(p => p.DqtSanctionId == alertId);
+            Assert.NotNull(alert);
+            Assert.Equal(Clock.UtcNow, alert.DeletedOn);
+        });
+    }
+
+    [Fact]
+    public async Task SyncAlert_WithDqtReactivatedAudit_CreatesExpectedEvents()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var auditDetailCollection = new AuditDetailCollection();
+        var entity = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection);
+
+        Clock.Advance();
+        var deactivatedVersion = await CreateDeactivatedEntityVersion(entity, dfeta_sanction.EntityLogicalName, auditDetailCollection);
+
+        Clock.Advance();
+        var reactivatedVersion = await CreateReactivatedEntityVersion(deactivatedVersion, dfeta_sanction.EntityLogicalName, auditDetailCollection);
+
+        // Act
+        await Helper.SyncAlert(reactivatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
+
+        // Assert
+        var events = await GetEventsForAlert(alertId);
+
+        await Assert.CollectionAsync(
+            events,
+            e =>
+            {
+                Assert.IsType<AlertCreatedEvent>(e);
+                return Task.CompletedTask;
+            },
+            e =>
+            {
+                Assert.IsType<AlertDqtDeactivatedEvent>(e);
+                return Task.CompletedTask;
+            },
+            async e =>
+            {
+                var reactivatedEvent = Assert.IsType<AlertDqtReactivatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, reactivatedEvent.CreatedUtc);
+                Assert.Equal(await TestData.GetCurrentCrmUserId(), reactivatedEvent.RaisedBy.DqtUserId);
+                Assert.Equal(person.PersonId, reactivatedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(reactivatedVersion, reactivatedEvent.Alert, expectMigrationMappingsApplied: false);
+            },
+            async e =>
+            {
+                var migratedEvent = Assert.IsType<AlertMigratedEvent>(e);
+                Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
+                Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
+                Assert.Equal(person.PersonId, migratedEvent.PersonId);
+                await AssertAlertEventMatchesEntity(reactivatedVersion, migratedEvent.Alert, expectMigrationMappingsApplied: true);
+            });
+    }
+
     private async Task<dfeta_sanction> CreateNewAlertEntityVersion(
         Guid sanctionId,
         Guid personContactId,
         AuditDetailCollection auditDetailCollection,
-        bool redundantType = false)
+        bool redundantType = false,
+        bool addCreateAudit = true)
     {
         Debug.Assert(auditDetailCollection.Count == 0);
 
@@ -90,8 +368,163 @@ public partial class TrsDataSyncHelperTests
             dfeta_SanctionCodeId = sanctionCodeId.ToEntityReference(dfeta_sanctioncode.EntityLogicalName),
         };
 
+        if (addCreateAudit)
+        {
+            var auditId = Guid.NewGuid();
+            auditDetailCollection.Add(new AttributeAuditDetail()
+            {
+                AuditRecord = new Audit()
+                {
+                    Action = Audit_Action.Create,
+                    AuditId = auditId,
+                    CreatedOn = Clock.UtcNow,
+                    Id = auditId,
+                    Operation = Audit_Operation.Create,
+                    UserId = currentDqtUser
+                },
+                OldValue = new Entity(),
+                NewValue = newSanction.Clone()
+            });
+        }
+
         return newSanction;
     }
+
+    private async Task<dfeta_sanction> CreateUpdatedAlertEntityVersion(
+        dfeta_sanction existingSanction,
+        AuditDetailCollection auditDetailCollection,
+        AlertUpdatedEventChanges? changes = null)
+    {
+        if (changes == AlertUpdatedEventChanges.None)
+        {
+            throw new ArgumentException("Changes cannot be None.", nameof(changes));
+        }
+
+        bool ChangeRequested(AlertUpdatedEventChanges field) =>
+            changes is null || changes.Value.HasFlag(field);
+
+        var sanctionCodes = await TestData.ReferenceDataCache.GetSanctionCodes(activeOnly: false);
+        var currentDqtUser = await TestData.GetCurrentCrmUser();
+
+        var existingExternalLink = existingSanction.dfeta_DetailsLink;
+
+        var externalLink = ChangeRequested(AlertUpdatedEventChanges.ExternalLink) ?
+            GenerateChanged(existingExternalLink, Faker.Internet.Url) :
+            existingExternalLink;
+
+        var existingDetails = existingSanction.dfeta_SanctionDetails;
+
+        var details = ChangeRequested(AlertUpdatedEventChanges.Details) ?
+            GenerateChanged(existingDetails, Faker.Lorem.Paragraph) :
+            existingDetails;
+
+        var existingStartDate = existingSanction.dfeta_StartDate;
+
+        var startDate = ChangeRequested(AlertUpdatedEventChanges.StartDate) ?
+            (existingSanction.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true) is DateOnly existingStartDateOnly ?
+                TestData.GenerateChangedDate(existingStartDateOnly, min: new DateOnly(2020, 4, 1)) :
+                TestData.GenerateDate(min: new DateOnly(2020, 4, 1))).ToDateTimeWithDqtBstFix(isLocalTime: true) :
+            existingStartDate;
+
+        var existingEndDate = existingSanction.dfeta_EndDate;
+        DateTime? endDate;
+
+        if (ChangeRequested(AlertUpdatedEventChanges.EndDate))
+        {
+            if (startDate is null)
+            {
+                throw new InvalidOperationException("Cannot generate an end date when there is no start date.");
+            }
+
+            var startDateOnly = startDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true);
+
+            endDate = (existingEndDate is null ?
+                    TestData.GenerateDate(min: startDateOnly.AddDays(1)) :
+                    TestData.GenerateChangedDate(existingEndDate.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true), min: startDateOnly.AddDays(1)))
+                .ToDateTimeWithDqtBstFix(isLocalTime: true);
+        }
+        else
+        {
+            endDate = null;
+        }
+
+        if (changes is not null && changes.Value.HasFlag(AlertUpdatedEventChanges.DqtSpent))
+        {
+            throw new NotSupportedException();
+        }
+
+        var spent = existingSanction.dfeta_Spent;
+
+        var existingSanctionCodeId = existingSanction.dfeta_SanctionCodeId.Id;
+
+        var sanctionCodeId = ChangeRequested(AlertUpdatedEventChanges.DqtSanctionCode) ?
+            sanctionCodes.Select(sc => sc.Id).RandomOneExcept(id => id == existingSanctionCodeId) :
+            existingSanctionCodeId;
+
+        var updatedSanction = existingSanction.Clone<dfeta_sanction>();
+        updatedSanction.ModifiedOn = Clock.UtcNow;
+        updatedSanction.dfeta_DetailsLink = externalLink;
+        updatedSanction.dfeta_SanctionDetails = details;
+        updatedSanction.dfeta_StartDate = startDate;
+        updatedSanction.dfeta_EndDate = endDate;
+        updatedSanction.dfeta_Spent = spent;
+        updatedSanction.dfeta_SanctionCodeId = sanctionCodeId.ToEntityReference(dfeta_sanctioncode.EntityLogicalName);
+
+        var changedAttrs = (
+            from newAttr in updatedSanction.Attributes
+            join oldAttr in existingSanction.Attributes on newAttr.Key equals oldAttr.Key
+            where !AttributeValuesEqual(newAttr.Value, oldAttr.Value)
+            select newAttr.Key).ToArray();
+
+        var oldValue = new Entity(dfeta_sanction.EntityLogicalName, existingSanction.Id);
+        Array.ForEach(changedAttrs, a => oldValue.Attributes[a] = existingSanction.Attributes[a]);
+
+        var newValue = new Entity(dfeta_sanction.EntityLogicalName, existingSanction.Id);
+        Array.ForEach(changedAttrs, a => newValue.Attributes[a] = updatedSanction.Attributes[a]);
+
+        var auditId = Guid.NewGuid();
+        auditDetailCollection.Add(new AttributeAuditDetail()
+        {
+            AuditRecord = new Audit()
+            {
+                Action = Audit_Action.Update,
+                AuditId = auditId,
+                CreatedOn = Clock.UtcNow,
+                Id = auditId,
+                Operation = Audit_Operation.Update,
+                UserId = currentDqtUser
+            },
+            OldValue = oldValue,
+            NewValue = newValue
+        });
+
+        return updatedSanction;
+
+        static bool AttributeValuesEqual(object? a, object? b) =>
+            a is null && b is null ||
+            (a is not null && b is not null && a.Equals(b));
+
+        static T? GenerateChanged<T>(T? current, Func<T> factory)
+        {
+            var value = current;
+
+            while ((value is null && current is null) || (value?.Equals(current) ?? false))
+            {
+                value = factory();
+            }
+
+            return value;
+        }
+    }
+
+    private static AlertUpdatedEventChanges GetChanges(dfeta_sanction first, dfeta_sanction second) =>
+        AlertUpdatedEventChanges.None |
+        (first.dfeta_SanctionDetails != second.dfeta_SanctionDetails ? AlertUpdatedEventChanges.Details : 0) |
+        (first.dfeta_DetailsLink != second.dfeta_DetailsLink ? AlertUpdatedEventChanges.ExternalLink : 0) |
+        (first.dfeta_StartDate != second.dfeta_StartDate ? AlertUpdatedEventChanges.StartDate : 0) |
+        (first.dfeta_EndDate != second.dfeta_EndDate ? AlertUpdatedEventChanges.EndDate : 0) |
+        (first.dfeta_SanctionCodeId?.Id != second.dfeta_SanctionCodeId?.Id ? AlertUpdatedEventChanges.DqtSanctionCode : 0) |
+        (first.dfeta_Spent != second.dfeta_Spent ? AlertUpdatedEventChanges.DqtSpent : 0);
 
     private async Task AssertDatabaseAlertMatchesEntity(dfeta_sanction entity)
     {
@@ -117,5 +550,57 @@ public partial class TrsDataSyncHelperTests
             Assert.Equal(entity.dfeta_EndDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), alert.EndDate);
             Assert.Equal(entity.dfeta_DetailsLink, alert.ExternalLink);
         });
+    }
+
+    private async Task AssertAlertEventMatchesEntity(
+        dfeta_sanction entity,
+        EventModels.Alert eventModel,
+        bool expectMigrationMappingsApplied)
+    {
+        Assert.Equal(entity.Id, eventModel.AlertId);
+        Assert.Equal(entity.dfeta_SanctionDetails, eventModel.Details);
+        Assert.Equal(entity.dfeta_DetailsLink, eventModel.ExternalLink);
+        Assert.Equal(entity.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), eventModel.StartDate);
+        Assert.Equal(entity.dfeta_EndDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), eventModel.EndDate);
+
+        if (expectMigrationMappingsApplied)
+        {
+            Assert.Null(eventModel.DqtSpent);
+            Assert.Null(eventModel.DqtSanctionCode);
+
+            var sanctionCodes = await TestData.ReferenceDataCache.GetSanctionCodes(activeOnly: false);
+            var alertTypes = await TestData.ReferenceDataCache.GetAlertTypes();
+
+            var expectedAlertTypeId = entity.dfeta_SanctionCodeId?.Id is Guid sanctionCodeId ?
+                alertTypes.SingleOrDefault(t => t.DqtSanctionCode == sanctionCodes.Single(sc => sc.Id == sanctionCodeId).dfeta_Value)?.AlertTypeId :
+                null;
+
+            Assert.Equal(expectedAlertTypeId, eventModel.AlertTypeId);
+        }
+        else
+        {
+            Assert.Equal(entity.dfeta_Spent, eventModel.DqtSpent);
+            Assert.Null(eventModel.AlertTypeId);
+        }
+    }
+
+    private Task<EventBase[]> GetEventsForAlert(Guid alertId) =>
+        DbFixture.WithDbContext(async dbContext =>
+        {
+            var results = await dbContext.Database.SqlQuery<AlertEventQueryResult>(
+                $"""
+                SELECT e.event_name, e.payload
+                FROM events as e
+                WHERE (e.payload -> 'Alert' ->> 'AlertId')::uuid = {alertId}
+                ORDER BY e.created
+                """).ToArrayAsync();
+
+            return results.Select(r => EventBase.Deserialize(r.Payload, r.EventName)).ToArray();
+        });
+
+    private class AlertEventQueryResult
+    {
+        public required string EventName { get; set; }
+        public required string Payload { get; set; }
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.MandatoryQualification.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.MandatoryQualification.cs
@@ -129,7 +129,7 @@ public partial class TrsDataSyncHelperTests
         var entity = await CreateNewMandatoryQualificationEntityVersion(qualificationId, person.ContactId, auditDetailCollection);
 
         Clock.Advance();
-        var deactivatedVersion = await CreateDeactivatedMandatoryQualificationEntityVersion(entity, auditDetailCollection);
+        var deactivatedVersion = await CreateDeactivatedEntityVersion(entity, dfeta_qualification.EntityLogicalName, auditDetailCollection);
 
         // Act
         await Helper.SyncMandatoryQualification(deactivatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
@@ -166,7 +166,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, createdEvent.CreatedUtc);
                 Assert.Equal(await TestData.GetCurrentCrmUserId(), createdEvent.RaisedBy.DqtUserId);
                 Assert.Equal(person.PersonId, createdEvent.PersonId);
-                await AssertEventMatchesEntity(initialVersion, createdEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+                await AssertMandatoryQualificationEventMatchesEntity(initialVersion, createdEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
             },
             async e =>
             {
@@ -174,7 +174,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
                 Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
                 Assert.Equal(person.PersonId, migratedEvent.PersonId);
-                await AssertEventMatchesEntity(initialVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
+                await AssertMandatoryQualificationEventMatchesEntity(initialVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
             });
     }
 
@@ -201,7 +201,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migatedEvent.CreatedUtc);
                 Assert.Equal(await TestData.GetCurrentCrmUserId(), migatedEvent.RaisedBy.DqtUserId);
                 Assert.Equal(person.PersonId, migatedEvent.PersonId);
-                await AssertEventMatchesEntity(initialVersion, migatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+                await AssertMandatoryQualificationEventMatchesEntity(initialVersion, migatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
             },
             async e =>
             {
@@ -209,7 +209,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
                 Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
                 Assert.Equal(person.PersonId, migratedEvent.PersonId);
-                await AssertEventMatchesEntity(initialVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
+                await AssertMandatoryQualificationEventMatchesEntity(initialVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
             });
     }
 
@@ -250,7 +250,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(created, importedEvent.CreatedUtc);
                 Assert.Equal(await TestData.GetCurrentCrmUserId(), importedEvent.RaisedBy.DqtUserId);
                 Assert.Equal(person.PersonId, importedEvent.PersonId);
-                await AssertEventMatchesEntity(initialVersion, importedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+                await AssertMandatoryQualificationEventMatchesEntity(initialVersion, importedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
             },
             e =>
             {
@@ -270,7 +270,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
                 Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
                 Assert.Equal(person.PersonId, migratedEvent.PersonId);
-                await AssertEventMatchesEntity(updatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
+                await AssertMandatoryQualificationEventMatchesEntity(updatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
             });
     }
 
@@ -299,7 +299,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, createdEvent.CreatedUtc);
                 Assert.Equal(await TestData.GetCurrentCrmUserId(), createdEvent.RaisedBy.DqtUserId);
                 Assert.Equal(person.PersonId, createdEvent.PersonId);
-                await AssertEventMatchesEntity(initialVersion, createdEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+                await AssertMandatoryQualificationEventMatchesEntity(initialVersion, createdEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
             },
             async e =>
             {
@@ -307,7 +307,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
                 Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
                 Assert.Equal(person.PersonId, migratedEvent.PersonId);
-                await AssertEventMatchesEntity(initialVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
+                await AssertMandatoryQualificationEventMatchesEntity(initialVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
             });
     }
 
@@ -343,7 +343,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
                 Assert.Equal(await TestData.GetCurrentCrmUserId(), updatedEvent.RaisedBy.DqtUserId);
                 Assert.Equal(person.PersonId, updatedEvent.PersonId);
-                await AssertEventMatchesEntity(updatedVersion, updatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+                await AssertMandatoryQualificationEventMatchesEntity(updatedVersion, updatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
                 Assert.Equal(GetChanges(initialVersion, updatedVersion), updatedEvent.Changes);
             },
             async e =>
@@ -352,7 +352,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
                 Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
                 Assert.Equal(person.PersonId, migratedEvent.PersonId);
-                await AssertEventMatchesEntity(updatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
+                await AssertMandatoryQualificationEventMatchesEntity(updatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
             });
     }
 
@@ -390,7 +390,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
                 Assert.Equal(await TestData.GetCurrentCrmUserId(), updatedEvent.RaisedBy.DqtUserId);
                 Assert.Equal(person.PersonId, updatedEvent.PersonId);
-                await AssertEventMatchesEntity(updatedVersion, updatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+                await AssertMandatoryQualificationEventMatchesEntity(updatedVersion, updatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
                 Assert.Equal(GetChanges(initialVersion, updatedVersion), updatedEvent.Changes);
             },
             async e =>
@@ -399,7 +399,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
                 Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
                 Assert.Equal(person.PersonId, migratedEvent.PersonId);
-                await AssertEventMatchesEntity(updatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
+                await AssertMandatoryQualificationEventMatchesEntity(updatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
             });
     }
 
@@ -413,7 +413,7 @@ public partial class TrsDataSyncHelperTests
         var entity = await CreateNewMandatoryQualificationEntityVersion(qualificationId, person.ContactId, auditDetailCollection);
 
         Clock.Advance();
-        var deactivatedVersion = await CreateDeactivatedMandatoryQualificationEntityVersion(entity, auditDetailCollection);
+        var deactivatedVersion = await CreateDeactivatedEntityVersion(entity, dfeta_qualification.EntityLogicalName, auditDetailCollection);
 
         // Act
         await Helper.SyncMandatoryQualification(deactivatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
@@ -426,7 +426,7 @@ public partial class TrsDataSyncHelperTests
         Assert.Equal(Clock.UtcNow, deactivatedEvent.CreatedUtc);
         Assert.Equal(await TestData.GetCurrentCrmUserId(), deactivatedEvent.RaisedBy.DqtUserId);
         Assert.Equal(person.PersonId, deactivatedEvent.PersonId);
-        await AssertEventMatchesEntity(deactivatedVersion, deactivatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+        await AssertMandatoryQualificationEventMatchesEntity(deactivatedVersion, deactivatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
     }
 
     [Fact]
@@ -439,10 +439,10 @@ public partial class TrsDataSyncHelperTests
         var entity = await CreateNewMandatoryQualificationEntityVersion(qualificationId, person.ContactId, auditDetailCollection);
 
         Clock.Advance();
-        var deactivatedVersion = await CreateDeactivatedMandatoryQualificationEntityVersion(entity, auditDetailCollection);
+        var deactivatedVersion = await CreateDeactivatedEntityVersion(entity, dfeta_qualification.EntityLogicalName, auditDetailCollection);
 
         Clock.Advance();
-        var reactivatedVersion = await CreateReactivatedMandatoryQualificationEntityVersion(deactivatedVersion, auditDetailCollection);
+        var reactivatedVersion = await CreateReactivatedEntityVersion(deactivatedVersion, dfeta_qualification.EntityLogicalName, auditDetailCollection);
 
         // Act
         await Helper.SyncMandatoryQualification(reactivatedVersion, auditDetailCollection, ignoreInvalid: false, createMigratedEvent: true);
@@ -468,7 +468,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, reactivatedEvent.CreatedUtc);
                 Assert.Equal(await TestData.GetCurrentCrmUserId(), reactivatedEvent.RaisedBy.DqtUserId);
                 Assert.Equal(person.PersonId, reactivatedEvent.PersonId);
-                await AssertEventMatchesEntity(reactivatedVersion, reactivatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+                await AssertMandatoryQualificationEventMatchesEntity(reactivatedVersion, reactivatedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
             },
             async e =>
             {
@@ -476,7 +476,7 @@ public partial class TrsDataSyncHelperTests
                 Assert.Equal(Clock.UtcNow, migratedEvent.CreatedUtc);
                 Assert.Equal(Core.DataStore.Postgres.Models.SystemUser.SystemUserId, migratedEvent.RaisedBy.UserId);
                 Assert.Equal(person.PersonId, migratedEvent.PersonId);
-                await AssertEventMatchesEntity(reactivatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
+                await AssertMandatoryQualificationEventMatchesEntity(reactivatedVersion, migratedEvent.MandatoryQualification, expectMigrationMappingsApplied: true);
             });
     }
 
@@ -504,7 +504,7 @@ public partial class TrsDataSyncHelperTests
         Assert.Equal(Clock.UtcNow, actualDeletedEvent.CreatedUtc);
         Assert.Equal(await TestData.GetCurrentCrmUserId(), actualDeletedEvent.RaisedBy.DqtUserId);
         Assert.Equal(person.PersonId, actualDeletedEvent.PersonId);
-        await AssertEventMatchesEntity(deletedVersion, actualDeletedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
+        await AssertMandatoryQualificationEventMatchesEntity(deletedVersion, actualDeletedEvent.MandatoryQualification, expectMigrationMappingsApplied: false);
     }
 
     private static MandatoryQualificationUpdatedEventChanges GetChanges(dfeta_qualification first, dfeta_qualification second) =>
@@ -567,7 +567,7 @@ public partial class TrsDataSyncHelperTests
         });
     }
 
-    private async Task AssertEventMatchesEntity(
+    private async Task AssertMandatoryQualificationEventMatchesEntity(
         dfeta_qualification entity,
         EventModels.MandatoryQualification eventModel,
         bool expectMigrationMappingsApplied)
@@ -933,94 +933,10 @@ public partial class TrsDataSyncHelperTests
         return (updatedQualification, deletedEvent);
     }
 
-    private async Task<dfeta_qualification> CreateDeactivatedMandatoryQualificationEntityVersion(
-        dfeta_qualification existingQualification,
-        AuditDetailCollection auditDetailCollection)
-    {
-        if (existingQualification.StateCode != dfeta_qualificationState.Active)
-        {
-            throw new ArgumentException("Entity must be active.", nameof(existingQualification));
-        }
-
-        var currentDqtUser = await TestData.GetCurrentCrmUser();
-
-        var updatedQualification = existingQualification.Clone<dfeta_qualification>();
-        updatedQualification.StateCode = dfeta_qualificationState.Inactive;
-        updatedQualification.Attributes["statuscode"] = new OptionSetValue(2);
-
-        var oldValue = new Entity(dfeta_qualification.EntityLogicalName, existingQualification.Id);
-        oldValue.Attributes[dfeta_qualification.Fields.StateCode] = new OptionSetValue((int)dfeta_qualificationState.Active);
-        oldValue.Attributes["statuscode"] = new OptionSetValue(1);
-
-        var newValue = new Entity(dfeta_qualification.EntityLogicalName, existingQualification.Id);
-        newValue.Attributes[dfeta_qualification.Fields.StateCode] = new OptionSetValue((int)dfeta_qualificationState.Inactive);
-        newValue.Attributes["statuscode"] = new OptionSetValue(2);
-
-        var auditId = Guid.NewGuid();
-        auditDetailCollection.Add(new AttributeAuditDetail()
-        {
-            AuditRecord = new Audit()
-            {
-                Action = Audit_Action.Update,
-                AuditId = auditId,
-                CreatedOn = Clock.UtcNow,
-                Id = auditId,
-                Operation = Audit_Operation.Update,
-                UserId = currentDqtUser
-            },
-            OldValue = oldValue,
-            NewValue = newValue
-        });
-
-        return updatedQualification;
-    }
-
-    private async Task<dfeta_qualification> CreateReactivatedMandatoryQualificationEntityVersion(
-        dfeta_qualification existingQualification,
-        AuditDetailCollection auditDetailCollection)
-    {
-        if (existingQualification.StateCode != dfeta_qualificationState.Inactive)
-        {
-            throw new ArgumentException("Entity must be inactive.", nameof(existingQualification));
-        }
-
-        var currentDqtUser = await TestData.GetCurrentCrmUser();
-
-        var updatedQualification = existingQualification.Clone<dfeta_qualification>();
-        updatedQualification.StateCode = dfeta_qualificationState.Active;
-        updatedQualification.Attributes["statuscode"] = new OptionSetValue(1);
-
-        var oldValue = new Entity(dfeta_qualification.EntityLogicalName, existingQualification.Id);
-        oldValue.Attributes[dfeta_qualification.Fields.StateCode] = new OptionSetValue((int)dfeta_qualificationState.Inactive);
-        oldValue.Attributes["statuscode"] = new OptionSetValue(2);
-
-        var newValue = new Entity(dfeta_qualification.EntityLogicalName, existingQualification.Id);
-        newValue.Attributes[dfeta_qualification.Fields.StateCode] = new OptionSetValue((int)dfeta_qualificationState.Active);
-        newValue.Attributes["statuscode"] = new OptionSetValue(1);
-
-        var auditId = Guid.NewGuid();
-        auditDetailCollection.Add(new AttributeAuditDetail()
-        {
-            AuditRecord = new Audit()
-            {
-                Action = Audit_Action.Update,
-                AuditId = auditId,
-                CreatedOn = Clock.UtcNow,
-                Id = auditId,
-                Operation = Audit_Operation.Update,
-                UserId = currentDqtUser
-            },
-            OldValue = oldValue,
-            NewValue = newValue
-        });
-
-        return updatedQualification;
-    }
-
     private Task<EventBase[]> GetEventsForQualification(Guid qualificationId) =>
         DbFixture.WithDbContext(async dbContext =>
         {
-            var results = await dbContext.Database.SqlQuery<EventQueryResult>(
+            var results = await dbContext.Database.SqlQuery<MandatoryQualificationEventQueryResult>(
                 $"""
                 SELECT e.event_name, e.payload
                 FROM events as e
@@ -1031,7 +947,7 @@ public partial class TrsDataSyncHelperTests
             return results.Select(r => EventBase.Deserialize(r.Payload, r.EventName)).ToArray();
         });
 
-    private class EventQueryResult
+    private class MandatoryQualificationEventQueryResult
     {
         public required string EventName { get; set; }
         public required string Payload { get; set; }


### PR DESCRIPTION
This extends the alert sync job to create audit events too.

The logic and tests here are lifted directly from what we've done for MQs.