### PR TITLE
Add a page for updating signed in user's roles

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureNames.cs
@@ -3,4 +3,5 @@ namespace TeachingRecordSystem.SupportUi;
 public static class FeatureNames
 {
     public const string Alerts = "Alerts";
+    public const string SwitchRoles = "SwitchRoles";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireFeatureEnabledFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireFeatureEnabledFilter.cs
@@ -18,7 +18,8 @@ public class RequireFeatureEnabledFilter(FeatureProvider featureProvider, string
     }
 }
 
-public class RequireFeatureEnabledFilterFactory(string featureName) : IFilterFactory, IOrderedFilter
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class RequireFeatureEnabledFilterFactoryAttribute(string featureName) : Attribute, IFilterFactory, IOrderedFilter
 {
     public bool IsReusable => false;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/Conventions.cs
@@ -11,7 +11,7 @@ public class Conventions : IConfigureFolderConventions
             this.GetFolderPathFromNamespace(),
             model =>
             {
-                model.Filters.Add(new RequireFeatureEnabledFilterFactory(FeatureNames.Alerts));
+                model.Filters.Add(new RequireFeatureEnabledFilterFactoryAttribute(FeatureNames.Alerts));
             });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/MyRoles.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/MyRoles.cshtml
@@ -1,0 +1,23 @@
+@page "/my-roles"
+@model TeachingRecordSystem.SupportUi.Pages.MyRolesModel
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.MyRoles);
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form asp-page="MyRoles" method="post">
+            <govuk-checkboxes asp-for="MyRoles">
+                <govuk-checkboxes-fieldset>
+                    <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--l" />
+                    @foreach (var role in Model.AllRoles)
+                    {
+                        <govuk-checkboxes-item value="@role">@UserRoles.GetDisplayNameForRole(role)</govuk-checkboxes-item>
+                    }
+                </govuk-checkboxes-fieldset>
+            </govuk-checkboxes>
+
+            <govuk-button type="submit">Save</govuk-button>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/MyRoles.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/MyRoles.cshtml.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages;
+
+[RequireFeatureEnabledFilterFactory(FeatureNames.SwitchRoles)]
+public class MyRolesModel : PageModel
+{
+    public IReadOnlyCollection<string> AllRoles => UserRoles.All;
+
+    [Display(Name = "My roles")]
+    [BindProperty]
+    public string[]? MyRoles { get; set; }
+
+    public void OnGet()
+    {
+        MyRoles = User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray();
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        var newRoles = MyRoles ?? [];
+
+        var identity = (ClaimsIdentity)User.Identity!;
+
+        // Remove any existing Role claims
+        foreach (var claim in identity.Claims.Where(c => c.Type == ClaimTypes.Role).ToArray())
+        {
+            identity.RemoveClaim(claim);
+        }
+
+        // Add a Role claim for every selected role
+        foreach (var role in newRoles)
+        {
+            identity.AddClaim(new Claim(ClaimTypes.Role, role));
+        }
+
+        var authenticateResult = await HttpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        var properties = authenticateResult.Properties!;
+        properties.RedirectUri = Url.Page("MyRoles");
+
+        TempData.SetFlashSuccess("Roles updated");
+
+        return SignIn(
+            User,
+            properties,
+            authenticationScheme: CookieAuthenticationDefaults.AuthenticationScheme);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -160,7 +160,6 @@ builder.Services
     .AddSingleton<FeatureProvider>()
     .AddTransient<ICurrentUserIdProvider, HttpContextCurrentUserIdProvider>()
     .AddTransient<CheckMandatoryQualificationExistsFilter>()
-    .AddTransient<CheckAlertExistsFilter>()
     .AddTransient<CheckUserExistsFilter>()
     .AddTransient<RequireClosedAlertFilter>()
     .AddTransient<RequireOpenAlertFilter>()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
@@ -1,3 +1,4 @@
 {
-  "DetailedErrors": true
+  "DetailedErrors": true,
+  "EnabledFeatures": [ "Alerts", "SwitchRoles" ]
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
@@ -6,5 +6,6 @@
         "Microsoft.AspNetCore": "Fatal"
       }
     }
-  }
+  },
+  "EnabledFeatures": [ "Alerts" ]
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Testing.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Testing.json
@@ -7,5 +7,6 @@
       }
     }
   },
-  "ConcurrentNameChangeWindowSeconds": 1
+  "ConcurrentNameChangeWindowSeconds": 1,
+  "EnabledFeatures": [ "Alerts" ]
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
@@ -13,6 +13,5 @@
     "SignedOutCallbackPath": "/signout-oidc"
   },
   "AllowedHosts": "*",
-  "ConcurrentNameChangeWindowSeconds": 5,
-  "EnabledFeatures": [ "Alerts" ]
+  "ConcurrentNameChangeWindowSeconds": 5
 }


### PR DESCRIPTION
For testing UI that's affected by the current user's role it's useful to be able to easily swap the roles of the signed in user. This adds such a page at `/my-roles`, controlled by a feature flag (which will obviously never be enabled in production).

There are no tests for this since this is a debugging aid and our tests don't work the same way w.r.t. authentication so it would be difficult to test any way.