### PR TITLE
Split CI test execution into multiple jobs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,12 +11,89 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
-    name: Build & test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
 
-    outputs:
-      run_crm_integration_tests: ${{ steps.check_changed_files.outputs.run_crm_integration_tests }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: extractions/setup-just@v2
+
+      - name: Install tools
+        run: just install-tools
+
+      - name: Lint
+        run: |
+          git fetch origin main --quiet --depth=1
+          CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA | { grep -oP '^TeachingRecordSystem\/\K.*\.cs(proj)?$' || true; })
+
+          if [ "$CHANGED_FILES" == "" ]; then
+            echo "::notice::No changes to lint"
+            exit 0
+          fi
+
+          # If project files have changed then dependencies may have been updated, which may effect lint results (e.g. namespace imports);
+          # lint everything.
+          if [ $(echo "$CHANGED_FILES" | grep -c '\.csproj$') -gt 0 ]; then
+            INCLUDE_ARG=""
+            echo "::notice::Linting entire codebase"
+          else
+            INCLUDE_ARG="--include $(echo "$CHANGED_FILES" | grep '\.cs$' | tr '\n' ' ')"
+            echo "::notice::Linting changed files only"
+          fi
+
+          dotnet format --no-restore --verify-no-changes $INCLUDE_ARG
+        working-directory: TeachingRecordSystem
+
+  validate_terraform:
+    name: Validate Terraform
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.5.0
+
+      - name: Check formatting
+        run: terraform fmt -check -diff
+        working-directory: terraform/aks
+
+      - name: Validate
+        run: |
+          curl -sL https://github.com/coretech/terrafile/releases/download/v0.8/terrafile_0.8_Linux_x86_64.tar.gz | tar xz terrafile
+          ./terrafile -p vendor/modules -f config/dev_Terrafile
+          terraform init -backend=false
+          terraform validate -no-color
+        working-directory: terraform/aks
+
+      - name: Lint
+        uses: reviewdog/action-tflint@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tflint_rulesets: azurerm
+          working_directory: terraform/aks
+        continue-on-error: true # temporary- we're getting sporadic 503 errors here in action setup
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          [
+            TeachingRecordSystem.Core.Tests,
+            TeachingRecordSystem.Api.Tests,
+            TeachingRecordSystem.SupportUi.Tests,
+            TeachingRecordSystem.AuthorizeAccess.Tests,
+            TeachingRecordSystem.SupportUi.EndToEndTests,
+            TeachingRecordSystem.AuthorizeAccess.EndToEndTests,
+          ]
 
     services:
       postgres:
@@ -25,6 +102,7 @@ jobs:
           POSTGRES_PASSWORD: trs
           POSTGRES_DB: trs
         options: >-
+          --name postgres
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
@@ -33,159 +111,75 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
+      - name: Set postgres wal_level to logical
+        run: |
+          docker exec -i postgres bash << EOF
+          echo "wal_level = logical" >> /var/lib/postgresql/data/postgresql.conf
+          EOF
 
-    - uses: extractions/setup-just@v2
+          docker restart --time 0 postgres
 
-    - name: Install tools
-      run: just install-tools
+      - uses: actions/checkout@v4
 
-    - name: Restore
-      run: just restore
+      - uses: extractions/setup-just@v2
 
-    - name: Lint
-      run: |
-        git fetch origin main --quiet --depth=1
-        CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA | { grep -oP '^TeachingRecordSystem\/\K.*\.cs(proj)?$' || true; })
+      - name: Install tools
+        run: just install-tools
 
-        if [ "$CHANGED_FILES" == "" ]; then
-          echo "::notice::No changes to lint"
-          exit 0
-        fi
+      - name: Restore
+        run: just restore
 
-        # If project files have changed then dependencies may have been updated, which may effect lint results (e.g. namespace imports);
-        # lint everything.
-        if [ $(echo "$CHANGED_FILES" | grep -c '\.csproj$') -gt 0 ]; then
-          INCLUDE_ARG=""
-          echo "::notice::Linting entire codebase"
-        else
-          INCLUDE_ARG="--include $(echo "$CHANGED_FILES" | grep '\.cs$' | tr '\n' ' ')"
-          echo "::notice::Linting changed files only"
-        fi
+      - name: Build project
+        run: dotnet build -c Release --no-restore
+        working-directory: TeachingRecordSystem/tests/${{ matrix.project }}
 
-        dotnet format --no-restore --verify-no-changes $INCLUDE_ARG
-      working-directory: TeachingRecordSystem
+      - name: Check for Playwright
+        run: |
+          playwright_script=./bin/Release/net8.0/playwright.ps1
+          if [ -f $playwright_script ]; then
+            pwsh $playwright_script install
+          fi
+        working-directory: TeachingRecordSystem/tests/${{ matrix.project }}
 
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-      working-directory: TeachingRecordSystem
+      - name: Run tests
+        uses: ./.github/workflows/actions/test
+        with:
+          test_project_path: TeachingRecordSystem/tests/${{ matrix.project }}
+          report_name: "${{ matrix.project }} test results"
+          dotnet_test_args: >-
+            --no-build
+            -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
+        timeout-minutes: 10
 
