### PR TITLE
Tidy rate limiting configuration

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/RateLimiting/ClientIdRateLimiterOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/RateLimiting/ClientIdRateLimiterOptions.cs
@@ -1,7 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace TeachingRecordSystem.Api.Infrastructure.RateLimiting;
 
 public class ClientIdRateLimiterOptions
 {
-    public required FixedWindowOptions DefaultRateLimit { get; set; } = new FixedWindowOptions { Window = TimeSpan.FromMinutes(1), PermitLimit = 300 };
-    public IDictionary<string, FixedWindowOptions>? ClientRateLimits { get; set; }
+    [Required]
+    public required FixedWindowOptions DefaultRateLimit { get; set; }
+
+    public required Dictionary<string, FixedWindowOptions> ClientRateLimits { get; set; } = [];
 }


### PR DESCRIPTION
This removes the duplicate client ID lookup and revises the configuration setup to be more consistent with how we usually do it.