### PR TITLE
Handle empty TRN in bulk search endpoint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
             echo "::notice::Linting changed files only"
           fi
 
-          dotnet format --no-restore --verify-no-changes $INCLUDE_ARG
+          dotnet format --verify-no-changes $INCLUDE_ARG
         working-directory: TeachingRecordSystem
 
   validate_terraform:

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonsByTrnAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/FindPersonsByTrnAndDateOfBirth.cs
@@ -35,7 +35,7 @@ public class FindPersonsByTrnAndDateOfBirthHandler(
     {
         var contacts = await crmQueryDispatcher.ExecuteQuery(
             new GetActiveContactsByTrnsQuery(
-                command.Persons.Select(p => p.Trn).Distinct(),
+                command.Persons.Select(p => p.Trn).Where(trn => !string.IsNullOrEmpty(trn)).Distinct(),
                 new ColumnSet(
                     Contact.Fields.dfeta_TRN,
                     Contact.Fields.BirthDate,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByTrnsHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetActiveContactsByTrnsHandler.cs
@@ -12,6 +12,13 @@ public class GetActiveContactsByTrnsHandler :
         GetActiveContactsByTrnsQuery query,
         IOrganizationServiceAsync organizationService)
     {
+        var trns = query.Trns.ToArray();
+
+        if (trns.Length == 0)
+        {
+            return new Dictionary<string, Contact?>();
+        }
+
         var queryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = query.ColumnSet,
@@ -20,7 +27,7 @@ public class GetActiveContactsByTrnsHandler :
                 Conditions =
                 {
                     new ConditionExpression(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active),
-                    new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.In, query.Trns.ToArray())
+                    new ConditionExpression(Contact.Fields.dfeta_TRN, ConditionOperator.In, trns)
                 }
             }
         };


### PR DESCRIPTION
We've got an error in Sentry caused by a missing TRN passed to a CRM query. This adds a check that TRNs aren't empty before running the query.