### PR TITLE
Add navigation properties to Alert models

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="DistributedLock.Azure" Version="1.0.0" />
     <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.2" />
     <PackageVersion Include="EFCore.NamingConventions" Version="8.0.3" />
+    <PackageVersion Include="EntityFrameworkCore.Projectables" Version="3.0.4" />
     <PackageVersion Include="Faker.Net" Version="2.0.154" />
     <PackageVersion Include="FakeXrmEasy.v9" Version="3.5.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/AlertMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/AlertMapping.cs
@@ -14,8 +14,9 @@ public class AlertMapping : IEntityTypeConfiguration<Alert>
         builder.Property(x => x.PersonId).IsRequired();
         builder.Property(x => x.Details);
         builder.HasIndex(x => x.AlertTypeId).HasDatabaseName(Alert.AlertTypeIdIndexName);
-        builder.HasOne<AlertType>().WithMany().HasForeignKey(x => x.AlertTypeId).HasConstraintName(Alert.AlertTypeForeignKeyName);
+        builder.HasOne<AlertType>(x => x.AlertType).WithMany().HasForeignKey(x => x.AlertTypeId).HasConstraintName(Alert.AlertTypeForeignKeyName);
         builder.HasIndex(x => x.PersonId).HasDatabaseName(Alert.PersonIdIndexName);
-        builder.HasOne<Person>().WithMany().HasForeignKey(x => x.PersonId).HasConstraintName(Alert.PersonForeignKeyName);
+        builder.HasOne<Person>().WithMany(p => p.Alerts).HasForeignKey(x => x.PersonId).HasConstraintName(Alert.PersonForeignKeyName);
+        builder.Ignore(x => x.IsActive);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/AlertTypeMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/AlertTypeMapping.cs
@@ -15,7 +15,7 @@ public class AlertTypeMapping : IEntityTypeConfiguration<AlertType>
         builder.Property(x => x.IsActive).IsRequired();
         builder.HasIndex(x => x.AlertCategoryId).HasDatabaseName(AlertType.AlertCategoryIdIndexName);
         builder.HasIndex(x => x.DisplayOrder).HasDatabaseName(AlertType.DisplayOrderIndexName).IsUnique();
-        builder.HasOne<AlertCategory>().WithMany(c => c.AlertTypes).HasForeignKey(x => x.AlertCategoryId).HasConstraintName(AlertType.AlertCategoryForeignKeyName);
+        builder.HasOne<AlertCategory>(x => x.AlertCategory).WithMany(c => c.AlertTypes).HasForeignKey(x => x.AlertCategoryId).HasConstraintName(AlertType.AlertCategoryForeignKeyName);
         builder.HasData(
             new AlertType { AlertTypeId = Guid.Parse("2ca98658-1d5b-49d5-b05f-cc08c8b8502c"), AlertCategoryId = Guid.Parse("ee78d44d-abf8-44a9-b22b-87a821f8d3c9"), Name = "Teacher sanctioned in other EEA member state", DqtSanctionCode = "T8", ProhibitionLevel = ProhibitionLevel.Notify, InternalOnly = true, IsActive = true, DisplayOrder = 1 },
             new AlertType { AlertTypeId = Guid.Parse("9fafaa80-f9f8-44a0-b7b3-cffedcbe0298"), AlertCategoryId = Guid.Parse("0ae0707b-1503-477d-bc0f-1505ed95dbdf"), Name = "Failed induction", DqtSanctionCode = "C2", ProhibitionLevel = ProhibitionLevel.Teaching, InternalOnly = false, IsActive = true, DisplayOrder = 2 },

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
@@ -12,7 +12,7 @@ public class QualificationMapping : IEntityTypeConfiguration<Qualification>
         builder.HasQueryFilter(q => EF.Property<DateTime?>(q, nameof(Qualification.DeletedOn)) == null);
         builder.HasDiscriminator(q => q.QualificationType)
             .HasValue<MandatoryQualification>(QualificationType.MandatoryQualification);
-        builder.HasOne<Person>().WithMany().HasForeignKey(q => q.PersonId).HasConstraintName(Qualification.PersonForeignKeyName);
+        builder.HasOne<Person>().WithMany(p => p.Qualifications).HasForeignKey(q => q.PersonId).HasConstraintName(Qualification.PersonForeignKeyName);
         builder.HasIndex(q => q.PersonId);
         builder.HasIndex(q => q.DqtQualificationId).HasFilter("dqt_qualification_id is not null").IsUnique();
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
@@ -1,3 +1,5 @@
+using EntityFrameworkCore.Projectables;
+
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class Alert
@@ -8,6 +10,7 @@ public class Alert
     public const string PersonForeignKeyName = "fk_alerts_person";
 
     public required Guid AlertId { get; init; }
+    public AlertType AlertType { get; } = null!;
     public required Guid AlertTypeId { get; init; }
     public required Guid PersonId { get; init; }
     public required string? Details { get; init; }
@@ -17,6 +20,7 @@ public class Alert
     public required DateTime CreatedOn { get; init; }
     public required DateTime UpdatedOn { get; set; }
     public DateTime? DeletedOn { get; set; }
+    [Projectable] public bool IsActive => EndDate == null;
 
     public Guid? DqtSanctionId { get; set; }
     public int? DqtState { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/AlertType.cs
@@ -10,6 +10,7 @@ public class AlertType
 
     public required Guid AlertTypeId { get; init; }
     public required Guid AlertCategoryId { get; init; }
+    public AlertCategory AlertCategory { get; } = null!;
     public required string Name { get; init; }
     public required string? DqtSanctionCode { get; init; }
     public required ProhibitionLevel ProhibitionLevel { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -13,6 +13,8 @@ public class Person
     public required DateOnly? DateOfBirth { get; set; }  // A few DQT records in prod have a null DOB
     public string? EmailAddress { get; set; }
     public string? NationalInsuranceNumber { get; set; }
+    public ICollection<Qualification> Qualifications { get; } = new List<Qualification>();
+    public ICollection<Alert> Alerts { get; } = new List<Alert>();
 
     public Guid? DqtContactId { get; init; }
     public DateTime? DqtFirstSync { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -102,7 +102,8 @@ public class TrsDbContext : DbContext
         optionsBuilder
             .UseSnakeCaseNamingConvention()
             .UseOpenIddict<Guid>()
-            .AddInterceptors(new PopulateOidcApplicationInterceptor());
+            .AddInterceptors(new PopulateOidcApplicationInterceptor())
+            .UseProjectables();
     }
 
     public void AddEvent(EventBase @event, DateTime? inserted = null)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -134,6 +134,7 @@
     <PackageReference Include="DistributedLock.Azure" />
     <PackageReference Include="DistributedLock.FileSystem" />
     <PackageReference Include="EFCore.NamingConventions" />
+    <PackageReference Include="EntityFrameworkCore.Projectables" />
     <PackageReference Include="Google.Cloud.Storage.V1" />
     <PackageReference Include="GovukNotify" />
     <PackageReference Include="Hangfire.Core" />


### PR DESCRIPTION
This adds navigation properties from `Alert` to `AlertType` and from `AlertType` to `AlertCategory` so we can more easily write queries that return alerts, their type and their category.
I've added an `Alerts` property to `Person` (and `Qualifications`) too.

In addition this adds `EntityFrameworkCore.Projectables` so that we can have queries that include computed properties but run on the DB. In this case we're using it for a new `IsActive` property on `Alert`.