### PR TITLE
Move mapping logic into response class

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
@@ -55,31 +55,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
             return NotFound();
         }
 
-        var response = mapper.Map<GetPersonResponse>(result);
-
-        if (User.IsInRole(ApiRoles.AppropriateBody))
-        {
-            response = response with
-            {
-                InitialTeacherTraining = response.InitialTeacherTraining
-                    .Map(itts => itts
-                        .Select(itt => new GetPersonResponseInitialTeacherTraining()
-                        {
-                            Provider = itt.Provider,
-                            Qualification = default,
-                            StartDate = default,
-                            EndDate = default,
-                            ProgrammeType = default,
-                            ProgrammeTypeDescription = default,
-                            Result = default,
-                            AgeRange = default,
-                            Subjects = default
-                        })
-                        .Where(itt => itt.Provider is not null)
-                        .AsReadOnly())
-            };
-        }
-
+        var response = GetPersonResponse.Map(result, mapper, User.IsInRole(ApiRoles.AppropriateBody));
         return Ok(response);
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/GetPersonResponse.cs
@@ -15,6 +15,36 @@ public partial record GetPersonResponse
     public required Option<IReadOnlyCollection<Alert>> Alerts { get; init; }
     public required Option<GetPersonResponseInduction?> Induction { get; init; }
     public required Option<IReadOnlyCollection<GetPersonResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
+
+    public static GetPersonResponse Map(GetPersonResult result, IMapper mapper, bool userHasAppropriateBodyRole)
+    {
+        var response = mapper.Map<GetPersonResponse>(result);
+
+        if (userHasAppropriateBodyRole)
+        {
+            response = response with
+            {
+                InitialTeacherTraining = response.InitialTeacherTraining
+                    .Map(itts => itts
+                        .Select(itt => new GetPersonResponseInitialTeacherTraining()
+                        {
+                            Provider = itt.Provider,
+                            Qualification = default,
+                            StartDate = default,
+                            EndDate = default,
+                            ProgrammeType = default,
+                            ProgrammeTypeDescription = default,
+                            Result = default,
+                            AgeRange = default,
+                            Subjects = default
+                        })
+                        .Where(itt => itt.Provider is not null)
+                        .AsReadOnly())
+            };
+        }
+
+        return response;
+    }
 }
 
 [AutoMap(typeof(GetPersonResultInduction))]


### PR DESCRIPTION
This moves the special AB mapping logic out of the `PersonsController` and into the response class itself. We don't want to have to repeat all this logic for subsequent API versions in the controller action.

In future we should look at moving all the mapping logic into the `Response` classes but I've left that for another day.