### PR TITLE
Fixed keyed service registration for .NET service update

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -75,7 +75,7 @@
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageVersion Include="RedisRateLimiting.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="Respawn" Version="6.1.0" />
-    <PackageVersion Include="Scrutor" Version="4.2.2" />
+    <PackageVersion Include="Scrutor" Version="5.0.1" />
     <PackageVersion Include="Sentry.AspNetCore" Version="4.9.0" />
     <PackageVersion Include="Sentry.Extensions.Logging" Version="4.9.0" />
     <PackageVersion Include="Sentry.Serilog" Version="4.9.0" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Xrm.Sdk;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.TestCommon.Infrastructure.FakeXrmEasy.FakeMessageExecutors;
 using TeachingRecordSystem.TestCommon.Infrastructure.FakeXrmEasy.Plugins;
 
@@ -59,6 +60,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IXrmFakedContext>(fakedXrmContext);
         var organizationService = fakedXrmContext.GetAsyncOrganizationService2();
         services.AddDefaultServiceClient(ServiceLifetime.Singleton, _ => organizationService);
+        services.AddNamedServiceClient(TrsDataSyncService.CrmClientName, ServiceLifetime.Singleton, _ => organizationService);
 
         fakedXrmContext.CallerProperties.CallerId = CreateTestUser();
 


### PR DESCRIPTION
A .NET service release has changed behavior around keyed service registrations in a way that breaks things for us. This fixes things.