### PR TITLE
Return newest ITT records first

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetPerson.cs
@@ -379,6 +379,7 @@ public class GetPersonHandler(
                         Provider = MapIttProvider(i),
                         Subjects = MapSubjects(i)
                     })
+                    .OrderByDescending(i => i.StartDate)
                     .AsReadOnly()) :
                 default,
             NpqQualifications = command.Include.HasFlag(GetPersonCommandIncludes.NpqQualifications) ?


### PR DESCRIPTION
API users with the AB role only get ITT provider name so there's no way of knowing which ITT record is the latest. This change means the newest ITT record will be returned first.