### PR TITLE
Add more alert migration jobs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ClearAlertsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ClearAlertsJob.cs
@@ -1,0 +1,16 @@
+using Hangfire;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+[AutomaticRetry(Attempts = 0)]
+public class ClearAlertsJob(TrsDbContext dbContext)
+{
+    public async Task Execute()
+    {
+        await using var txn = await dbContext.Database.BeginTransactionAsync();
+        await dbContext.Database.ExecuteSqlAsync($"delete from events where event_name like 'Alert%';");
+        await dbContext.Database.ExecuteSqlAsync($"delete from alerts;");
+        await txn.CommitAsync();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -151,7 +151,22 @@ public static class HostApplicationBuilderExtensions
 
                 recurringJobManager.AddOrUpdate<SyncAllAlertsFromCrmJob>(
                     nameof(SyncAllAlertsFromCrmJob),
-                    job => job.Execute(CancellationToken.None),
+                    job => job.Execute(/*createMigratedEvent: */false, /*dryRun: */false, CancellationToken.None),
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<SyncAllAlertsFromCrmJob>(
+                    $"{nameof(SyncAllAlertsFromCrmJob)} (dry-run)",
+                    job => job.Execute(/*createMigratedEvent: */true, /*dryRun: */true, CancellationToken.None),
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<SyncAllAlertsFromCrmJob>(
+                    $"{nameof(SyncAllAlertsFromCrmJob)} & migrate",
+                    job => job.Execute(/*createMigratedEvent: */true, /*dryRun: */false, CancellationToken.None),
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<ClearAlertsJob>(
+                    nameof(ClearAlertsJob),
+                    job => job.Execute(),
                     Cron.Never);
 
                 return Task.CompletedTask;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllAlertsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllAlertsFromCrmJob.cs
@@ -3,7 +3,6 @@ using Hangfire;
 using Microsoft.Extensions.Options;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
-using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 
@@ -14,22 +13,19 @@ public class SyncAllAlertsFromCrmJob
 {
     private readonly ICrmServiceClientProvider _crmServiceClientProvider;
     private readonly TrsDataSyncHelper _trsDataSyncHelper;
-    private readonly TrsDbContext _dbContext;
     private readonly IOptions<TrsDataSyncServiceOptions> _syncOptionsAccessor;
 
     public SyncAllAlertsFromCrmJob(
         ICrmServiceClientProvider crmServiceClientProvider,
         TrsDataSyncHelper trsDataSyncHelper,
-        TrsDbContext dbContext,
         IOptions<TrsDataSyncServiceOptions> syncOptionsAccessor)
     {
         _crmServiceClientProvider = crmServiceClientProvider;
         _trsDataSyncHelper = trsDataSyncHelper;
-        _dbContext = dbContext;
         _syncOptionsAccessor = syncOptionsAccessor;
     }
 
-    public async Task Execute(CancellationToken cancellationToken)
+    public async Task Execute(bool createMigratedEvent, bool dryRun, CancellationToken cancellationToken)
     {
         const int pageSize = 1000;
 
@@ -68,8 +64,8 @@ public class SyncAllAlertsFromCrmJob
             await _trsDataSyncHelper.SyncAlerts(
                 result.Entities.Select(e => e.ToEntity<dfeta_sanction>()).ToArray(),
                 ignoreInvalid: _syncOptionsAccessor.Value.IgnoreInvalidData,
-                createMigratedEvent: true,
-                dryRun: true,
+                createMigratedEvent,
+                dryRun,
                 cancellationToken);
 
             if (result.MoreRecords)


### PR DESCRIPTION
This adds a job to clear alerts and their events (since I ran the migration on prod when the dry-run flag wasn't be observed 🙈).
It also adds a couple more migration jobs so we have:
* dry-run;
* copy data without a migration event;
* copy data with a migration event.

We may well schedule the 'copy data without a migration event' job to run on a schedule once we've got the reporting table in place so that reports can be amended pre-migration.