-    - name: Check changed files
-      id: check_changed_files
-      run: |
-        # If no CRM integration files (or their tests) have been changed in this PR then skip CRM integration tests
-        RUN_CRM_INTEGRATION_TESTS=true
-        git fetch origin main --quiet --depth=1
-        CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA)
-        if [[ $(echo "$CHANGED_FILES" | grep -EL "TeachingRecordSystem.Core.Dqt") ]]; then
-          RUN_CRM_INTEGRATION_TESTS=false
-        fi
-
-        echo run_crm_integration_tests=$RUN_CRM_INTEGRATION_TESTS >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Core tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests
-        report_name: "Core test results"
-        dotnet_test_args: >-
-          --no-build
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-      timeout-minutes: 5
-
-    - name: API tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests
-        report_name: "API test results"
-        dotnet_test_args: >-
-          --no-build
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-      timeout-minutes: 5
-
-    - name: Support UI tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests
-        report_name: "Support UI test results"
-        dotnet_test_args: >-
-          --no-build
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-      timeout-minutes: 10
-
-    - name: Authorize access tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests
-        report_name: "Authorize access test results"
-        dotnet_test_args: >-
-          --no-build
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-      timeout-minutes: 5
-
-    - name: Install Playwright
-      run: pwsh ./tests/TeachingRecordSystem.SupportUi.EndToEndTests/bin/Release/net8.0/playwright.ps1 install
-      working-directory: TeachingRecordSystem
-
-    - name: Support UI end-to-end tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests
-        report_name: "Support UI end-to-end test results"
-        dotnet_test_args: >-
-          --no-build
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-      timeout-minutes: 5
-
-    - name: Authorize access end-to-end tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests
-        report_name: "Authorize access end-to-end test results"
-        dotnet_test_args: >-
-          --no-build
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-      timeout-minutes: 5
-
-  validate_terraform:
-    name: Validate Terraform
+  check_dqt_integration_changes:
+    name: Check for DQT integration changes
     runs-on: ubuntu-latest
 
+    outputs:
+      run_crm_integration_tests: ${{ steps.check_changed_files.outputs.run_crm_integration_tests }}
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.5.0
+      - name: Check changed files
+        id: check_changed_files
+        run: |
+          # If no CRM integration files (or their tests) have been changed in this PR then skip CRM integration tests
+          RUN_CRM_INTEGRATION_TESTS=true
+          git fetch origin main --quiet --depth=1
+          CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA)
+          if [[ $(echo "$CHANGED_FILES" | grep -EL "TeachingRecordSystem.Core.Dqt") ]]; then
+            RUN_CRM_INTEGRATION_TESTS=false
+          fi
 
-    - name: Check formatting
-      run: terraform fmt -check -diff
-      working-directory: terraform/aks
-
-    - name: Validate
-      run: |
-        curl -sL https://github.com/coretech/terrafile/releases/download/v0.8/terrafile_0.8_Linux_x86_64.tar.gz | tar xz terrafile
-        ./terrafile -p vendor/modules -f config/dev_Terrafile
-        terraform init -backend=false
-        terraform validate -no-color
-      working-directory: terraform/aks
-
-    - name: Lint
-      uses: reviewdog/action-tflint@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        tflint_rulesets: azurerm
-        working_directory: terraform/aks
-      continue-on-error: true  # temporary- we're getting sporadic 503 errors here in action setup
+          echo run_crm_integration_tests=$RUN_CRM_INTEGRATION_TESTS >> $GITHUB_OUTPUT
+        shell: bash
 
   dqt_tests:
     name: DQT integration tests
     runs-on: ubuntu-latest
-    needs: [build]
-    if: ${{ needs.build.outputs.run_crm_integration_tests == 'true' }}
+    needs: [check_dqt_integration_changes]
+    if: ${{ needs.check_dqt_integration_changes.outputs.run_crm_integration_tests == 'true' }}
     concurrency: dqt-tests
 
     env:
@@ -221,60 +215,60 @@ jobs:
           --health-retries 3
 
     steps:
-    - name: Set postgres wal_level to logical
-      run: |
-        docker exec -i postgres bash << EOF
-        echo "wal_level = logical" >> /var/lib/postgresql/data/postgresql.conf
-        EOF
+      - name: Set postgres wal_level to logical
+        run: |
+          docker exec -i postgres bash << EOF
+          echo "wal_level = logical" >> /var/lib/postgresql/data/postgresql.conf
+          EOF
 
