### PR TITLE
Create users with required set of roles on the fly

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/RoleNamesData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/RoleNamesData.cs
@@ -7,8 +7,8 @@ public class RoleNamesData(params string[] except) : DataAttribute
 {
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        var allRoles = new object[] { ApiRoles.UpdateNpq, ApiRoles.UpdatePerson, ApiRoles.GetPerson, ApiRoles.UnlockPerson, ApiRoles.AssignQtls };
-        var excluded = allRoles.Except(except);
-        return new[] { new object[] { excluded } };
+        var allRoles = new string[] { ApiRoles.UpdateNpq, ApiRoles.UpdatePerson, ApiRoles.GetPerson, ApiRoles.UnlockPerson, ApiRoles.AssignQtls };
+        var roles = allRoles.Except(except);
+        return roles.Select(r => new object[] { new string[] { r } });
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -47,8 +47,7 @@ public class HostFixture : WebApplicationFactory<Program>
             PublishEventsDbCommandInterceptor.ConfigureServices(services);
 
             services.AddSingleton<CurrentUserProvider>();
-            services.AddStartupTask<TestUsers.CreateUsersStartupTask>();
-
+            services.AddSingleton<TestUsers>();
             services.AddSingleton<IEventPublisher>(_ => new ForwardToTestScopedEventPublisher());
             services.AddTestScoped<IClock>(tss => tss.Clock);
             services.AddTestScoped<IDataverseAdapter>(tss => tss.DataverseAdapterMock.Object);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/CheckAnswersTests.cs
@@ -6,14 +6,14 @@ public class CheckAnswersTests : TestBase
 {
     public CheckAnswersTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
@@ -143,7 +143,7 @@ public class CheckAnswersTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).Where(a => a.IsActive).RandomOne();
         var details = "Some details";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/DetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/DetailsTests.cs
@@ -6,14 +6,14 @@ public class DetailsTests : TestBase
 {
     public DetailsTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
 
@@ -120,7 +120,7 @@ public class DetailsTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/LinkTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/LinkTests.cs
@@ -6,14 +6,14 @@ public class LinkTests : TestBase
 {
     public LinkTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
@@ -131,7 +131,7 @@ public class LinkTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/ReasonTests.cs
@@ -6,14 +6,14 @@ public class ReasonTests : TestBase
 {
     public ReasonTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var personId = Guid.NewGuid();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
@@ -166,7 +166,7 @@ public class ReasonTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
@@ -6,14 +6,14 @@ public class StartDateTests : TestBase
 {
     public StartDateTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
@@ -140,7 +140,7 @@ public class StartDateTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/TypeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/TypeTests.cs
@@ -7,14 +7,14 @@ public class TypeTests : TestBase
 {
     public TypeTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
 
@@ -67,7 +67,7 @@ public class TypeTests : TestBase
     public async Task Get_UserHasDbsAlertReadWriteRole_ShowsDbsAlertType()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson();
 
@@ -88,7 +88,7 @@ public class TypeTests : TestBase
     public async Task Get_UserDoesNotHaveDbsAlertReadWriteRole_DoesNotShowDbsAlertType()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NonDbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var person = await TestData.CreatePerson();
 
@@ -109,7 +109,7 @@ public class TypeTests : TestBase
     public async Task Get_UserHasAlertsReadWriteRole_ShowsAllNonDbsRoles()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NonDbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var person = await TestData.CreatePerson();
 
@@ -131,7 +131,7 @@ public class TypeTests : TestBase
     public async Task Get_UserDoesNotHaveAlertsReadWriteRole_DoesNotShowAnyNonDbsRoles()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson();
 
@@ -178,7 +178,7 @@ public class TypeTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AlertDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AlertDetailsTests.cs
@@ -6,7 +6,7 @@ public class AlertDetailsTests : TestBase
 {
     public AlertDetailsTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class AlertDetailsTests : TestBase
     public async Task Get_AlertIsDbsAlertAndUserDoesNotHavePermissionToRead_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(b => b
             .WithAlert(a => a.WithStartDate(new(2024, 1, 1)).WithEndDate(new(2024, 10, 10)).WithAlertTypeId(AlertType.DbsAlertTypeId)));
@@ -91,7 +91,7 @@ public class AlertDetailsTests : TestBase
     public async Task Get_AlertIsDbsAlertAndUserDoesHavePermissionToRead_ReturnsOk()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadOnly));
 
         var person = await TestData.CreatePerson(b => b
             .WithAlert(a => a.WithStartDate(new(2024, 1, 1)).WithEndDate(new(2024, 10, 10)).WithAlertTypeId(AlertType.DbsAlertTypeId)));
@@ -111,7 +111,7 @@ public class AlertDetailsTests : TestBase
     public async Task Get_AlertIsDbsAlertAndUserDoesHavePermissionToReadAndWrite_ReturnsOk()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson(b => b
             .WithAlert(a => a.WithStartDate(new(2024, 1, 1)).WithEndDate(new(2024, 10, 10)).WithAlertTypeId(AlertType.DbsAlertTypeId)));
@@ -131,7 +131,7 @@ public class AlertDetailsTests : TestBase
     public async Task Get_DbsAlertAndUserDoesNotHaveWritePermission_DoesNotShowChangeLinks()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadOnly));
 
         var person = await TestData.CreatePerson(b => b
             .WithAlert(a => a.WithStartDate(new(2024, 1, 1)).WithEndDate(new(2024, 10, 10)).WithAlertTypeId(AlertType.DbsAlertTypeId)));
@@ -152,7 +152,7 @@ public class AlertDetailsTests : TestBase
     public async Task Get_DbsAlertAndUserDoesHaveWritePermission_DoesShowChangeLinks()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson(b => b
             .WithAlert(a => a.WithStartDate(new(2024, 1, 1)).WithEndDate(new(2024, 10, 10)).WithAlertTypeId(AlertType.DbsAlertTypeId)));
@@ -173,7 +173,7 @@ public class AlertDetailsTests : TestBase
     public async Task Get_NonDbsAlertAndUserDoesNotHaveWritePermission_DoesNotShowChangeLinks()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes(activeOnly: true)).RandomOneExcept(at => at.AlertTypeId == AlertType.DbsAlertTypeId);
         var person = await TestData.CreatePerson(b => b
@@ -195,7 +195,7 @@ public class AlertDetailsTests : TestBase
     public async Task Get_NonDbsAlertAndUserDoesHaveWritePermission_DoesShowChangeLinks()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NonDbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes(activeOnly: true)).RandomOneExcept(at => at.AlertTypeId == AlertType.DbsAlertTypeId);
         var person = await TestData.CreatePerson(b => b

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -6,7 +6,7 @@ public class CheckAnswersTests : TestBase
 {
     public CheckAnswersTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
@@ -6,7 +6,7 @@ public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
@@ -7,7 +7,7 @@ public class ReasonTests : TestBase
 {
     public ReasonTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/ConfirmTests.cs
@@ -6,14 +6,14 @@ public class ConfirmTests : TestBase
 {
     public ConfirmTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(b => b.WithAlert());
         var alert = person.Alerts.Single();
@@ -113,7 +113,7 @@ public class ConfirmTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(b => b.WithAlert());
         var alert = person.Alerts.Single();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/IndexTests.cs
@@ -6,14 +6,14 @@ public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(b => b.WithAlert());
         var alert = person.Alerts.Single();
@@ -115,7 +115,7 @@ public class IndexTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(b => b.WithAlert());
         var alert = person.Alerts.Single();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/CheckAnswersTests.cs
@@ -8,7 +8,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseDetails = TestData.GenerateLoremIpsum();
         var journeyDetails = TestData.GenerateLoremIpsum();
@@ -149,7 +149,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseDetails = TestData.GenerateLoremIpsum();
         var journeyDetails = TestData.GenerateLoremIpsum();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/IndexTests.cs
@@ -8,7 +8,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate).WithEndDate(null)));
@@ -102,7 +102,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseDetails = TestData.GenerateLoremIpsum();
         var newDetails = TestData.GenerateLoremIpsum();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/ReasonTests.cs
@@ -9,7 +9,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseDetails = TestData.GenerateLoremIpsum();
         var journeyDetails = TestData.GenerateLoremIpsum();
@@ -166,7 +166,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseDetails = TestData.GenerateLoremIpsum();
         var journeyDetails = TestData.GenerateLoremIpsum();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
@@ -6,14 +6,14 @@ public class CheckAnswersTests : TestBase
 {
     public CheckAnswersTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = TestData.Clock.Today.AddDays(-50);
         var databaseEndDate = TestData.Clock.Today.AddDays(-10);
@@ -264,7 +264,7 @@ public class CheckAnswersTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = TestData.Clock.Today.AddDays(-50);
         var databaseEndDate = TestData.Clock.Today.AddDays(-10);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/IndexTests.cs
@@ -6,7 +6,7 @@ public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/ReasonTests.cs
@@ -7,14 +7,14 @@ public class ReasonTests : TestBase
 {
     public ReasonTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = TestData.Clock.Today.AddDays(-50);
         var databaseEndDate = TestData.Clock.Today.AddDays(-10);
@@ -155,7 +155,7 @@ public class ReasonTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = TestData.Clock.Today.AddDays(-50);
         var databaseEndDate = TestData.Clock.Today.AddDays(-10);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/CheckAnswersTests.cs
@@ -8,7 +8,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseLink = TestData.GenerateUrl();
         var journeyLink = TestData.GenerateUrl();
@@ -151,7 +151,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseLink = TestData.GenerateUrl();
         var journeyLink = TestData.GenerateUrl();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/IndexTests.cs
@@ -6,14 +6,14 @@ public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate).WithEndDate(null)));
@@ -107,7 +107,7 @@ public class IndexTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var link = TestData.GenerateUrl();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/ReasonTests.cs
@@ -8,14 +8,14 @@ public class ReasonTests : TestBase
 {
     public ReasonTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(b => b.WithAlert());
         var alertId = person.Alerts.Single().AlertId;
@@ -170,7 +170,7 @@ public class ReasonTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseLink = TestData.GenerateUrl();
         var journeyLink = TestData.GenerateUrl();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
@@ -6,14 +6,14 @@ public class CheckAnswersTests : TestBase
 {
     public CheckAnswersTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var journeyStartDate = new DateOnly(2021, 10, 6);
@@ -260,7 +260,7 @@ public class CheckAnswersTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var journeyStartDate = new DateOnly(2021, 10, 6);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
@@ -6,14 +6,14 @@ public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate).WithEndDate(null)));
@@ -111,7 +111,7 @@ public class IndexTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = Clock.Today.AddDays(-20);
         var newStartDate = Clock.Today.AddDays(-18);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/ReasonTests.cs
@@ -7,14 +7,14 @@ public class ReasonTests : TestBase
 {
     public ReasonTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var journeyStartDate = new DateOnly(2021, 10, 6);
@@ -164,7 +164,7 @@ public class ReasonTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var journeyStartDate = new DateOnly(2021, 10, 6);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
@@ -6,7 +6,7 @@ public class CheckAnswersTests : TestBase
 {
     public CheckAnswersTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
@@ -6,7 +6,7 @@ public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture) : base(hostFixture)
     {
-        SetCurrentUser(TestUsers.AllAlertsWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKeyTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKeyTests.cs
@@ -8,7 +8,7 @@ public class AddApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var applicationUser = await TestData.CreateApplicationUser();
 
@@ -55,7 +55,7 @@ public class AddApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var applicationUser = await TestData.CreateApplicationUser();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKeyTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKeyTests.cs
@@ -6,7 +6,7 @@ public class EditApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var applicationUser = await TestData.CreateApplicationUser();
         var apiKey = await TestData.CreateApiKey(applicationUser.UserId);
@@ -90,7 +90,7 @@ public class EditApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task PostExpire_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var applicationUser = await TestData.CreateApplicationUser();
         var apiKey = await TestData.CreateApiKey(applicationUser.UserId, expired: false);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUserTests.cs
@@ -8,7 +8,7 @@ public class AddApplicationUserTests(HostFixture hostFixture) : TestBase(hostFix
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/application-users/add");
 
@@ -36,7 +36,7 @@ public class AddApplicationUserTests(HostFixture hostFixture) : TestBase(hostFix
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var name = TestData.GenerateApplicationUserName();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
@@ -9,7 +9,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var applicationUser = await TestData.CreateApplicationUser(apiRoles: []);
 
@@ -80,7 +80,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var applicationUser = await TestData.CreateApplicationUser(apiRoles: []);
         var originalName = applicationUser.Name;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/IndexTests.cs
@@ -5,13 +5,14 @@ public class IndexTests : TestBase
     public IndexTests(HostFixture hostFixture)
         : base(hostFixture)
     {
+        SetCurrentUser(TestUsers.GetUser(UserRoles.Helpdesk));
     }
 
     [Fact]
     public async Task Get_UserWithNoRoles_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
         var createPersonResult = await TestData.CreatePerson();
         var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
 
@@ -24,11 +25,12 @@ public class IndexTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_UserWithoutHelpdeskOrAdministratorRole_ReturnsForbidden()
+    [Theory]
+    [RoleNamesData(except: [UserRoles.Helpdesk, UserRoles.Administrator])]
+    public async Task Get_UserWithoutHelpdeskOrAdministratorRole_ReturnsForbidden(string role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.UnusedRole);
+        SetCurrentUser(TestUsers.GetUser(role));
         var createPersonResult = await TestData.CreatePerson();
         var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
 
@@ -45,7 +47,6 @@ public class IndexTests : TestBase
     public async Task Get_WithTicketNumberForNonExistentIncident_ReturnsNotFound()
     {
         // Arrange
-        SetCurrentUser(TestUsers.Helpdesk);
         var nonExistentTicketNumber = Guid.NewGuid().ToString();
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{nonExistentTicketNumber}");
@@ -61,7 +62,6 @@ public class IndexTests : TestBase
     public async Task Get_WithTicketNumberForInactiveIncident_ReturnsBadRequest()
     {
         // Arrange
-        SetCurrentUser(TestUsers.Helpdesk);
         var createPersonResult = await TestData.CreatePerson();
         var createIncidentResult = await TestData.CreateNameChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId).WithCanceledStatus());
 
@@ -85,7 +85,6 @@ public class IndexTests : TestBase
     public async Task Get_WithTicketNumberForActiveNameChangeIncident_RendersExpectedContent(bool hasNewFirstName, bool hasNewMiddleName, bool hasNewLastName)
     {
         // Arrange
-        SetCurrentUser(TestUsers.Helpdesk);
         var createPersonResult = await TestData.CreatePerson();
         var createIncidentResult = await TestData.CreateNameChangeIncident(
             b => b.WithCustomerId(createPersonResult.ContactId)
@@ -153,7 +152,6 @@ public class IndexTests : TestBase
     public async Task Get_WithTicketNumberForActiveDateOfBirthChangeIncident_RendersExpectedContent()
     {
         // Arrange
-        SetCurrentUser(TestUsers.Helpdesk);
         var createPersonResult = await TestData.CreatePerson();
         var createIncidentResult = await TestData.CreateDateOfBirthChangeIncident(b => b.WithCustomerId(createPersonResult.ContactId));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
@@ -118,7 +118,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHaveAddAlertPermission_DoesNotShowAddAnAlertButton()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson();
 
@@ -136,7 +136,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasAddDbsAlertPermission_DoesShowAddAnAlertButton()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NonDbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var person = await TestData.CreatePerson();
 
@@ -154,7 +154,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasAddNonDbsAlertPermission_DoesShowAddAnAlertButton()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson();
 
@@ -172,7 +172,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHaveReadPermissionToOpenDbsAlert_DoesNotShowAlertCard()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithEndDate(null)));
@@ -191,7 +191,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesHaveReadPermissionToOpenDbsAlert_DoesShowAlertCard()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadOnly));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithEndDate(null)));
@@ -210,7 +210,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadButNotWritePermissionToOpenDbsAlert_DoesNotShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadOnly));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithEndDate(null)));
@@ -234,7 +234,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadAndWritePermissionsToOpenDbsAlert_DoesShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithEndDate(null)));
@@ -258,7 +258,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadButNotWritePermissionToOpenNonDbsAlert_DoesNotShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes(activeOnly: true)).RandomOneExcept(at => at.AlertTypeId == AlertType.DbsAlertTypeId);
         var person = await TestData.CreatePerson(p => p
@@ -283,7 +283,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadAndWritePermissionsToOpenNonDbsAlert_DoesShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NonDbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes(activeOnly: true)).RandomOneExcept(at => at.AlertTypeId == AlertType.DbsAlertTypeId);
         var person = await TestData.CreatePerson(p => p
@@ -308,7 +308,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesNotHaveReadPermissionToClosedDbsAlert_DoesNotShowAlertRow()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithStartDate(new DateOnly(2024, 1, 1)).WithEndDate(new DateOnly(2024, 10, 1))));
@@ -327,7 +327,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserDoesHaveReadPermissionToClosedDbsAlert_DoesShowAlertRow()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadOnly));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithStartDate(new DateOnly(2024, 1, 1)).WithEndDate(new DateOnly(2024, 10, 1))));
@@ -346,7 +346,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadButNotWritePermissionToClosedDbsAlert_DoesNotShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadOnly));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithStartDate(new DateOnly(2024, 1, 1)).WithEndDate(new DateOnly(2024, 10, 1))));
@@ -369,7 +369,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadAndWritePermissionsToClosedDbsAlert_DoesShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithStartDate(new DateOnly(2024, 1, 1)).WithEndDate(new DateOnly(2024, 10, 1))));
@@ -392,7 +392,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadButNotWritePermissionToClosedNonDbsAlert_DoesNotShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes(activeOnly: true)).RandomOneExcept(at => at.AlertTypeId == AlertType.DbsAlertTypeId);
         var person = await TestData.CreatePerson(p => p
@@ -416,7 +416,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_UserHasReadAndWritePermissionsToClosedNonDbsAlert_DoesShowActions()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NonDbsAlertWriter);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes(activeOnly: true)).RandomOneExcept(at => at.AlertTypeId == AlertType.DbsAlertTypeId);
         var person = await TestData.CreatePerson(p => p
@@ -440,7 +440,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasOpenDbsAlertButUserCannotRead_ShowsFlagMessage()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithEndDate(null)));
@@ -459,7 +459,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasClosedDbsAlertAndUserCannotRead_DoesNotShowFlagMessage()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithStartDate(new DateOnly(2024, 1, 1)).WithEndDate(new DateOnly(2024, 10, 1))));
@@ -478,7 +478,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasOpenDbsAlertAndUserCanRead_DoesNotShowFlagMessage()
     {
         // Arrange
-        SetCurrentUser(TestUsers.DbsAlertReader);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadOnly));
 
         var person = await TestData.CreatePerson(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithStartDate(new DateOnly(2024, 1, 1)).WithEndDate(new DateOnly(2024, 10, 1))));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
