### PR TITLE
Amend DeletedOn to match migration time

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -905,22 +905,10 @@ public class TrsDataSyncHelper(
                 }
             }
 
-            // If the record is deactivated we should have an AlertDqtDeactivatedEvent or AlertDqtImportedEvent (with inactive status)
+            // If the record is deactivated then it's migrated as deleted
             if (s.StateCode == dfeta_sanctionState.Inactive)
             {
-                var lastEvent = events.Last();
-
-                if (lastEvent is AlertDqtDeactivatedEvent or AlertDqtImportedEvent { DqtState: (int)dfeta_qualificationState.Inactive })
-                {
-                    mapped.DeletedOn = lastEvent.CreatedUtc;
-                }
-                else
-                {
-                    throw new InvalidOperationException(
-                        $"Expected last event to be a {nameof(AlertDqtDeactivatedEvent)} or {nameof(AlertDqtImportedEvent)}" +
-                        $" but was {lastEvent.GetEventName()}" +
-                        $" (sanction ID: '{s.Id}').");
-                }
+                mapped.DeletedOn = clock.UtcNow;
             }
             else if (createMigratedEvent)
             {


### PR DESCRIPTION
We're migrating deactivated alerts as deleted, just as we did for MQs. Until now we've used the deactivation time as the 'deleted on' timestamp. That's causing problems as it assumes the deactivation is the last action yet some production records have been updated _after_ their deactivation. (This would give us an audit trail that says a record has been updated after it's been deleted which clearly doesn't make sense.)

This change amends the migration process to use `$now` as the 'deleted on' timestamp. That way, we'll never have any audit records appearing after the 'deleted on' timestamp.