### PR TITLE
Implemented re-open alert journey + tests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -14,4 +14,5 @@ public static class JourneyNames
     public const string EditAlertStartDate = nameof(EditAlertStartDate);
     public const string EditAlertEndDate = nameof(EditAlertEndDate);
     public const string CloseAlert = nameof(CloseAlert);
+    public const string ReopenAlert = nameof(ReopenAlert);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.AlertEditEndDateCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.PersonAlerts(Model.PersonId))">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.AlertEditEndDateCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alert(Model.AlertId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
@@ -1,0 +1,75 @@
+@page "/alerts/{alertId}/reopen/check-answers/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert.CheckAnswersModel
+@{
+    ViewBag.Title = "Check details and confirm change";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.AlertReopen(Model.PersonId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-from-desktop">
+        <form action="@LinkGenerator.AlertReopenCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Alert type</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="alert-type">@Model.AlertTypeName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Details</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value><multi-line-text text="@Model.Details" data-testid="details" /></govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Link</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.Link is not null)
+                        {
+                            <a href="@Model.Link" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="link">@($"{Model.Link} (opens in new tab)")</a>
+                        }
+                        else
+                        {
+                            <span data-testid="link" use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="start-date">@Model.StartDate?.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value><multi-line-text text="@Model.ChangeReason" data-testid="change-reason" /></govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertReopen(Model.AlertId, Model.JourneyInstance!.InstanceId)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Evidence</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.UploadedEvidenceFileUrl is not null)
+                        {
+                            <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} (opens in new tab)")</a>
+                        }
+                        else
+                        {
+                            <span data-testid="uploaded-evidence-link" use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertReopen(Model.AlertId, Model.JourneyInstance!.InstanceId)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <h2 class="govuk-heading-m">Are you sure you want to close this alert?</h2>
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Confirm and re-open alert</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertReopenCheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
@@ -65,7 +65,7 @@
                 </govuk-summary-list-row>
             </govuk-summary-list>
 
-            <h2 class="govuk-heading-m">Are you sure you want to close this alert?</h2>
+            <h2 class="govuk-heading-m">Are you sure you want to re-open this alert?</h2>
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and re-open alert</govuk-button>
                 <govuk-button formaction="@LinkGenerator.AlertReopenCheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
@@ -1,0 +1,121 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+[Journey(JourneyNames.ReopenAlert), RequireJourneyInstance]
+public class CheckAnswersModel(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService,
+    IClock clock,
+    ReferenceDataCache referenceDataCache) : PageModel
+{
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    public JourneyInstance<ReopenAlertState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public string? AlertTypeName { get; set; }
+
+    public string? Details { get; set; }
+
+    public string? Link { get; set; }
+
+    public DateOnly? StartDate { get; set; }
+
+    public string? ChangeReason { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public async Task<IActionResult> OnPost()
+    {
+        var now = clock.UtcNow;
+
+        var alert = await dbContext.Alerts
+            .SingleAsync(a => a.AlertId == AlertId);
+
+        var oldAlertEventModel = EventModels.Alert.FromModel(alert);
+        alert.EndDate = null;
+        alert.UpdatedOn = now;
+
+        var updatedEvent = new AlertUpdatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = User.GetUserId(),
+            PersonId = PersonId,
+            Alert = EventModels.Alert.FromModel(alert),
+            OldAlert = oldAlertEventModel,
+            ChangeReason = ChangeReason,
+            EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
+            new EventModels.File()
+            {
+                FileId = fileId,
+                Name = JourneyInstance.State.EvidenceFileName!
+            } :
+            null,
+            Changes = AlertUpdatedEventChanges.EndDate
+        };
+
+        dbContext.AddEvent(updatedEvent);
+
+        await dbContext.SaveChangesAsync();
+
+        await JourneyInstance!.CompleteAsync();
+        TempData.SetFlashSuccess("Alert re-opened");
+
+        return Redirect(linkGenerator.PersonAlerts(PersonId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.Alert(AlertId));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (!JourneyInstance!.State.IsComplete)
+        {
+            context.Result = Redirect(linkGenerator.AlertReopen(AlertId, JourneyInstance.InstanceId));
+            return;
+        }
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+        var alertInfo = context.HttpContext.GetCurrentAlertFeature();
+        var alertType = await referenceDataCache.GetAlertTypeById(alertInfo.Alert.AlertTypeId);
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+        AlertTypeName = alertType.Name;
+        Details = alertInfo.Alert.Details;
+        Link = alertInfo.Alert.ExternalLink;
+        StartDate = alertInfo.Alert.StartDate;
+        ChangeReason = JourneyInstance.State.ChangeReason != ReopenAlertReasonOption.AnotherReason ?
+            JourneyInstance.State.ChangeReason!.GetDisplayName() :
+            JourneyInstance!.State.ChangeReasonDetail;
+        EvidenceFileName = JourneyInstance.State.EvidenceFileName;
+        UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance!.State.EvidenceFileId!.Value, _fileUrlExpiresAfter) :
+            null;
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
@@ -1,0 +1,62 @@
+@page "/alerts/{alertId}/reopen/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert.IndexModel
+@{
+    ViewBag.Title = "Why are you removing the end date?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.Alert(Model.AlertId)">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AlertReopen(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
+            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
+
+            <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@ReopenAlertReasonOption.ClosedInError">
+                        @ReopenAlertReasonOption.ClosedInError.GetDisplayName()
+                    </govuk-radios-item>                    
+                    <govuk-radios-item value="@ReopenAlertReasonOption.AnotherReason">
+                        @ReopenAlertReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional>
+                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="4000" />
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-radios asp-for="UploadEvidence" data-testid="upload-evidence-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@true">
+                        Yes
+                        <govuk-radios-item-conditional>
+                            @if (Model.EvidenceFileId is not null)
+                            {
+                                <span class="govuk-caption-m">Currently uploaded file</span>
+                                <p class="govuk-body">
+                                    <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} ({Model.EvidenceFileSizeDescription})")</a>
+                                </p>
+                            }
+                            <govuk-file-upload asp-for="EvidenceFile" input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+                                <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+                            </govuk-file-upload>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.AlertReopenCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
@@ -1,0 +1,147 @@
+using System.ComponentModel.DataAnnotations;
+using Humanizer;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.DataAnnotations;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+[Journey(JourneyNames.ReopenAlert), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService) : PageModel
+{
+    public const int MaxFileSizeMb = 50;
+
+    private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
+
+    public JourneyInstance<ReopenAlertState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid AlertId { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Select a reason")]
+    [Required(ErrorMessage = "Select a reason")]
+    public ReopenAlertReasonOption? ChangeReason { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Enter details")]
+    public string? ChangeReasonDetail { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Upload evidence")]
+    [Required(ErrorMessage = "Select yes if you want to upload evidence")]
+    public bool? UploadEvidence { get; set; }
+
+    [BindProperty]
+    [EvidenceFile]
+    [FileSize(MaxFileSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    public IFormFile? EvidenceFile { get; set; }
+
+    public Guid? EvidenceFileId { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    public string? UploadedEvidenceFileUrl { get; set; }
+
+    public async Task OnGet()
+    {
+        ChangeReason = JourneyInstance!.State.ChangeReason;
+        ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
+        UploadEvidence = JourneyInstance?.State.UploadEvidence;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
+        UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
+            await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
+            null;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (ChangeReason == ReopenAlertReasonOption.AnotherReason && string.IsNullOrWhiteSpace(ChangeReasonDetail))
+        {
+            ModelState.AddModelError(nameof(ChangeReasonDetail), "Enter details");
+        }
+
+        if (UploadEvidence == true && EvidenceFileId is null && EvidenceFile is null)
+        {
+            ModelState.AddModelError(nameof(EvidenceFile), "Select a file");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        if (UploadEvidence == true)
+        {
+            if (EvidenceFile is not null)
+            {
+                if (EvidenceFileId is not null)
+                {
+                    await fileService.DeleteFile(EvidenceFileId.Value);
+                }
+
+                using var stream = EvidenceFile.OpenReadStream();
+                var evidenceFileId = await fileService.UploadFile(stream, EvidenceFile.ContentType);
+                await JourneyInstance!.UpdateStateAsync(state =>
+                {
+                    state.EvidenceFileId = evidenceFileId;
+                    state.EvidenceFileName = EvidenceFile.FileName;
+                    state.EvidenceFileSizeDescription = EvidenceFile.Length.Bytes().Humanize();
+                });
+            }
+        }
+        else if (EvidenceFileId is not null)
+        {
+            await fileService.DeleteFile(EvidenceFileId.Value);
+            await JourneyInstance!.UpdateStateAsync(state =>
+            {
+                state.EvidenceFileId = null;
+                state.EvidenceFileName = null;
+                state.EvidenceFileSizeDescription = null;
+            });
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.ChangeReason = ChangeReason;
+            state.ChangeReasonDetail = ChangeReasonDetail;
+            state.UploadEvidence = UploadEvidence;
+        });
+
+        return Redirect(linkGenerator.AlertReopenCheckAnswers(AlertId, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancel()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.Alert(AlertId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var alertInfo = context.HttpContext.GetCurrentAlertFeature();
+        if (alertInfo.Alert.EndDate is null)
+        {
+            context.Result = BadRequest(); ;
+            return;
+        }
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertReasonOption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertReasonOption.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+public enum ReopenAlertReasonOption
+{
+    [Display(Name = "Closed in error")]
+    ClosedInError,
+    [Display(Name = "Another reason")]
+    AnotherReason
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertState.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+public class ReopenAlertState
+{
+    public ReopenAlertReasonOption? ChangeReason { get; set; }
+
+    public string? ChangeReasonDetail { get; set; }
+
+    public bool? UploadEvidence { get; set; }
+
+    public Guid? EvidenceFileId { get; set; }
+
+    public string? EvidenceFileName { get; set; }
+
+    public string? EvidenceFileSizeDescription { get; set; }
+
+    [JsonIgnore]
+    [MemberNotNullWhen(true, nameof(ChangeReason), nameof(UploadEvidence), nameof(EvidenceFileId))]
+    public bool IsComplete => ChangeReason.HasValue &&
+        (ChangeReason.Value == ReopenAlertReasonOption.AnotherReason ? !string.IsNullOrWhiteSpace(ChangeReasonDetail) : true) &&
+        UploadEvidence.HasValue &&
+        (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -127,6 +127,13 @@ builder.Services
             });
 
         options.Conventions.AddFolderApplicationModelConvention(
+            "/Alerts/ReopenAlert",
+            model =>
+            {
+                model.Filters.Add(new ServiceFilterAttribute<CheckAlertExistsFilter>());
+            });
+
+        options.Conventions.AddFolderApplicationModelConvention(
             "/Mqs/AddMq",
             model =>
             {
@@ -261,6 +268,12 @@ builder.Services
         options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
             JourneyNames.CloseAlert,
             typeof(TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.CloseAlertState),
+            requestDataKeys: ["alertId"],
+            appendUniqueKey: true));
+
+        options.JourneyRegistry.RegisterJourney(new JourneyDescriptor(
+            JourneyNames.ReopenAlert,
+            typeof(TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert.ReopenAlertState),
             requestDataKeys: ["alertId"],
             appendUniqueKey: true));
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -109,6 +109,18 @@ public class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string AlertCloseCheckAnswersCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/Alerts/CloseAlert/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
 
+    public string AlertReopen(Guid alertId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/ReopenAlert/Index", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertReopenCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/ReopenAlert/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertReopenCheckAnswers(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/ReopenAlert/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
+    public string AlertReopenCheckAnswersCancel(Guid alertId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/Alerts/ReopenAlert/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+
     public string EditChangeRequest(string ticketNumber) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Index", routeValues: new { ticketNumber });
 
     public string ChangeRequestDocument(string ticketNumber, Guid documentId) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Index", "documents", routeValues: new { ticketNumber, id = documentId });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -51,6 +51,11 @@ public static class PageExtensions
         await page.GotoAsync($"/alerts/{alertId}/close");
     }
 
+    public static async Task GoToReopenAlertPage(this IPage page, Guid alertId)
+    {
+        await page.GotoAsync($"/alerts/{alertId}/reopen");
+    }
+
     public static async Task GoToAddMqPage(this IPage page, Guid personId)
     {
         await page.GotoAsync($"/mqs/add?personId={personId}");
@@ -220,6 +225,16 @@ public static class PageExtensions
     public static async Task AssertOnCloseAlertCheckAnswersPage(this IPage page, Guid alertId)
     {
         await page.WaitForUrlPathAsync($"/alerts/{alertId}/close/check-answers");
+    }
+
+    public static async Task AssertOnReopenAlertPage(this IPage page, Guid alertId)
+    {
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/reopen");
+    }
+
+    public static async Task AssertOnReopenAlertCheckAnswersPage(this IPage page, Guid alertId)
+    {
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/reopen/check-answers");
     }
 
     public static async Task AssertOnPersonEditNamePage(this IPage page, Guid personId)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
@@ -1,0 +1,264 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.ReopenAlert;
+
+public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/reopen", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_WithValidJourneyState_ReturnsOk(bool populateOptional)
+    {
+        // Arrange
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var details = "Some details";
+        var link = populateOptional ? TestData.GenerateUrl() : null;
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var changeReason = populateOptional ? ReopenAlertReasonOption.AnotherReason : ReopenAlertReasonOption.ClosedInError;
+        var changeReasonDetail = populateOptional ? "Some details" : null;
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(
+            b => b.WithAlert(
+                a => a.WithAlertTypeId(alertType.AlertTypeId)
+                    .WithDetails(details)
+                    .WithExternalLink(link)
+                    .WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new ReopenAlertState()
+            {
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = populateOptional ? true : false,
+                EvidenceFileId = populateOptional ? evidenceFileId : null,
+                EvidenceFileName = populateOptional ? evidenceFileName : null
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal(alertType.Name, doc.GetElementByTestId("alert-type")!.TextContent);
+        Assert.Equal(details, doc.GetElementByTestId("details")!.TextContent);
+        Assert.Equal(populateOptional ? $"{link} (opens in new tab)" : "-", doc.GetElementByTestId("link")!.TextContent);
+        Assert.Equal(startDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("start-date")!.TextContent);
+        if (changeReason == ReopenAlertReasonOption.AnotherReason)
+        {
+            Assert.Equal(changeReasonDetail, doc.GetElementByTestId("change-reason")!.TextContent);
+        }
+        else
+        {
+            Assert.Equal(changeReason.GetDisplayName(), doc.GetElementByTestId("change-reason")!.TextContent);
+        }
+        Assert.Equal(populateOptional ? $"{evidenceFileName} (opens in new tab)" : "-", doc.GetElementByTestId("uploaded-evidence-link")!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
+    {
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/reopen", response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(ReopenAlertReasonOption.ClosedInError)]
+    [InlineData(ReopenAlertReasonOption.AnotherReason)]
+    public async Task Post_Confirm_UpdatesAlertCreatesEventCompletesJourneyAndRedirectsWithFlashMessage(ReopenAlertReasonOption changeReason)
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var endDate = TestData.Clock.Today.AddDays(-5);
+        var changeReasonDetail = "Some reason or other";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var originalAlert = person.Alerts.Single();
+        var alertId = originalAlert.AlertId;
+
+        EventPublisher.Clear();
+
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new ReopenAlertState()
+            {
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var redirectResponse = await response.FollowRedirect(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "Alert re-opened");
+
+        await WithDbContext(async dbContext =>
+        {
+            var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alertId);
+            Assert.Null(updatedAlert!.EndDate);
+        });
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var expectedAlertUpdatedEvent = new AlertUpdatedEvent()
+            {
+                EventId = Guid.Empty,
+                CreatedUtc = Clock.UtcNow,
+                RaisedBy = GetCurrentUserId(),
+                PersonId = person.PersonId,
+                Alert = new()
+                {
+                    AlertId = alertId,
+                    AlertTypeId = originalAlert.AlertTypeId,
+                    Details = originalAlert.Details,
+                    ExternalLink = originalAlert.ExternalLink,
+                    StartDate = originalAlert.StartDate,
+                    EndDate = null
+                },
+                OldAlert = new()
+                {
+                    AlertId = alertId,
+                    AlertTypeId = originalAlert.AlertTypeId,
+                    Details = originalAlert.Details,
+                    ExternalLink = originalAlert.ExternalLink,
+                    StartDate = originalAlert.StartDate,
+                    EndDate = originalAlert.EndDate
+                },
+                ChangeReason = changeReason == ReopenAlertReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                EvidenceFile = new()
+                {
+                    FileId = evidenceFileId,
+                    Name = evidenceFileName
+                },
+                Changes = AlertUpdatedEventChanges.EndDate
+            };
+
+            var actualAlertUpdatedEvent = Assert.IsType<AlertUpdatedEvent>(e);
+            Assert.Equivalent(expectedAlertUpdatedEvent with { EventId = actualAlertUpdatedEvent.EventId }, actualAlertUpdatedEvent);
+        });
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.True(journeyInstance.Completed);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var endDate = TestData.Clock.Today.AddDays(-5);
+        var changeReason = ReopenAlertReasonOption.AnotherReason;
+        var changeReasonDetail = "Some reason or other";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new ReopenAlertState()
+            {
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private async Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstance(Guid alertId, ReopenAlertState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.ReopenAlert,
+            state ?? new ReopenAlertState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
@@ -1,0 +1,295 @@
+using TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.ReopenAlert;
+
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WhenAlertHasNoEndDateSet_ReturnsBadRequest()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_ReturnsOk()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var endDate = TestData.Clock.Today.AddDays(-10);
+        var changeReason = ReopenAlertReasonOption.AnotherReason;
+        var changeReasonDetail = "Some details";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var evidenceFileSizeDescription = "1 MB";
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new ReopenAlertState()
+            {
+                ChangeReason = changeReason,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName,
+                EvidenceFileSizeDescription = evidenceFileSizeDescription
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var changeReasons = doc.GetElementsByName("ChangeReason");
+        var selectedChangeReason = changeReasons.Single(r => r.HasAttribute("checked"));
+        Assert.Equal(changeReason.ToString(), selectedChangeReason.GetAttribute("value"));
+        Assert.Equal(changeReasonDetail, doc.GetElementById("ChangeReasonDetail")!.TextContent);
+        var uploadEvidence = doc.GetElementsByName("UploadEvidence");
+        var selectedUploadEvidenceOption = uploadEvidence.Single(r => r.HasAttribute("checked"));
+        Assert.Equal("True", selectedUploadEvidenceOption.GetAttribute("value"));
+        var uploadedEvidenceLink = doc.GetElementByTestId("uploaded-evidence-link");
+        Assert.NotNull(uploadedEvidenceLink);
+        Assert.Equal($"{evidenceFileName} ({evidenceFileSizeDescription})", uploadedEvidenceLink!.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePerson();
+        var alertId = Guid.NewGuid();
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenAlertHasNoEndDateSet_ReturnsBadRequest()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoChangeReasonIsSelected_ReturnsError()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["UploadEvidence"] = "False"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "ChangeReason", "Select a reason");
+    }
+
+    [Fact]
+    public async Task Post_WhenChangeReasonAnotherReasonIsSelectedAndDetailsAreEmpty_ReturnsError()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["ChangeReason"] = ReopenAlertReasonOption.AnotherReason.ToString(),
+                ["UploadEvidence"] = "False"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "ChangeReasonDetail", "Enter details");
+    }
+
+    [Fact]
+    public async Task Post_WhenUploadEvidenceOptionIsYesAndNoFileIsSelected_ReturnsError()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["ChangeReason"] = ReopenAlertReasonOption.AnotherReason.ToString(),
+                ["ChangeReasonDetail"] = "Some details",
+                ["UploadEvidence"] = "True"
+            })
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "Select a file");
+    }
+
+    [Fact]
+    public async Task Post_WhenEvidenceFileIsInvalidType_ReturnsError()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var multipartContent = CreateFormFileUpload(".cs");
+        multipartContent.Add(new StringContent(ReopenAlertReasonOption.AnotherReason.ToString()), "ChangeReason");
+        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
+        multipartContent.Add(new StringContent("True"), "UploadEvidence");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "EvidenceFile", "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX");
+    }
+
+    [Fact]
+    public async Task Post_WhenValidInput_RedirectsToCheckAnswersPage()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var multipartContent = CreateFormFileUpload(".pdf");
+        multipartContent.Add(new StringContent(ReopenAlertReasonOption.AnotherReason.ToString()), "ChangeReason");
+        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
+        multipartContent.Add(new StringContent("True"), "UploadEvidence");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = multipartContent
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/reopen/check-answers", response.Headers.Location!.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirects()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/reopen/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/alerts/{alertId}", response.Headers.Location!.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Null(journeyInstance);
+    }
+
+    private MultipartFormDataContent CreateFormFileUpload(string fileExtension)
+    {
+        var byteArrayContent = new ByteArrayContent(new byte[] { });
+        byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
+
+        var multipartContent = new MultipartFormDataContent
+        {
+            { byteArrayContent, "EvidenceFile", $"evidence{fileExtension}" }
+        };
+
+        return multipartContent;
+    }
+
+    private async Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstance(Guid alertId, ReopenAlertState? state = null) =>
+        await CreateJourneyInstance(
+            JourneyNames.ReopenAlert,
+            state ?? new ReopenAlertState(),
+            new KeyValuePair<string, object>("alertId", alertId));
+}


### PR DESCRIPTION
### Context

We need to build out the front end of the TRS console to enable users to interact with Alerts data through the TRS console.

### Changes proposed in this pull request

Build out the TRS console as per the attached Figma designs ensuring that an `AlertUpdatedEvent` is created with the original and changed end date.

The endpoint for the start of this journey should be `/alerts/{alertId}/reopen`

This journey will be accessed from a Remove action next to and end date on the previously closed alerts detail page (which is not in the scope of this card).

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