@@ -10,7 +10,7 @@ public class ConfirmTests : TestBase
     public async Task Get_UserWithoutAdministratorRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var email = Faker.Internet.Email();
         var name = Faker.Name.FullName();
@@ -139,7 +139,7 @@ public class ConfirmTests : TestBase
     public async Task Post_UserWithoutAdministratorRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var email = Faker.Internet.Email();
         var name = Faker.Name.FullName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
@@ -10,7 +10,7 @@ public class IndexTests : TestBase
     public async Task Get_UserWithoutAdministratorRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
         var request = new HttpRequestMessage(HttpMethod.Get, "/users/add");
 
         // Act
@@ -37,7 +37,7 @@ public class IndexTests : TestBase
     public async Task Post_UserWithoutAdministratorRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
         var request = new HttpRequestMessage(HttpMethod.Post, "/users/add");
 
         // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
@@ -10,7 +10,7 @@ public class EditUserTests : TestBase
     public async Task Get_UserWithOutAdministratorRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
         var userId = Guid.NewGuid();
 
         var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(userId));
@@ -120,7 +120,7 @@ public class EditUserTests : TestBase
     public async Task Post_UserWithoutAdministratorRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var user = await TestData.CreateUser();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
@@ -12,7 +12,7 @@ public class UsersTests : TestBase
     public async Task Get_UserWithOutAdministratorRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var request = new HttpRequestMessage(HttpMethod.Get, RequestPath);
 
