### PR TITLE
Add Alerts to sync service

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241007154621_AlertDqtSyncFields.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241007154621_AlertDqtSyncFields.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241007154621_AlertDqtSyncFields")]
+    partial class AlertDqtSyncFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241007154621_AlertDqtSyncFields.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241007154621_AlertDqtSyncFields.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AlertDqtSyncFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "dqt_first_sync",
+                table: "alerts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "dqt_last_sync",
+                table: "alerts",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "dqt_first_sync",
+                table: "alerts");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_last_sync",
+                table: "alerts");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
@@ -23,6 +23,8 @@ public class Alert
     [Projectable] public bool IsOpen => EndDate == null;
 
     public Guid? DqtSanctionId { get; set; }
+    public DateTime? DqtFirstSync { get; set; }
+    public DateTime? DqtLastSync { get; set; }
     public int? DqtState { get; set; }
     public DateTime? DqtCreatedOn { get; set; }
     public DateTime? DqtModifiedOn { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0031_TrsAlertsSyncMetadata.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0031_TrsAlertsSyncMetadata.sql
@@ -1,0 +1,2 @@
+alter table trs_alerts add dqt_first_sync datetime
+alter table trs_alerts add dqt_last_sync datetime

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -783,10 +783,10 @@ public class TrsDataSyncHelper(
 
         var insertStatement =
             $"""
-            INSERT INTO {tableName} AS t ({columnList})
-            SELECT {columnList} FROM {tempTableName}
+            INSERT INTO {tableName} AS t ({columnList}, dqt_first_sync, dqt_last_sync)
+            SELECT {columnList}, {NowParameterName}, {NowParameterName} FROM {tempTableName}
             ON CONFLICT (alert_id) DO UPDATE
-            SET {string.Join(", ", columnsToUpdate.Select(c => $"{c} = EXCLUDED.{c}"))}
+            SET dqt_last_sync = {NowParameterName}, {string.Join(", ", columnsToUpdate.Select(c => $"{c} = EXCLUDED.{c}"))}
             WHERE t.dqt_modified_on < EXCLUDED.dqt_modified_on
             """;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -63,6 +63,7 @@ public class TrsDataSyncService(
         // Order is important here; the dependees should come before dependents
         await SyncIfEnabled(TrsDataSyncHelper.ModelTypes.Person);
         await SyncIfEnabled(TrsDataSyncHelper.ModelTypes.Event);
+        await SyncIfEnabled(TrsDataSyncHelper.ModelTypes.Alert);
 
         async Task SyncIfEnabled(string modelType)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -63,6 +63,7 @@
     <None Remove="Services\DqtReporting\Migrations\0028_TrsEstablishments.sql" />
     <None Remove="Services\DqtReporting\Migrations\0029_TrsPersons.sql" />
     <None Remove="Services\DqtReporting\Migrations\0030_TrsAlerts.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0031_TrsAlertsSyncMetadata.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -124,6 +125,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0028_TrsEstablishments.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0029_TrsPersons.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0030_TrsAlerts.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0031_TrsAlertsSyncMetadata.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
@@ -76,7 +76,8 @@
     "PollIntervalSeconds": 60,
     "ModelTypes": [
       "Person",
-      "Event"
+      "Event",
+      "Alert"
     ],
     "IgnoreInvalidData": false,
     "RunService": false


### PR DESCRIPTION
This adds alerts to the sync service so that TRS and the DQT reporting DB are updated in near-real time. I've added the `dqt_{first|last}_sync` tracking columns too.