### PR TITLE
Shorten the session lifetime for the TRS Console

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -53,7 +53,7 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
     var graphApiScopes = new[] { "User.Read", "User.ReadBasic.All" };
 
     builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
-        .AddMicrosoftIdentityWebApp(builder.Configuration, "AzureAd")
+        .AddMicrosoftIdentityWebApp(builder.Configuration, "AzureAd", cookieScheme: CookieAuthenticationDefaults.AuthenticationScheme)
         .EnableTokenAcquisitionToCallDownstreamApi(initialScopes: graphApiScopes)
         .AddDistributedTokenCaches()
         .AddMicrosoftGraph(defaultScopes: graphApiScopes);
@@ -63,6 +63,7 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
     builder.Services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme, options =>
     {
         options.Cookie.Name = "trs-auth";
+        options.Cookie.MaxAge = TimeSpan.FromHours(8);
 
         options.Events.OnSigningOut = ctx =>
         {


### PR DESCRIPTION
We've got folks who have an old authentication cookie who are still signed in but we've since changed their roles and they're not 'seeing' the change. Also, we should force users to sign in at least once a day. This adds an 8 hour lifetime to the authentication cookie.