-        docker restart --time 0 postgres
+          docker restart --time 0 postgres
 
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v2
 
-    - uses: Azure/login@v2
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - uses: Azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - uses: Azure/get-keyvault-secrets@v1
-      name: Get secrets
-      id: get_secrets
-      with:
-        keyvault: s165d01-dqtapi-dv-kv
-        secrets: INTEGRATION-TEST-CONFIG
+      - uses: Azure/get-keyvault-secrets@v1
+        name: Get secrets
+        id: get_secrets
+        with:
+          keyvault: s165d01-dqtapi-dv-kv
+          secrets: INTEGRATION-TEST-CONFIG
 
-    - name: Install tools
-      run: just install-tools
+      - name: Install tools
+        run: just install-tools
 
-    - name: Create test reporting database
-      run: docker exec $(docker ps --latest --quiet) /opt/mssql-tools18/bin/sqlcmd -C -U "sa" -P "$MSSQL_PASSWORD" -Q "create database $MSSQL_DB; alter database $MSSQL_DB set ALLOW_SNAPSHOT_ISOLATION on;"
+      - name: Create test reporting database
+        run: docker exec $(docker ps --latest --quiet) /opt/mssql-tools18/bin/sqlcmd -C -U "sa" -P "$MSSQL_PASSWORD" -Q "create database $MSSQL_DB; alter database $MSSQL_DB set ALLOW_SNAPSHOT_ISOLATION on;"
 
-    - name: Get test filter
-      id: test_filter
-      run: |
-        # If no DataverseAdapter files (or their tests) have been changed in this PR then filter out related tests
-        DOTNET_TEST_FILTER=""
-        git fetch origin main --quiet --depth=1
-        CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA)
-        if [[ $(echo "$CHANGED_FILES" | grep -EL "DataverseAdapter") ]]; then
-          echo "::notice::Skipping DataverseAdapter tests"
-          DOTNET_TEST_FILTER='--filter "FullyQualifiedName!~TeachingRecordSystem.Core.Dqt.CrmIntegrationTests.DataverseAdapterTests"'
-        fi
+      - name: Get test filter
+        id: test_filter
+        run: |
+          # If no DataverseAdapter files (or their tests) have been changed in this PR then filter out related tests
+          DOTNET_TEST_FILTER=""
+          git fetch origin main --quiet --depth=1
+          CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA)
+          if [[ $(echo "$CHANGED_FILES" | grep -EL "DataverseAdapter") ]]; then
+            echo "::notice::Skipping DataverseAdapter tests"
+            DOTNET_TEST_FILTER='--filter "FullyQualifiedName!~TeachingRecordSystem.Core.Dqt.CrmIntegrationTests.DataverseAdapterTests"'
+          fi
 
-        echo filter_arg=$DOTNET_TEST_FILTER >> $GITHUB_OUTPUT
+          echo filter_arg=$DOTNET_TEST_FILTER >> $GITHUB_OUTPUT
 
-    - name: Run tests
-      uses: ./.github/workflows/actions/test
-      with:
-        test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests
-        report_name: "DQT integration test results"
-        dotnet_test_args: >-
-          -e DqtReporting__ReportingDbConnectionString="Data Source=(local); Initial Catalog=${{ env.MSSQL_DB }}; User=sa; Password=${{ env.MSSQL_PASSWORD }}; TrustServerCertificate=True"
-          -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-          ${{ steps.test_filter.outputs.filter_arg }}
-        config_json: ${{ steps.get_secrets.outputs.INTEGRATION-TEST-CONFIG }}
-      timeout-minutes: 45
+      - name: Run tests
+        uses: ./.github/workflows/actions/test
+        with:
+          test_project_path: TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests
+          report_name: "DQT integration test results"
+          dotnet_test_args: >-
+            -e DqtReporting__ReportingDbConnectionString="Data Source=(local); Initial Catalog=${{ env.MSSQL_DB }}; User=sa; Password=${{ env.MSSQL_PASSWORD }}; TrustServerCertificate=True"
+            -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
+            ${{ steps.test_filter.outputs.filter_arg }}
+          config_json: ${{ steps.get_secrets.outputs.INTEGRATION-TEST-CONFIG }}
+        timeout-minutes: 45
 
   package:
     name: Package application
@@ -283,7 +277,7 @@ jobs:
 
   deploy_dev:
     name: Deploy dev environment
-    needs: [build, validate_terraform, package]
+    needs: [lint, validate_terraform, tests, package]
     uses: ./.github/workflows/deploy-dev.yml
     with:
       docker_image: ${{ needs.package.outputs.docker_image }}


### PR DESCRIPTION
Until now we've run tests sequentially in the same job (aside from DQT integration tests). This moves each project into its own job that can be run in parallel. I've also removed the upfront solution build step (since it's already being done by the package process).

Combined, these changes more than half our PR workflow run times.