### PR TITLE
Aligned End date journey with designs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
@@ -19,7 +19,7 @@
                     <govuk-summary-list-row-key>New end date</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="new-end-date">@Model.NewEndDate!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDate(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="new endd date">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDate(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="new end date">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
@@ -19,7 +19,7 @@
                     <govuk-summary-list-row-key>New end date</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="new-end-date">@Model.NewEndDate!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDate(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDate(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="new endd date">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
@@ -28,9 +28,25 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value><multi-line-text text="@Model.ChangeReason" data-testid="change-reason" /></govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@Model.ChangeReason.GetDisplayName()</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Reason details</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.ChangeReasonDetail is not null)
+                        {
+                            <multi-line-text text="@Model.ChangeReasonDetail" />
+                        }
+                        else
+                        {
+                            <span use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
@@ -46,7 +62,7 @@
                         }
                     </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertEditEndDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
         <form action="@LinkGenerator.AlertEditEndDateCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post">
-            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <span class="govuk-caption-l">Change closed alert - @Model.PersonName</span>
             <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
             <govuk-summary-list data-testid="change-summary">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
@@ -31,7 +31,9 @@ public class CheckAnswersModel(
 
     public DateOnly? CurrentEndDate { get; set; }
 
-    public string? ChangeReason { get; set; }
+    public AlertChangeEndDateReasonOption ChangeReason { get; set; }
+
+    public string? ChangeReasonDetail { get; set; }
 
     public string? EvidenceFileName { get; set; }
 
@@ -65,8 +67,8 @@ public class CheckAnswersModel(
                 PersonId = PersonId,
                 Alert = EventModels.Alert.FromModel(alert),
                 OldAlert = oldAlertEventModel,
-                ChangeReason = null!,
-                ChangeReasonDetail = ChangeReason,  // FIXME
+                ChangeReason = ChangeReason.GetDisplayName(),
+                ChangeReasonDetail = ChangeReasonDetail,
                 EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
                     new EventModels.File()
                     {
@@ -109,9 +111,8 @@ public class CheckAnswersModel(
         PersonName = personInfo.Name;
         NewEndDate = JourneyInstance!.State.EndDate;
         CurrentEndDate = alertInfo.Alert.EndDate;
-        ChangeReason = JourneyInstance.State.ChangeReason != AlertChangeEndDateReasonOption.AnotherReason ?
-            JourneyInstance.State.ChangeReason!.GetDisplayName() :
-            JourneyInstance!.State.ChangeReasonDetail;
+        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
+        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance!.State.EvidenceFileId!.Value, _fileUrlExpiresAfter) :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateState.cs
@@ -19,6 +19,8 @@ public class EditAlertEndDateState : IRegisterJourney
 
     public AlertChangeEndDateReasonOption? ChangeReason { get; set; }
 
+    public bool? HasAdditionalReasonDetail { get; set; }
+
     public string? ChangeReasonDetail { get; set; }
 
     public bool? UploadEvidence { get; set; }
@@ -33,7 +35,7 @@ public class EditAlertEndDateState : IRegisterJourney
     [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(UploadEvidence), nameof(EvidenceFileId))]
     public bool IsComplete => EndDate is not null &&
         ChangeReason.HasValue &&
-        (ChangeReason.Value == AlertChangeEndDateReasonOption.AnotherReason ? !string.IsNullOrWhiteSpace(ChangeReasonDetail) : true) &&
+        HasAdditionalReasonDetail.HasValue &&
         UploadEvidence.HasValue &&
         (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.AlertEditEndDateReason(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
-            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <span class="govuk-caption-l">Change closed alert - @Model.PersonName</span>
             <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
             <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
@@ -25,9 +25,21 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@AlertChangeEndDateReasonOption.AnotherReason">
                         @AlertChangeEndDateReasonOption.AnotherReason.GetDisplayName()
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-radios asp-for="HasAdditionalReasonDetail">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@true">
+                        Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="4000" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="@ReasonModel.ChangeReasonDetailMaxLength" />
                         </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
@@ -12,6 +12,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileService) : PageModel
 {
     public const int MaxFileSizeMb = 50;
+    public const int ChangeReasonDetailMaxLength = 4000;
 
     private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
 
@@ -33,11 +34,17 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
     public AlertChangeEndDateReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    [Display(Name = "Enter details")]
+    [Display(Name = "Do you want to add more information about why you’re changing the end date?")]
+    [Required(ErrorMessage = "Select yes if you want to add more information about why you’re changing the end date")]
+    public bool? HasAdditionalReasonDetail { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Add additional detail")]
+    [MaxLength(ChangeReasonDetailMaxLength, ErrorMessage = "Additional detail must be 4000 characters or less")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
-    [Display(Name = "Upload evidence")]
+    [Display(Name = "Do you want to upload evidence?")]
     [Required(ErrorMessage = "Select yes if you want to upload evidence")]
     public bool? UploadEvidence { get; set; }
 
@@ -57,6 +64,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
     public async Task OnGet()
     {
         ChangeReason = JourneyInstance!.State.ChangeReason;
+        HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
         EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
@@ -69,9 +77,9 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     public async Task<IActionResult> OnPost()
     {
-        if (ChangeReason == AlertChangeEndDateReasonOption.AnotherReason && string.IsNullOrWhiteSpace(ChangeReasonDetail))
+        if (HasAdditionalReasonDetail == true && ChangeReasonDetail is null)
         {
-            ModelState.AddModelError(nameof(ChangeReasonDetail), "Enter details");
+            ModelState.AddModelError(nameof(ChangeReasonDetail), "Enter additional detail");
         }
 
         if (UploadEvidence == true && EvidenceFileId is null && EvidenceFile is null)
@@ -117,6 +125,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
+            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
             state.ChangeReasonDetail = ChangeReasonDetail;
             state.UploadEvidence = UploadEvidence;
         });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Playwright;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
 
@@ -194,7 +195,8 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
         var personId = person.PersonId;
         var alertId = person.Alerts.First().AlertId;
         var newEndDate = TestData.Clock.Today.AddDays(-5);
-        var changeReason = TestData.GenerateLoremIpsum();
+        var reason = AlertChangeEndDateReasonOption.AnotherReason;
+        var reasonDetail = TestData.GenerateLoremIpsum();
         var evidenceFileName = "evidence.jpg";
         var evidenceFileMimeType = "image/jpeg";
 
@@ -211,10 +213,10 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditAlertEndDateChangeReasonPage(alertId);
 
-        await page.CheckAsync("label:text-is('Another reason')");
-        await page.FillAsync("label:text-is('Enter details')", changeReason);
-
-        await page.CheckAsync("label:text-is('Yes')");
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{reason.GetDisplayName()}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re changing the end date?')").Locator("label:text-is('Yes')").CheckAsync();
+        await page.FillAsync("label:text-is('Add additional detail')", reasonDetail);
+        await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
         await page
             .GetByLabel("Upload a file")
             .SetInputFilesAsync(


### PR DESCRIPTION
### Context

The designs for the Edit end date journey have evolved since they were first built.

### Changes proposed in this pull request

Align the implementation with the latest Figma designs.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
