### PR TITLE
Unify change reason field names in events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
@@ -8,6 +8,6 @@ public record class AlertCreatedEvent : EventBase, IEventWithPersonId, IEventWit
     public string? Key { get; init; }
     public required Guid PersonId { get; init; }
     public required Alert Alert { get; init; }
-    public required string? Reason { get; init; }
+    public required string? AddReasonDetail { get; init; }
     public required File? EvidenceFile { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDeletedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDeletedEvent.cs
@@ -7,6 +7,6 @@ public record class AlertDeletedEvent : EventBase, IEventWithPersonId, IEventWit
 {
     public required Guid PersonId { get; init; }
     public required Alert Alert { get; init; }
-    public required string? Reason { get; init; }
+    public required string? DeletionReasonDetail { get; init; }
     public required File? EvidenceFile { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
@@ -9,7 +9,7 @@ public record class AlertUpdatedEvent : EventBase, IEventWithPersonId, IEventWit
     public required Guid PersonId { get; init; }
     public required Alert Alert { get; init; }
     public required Alert OldAlert { get; init; }
-    public required string? ChangeReason { get; init; }
+    public required string? ChangeReasonDetail { get; init; }
     public required File? EvidenceFile { get; init; }
     public required AlertUpdatedEventChanges Changes { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -930,7 +930,7 @@ public class TrsDataSyncHelper(
                 RaisedBy = EventModels.RaisedByUserInfo.FromDqtUser(snapshot.UserId, snapshot.UserName),
                 PersonId = snapshot.Entity.dfeta_PersonId.Id,
                 Alert = GetEventAlert(snapshot.Entity, applyMigrationMappings: false),
-                Reason = null,
+                AddReasonDetail = null,
                 EvidenceFile = null,
             };
         }
@@ -997,7 +997,7 @@ public class TrsDataSyncHelper(
                 PersonId = snapshot.Entity.dfeta_PersonId.Id,
                 Alert = GetEventAlert(snapshot.Entity, applyMigrationMappings: false),
                 OldAlert = GetEventAlert(previous.Entity, applyMigrationMappings: false),
-                ChangeReason = null,
+                ChangeReasonDetail = null,
                 EvidenceFile = null,
                 Changes = changes
             };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
@@ -68,7 +68,7 @@ public class CheckAnswersModel(
             RaisedBy = User.GetUserId(),
             PersonId = PersonId,
             Alert = EventModels.Alert.FromModel(alert),
-            Reason = Reason,
+            AddReasonDetail = Reason,
             EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
                 new EventModels.File()
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -65,7 +65,7 @@ public class CheckAnswersModel(
             PersonId = PersonId,
             Alert = EventModels.Alert.FromModel(alert),
             OldAlert = oldAlertEventModel,
-            ChangeReason = ChangeReason,
+            ChangeReasonDetail = ChangeReason,
             EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
             new EventModels.File()
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Confirm.cshtml.cs
@@ -96,7 +96,7 @@ public class ConfirmModel(
             RaisedBy = User.GetUserId(),
             PersonId = PersonId,
             Alert = EventModels.Alert.FromModel(alert),
-            Reason = HasAdditionalDetail == true ? AdditionalDetail : null,
+            DeletionReasonDetail = HasAdditionalDetail == true ? AdditionalDetail : null,
             EvidenceFile = evidenceFileId is Guid fileId ?
                 new EventModels.File()
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
@@ -65,7 +65,7 @@ public class CheckAnswersModel(
                 PersonId = PersonId,
                 Alert = EventModels.Alert.FromModel(alert),
                 OldAlert = oldAlertEventModel,
-                ChangeReason = ChangeReason,
+                ChangeReasonDetail = ChangeReason,
                 EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
                 new EventModels.File()
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
@@ -65,7 +65,7 @@ public class CheckAnswersModel(
                 PersonId = PersonId,
                 Alert = EventModels.Alert.FromModel(alert),
                 OldAlert = oldAlertEventModel,
-                ChangeReason = ChangeReason,
+                ChangeReasonDetail = ChangeReason,
                 EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
                 new EventModels.File()
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
@@ -63,7 +63,7 @@ public class CheckAnswersModel(
             PersonId = PersonId,
             Alert = EventModels.Alert.FromModel(alert),
             OldAlert = oldAlertEventModel,
-            ChangeReason = ChangeReason,
+            ChangeReasonDetail = ChangeReason,
             EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
             new EventModels.File()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/CheckAnswersTests.cs
@@ -160,7 +160,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 CreatedUtc = Clock.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
-                Reason = reason,
+                AddReasonDetail = reason,
                 Alert = new()
                 {
                     AlertId = Guid.Empty,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -206,7 +206,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     StartDate = originalAlert.StartDate,
                     EndDate = null
                 },
-                ChangeReason = changeReason == CloseAlertReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                ChangeReasonDetail = changeReason == CloseAlertReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
                 EvidenceFile = new()
                 {
                     FileId = evidenceFileId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/ConfirmTests.cs
@@ -312,7 +312,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
                 CreatedUtc = Clock.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
-                Reason = additionalDetail,
+                DeletionReasonDetail = additionalDetail,
                 Alert = new()
                 {
                     AlertId = Guid.Empty,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
@@ -198,7 +198,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     StartDate = originalAlert.StartDate,
                     EndDate = databaseEndDate
                 },
-                ChangeReason = changeReason == AlertChangeEndDateReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                ChangeReasonDetail = changeReason == AlertChangeEndDateReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
                 EvidenceFile = new()
                 {
                     FileId = evidenceFileId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
@@ -198,7 +198,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     StartDate = databaseStartDate,
                     EndDate = originalAlert.EndDate
                 },
-                ChangeReason = changeReason == AlertChangeStartDateReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                ChangeReasonDetail = changeReason == AlertChangeStartDateReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
                 EvidenceFile = new()
                 {
                     FileId = evidenceFileId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
@@ -203,7 +203,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     StartDate = originalAlert.StartDate,
                     EndDate = originalAlert.EndDate
                 },
-                ChangeReason = changeReason == ReopenAlertReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                ChangeReasonDetail = changeReason == ReopenAlertReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
                 EvidenceFile = new()
                 {
                     FileId = evidenceFileId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -774,7 +774,7 @@ public partial class TestData
                 RaisedBy = createdByUser,
                 Alert = TeachingRecordSystem.Core.Events.Models.Alert.FromModel(alert),
                 PersonId = personId,
-                Reason = reason,
+                AddReasonDetail = reason,
                 EvidenceFile = null
             };
 


### PR DESCRIPTION
The change reason field names in our Alert events are different from those for MQs. This unifies them.