### PR TITLE
Remove the payload column from event index

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -17,6 +17,6 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.HasKey(e => e.EventId);
         builder.HasIndex(e => e.Payload).HasMethod("gin");
         builder.HasIndex(e => e.Key).IsUnique().HasFilter("key is not null").HasDatabaseName(Event.KeyUniqueIndexName);
-        builder.HasIndex(e => new { e.PersonId, e.EventName }).IncludeProperties(e => e.Payload).HasFilter("person_id is not null");
+        builder.HasIndex(e => new { e.PersonId, e.EventName }).HasFilter("person_id is not null");
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241003094321_RemovePayloadFromEventIndex.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241003094321_RemovePayloadFromEventIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241003094321_RemovePayloadFromEventIndex")]
+    partial class RemovePayloadFromEventIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241003094321_RemovePayloadFromEventIndex.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241003094321_RemovePayloadFromEventIndex.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemovePayloadFromEventIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_events_person_id_event_name",
+                table: "events");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_events_person_id_event_name",
+                table: "events",
+                columns: new[] { "person_id", "event_name" },
+                filter: "person_id is not null");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_events_person_id_event_name",
+                table: "events");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_events_person_id_event_name",
+                table: "events",
+                columns: new[] { "person_id", "event_name" },
+                filter: "person_id is not null")
+                .Annotation("Npgsql:IndexInclude", new[] { "payload" });
+        }
+    }
+}


### PR DESCRIPTION
We've got errors caused by trying to insert records that exceed the maximum row size allowed by `ix_events_person_id_event_name`. That index is large because it includes the `payload` column; this change removes it.