### PR TITLE
Reduce API replicas to 3

### DIFF
--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -9,7 +9,7 @@
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": true,
   "enable_logit": true,
-  "api_replicas": 4,
+  "api_replicas": 3,
   "api_max_memory": "4Gi",
   "authz_replicas": 2,
   "ui_replicas": 2,


### PR DESCRIPTION
We increased the API replicas from 2 to 4 to mitigate an incident recently but we've since solved the problem. This drops the replicas down to 3. Assuming that doesn't cause any issues overnight we can further reduce back down to 2 tomorrow.