@@ -46,7 +46,6 @@ public class UsersTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser(roles: new[] { UserRoles.Administrator });
-        SetCurrentUser(TestUsers.Administrator);
 
         var request = new HttpRequestMessage(HttpMethod.Get, RequestPath);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/RoleNamesData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/RoleNamesData.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace TeachingRecordSystem.SupportUi.Tests;
+
+public class RoleNamesData(params string[] except) : DataAttribute
+{
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+    {
+        var allRoles = UserRoles.All;
+        var roles = allRoles.Except(except);
+        return roles.Select(r => new object[] { r });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -21,7 +21,7 @@ public abstract class TestBase : IDisposable
         HostFixture = hostFixture;
 
         _testServices = TestScopedServices.Reset();
-        SetCurrentUser(TestUsers.Administrator);
+        SetCurrentUser(TestUsers.GetUser(UserRoles.Administrator));
 
         HttpClient = hostFixture.CreateClient(new()
         {
@@ -52,6 +52,8 @@ public abstract class TestBase : IDisposable
     public HttpClient HttpClient { get; }
 
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
+
+    public TestUsers TestUsers => HostFixture.Services.GetRequiredService<TestUsers>();
 
     public IXrmFakedContext XrmFakedContext => HostFixture.Services.GetRequiredService<IXrmFakedContext>();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/PublishEventsDbCommandInterceptor.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/PublishEventsDbCommandInterceptor.cs
@@ -18,7 +18,14 @@ public class PublishEventsDbCommandInterceptor : SaveChangesInterceptor
 
     public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
-        throw new NotImplementedException();
+        var events = eventData.Context!.ChangeTracker.Entries<Event>();
+
+        if (events.Any())
+        {
+            throw new NotSupportedException();
+        }
+
+        return base.SavingChanges(eventData, result);
     }
 
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Until now we've had a fixed set of test users each with a different set of roles. Now that we're adding more roles and we want to test more combinations, this isn't quite sufficient. This change moves to create a users with a particular set of roles on the fly. We cache the created users so that we don't need to create a new user every time.

In addition, this adds a `RolesNamesDataAttribute` similar to what we have for the API. This returns all the roles, optionally excluding specified roles. With this we can create `Theory`s and test any combinations of roles we want to.