### PR TITLE
Implemented close alert journey

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,7 +114,7 @@ jobs:
         dotnet_test_args: >-
           --no-build
           -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-      timeout-minutes: 5
+      timeout-minutes: 10
 
     - name: Authorize access tests
       uses: ./.github/workflows/actions/test

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -13,4 +13,5 @@ public static class JourneyNames
     public const string AddAlert = nameof(AddAlert);
     public const string EditAlertStartDate = nameof(EditAlertStartDate);
     public const string EditAlertEndDate = nameof(EditAlertEndDate);
+    public const string CloseAlert = nameof(CloseAlert);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml
@@ -1,0 +1,82 @@
+@page "/alerts/{alertId}/close/check-answers/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.CheckAnswersModel
+@{
+    ViewBag.Title = "Check details and confirm change";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.AlertCloseReason(Model.PersonId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-from-desktop">
+        <form action="@LinkGenerator.AlertCloseCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Alert type</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="alert-type">@Model.AlertTypeName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Details</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value><multi-line-text text="@Model.Details" data-testid="details" /></govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Link</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.Link is not null)
+                        {
+                            <a href="@Model.Link" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="link">@($"{Model.Link} (opens in new tab)")</a>
+                        }
+                        else
+                        {
+                            <span data-testid="link" use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="start-date">@Model.StartDate?.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="end-date">@Model.EndDate!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertClose(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value><multi-line-text text="@Model.ChangeReason" data-testid="change-reason" /></govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Evidence</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.UploadedEvidenceFileUrl is not null)
+                        {
+                            <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} (opens in new tab)")</a>
+                        }
+                        else
+                        {
+                            <span data-testid="uploaded-evidence-link" use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <h2 class="govuk-heading-m">Are you sure you want to close this alert?</h2>
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Confirm and close alert</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertCloseCheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -1,0 +1,125 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+[Journey(JourneyNames.CloseAlert), ActivatesJourney, RequireJourneyInstance]
+public class CheckAnswersModel(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService,
+    IClock clock,
+    ReferenceDataCache referenceDataCache) : PageModel
+{
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    public JourneyInstance<CloseAlertState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public string? AlertTypeName { get; set; }
+
+    public string? Details { get; set; }
+
+    public string? Link { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+
+    public string? ChangeReason { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        var now = clock.UtcNow;
+
+        var alert = await dbContext.Alerts
+            .SingleAsync(a => a.AlertId == AlertId);
+
+        var oldAlertEventModel = EventModels.Alert.FromModel(alert);
+        alert.EndDate = EndDate;
+        alert.UpdatedOn = now;
+
+        var updatedEvent = new AlertUpdatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = User.GetUserId(),
+            PersonId = PersonId,
+            Alert = EventModels.Alert.FromModel(alert),
+            OldAlert = oldAlertEventModel,
+            ChangeReason = ChangeReason,
+            EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
+            new EventModels.File()
+            {
+                FileId = fileId,
+                Name = JourneyInstance.State.EvidenceFileName!
+            } :
+            null,
+            Changes = AlertUpdatedEventChanges.EndDate
+        };
+
+        dbContext.AddEvent(updatedEvent);
+
+        await dbContext.SaveChangesAsync();
+
+        await JourneyInstance!.CompleteAsync();
+        TempData.SetFlashSuccess("Alert closed");
+
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (!JourneyInstance!.State.IsComplete)
+        {
+            context.Result = Redirect(linkGenerator.AlertClose(AlertId, JourneyInstance.InstanceId));
+            return;
+        }
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+        var alertInfo = context.HttpContext.GetCurrentAlertFeature();
+        var alertType = await referenceDataCache.GetAlertTypeById(alertInfo.Alert.AlertTypeId);
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+        AlertTypeName = alertType.Name;
+        Details = alertInfo.Alert.Details;
+        Link = alertInfo.Alert.ExternalLink;
+        StartDate = alertInfo.Alert.StartDate;
+        EndDate = JourneyInstance!.State.EndDate;
+        ChangeReason = JourneyInstance.State.ChangeReason != CloseAlertReasonOption.AnotherReason ?
+            JourneyInstance.State.ChangeReason!.GetDisplayName() :
+            JourneyInstance!.State.ChangeReasonDetail;
+        EvidenceFileName = JourneyInstance.State.EvidenceFileName;
+        UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance!.State.EvidenceFileId!.Value, _fileUrlExpiresAfter) :
+            null;
+
+        await next();
+    }
+}
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertReasonOption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertReasonOption.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+public enum CloseAlertReasonOption
+{
+    [Display(Name = "End date set")]
+    EndDateSet,
+    [Display(Name = "Alert period has ended")]
+    AlertPeriodHasEnded,
+    [Display(Name = "Alert type is no longer valid")]
+    AlertTypeIsNoLongerValid,
+    [Display(Name = "Another reason")]
+    AnotherReason
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+public class CloseAlertState
+{
+    public DateOnly? EndDate { get; set; }
+
+    public CloseAlertReasonOption? ChangeReason { get; set; }
+
+    public string? ChangeReasonDetail { get; set; }
+
+    public bool? UploadEvidence { get; set; }
+
+    public Guid? EvidenceFileId { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    [JsonIgnore]
+    [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(UploadEvidence), nameof(EvidenceFileId))]
+    public bool IsComplete => EndDate is not null &&
+        ChangeReason.HasValue &&
+        (ChangeReason.Value == CloseAlertReasonOption.AnotherReason ? !string.IsNullOrWhiteSpace(ChangeReasonDetail) : true) &&
+        UploadEvidence.HasValue &&
+        (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml
@@ -1,0 +1,27 @@
+@page "/alerts/{alertId}/close/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.IndexModel
+@{
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.AlertCloseCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.PersonAlerts(Model.PersonId))">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AlertClose(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
+            <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
+
+            <govuk-date-input asp-for="EndDate">
+                <govuk-date-input-fieldset>
+                    <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
+                </govuk-date-input-fieldset>
+            </govuk-date-input>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertCloseCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </<div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+[Journey(JourneyNames.CloseAlert), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator, IClock clock) : PageModel
+{
+    public JourneyInstance<CloseAlertState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Add an end date")]
+    public DateOnly? EndDate { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public void OnGet()
+    {
+        EndDate = JourneyInstance!.State.EndDate;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (EndDate is null)
+        {
+            ModelState.AddModelError(nameof(EndDate), "Enter an end date");
+        }
+        else if (EndDate > clock.Today)
+        {
+            ModelState.AddModelError(nameof(EndDate), "End date cannot be in the future");
+        }
+        else if (EndDate <= StartDate)
+        {
+            ModelState.AddModelError(nameof(EndDate), "End date must be after the start date");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state => state.EndDate = EndDate);
+
+        return Redirect(FromCheckAnswers
+            ? linkGenerator.AlertCloseCheckAnswers(AlertId, JourneyInstance.InstanceId)
+            : linkGenerator.AlertCloseReason(AlertId, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var alertInfo = context.HttpContext.GetCurrentAlertFeature();
+        if (alertInfo.Alert.EndDate is not null)
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+        StartDate = alertInfo.Alert.StartDate;
+    }
+
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
@@ -1,0 +1,68 @@
+@page "/alerts/{alertId}/close/change-reason/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.ReasonModel
+@{
+    ViewBag.Title = "Why are you adding an end date?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.AlertCloseCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.AlertClose(Model.AlertId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
+            <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@CloseAlertReasonOption.EndDateSet">
+                        @CloseAlertReasonOption.EndDateSet.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@CloseAlertReasonOption.AlertPeriodHasEnded">
+                        @CloseAlertReasonOption.AlertPeriodHasEnded.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@CloseAlertReasonOption.AlertTypeIsNoLongerValid">
+                        @CloseAlertReasonOption.AlertTypeIsNoLongerValid.GetDisplayName()
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@CloseAlertReasonOption.AnotherReason">
+                        @CloseAlertReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional>
+                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="4000" />
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-radios asp-for="UploadEvidence" data-testid="upload-evidence-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@true">
+                        Yes
+                        <govuk-radios-item-conditional>
+                            @if (Model.EvidenceFileId is not null)
+                            {
+                                <span class="govuk-caption-m">Currently uploaded file</span>
+                                <p class="govuk-body">
+                                    <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} ({Model.EvidenceFileSizeDescription})")</a>
+                                </p>
+                            }
+                            <govuk-file-upload asp-for="EvidenceFile" input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+                                <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+                            </govuk-file-upload>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertCloseReasonCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
@@ -1,0 +1,146 @@
+using System.ComponentModel.DataAnnotations;
+using Humanizer;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.DataAnnotations;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+[Journey(JourneyNames.CloseAlert), RequireJourneyInstance]
+public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileService) : PageModel
+{
+    public const int MaxFileSizeMb = 50;
+
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    public JourneyInstance<CloseAlertState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Select a reason")]
+    [Required(ErrorMessage = "Select a reason")]
+    public CloseAlertReasonOption? ChangeReason { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Enter details")]
+    public string? ChangeReasonDetail { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Upload evidence")]
+    [Required(ErrorMessage = "Select yes if you want to upload evidence")]
+    public bool? UploadEvidence { get; set; }
+
+    [BindProperty]
+    [EvidenceFile]
+    [FileSize(MaxFileSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    public IFormFile? EvidenceFile { get; set; }
+
+    public Guid? EvidenceFileId { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public async Task OnGet()
+    {
+        ChangeReason = JourneyInstance!.State.ChangeReason;
+        ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
+        UploadEvidence = JourneyInstance?.State.UploadEvidence;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
+        UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
+            null;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (ChangeReason == CloseAlertReasonOption.AnotherReason && string.IsNullOrWhiteSpace(ChangeReasonDetail))
+        {
+            ModelState.AddModelError(nameof(ChangeReasonDetail), "Enter details");
+        }
+
+        if (UploadEvidence == true && EvidenceFileId is null && EvidenceFile is null)
+        {
+            ModelState.AddModelError(nameof(EvidenceFile), "Select a file");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        if (UploadEvidence == true)
+        {
+            if (EvidenceFile is not null)
+            {
+                if (EvidenceFileId is not null)
+                {
+                    await fileService.DeleteFile(EvidenceFileId.Value);
+                }
+
+                using var stream = EvidenceFile.OpenReadStream();
+                var evidenceFileId = await fileService.UploadFile(stream, EvidenceFile.ContentType);
+                await JourneyInstance!.UpdateStateAsync(state =>
+                {
+                    state.EvidenceFileId = evidenceFileId;
+                    state.EvidenceFileName = EvidenceFile.FileName;
+                    state.EvidenceFileSizeDescription = EvidenceFile.Length.Bytes().Humanize();
+                });
+            }
+        }
+        else if (EvidenceFileId is not null)
+        {
+            await fileService.DeleteFile(EvidenceFileId.Value);
+            await JourneyInstance!.UpdateStateAsync(state =>
+            {
+                state.EvidenceFileId = null;
+                state.EvidenceFileName = null;
+                state.EvidenceFileSizeDescription = null;
+            });
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.ChangeReason = ChangeReason;
+            state.ChangeReasonDetail = ChangeReasonDetail;
+            state.UploadEvidence = UploadEvidence;
+        });
+
+        return Redirect(linkGenerator.AlertCloseCheckAnswers(AlertId, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (JourneyInstance!.State.EndDate is null)
+        {
+            context.Result = Redirect(linkGenerator.AlertClose(AlertId, JourneyInstance.InstanceId));
+            return;
+        }
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -120,6 +120,13 @@ builder.Services
             });
 
         options.Conventions.AddFolderApplicationModelConvention(
+            "/Alerts/CloseAlert",
+            model =>
+            {
+                model.Filters.Add(new ServiceFilterAttribute<CheckAlertExistsFilter>());
+            });
+
+        options.Conventions.AddFolderApplicationModelConvention(
             "/Mqs/AddMq",
             model =>
             {
@@ -248,6 +255,12 @@ builder.Services
         options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
             JourneyNames.EditAlertEndDate,
             typeof(TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate.EditAlertEndDateState),
+            requestDataKeys: ["alertId"],
+            appendUniqueKey: true));
+
+        options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
+            JourneyNames.CloseAlert,
+            typeof(TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.CloseAlertState),
             requestDataKeys: ["alertId"],
             appendUniqueKey: true));
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -91,11 +91,23 @@ public class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string AlertEditEndDateCheckAnswersCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/Alerts/EditAlert/EndDate/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
 
-    public string AlertClose(Guid alertId, JourneyInstanceId? journeyInstanceId) =>
-        GetRequiredPathByPage("/Alerts/CloseAlert/Index", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string AlertClose(Guid alertId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/Alerts/CloseAlert/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
-    public string AlertCloseConfirm(Guid alertId, JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/Alerts/CloseAlert/Confirm", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string AlertCloseCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/CloseAlert/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertCloseReason(Guid alertId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/Alerts/CloseAlert/Reason", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertCloseReasonCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/CloseAlert/Reason", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertCloseCheckAnswers(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/CloseAlert/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertCloseCheckAnswersCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/CloseAlert/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
 
     public string EditChangeRequest(string ticketNumber) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Index", routeValues: new { ticketNumber });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -46,6 +46,11 @@ public static class PageExtensions
         await page.GotoAsync($"/alerts/{alertId}/end-date");
     }
 
+    public static async Task GoToCloseAlertPage(this IPage page, Guid alertId)
+    {
+        await page.GotoAsync($"/alerts/{alertId}/close");
+    }
+
     public static async Task GoToAddMqPage(this IPage page, Guid personId)
     {
         await page.GotoAsync($"/mqs/add?personId={personId}");
@@ -197,7 +202,6 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/alerts/{alertId}/end-date/check-answers");
     }
 
-
     public static async Task AssertOnAlertDetailPage(this IPage page, Guid alertId)
     {
         await page.WaitForUrlPathAsync($"/alerts/{alertId}");
@@ -208,9 +212,14 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/alerts/{alertId}/close");
     }
 
-    public static async Task AssertOnCloseAlertConfirmPage(this IPage page, Guid alertId)
+    public static async Task AssertOnCloseAlertChangeReasonPage(this IPage page, Guid alertId)
     {
-        await page.WaitForUrlPathAsync($"/alerts/{alertId}/close/confirm");
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/close/change-reason");
+    }
+
+    public static async Task AssertOnCloseAlertCheckAnswersPage(this IPage page, Guid alertId)
+    {
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/close/check-answers");
     }
 
     public static async Task AssertOnPersonEditNamePage(this IPage page, Guid personId)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -1,0 +1,269 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.CloseAlert;
+
+public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange        
+        var person = await TestData.CreatePerson(b => b.WithAlert());
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/close", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_WithValidJourneyState_ReturnsOk(bool populateOptional)
+    {
+        // Arrange
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var details = "Some details";
+        var link = populateOptional ? TestData.GenerateUrl() : null;
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var changeReason = populateOptional ? CloseAlertReasonOption.AnotherReason : CloseAlertReasonOption.EndDateSet;
+        var changeReasonDetail = populateOptional ? "Some details" : null;
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(
+            b => b.WithAlert(
+                a => a.WithAlertTypeId(alertType.AlertTypeId)
+                    .WithDetails(details)
+                    .WithExternalLink(link)
+                    .WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate,
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = populateOptional ? true : false,
+                EvidenceFileId = populateOptional ? evidenceFileId : null,
+                EvidenceFileName = populateOptional ? evidenceFileName : null
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(alertType.Name, doc.GetElementByTestId("alert-type")!.TextContent);
+        Assert.Equal(details, doc.GetElementByTestId("details")!.TextContent);
+        Assert.Equal(populateOptional ? $"{link} (opens in new tab)" : "-", doc.GetElementByTestId("link")!.TextContent);
+        Assert.Equal(startDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("start-date")!.TextContent);
+        Assert.Equal(journeyEndDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("end-date")!.TextContent);
+        if (changeReason == CloseAlertReasonOption.AnotherReason)
+        {
+            Assert.Equal(changeReasonDetail, doc.GetElementByTestId("change-reason")!.TextContent);
+        }
+        else
+        {
+            Assert.Equal(changeReason.GetDisplayName(), doc.GetElementByTestId("change-reason")!.TextContent);
+        }
+        Assert.Equal(populateOptional ? $"{evidenceFileName} (opens in new tab)" : "-", doc.GetElementByTestId("uploaded-evidence-link")!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithAlert());
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/close", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(CloseAlertReasonOption.EndDateSet)]
+    [InlineData(CloseAlertReasonOption.AlertPeriodHasEnded)]
+    [InlineData(CloseAlertReasonOption.AlertTypeIsNoLongerValid)]
+    [InlineData(CloseAlertReasonOption.AnotherReason)]
+    public async Task Post_Confirm_UpdatesAlertCreatesEventCompletesJourneyAndRedirectsWithFlashMessage(CloseAlertReasonOption changeReason)
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var changeReasonDetail = "Some reason or other";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var originalAlert = person.Alerts.Single();
+        var alertId = originalAlert.AlertId;
+
+        EventPublisher.Clear();
+
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate,
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "Alert closed");
+
+        await WithDbContext(async dbContext =>
+        {
+            var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alertId);
+            Assert.Equal(journeyEndDate, updatedAlert!.EndDate);
+        });
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var expectedAlertUpdatedEvent = new AlertUpdatedEvent()
+            {
+                EventId = Guid.Empty,
+                CreatedUtc = Clock.UtcNow,
+                RaisedBy = GetCurrentUserId(),
+                PersonId = person.PersonId,
+                Alert = new()
+                {
+                    AlertId = alertId,
+                    AlertTypeId = originalAlert.AlertTypeId,
+                    Details = originalAlert.Details,
+                    ExternalLink = originalAlert.ExternalLink,
+                    StartDate = originalAlert.StartDate,
+                    EndDate = journeyEndDate
+                },
+                OldAlert = new()
+                {
+                    AlertId = alertId,
+                    AlertTypeId = originalAlert.AlertTypeId,
+                    Details = originalAlert.Details,
+                    ExternalLink = originalAlert.ExternalLink,
+                    StartDate = originalAlert.StartDate,
+                    EndDate = null
+                },
+                ChangeReason = changeReason == CloseAlertReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                EvidenceFile = new()
+                {
+                    FileId = evidenceFileId,
+                    Name = evidenceFileName
+                },
+                Changes = AlertUpdatedEventChanges.EndDate
+            };
+
+            var actualAlertUpdatedEvent = Assert.IsType<AlertUpdatedEvent>(e);
+            Assert.Equivalent(expectedAlertUpdatedEvent with { EventId = actualAlertUpdatedEvent.EventId }, actualAlertUpdatedEvent);
+        });
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.True(journeyInstance.Completed);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var changeReason = CloseAlertReasonOption.AnotherReason;
+        var changeReasonDetail = "Some reason or other";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate,
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private async Task<JourneyInstance<CloseAlertState>> CreateJourneyInstance(Guid alertId, CloseAlertState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.CloseAlert,
+            state ?? new CloseAlertState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}
+

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
@@ -1,0 +1,201 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.CloseAlert;
+
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WhenAlertHasEndDateSet_ReturnsBadRequest()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenAlertHasEndDateSet_ReturnsBadRequest()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoEndDateIsEntered_ReturnsError()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EndDate", "Enter an end date");
+    }
+
+    [Fact]
+    public async Task Post_WhenEndDateIsInTheFuture_ReturnsError()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var futureDate = Clock.Today.AddDays(2);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "EndDate.Day", $"{futureDate:%d}" },
+                { "EndDate.Month", $"{futureDate:%M}" },
+                { "EndDate.Year", $"{futureDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EndDate", "End date cannot be in the future");
+    }
+
+    [Fact]
+    public async Task Post_WhenEndDateIsBeforeStartDate_ReturnsError()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var newEndDate = Clock.Today.AddDays(-51);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "EndDate.Day", $"{newEndDate:%d}" },
+                { "EndDate.Month", $"{newEndDate:%M}" },
+                { "EndDate.Year", $"{newEndDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EndDate", "End date must be after the start date");
+    }
+
+    [Fact]
+    public async Task Post_WhenEndDateIsEntered_RedirectsToChangeReasonPage()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var newEndDate = Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "EndDate.Day", $"{newEndDate:%d}" },
+                { "EndDate.Month", $"{newEndDate:%M}" },
+                { "EndDate.Year", $"{newEndDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/close/change-reason", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private async Task<JourneyInstance<CloseAlertState>> CreateJourneyInstance(Guid alertId, CloseAlertState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.CloseAlert,
+            state ?? new CloseAlertState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
@@ -1,0 +1,307 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.CloseAlert;
+
+public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithAlert());
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_ReturnsOK()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson(b => b.WithAlert());
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoChangeReasonIsSelected_ReturnsError()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["UploadEvidence"] = "False"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "ChangeReason", "Select a reason");
+    }
+
+    [Fact]
+    public async Task Post_WhenChangeReasonAnotherReasonIsSelectedAndDetailsAreEmpty_ReturnsError()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["ChangeReason"] = "AnotherReason",
+                ["ChangeReasonDetail"] = "",
+                ["UploadEvidence"] = "False"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "ChangeReasonDetail", "Enter details");
+    }
+
+    [Fact]
+    public async Task Post_WhenUploadEvidenceOptionIsYesAndNoFileIsSelected_ReturnsError()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["ChangeReason"] = "AnotherReason",
+                ["ChangeReasonDetail"] = "Some details",
+                ["UploadEvidence"] = "True"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "Select a file");
+    }
+
+    [Fact]
+    public async Task Post_WhenEvidenceFileIsInvalidType_ReturnsError()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var multipartContent = CreateFormFileUpload(".cs");
+        multipartContent.Add(new StringContent(AlertChangeEndDateReasonOption.AnotherReason.ToString()), "ChangeReason");
+        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
+        multipartContent.Add(new StringContent("True"), "UploadEvidence");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX");
+    }
+
+    [Fact]
+    public async Task Post_WhenValidInput_RedirectsToCheckAnswersPage()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var multipartContent = CreateFormFileUpload(".pdf");
+        multipartContent.Add(new StringContent(AlertChangeEndDateReasonOption.AnotherReason.ToString()), "ChangeReason");
+        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
+        multipartContent.Add(new StringContent("True"), "UploadEvidence");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private MultipartFormDataContent CreateFormFileUpload(string fileExtension)
+    {
+        var byteArrayContent = new ByteArrayContent(new byte[] { });
+        byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
+
+        var multipartContent = new MultipartFormDataContent
+        {
+            { byteArrayContent, "EvidenceFile", $"evidence{fileExtension}" }
+        };
+
+        return multipartContent;
+    }
+    private async Task<JourneyInstance<CloseAlertState>> CreateJourneyInstance(Guid alertId, CloseAlertState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.CloseAlert,
+            state ?? new CloseAlertState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -705,7 +705,7 @@ public partial class TestData
 
             var alertTypeId = _alertTypeId.ValueOr((await testData.ReferenceDataCache.GetAlertTypes()).RandomOne().AlertTypeId);
             var details = _details.ValueOr(testData.GenerateLoremIpsum());
-            var externalLink = _externalLink.ValueOr(testData.GenerateUrl());
+            var externalLink = _externalLink.ValueOr((string?)null);
             var startDate = _startDate.ValueOr(testData.GenerateDate(min: new DateOnly(2000, 1, 1)));
             var endDate = _endDate.ValueOr((DateOnly?)null);
             var reason = _reason.ValueOr(testData.GenerateLoremIpsum());


### PR DESCRIPTION
### Context

We need to build out the front end of the TRS console to enable users to interact with Alerts data through the TRS console.

### Changes proposed in this pull request

Build out the TRS console as per the Figma designs ensuring that an `AlertUpdatedEvent` is created with the original (i.e. null) and changed end date.

The endpoint for the start of this journey should be `/alerts/{alertId}/close`

This journey will be accessed from a `Close Alert` action on the current alerts detail page (which is not in the scope of this card).

### Guidance to review

UI + tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
