### PR TITLE
Only use impersonation for DQT write actions

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/CrmQueryDispatcherExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/CrmQueryDispatcherExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+
+namespace TeachingRecordSystem.SupportUi;
+
+public static class CrmQueryDispatcherExtensions
+{
+    public static ICrmQueryDispatcher WithDqtUserImpersonation(this ICrmQueryDispatcher dispatcher) =>
+        new CrmQueryDispatcherWithDqtUserImpersonation(dispatcher as CrmQueryDispatcher ??
+            throw new InvalidOperationException($"{nameof(ICrmQueryDispatcher)} is not a {nameof(CrmQueryDispatcher)}."));
+
+    private class CrmQueryDispatcherWithDqtUserImpersonation(CrmQueryDispatcher innerDispatcher) : ICrmQueryDispatcher
+    {
+        public Task<TResult> ExecuteQuery<TResult>(ICrmQuery<TResult> query) =>
+            innerDispatcher.ExecuteQuery(GetOrganizationService, query);
+
+        public IAsyncEnumerable<TResult> ExecuteQuery<TResult>(IEnumerableCrmQuery<TResult> query, CancellationToken cancellationToken = default) =>
+            innerDispatcher.ExecuteQuery(GetOrganizationService, query, cancellationToken);
+
+        private IOrganizationServiceAsync GetOrganizationService(IServiceProvider serviceProvider)
+        {
+            var organizationService = innerDispatcher.GetOrganizationService(serviceProvider);
+
+            // Horrible check if to see if we're running Tests with FakeXrmEasy. If we are, we can't do impersonation.
+            if (organizationService.GetType().FullName == "Castle.Proxies.ObjectProxy_2")
+            {
+                return organizationService;
+            }
+
+            var serviceClient = organizationService as ServiceClient ??
+                throw new InvalidOperationException($"{nameof(IOrganizationServiceAsync)} is not a {nameof(ServiceClient)}.");
+
+            var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+            var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext.");
+            var dqtUserId = httpContext.User.GetDqtUserId();
+
+            serviceClient.CallerId = dqtUserId;
+
+            return serviceClient;
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AssignUserInfoOnSignIn.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AssignUserInfoOnSignIn.cs
@@ -72,7 +72,7 @@ public class AssignUserInfoOnSignIn(string name) : IConfigureNamedOptions<OpenId
 
             async Task<Guid?> GetDqtUserId()
             {
-                var organizationService = ctx.HttpContext.RequestServices.GetRequiredKeyedService<IOrganizationServiceAsync>("WithoutImpersonation");
+                var organizationService = ctx.HttpContext.RequestServices.GetRequiredService<IOrganizationServiceAsync>();
 
                 var request = new QueryByAttribute(SystemUser.EntityLogicalName);
                 request.AddAttributeValue(SystemUser.Fields.AzureActiveDirectoryObjectId, new Guid(aadUserId));

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
@@ -44,7 +44,7 @@ public class AcceptModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
-        _ = await _crmQueryDispatcher.ExecuteQuery(new ApproveIncidentQuery(IncidentDetail!.Incident.Id));
+        await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(new ApproveIncidentQuery(IncidentDetail!.Incident.Id));
 
         TempData.SetFlashSuccess(
             $"The request has been accepted",
@@ -55,7 +55,7 @@ public class AcceptModel : PageModel
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        IncidentDetail = await _crmQueryDispatcher.ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
+        IncidentDetail = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
         if (IncidentDetail is null)
         {
             context.Result = NotFound();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Index.cshtml.cs
@@ -32,7 +32,7 @@ public partial class IndexModel : PageModel
 
     public async Task<IActionResult> OnGet()
     {
-        var incidentDetail = await _crmQueryDispatcher.ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
+        var incidentDetail = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
         if (incidentDetail is null)
         {
             return NotFound();
@@ -49,7 +49,7 @@ public partial class IndexModel : PageModel
     }
     public async Task<IActionResult> OnGetDocuments(Guid id)
     {
-        var document = await _crmQueryDispatcher.ExecuteQuery(new GetDocumentByIdQuery(id));
+        var document = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(new GetDocumentByIdQuery(id));
         var annotation = document?.Extract<Annotation>("annotation", Annotation.PrimaryIdAttribute);
 
         if (document is null || annotation is null)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
@@ -51,11 +51,11 @@ public class RejectModel : PageModel
             requestStatus = "cancelled";
             flashMessage = "The user’s record has not been changed and they have not been notified.";
 
-            _ = await _crmQueryDispatcher.ExecuteQuery(new CancelIncidentQuery(IncidentDetail!.Incident.Id));
+            _ = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(new CancelIncidentQuery(IncidentDetail!.Incident.Id));
         }
         else
         {
-            _ = await _crmQueryDispatcher.ExecuteQuery(new RejectIncidentQuery(IncidentDetail!.Incident.Id, RejectionReasonChoice.Value.GetDisplayName()!));
+            _ = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(new RejectIncidentQuery(IncidentDetail!.Incident.Id, RejectionReasonChoice.Value.GetDisplayName()!));
         }
 
         TempData.SetFlashSuccess(
@@ -67,7 +67,7 @@ public class RejectModel : PageModel
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        IncidentDetail = await _crmQueryDispatcher.ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
+        IncidentDetail = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(new GetIncidentByTicketNumberQuery(TicketNumber));
         if (IncidentDetail is null)
         {
             context.Result = NotFound();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDateOfBirth/Confirm.cshtml.cs
@@ -31,7 +31,7 @@ public class ConfirmModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
-        await _crmQueryDispatcher.ExecuteQuery(
+        await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(
             new UpdateContactDateOfBirthQuery(
                 PersonId,
                 JourneyInstance!.State.DateOfBirth));
@@ -52,7 +52,7 @@ public class ConfirmModel : PageModel
             return;
         }
 
-        var person = await _crmQueryDispatcher.ExecuteQuery(
+        var person = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(
             new GetActiveContactDetailByIdQuery(
                 PersonId,
                 new ColumnSet(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditName/Confirm.cshtml.cs
@@ -31,7 +31,7 @@ public class ConfirmModel : PageModel
 
     public async Task<IActionResult> OnPost()
     {
-        await _crmQueryDispatcher.ExecuteQuery(
+        await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(
             new UpdateContactNameQuery(
                 PersonId,
                 JourneyInstance!.State.FirstName,
@@ -54,7 +54,7 @@ public class ConfirmModel : PageModel
             return;
         }
 
-        var person = await _crmQueryDispatcher.ExecuteQuery(
+        var person = await _crmQueryDispatcher.WithDqtUserImpersonation().ExecuteQuery(
             new GetActiveContactDetailByIdQuery(
                 PersonId,
                 new ColumnSet(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml
@@ -16,15 +16,15 @@
 
             @if (!Model.HasCrmAccount)
             {
-                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-crm-account-warning">User does not have an account in CRM.<br />The user will not be able to access the TRS Console.</govuk-warning-text>
+                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-crm-account-warning">User does not have an account in CRM.<br />Some functionality will not be available.</govuk-warning-text>
             }
             else if (Model.CrmAccountIsDisabled)
             {
-                <govuk-warning-text icon-fallback-text="Warning" data-testid="disabled-crm-account-warning">User CRM account is disabled.<br />The user will not be able to access the TRS Console.</govuk-warning-text>
+                <govuk-warning-text icon-fallback-text="Warning" data-testid="disabled-crm-account-warning">User CRM account is disabled.<br />Some functionality will not be available.</govuk-warning-text>
             }
             else if (Model.DqtRoles is null || Model.DqtRoles.Length == 0)
             {
-                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-dqt-roles-warning">User does not have any roles in CRM.<br />The user will not be able to access the TRS Console.</govuk-warning-text>
+                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-dqt-roles-warning">User does not have any roles in CRM.<br />Some functionality will not be available.</govuk-warning-text>
             }
 
             <govuk-input asp-for="Email" label-class="govuk-label--m" type="email" disabled />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml
@@ -16,15 +16,15 @@
 
             @if (!Model.HasCrmAccount)
             {
-                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-crm-account-warning">User does not have an account in CRM.<br />The user will not be able to access the TRS Console.</govuk-warning-text>
+                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-crm-account-warning">User does not have an account in CRM.<br />Some functionality will not be available.</govuk-warning-text>
             }
             else if (Model.CrmAccountIsDisabled)
             {
-                <govuk-warning-text icon-fallback-text="Warning" data-testid="disabled-crm-account-warning">User CRM account is disabled.<br />The user will not be able to access the TRS Console.</govuk-warning-text>
+                <govuk-warning-text icon-fallback-text="Warning" data-testid="disabled-crm-account-warning">User CRM account is disabled.<br />Some functionality will not be available.</govuk-warning-text>
             }
             else if (Model.DqtRoles is null || Model.DqtRoles.Length == 0)
             {
-                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-dqt-roles-warning">User does not have any roles in CRM.<br />The user will not be able to access the TRS Console.</govuk-warning-text>
+                <govuk-warning-text icon-fallback-text="Warning" data-testid="no-dqt-roles-warning">User does not have any roles in CRM.<br />Some functionality will not be available.</govuk-warning-text>
             }
 
             <govuk-input asp-for="Email" label-class="govuk-label--m" type="email" disabled />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -205,25 +205,7 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
         RetryPauseTime = TimeSpan.FromSeconds(1)
     };
 
-    builder.Services.AddDefaultServiceClient(
-        ServiceLifetime.Transient,
-        sp =>
-        {
-            var sc = serviceClient.Clone();
-
-            var httpContext = sp.GetRequiredService<IHttpContextAccessor>().HttpContext;
-            if (httpContext?.User?.Identity?.IsAuthenticated == true)
-            {
-                sc.CallerId = httpContext.User.GetDqtUserId();
-            }
-
-            return sc;
-        });
-
-    builder.Services.AddNamedServiceClient(
-        "WithoutImpersonation",
-        ServiceLifetime.Transient,
-        _ => serviceClient.Clone());
+    builder.Services.AddDefaultServiceClient(ServiceLifetime.Transient, _ => serviceClient.Clone());
 
     builder.Services.AddHealthChecks()
         .AddCheck("CRM", () => serviceClient.IsReady ? HealthCheckResult.Healthy() : HealthCheckResult.Degraded());


### PR DESCRIPTION
Currently the TRS Console requires each user to have an account in DQT so that we can use impersonation in API calls. We do this so that data changes have a ‘real’ user’s name in the audit history instead of a generic ‘TRS’ user. However, relatively few pages in the console are writing data to DQT.

This change adds a `WithDqtUserImpersonation()` extension method that can be used to selectively opt-in to user impersonation per-call. It's used in the few places where we write data to DQT only.