### PR TITLE
Reduce the page size in TrsDataSyncService

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -27,7 +27,7 @@ public class TrsDataSyncService(
         })
         .Build();
 
-    private const int PageSize = 1000;
+    private const int PageSize = 500;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {


### PR DESCRIPTION
We're still getting out of memory exceptions, even after increasing the worker's memory. This halves the page size used for backfill queries to reduce the memory requirement.