### PR TITLE
Move feature flag detection into a FeatureProvider type

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureNames.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.SupportUi;
+
+public static class FeatureNames
+{
+    public const string Alerts = "Alerts";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureProvider.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.SupportUi;
+
+public class FeatureProvider(IConfiguration configuration)
+{
+    private readonly HashSet<string> _features = new(configuration.GetSection("EnabledFeatures").Get<string[]>() ?? [], StringComparer.OrdinalIgnoreCase);
+
+    public bool IsEnabled(string featureName) => _features.Contains(featureName);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireFeatureEnabledFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireFeatureEnabledFilter.cs
@@ -3,12 +3,11 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
-public class RequireFeatureEnabledFilter(IConfiguration configuration, string featureName) : IResourceFilter
+public class RequireFeatureEnabledFilter(FeatureProvider featureProvider, string featureName) : IResourceFilter
 {
     public void OnResourceExecuting(ResourceExecutingContext context)
     {
-        var features = configuration.GetSection("EnabledFeatures").Get<List<string>>();
-        if (features is null || !features.Contains(featureName))
+        if (!featureProvider.IsEnabled(featureName))
         {
             context.Result = new NotFoundResult();
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/_ViewImports.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/_ViewImports.cshtml
@@ -6,3 +6,4 @@
 @addTagHelper *, GovUk.Frontend.AspNetCore
 @addTagHelper *, TeachingRecordSystem.SupportUi
 @inject TeachingRecordSystem.SupportUi.TrsLinkGenerator LinkGenerator
+@inject TeachingRecordSystem.SupportUi.FeatureProvider FeatureProvider

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -101,7 +101,7 @@ builder.Services
             "/Alerts",
             model =>
             {
-                model.Filters.Add(new RequireFeatureEnabledFilterFactory("Alerts"));
+                model.Filters.Add(new RequireFeatureEnabledFilterFactory(FeatureNames.Alerts));
             });
 
         options.Conventions.AddFolderApplicationModelConvention(
@@ -251,6 +251,7 @@ builder.Services
     .AddSingleton<ReferenceDataCache>()
     .AddSingleton<SanctionTextLookup>()
     .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>()
+    .AddSingleton<FeatureProvider>()
     .AddFileService()
     .AddPersonMatching();
 


### PR DESCRIPTION
We need to be able to check for enabled filters in views as well as the existing `IResourceFilter`. This moves all the logic into a `FeatureProvider` type. It also adds a `FeatureNames` class where we can list all the feature names.