### PR TITLE
Propagate the 'ignore invalid' flag when syncing an alert's Person

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -140,7 +140,7 @@ public class TrsDataSyncHelper(
         return modelTypeSyncInfo.GetSyncHandler(this)(entities, ignoreInvalid, dryRun, cancellationToken);
     }
 
-    public async Task<bool> SyncPerson(Guid contactId, bool dryRun = false, CancellationToken cancellationToken = default)
+    public async Task<bool> SyncPerson(Guid contactId, bool ignoreInvalid = false, bool dryRun = false, CancellationToken cancellationToken = default)
     {
         var modelTypeSyncInfo = GetModelTypeSyncInfo(ModelTypes.Person);
 
@@ -151,7 +151,7 @@ public class TrsDataSyncHelper(
             modelTypeSyncInfo.AttributeNames,
             cancellationToken);
 
-        return await SyncPersons(contacts, ignoreInvalid: false, dryRun, cancellationToken) == 1;
+        return await SyncPersons(contacts, ignoreInvalid, dryRun, cancellationToken) == 1;
     }
 
     public async Task<bool> SyncPerson(Contact entity, bool ignoreInvalid, bool dryRun = false, CancellationToken cancellationToken = default) =>
@@ -356,7 +356,7 @@ public class TrsDataSyncHelper(
                 // ex.Detail will be something like "Key (person_id)=(6ac8dc26-c8ae-e311-b8ed-005056822391) is not present in table "persons"."
                 var personId = Guid.Parse(ex.Detail!.Substring("Key (person_id)=(".Length, Guid.Empty.ToString().Length));
 
-                var personSynced = await SyncPerson(personId, dryRun: false, cancellationToken);
+                var personSynced = await SyncPerson(personId, ignoreInvalid, dryRun: false, cancellationToken);
                 if (!personSynced)
                 {
                     // The person sync may fail if the record doesn't meet the criteria (e.g. it doesn't have a TRN).

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -65,7 +65,7 @@ public class CheckPersonExistsFilter(
         // Ensure we've synced this person into the TRS DB at least once
         if (!await dbContext.Persons.AnyAsync(p => p.PersonId == personId))
         {
-            await backgroundJobScheduler.Enqueue<TrsDataSyncHelper>(helper => helper.SyncPerson(personId, /*dryRun:*/ false, CancellationToken.None));
+            await backgroundJobScheduler.Enqueue<TrsDataSyncHelper>(helper => helper.SyncPerson(personId, /*ignoreInvalid: */ false, /*dryRun:*/ false, CancellationToken.None));
         }
 
         await next();


### PR DESCRIPTION
When an alert cannot be synced because its `Person` hasn't been synced yet we forcibly sync the person. In dev we have a few invalid records that are causing errors. This tweak passes along the `ignoreInvalid` flag so we get a better error message in such situations.