### PR TITLE
Amend filter that checks a person exists to check TRS first

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
@@ -12,6 +12,15 @@ public static class HttpContextExtensions
     public static void SetCurrentPersonFeature(this HttpContext context, CurrentPersonFeature currentPersonInfo) =>
         context.Features.Set(currentPersonInfo);
 
+    public static void SetCurrentPersonFeature(this HttpContext context, Person person) =>
+        SetCurrentPersonFeature(
+            context,
+            new CurrentPersonFeature(
+                person.PersonId,
+                person.FirstName,
+                person.MiddleName,
+                person.LastName));
+
     public static void SetCurrentPersonFeature(this HttpContext context, ContactDetail contactDetail) =>
         SetCurrentPersonFeature(
             context,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.UpdatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.UpdatePerson.cs
@@ -58,6 +58,8 @@ public partial class TestData
                         LastName = _updatedName.Value.LastName
                     }
                 });
+
+                await testData.SyncConfiguration.SyncIfEnabled(helper => helper.SyncPerson(_personId.Value, ignoreInvalid: false));
             }
         }
     }


### PR DESCRIPTION
Instead of going to DQT to get the person then checking it exists in TRS, go to TRS first and only go to DQT if the TRS lookup failed.