### PR TITLE
Aiigned close alert journey with designs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
         <form action="@LinkGenerator.AlertCloseCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post">
-            <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
+            <span class="govuk-caption-l">Close an alert - @Model.PersonName</span>
             <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
             <govuk-summary-list>
@@ -44,14 +44,30 @@
                     <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="end-date">@Model.EndDate!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AlertClose(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertClose(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value><multi-line-text text="@Model.ChangeReason" data-testid="change-reason" /></govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@Model.ChangeReason.GetDisplayName()</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Reason details</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.ChangeReasonDetail is not null)
+                        {
+                            <multi-line-text text="@Model.ChangeReasonDetail" />
+                        }
+                        else
+                        {
+                            <span use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
@@ -67,7 +83,7 @@
                         }
                     </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.Core.Services.Files;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 
-[Journey(JourneyNames.CloseAlert), ActivatesJourney, RequireJourneyInstance]
+[Journey(JourneyNames.CloseAlert), RequireJourneyInstance]
 public class CheckAnswersModel(
     TrsDbContext dbContext,
     TrsLinkGenerator linkGenerator,
@@ -38,7 +38,9 @@ public class CheckAnswersModel(
 
     public DateOnly? EndDate { get; set; }
 
-    public string? ChangeReason { get; set; }
+    public CloseAlertReasonOption ChangeReason { get; set; }
+
+    public string? ChangeReasonDetail { get; set; }
 
     public string? EvidenceFileName { get; set; }
 
@@ -65,8 +67,8 @@ public class CheckAnswersModel(
             PersonId = PersonId,
             Alert = EventModels.Alert.FromModel(alert),
             OldAlert = oldAlertEventModel,
-            ChangeReason = null!,
-            ChangeReasonDetail = ChangeReason,  // FIXME
+            ChangeReason = ChangeReason.GetDisplayName(),
+            ChangeReasonDetail = ChangeReasonDetail,
             EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
                 new EventModels.File()
                 {
@@ -112,9 +114,8 @@ public class CheckAnswersModel(
         Link = alertInfo.Alert.ExternalLink;
         StartDate = alertInfo.Alert.StartDate;
         EndDate = JourneyInstance!.State.EndDate;
-        ChangeReason = JourneyInstance.State.ChangeReason != CloseAlertReasonOption.AnotherReason ?
-            JourneyInstance.State.ChangeReason!.GetDisplayName() :
-            JourneyInstance!.State.ChangeReasonDetail;
+        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
+        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance!.State.EvidenceFileId!.Value, _fileUrlExpiresAfter) :

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
@@ -15,6 +15,8 @@ public class CloseAlertState : IRegisterJourney
 
     public CloseAlertReasonOption? ChangeReason { get; set; }
 
+    public bool? HasAdditionalReasonDetail { get; set; }
+
     public string? ChangeReasonDetail { get; set; }
 
     public bool? UploadEvidence { get; set; }
@@ -26,10 +28,11 @@ public class CloseAlertState : IRegisterJourney
     public string? EvidenceFileSizeDescription { get; set; }
 
     [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(UploadEvidence), nameof(EvidenceFileId))]
+    [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(HasAdditionalReasonDetail), nameof(UploadEvidence), nameof(EvidenceFileId))]
     public bool IsComplete => EndDate is not null &&
         ChangeReason.HasValue &&
-        (ChangeReason.Value == CloseAlertReasonOption.AnotherReason ? !string.IsNullOrWhiteSpace(ChangeReasonDetail) : true) &&
+        HasAdditionalReasonDetail.HasValue &&
+        (!HasAdditionalReasonDetail.Value || (HasAdditionalReasonDetail.Value && !string.IsNullOrWhiteSpace(ChangeReasonDetail))) &&
         UploadEvidence.HasValue &&
         (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Conventions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
@@ -12,6 +13,7 @@ public class Conventions : IConfigureFolderConventions
             model =>
             {
                 model.Filters.Add(new CheckAlertExistsFilterFactory(requiredPermission: Permissions.Alerts.Write));
+                model.Filters.Add(new ServiceFilterAttribute<RequireOpenAlertFilter>());
             });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.AlertClose(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
-            <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
+            <span class="govuk-caption-l">Close an alert - @Model.PersonName</span>
 
             <govuk-date-input asp-for="EndDate">
                 <govuk-date-input-fieldset>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml.cs
@@ -67,12 +67,6 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IClock clock) : PageMode
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
-        if (alertInfo.Alert.EndDate is not null)
-        {
-            context.Result = BadRequest();
-            return;
-        }
-
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonId = personInfo.PersonId;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
-            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <span class="govuk-caption-l">Close an alert - @Model.PersonName</span>
             <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
             <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
@@ -28,9 +28,21 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@CloseAlertReasonOption.AnotherReason">
                         @CloseAlertReasonOption.AnotherReason.GetDisplayName()
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-radios asp-for="HasAdditionalReasonDetail">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@true">
+                        Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="4000" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="@ReasonModel.ChangeReasonDetailMaxLength" />
                         </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
@@ -12,6 +12,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileService) : PageModel
 {
     public const int MaxFileSizeMb = 50;
+    public const int ChangeReasonDetailMaxLength = 4000;
 
     private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
 
@@ -33,11 +34,17 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
     public CloseAlertReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    [Display(Name = "Enter details")]
+    [Display(Name = "Do you want to add more information about why you’re adding an end date?")]
+    [Required(ErrorMessage = "Select yes if you want to add more information about why you’re adding an end date")]
+    public bool? HasAdditionalReasonDetail { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Add additional detail")]
+    [MaxLength(ChangeReasonDetailMaxLength, ErrorMessage = "Additional detail must be 4000 characters or less")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
-    [Display(Name = "Upload evidence")]
+    [Display(Name = "Do you want to upload evidence?")]
     [Required(ErrorMessage = "Select yes if you want to upload evidence")]
     public bool? UploadEvidence { get; set; }
 
@@ -57,11 +64,9 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
     public async Task OnGet()
     {
         ChangeReason = JourneyInstance!.State.ChangeReason;
+        HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
-        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
-        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
-        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
@@ -69,9 +74,9 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     public async Task<IActionResult> OnPost()
     {
-        if (ChangeReason == CloseAlertReasonOption.AnotherReason && string.IsNullOrWhiteSpace(ChangeReasonDetail))
+        if (HasAdditionalReasonDetail == true && ChangeReasonDetail is null)
         {
-            ModelState.AddModelError(nameof(ChangeReasonDetail), "Enter details");
+            ModelState.AddModelError(nameof(ChangeReasonDetail), "Enter additional detail");
         }
 
         if (UploadEvidence == true && EvidenceFileId is null && EvidenceFile is null)
@@ -117,6 +122,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
+            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
             state.ChangeReasonDetail = ChangeReasonDetail;
             state.UploadEvidence = UploadEvidence;
         });
@@ -142,5 +148,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml.cs
@@ -67,9 +67,6 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
         ChangeReasonDetail = JourneyInstance!.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
-        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
-        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
-        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
@@ -151,5 +148,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateState.cs
@@ -32,10 +32,11 @@ public class EditAlertEndDateState : IRegisterJourney
     public string? EvidenceFileSizeDescription { get; set; }
 
     [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(UploadEvidence), nameof(EvidenceFileId))]
+    [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(HasAdditionalReasonDetail), nameof(UploadEvidence), nameof(EvidenceFileId))]
     public bool IsComplete => EndDate is not null &&
         ChangeReason.HasValue &&
         HasAdditionalReasonDetail.HasValue &&
+        (!HasAdditionalReasonDetail.Value || (HasAdditionalReasonDetail.Value && !string.IsNullOrWhiteSpace(ChangeReasonDetail))) &&
         UploadEvidence.HasValue &&
         (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
@@ -67,9 +67,6 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
-        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
-        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
-        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
@@ -151,5 +148,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml.cs
@@ -67,9 +67,6 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
         ChangeReasonDetail = JourneyInstance!.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
-        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
-        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
-        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
@@ -151,5 +148,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
@@ -67,9 +67,6 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
-        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
-        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
-        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
             await fileService.GetFileUrl(JourneyInstance.State.EvidenceFileId.Value, _fileUrlExpiresAfter) :
             null;
@@ -152,5 +149,8 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
+        EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
+        EvidenceFileName = JourneyInstance!.State.EvidenceFileName;
+        EvidenceFileSizeDescription = JourneyInstance!.State.EvidenceFileSizeDescription;
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
@@ -309,7 +310,8 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
         var personId = person.PersonId;
         var alertId = person.Alerts.First().AlertId;
         var newEndDate = TestData.Clock.Today.AddDays(-5);
-        var changeReason = TestData.GenerateLoremIpsum();
+        var changeReason = CloseAlertReasonOption.AlertPeriodHasEnded;
+        var changeReasonDetail = TestData.GenerateLoremIpsum();
         var evidenceFileName = "evidence.jpg";
         var evidenceFileMimeType = "image/jpeg";
 
@@ -326,10 +328,10 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnCloseAlertChangeReasonPage(alertId);
 
-        await page.CheckAsync("label:text-is('Another reason')");
-        await page.FillAsync("label:text-is('Enter details')", changeReason);
-
-        await page.CheckAsync("label:text-is('Yes')");
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{changeReason.GetDisplayName()}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re adding an end date?')").Locator("label:text-is('Yes')").CheckAsync();
+        await page.FillAsync("label:text-is('Add additional detail')", changeReasonDetail);
+        await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
         await page
             .GetByLabel("Upload a file")
             .SetInputFilesAsync(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -13,7 +13,7 @@ public class CheckAnswersTests : TestBase
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
         var startDate = TestData.Clock.Today.AddDays(-50);
@@ -311,7 +311,7 @@ public class CheckAnswersTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
         var startDate = TestData.Clock.Today.AddDays(-50);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -10,6 +10,50 @@ public class CheckAnswersTests : TestBase
     }
 
     [Fact]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var details = "Some details";
+        var link = TestData.GenerateUrl();
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var changeReason = CloseAlertReasonOption.EndDateSet;
+        var changeReasonDetail = "Some details";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(
+            b => b.WithAlert(
+                a => a.WithAlertTypeId(alertType.AlertTypeId)
+                    .WithDetails(details)
+                    .WithExternalLink(link)
+                    .WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate,
+                ChangeReason = changeReason,
+                HasAdditionalReasonDetail = true,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
     public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
@@ -24,6 +68,25 @@ public class CheckAnswersTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithClosedAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var databaseEndDate = new DateOnly(2022, 11, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate).WithEndDate(databaseEndDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId, state: new());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -55,7 +118,7 @@ public class CheckAnswersTests : TestBase
         var details = "Some details";
         var link = populateOptional ? TestData.GenerateUrl() : null;
         var journeyEndDate = TestData.Clock.Today.AddDays(-5);
-        var changeReason = populateOptional ? CloseAlertReasonOption.AnotherReason : CloseAlertReasonOption.EndDateSet;
+        var changeReason = CloseAlertReasonOption.EndDateSet;
         var changeReasonDetail = populateOptional ? "Some details" : null;
         var evidenceFileId = Guid.NewGuid();
         var evidenceFileName = "test.pdf";
@@ -72,6 +135,7 @@ public class CheckAnswersTests : TestBase
             {
                 EndDate = journeyEndDate,
                 ChangeReason = changeReason,
+                HasAdditionalReasonDetail = populateOptional,
                 ChangeReasonDetail = changeReasonDetail,
                 UploadEvidence = populateOptional ? true : false,
                 EvidenceFileId = populateOptional ? evidenceFileId : null,
@@ -85,20 +149,14 @@ public class CheckAnswersTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
-        Assert.Equal(alertType.Name, doc.GetElementByTestId("alert-type")!.TextContent);
-        Assert.Equal(details, doc.GetElementByTestId("details")!.TextContent);
-        Assert.Equal(populateOptional ? $"{link} (opens in new tab)" : "-", doc.GetElementByTestId("link")!.TextContent);
-        Assert.Equal(startDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("start-date")!.TextContent);
-        Assert.Equal(journeyEndDate.ToString("d MMMM yyyy"), doc.GetElementByTestId("end-date")!.TextContent);
-        if (changeReason == CloseAlertReasonOption.AnotherReason)
-        {
-            Assert.Equal(changeReasonDetail, doc.GetElementByTestId("change-reason")!.TextContent);
-        }
-        else
-        {
-            Assert.Equal(changeReason.GetDisplayName(), doc.GetElementByTestId("change-reason")!.TextContent);
-        }
-        Assert.Equal(populateOptional ? $"{evidenceFileName} (opens in new tab)" : "-", doc.GetElementByTestId("uploaded-evidence-link")!.TextContent);
+        Assert.Equal(alertType.Name, doc.GetSummaryListValueForKey("Alert type"));
+        Assert.Equal(details, doc.GetSummaryListValueForKey("Details"));
+        Assert.Equal(populateOptional ? $"{link} (opens in new tab)" : "-", doc.GetSummaryListValueForKey("Link"));
+        Assert.Equal(startDate.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("Start date"));
+        Assert.Equal(journeyEndDate.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("End date"));
+        Assert.Equal(changeReason.GetDisplayName(), doc.GetSummaryListValueForKey("Reason for change"));
+        Assert.Equal(populateOptional ? changeReasonDetail : "-", doc.GetSummaryListValueForKey("Reason details"));
+        Assert.Equal(populateOptional ? $"{evidenceFileName} (opens in new tab)" : "-", doc.GetSummaryListValueForKey("Evidence"));
     }
 
     [Fact]
@@ -116,6 +174,25 @@ public class CheckAnswersTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WithClosedAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var databaseStartDate = new DateOnly(2021, 10, 5);
+        var databaseEndDate = new DateOnly(2022, 11, 6);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(databaseStartDate).WithEndDate(databaseEndDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId, state: new());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -161,6 +238,7 @@ public class CheckAnswersTests : TestBase
             {
                 EndDate = journeyEndDate,
                 ChangeReason = changeReason,
+                HasAdditionalReasonDetail = true,
                 ChangeReasonDetail = changeReasonDetail,
                 UploadEvidence = true,
                 EvidenceFileId = evidenceFileId,
@@ -211,8 +289,8 @@ public class CheckAnswersTests : TestBase
                     StartDate = originalAlert.StartDate,
                     EndDate = null
                 },
-                ChangeReason = null,
-                ChangeReasonDetail = changeReason == CloseAlertReasonOption.AnotherReason ? changeReasonDetail : changeReason.GetDisplayName(),
+                ChangeReason = changeReason.GetDisplayName(),
+                ChangeReasonDetail = changeReasonDetail,
                 EvidenceFile = new()
                 {
                     FileId = evidenceFileId,
@@ -227,6 +305,50 @@ public class CheckAnswersTests : TestBase
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.True(journeyInstance.Completed);
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var details = "Some details";
+        var link = TestData.GenerateUrl();
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var changeReason = CloseAlertReasonOption.EndDateSet;
+        var changeReasonDetail = "Some details";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "test.pdf";
+        var person = await TestData.CreatePerson(
+            b => b.WithAlert(
+                a => a.WithAlertTypeId(alertType.AlertTypeId)
+                    .WithDetails(details)
+                    .WithExternalLink(link)
+                    .WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate,
+                ChangeReason = changeReason,
+                HasAdditionalReasonDetail = true,
+                ChangeReasonDetail = changeReasonDetail,
+                UploadEvidence = true,
+                EvidenceFileId = evidenceFileId,
+                EvidenceFileName = evidenceFileName
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
     [Fact]
@@ -247,6 +369,7 @@ public class CheckAnswersTests : TestBase
             {
                 EndDate = journeyEndDate,
                 ChangeReason = changeReason,
+                HasAdditionalReasonDetail = true,
                 ChangeReasonDetail = changeReasonDetail,
                 UploadEvidence = true,
                 EvidenceFileId = evidenceFileId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
@@ -13,7 +13,7 @@ public class IndexTests : TestBase
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = Clock.Today.AddDays(-50);
         var endDate = Clock.Today.AddDays(-10);
@@ -115,7 +115,7 @@ public class IndexTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = Clock.Today.AddDays(-50);
         var newEndDate = Clock.Today.AddDays(-5);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
@@ -10,6 +10,27 @@ public class IndexTests : TestBase
     }
 
     [Fact]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
     public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
@@ -27,7 +48,7 @@ public class IndexTests : TestBase
     }
 
     [Fact]
-    public async Task Get_WhenAlertHasEndDateSet_ReturnsBadRequest()
+    public async Task Get_WithClosedAlert_ReturnsBadRequest()
     {
         // Arrange
         var startDate = Clock.Today.AddDays(-50);
@@ -43,6 +64,80 @@ public class IndexTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithUninitializedJourneyState_ReturnsOK()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithInitializedJourneyState_PopulatesModelFromJourneyState()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var journeyEndDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            state: new()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        Assert.Equal($"{journeyEndDate:%d}", doc.GetElementById("EndDate.Day")?.GetAttribute("value"));
+        Assert.Equal($"{journeyEndDate:%M}", doc.GetElementById("EndDate.Month")?.GetAttribute("value"));
+        Assert.Equal($"{journeyEndDate:yyyy}", doc.GetElementById("EndDate.Year")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+
+        var startDate = Clock.Today.AddDays(-50);
+        var newEndDate = Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "EndDate.Day", $"{newEndDate:%d}" },
+                { "EndDate.Month", $"{newEndDate:%M}" },
+                { "EndDate.Year", $"{newEndDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
     [Fact]
@@ -63,7 +158,7 @@ public class IndexTests : TestBase
     }
 
     [Fact]
-    public async Task Post_WhenAlertHasEndDateSet_ReturnsBadRequest()
+    public async Task Post_WithClosedAlert_ReturnsBadRequest()
     {
         // Arrange
         var startDate = Clock.Today.AddDays(-50);
@@ -151,7 +246,7 @@ public class IndexTests : TestBase
     }
 
     [Fact]
-    public async Task Post_WhenEndDateIsEntered_RedirectsToChangeReasonPage()
+    public async Task Post_WhenEndDateIsEntered_UpdatesStateAndRedirectsToChangeReasonPage()
     {
         var startDate = Clock.Today.AddDays(-50);
         var newEndDate = Clock.Today.AddDays(-5);
@@ -175,6 +270,9 @@ public class IndexTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alertId}/close/change-reason", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(newEndDate, journeyInstance.State.EndDate);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
@@ -13,7 +13,7 @@ public class ReasonTests : TestBase
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = TestData.Clock.Today.AddDays(-50);
         var journeyEndDate = TestData.Clock.Today.AddDays(-5);
@@ -166,7 +166,7 @@ public class ReasonTests : TestBase
     public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.NoRoles);
+        SetCurrentUser(TestUsers.GetUser(roles: []));
 
         var startDate = TestData.Clock.Today.AddDays(-50);
         var journeyEndDate = TestData.Clock.Today.AddDays(-5);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
@@ -1,5 +1,4 @@
 using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
-using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.CloseAlert;
 
@@ -8,6 +7,32 @@ public class ReasonTests : TestBase
     public ReasonTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
     [Fact]
@@ -25,6 +50,25 @@ public class ReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithClosedAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddDays(-50);
+        var endDate = Clock.Today.AddDays(-10);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -46,7 +90,7 @@ public class ReasonTests : TestBase
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_ReturnsOK()
+    public async Task Get_ValidRequest_ReturnsOK()
     {
         // Arrange
         var startDate = TestData.Clock.Today.AddDays(-50);
@@ -70,6 +114,92 @@ public class ReasonTests : TestBase
     }
 
     [Fact]
+    public async Task Get_ValidRequestWithReasonPopulatedDataInJourneyState_ReturnsExpectedContent()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var reason = CloseAlertReasonOption.AnotherReason;
+        var reasonDetail = "My Reason";
+        var evidenceFileId = Guid.NewGuid();
+        var evidenceFileName = "evidence.jpg";
+        var evidenceFileSizeDescription = "1 MB";
+
+        var journeyInstance = await CreateJourneyInstance(alertId, state: new()
+        {
+            EndDate = journeyEndDate,
+            ChangeReason = reason,
+            HasAdditionalReasonDetail = true,
+            ChangeReasonDetail = reasonDetail,
+            UploadEvidence = true,
+            EvidenceFileId = evidenceFileId,
+            EvidenceFileName = evidenceFileName,
+            EvidenceFileSizeDescription = evidenceFileSizeDescription,
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        AssertCheckedRadioOption("ChangeReason", reason.ToString());
+        AssertCheckedRadioOption("HasAdditionalReasonDetail", bool.TrueString);
+        AssertCheckedRadioOption("UploadEvidence", bool.TrueString);
+
+        var uploadedEvidenceLink = doc.GetElementByTestId("uploaded-evidence-link");
+        Assert.NotNull(uploadedEvidenceLink);
+        Assert.Equal($"{evidenceFileName} ({evidenceFileSizeDescription})", uploadedEvidenceLink!.TextContent);
+
+        void AssertCheckedRadioOption(string name, string expectedCheckedValue)
+        {
+            var selectedOption = doc.GetElementsByName(name).SingleOrDefault(r => r.HasAttribute("checked"));
+            Assert.Equal(expectedCheckedValue, selectedOption?.GetAttribute("value"));
+        }
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.NoRoles);
+
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId, state: new()
+        {
+            EndDate = journeyEndDate
+        });
+
+        var reason = CloseAlertReasonOption.AnotherReason;
+        var HasAdditionalReasonDetail = true;
+        var reasonDetail = "More details";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder()
+            {
+                { "ChangeReason", reason },
+                { "HasAdditionalReasonDetail", HasAdditionalReasonDetail },
+                { "ChangeReasonDetail", reasonDetail },
+                { "UploadEvidence", bool.FalseString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
     public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
@@ -84,6 +214,37 @@ public class ReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WithClosedAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var databaseEndDate = TestData.Clock.Today.AddDays(-5);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(alertId, state: new()
+        {
+            EndDate = journeyEndDate
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder()
+            {
+                { "ChangeReason", CloseAlertReasonOption.AnotherReason },
+                { "HasAdditionalReasonDetail", bool.FalseString },
+                { "UploadEvidence", bool.FalseString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -122,10 +283,11 @@ public class ReasonTests : TestBase
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            Content = new MultipartFormDataContentBuilder()
             {
-                ["UploadEvidence"] = "False"
-            })
+                { "HasAdditionalReasonDetail", bool.FalseString },
+                { "UploadEvidence", bool.FalseString }
+            }
         };
 
         // Act
@@ -136,7 +298,38 @@ public class ReasonTests : TestBase
     }
 
     [Fact]
-    public async Task Post_WhenChangeReasonAnotherReasonIsSelectedAndDetailsAreEmpty_ReturnsError()
+    public async Task Post_WhenNoHasAdditionalReasonDetailIsSelected_ReturnsError()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+           alertId,
+           new CloseAlertState()
+           {
+               EndDate = journeyEndDate
+           });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder()
+            {
+                { "ChangeReason", CloseAlertReasonOption.AnotherReason },
+                { "UploadEvidence", bool.FalseString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasAdditionalReasonDetail", "Select yes if you want to add more information about why you’re adding an end date");
+    }
+
+    [Fact]
+    public async Task Post_WhenAdditionalDetailIsYesButAdditionalDetailsAreEmpty_ReturnsError()
     {
         // Arrange
         var startDate = TestData.Clock.Today.AddDays(-50);
@@ -152,19 +345,19 @@ public class ReasonTests : TestBase
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            Content = new MultipartFormDataContentBuilder()
             {
-                ["ChangeReason"] = "AnotherReason",
-                ["ChangeReasonDetail"] = "",
-                ["UploadEvidence"] = "False"
-            })
+                { "ChangeReason", CloseAlertReasonOption.EndDateSet },
+                { "HasAdditionalReasonDetail", bool.TrueString },
+                { "UploadEvidence", bool.FalseString }
+            }
         };
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "ChangeReasonDetail", "Enter details");
+        await AssertEx.HtmlResponseHasError(response, "ChangeReasonDetail", "Enter additional detail");
     }
 
     [Fact]
@@ -184,12 +377,12 @@ public class ReasonTests : TestBase
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            Content = new MultipartFormDataContentBuilder()
             {
-                ["ChangeReason"] = "AnotherReason",
-                ["ChangeReasonDetail"] = "Some details",
-                ["UploadEvidence"] = "True"
-            })
+                { "ChangeReason", CloseAlertReasonOption.EndDateSet },
+                { "HasAdditionalReasonDetail", bool.TrueString },
+                { "UploadEvidence", bool.TrueString }
+            }
         };
 
         // Act
@@ -214,14 +407,15 @@ public class ReasonTests : TestBase
                 EndDate = journeyEndDate
             });
 
-        var multipartContent = CreateFormFileUpload(".cs");
-        multipartContent.Add(new StringContent(AlertChangeEndDateReasonOption.AnotherReason.ToString()), "ChangeReason");
-        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
-        multipartContent.Add(new StringContent("True"), "UploadEvidence");
-
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = multipartContent
+            Content = new MultipartFormDataContentBuilder()
+            {
+                { "ChangeReason", CloseAlertReasonOption.EndDateSet },
+                { "HasAdditionalReasonDetail", bool.TrueString },
+                { "UploadEvidence", bool.TrueString },
+                { "EvidenceFile", CreateEvidenceFileBinaryContent(), "invalidfile.cs" }
+            }
         };
 
         // Act
@@ -232,13 +426,12 @@ public class ReasonTests : TestBase
     }
 
     [Fact]
-    public async Task Post_WhenValidInput_RedirectsToCheckAnswersPage()
+    public async Task Post_ValidInputWithoutEvidenceFile_UpdatesStateAndRedirectsToCheckAnswersPage()
     {
         // Arrange
         var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
         var journeyEndDate = TestData.Clock.Today.AddDays(-5);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
         var alertId = person.Alerts.Single().AlertId;
         var journeyInstance = await CreateJourneyInstance(
             alertId,
@@ -247,14 +440,19 @@ public class ReasonTests : TestBase
                 EndDate = journeyEndDate
             });
 
-        var multipartContent = CreateFormFileUpload(".pdf");
-        multipartContent.Add(new StringContent(AlertChangeEndDateReasonOption.AnotherReason.ToString()), "ChangeReason");
-        multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
-        multipartContent.Add(new StringContent("True"), "UploadEvidence");
+        var reason = CloseAlertReasonOption.AlertPeriodHasEnded;
+        var HasAdditionalReasonDetail = true;
+        var reasonDetail = "More details";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = multipartContent
+            Content = new MultipartFormDataContentBuilder()
+            {
+                { "ChangeReason", reason },
+                { "HasAdditionalReasonDetail", HasAdditionalReasonDetail },
+                { "ChangeReasonDetail", reasonDetail },
+                { "UploadEvidence", bool.FalseString }
+            }
         };
 
         // Act
@@ -263,11 +461,66 @@ public class ReasonTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(reason, journeyInstance.State.ChangeReason);
+        Assert.True(journeyInstance.State.HasAdditionalReasonDetail);
+        Assert.Equal(reasonDetail, journeyInstance.State.ChangeReasonDetail);
+        Assert.Null(journeyInstance.State.EvidenceFileName);
+        Assert.Null(journeyInstance.State.EvidenceFileId);
+        Assert.Null(journeyInstance.State.EvidenceFileSizeDescription);
+    }
+
+    [Fact]
+    public async Task Post_WhenValidInputWithEvidenceFile_UpdatesStateAndRedirectsToCheckAnswersPage()
+    {
+        // Arrange
+        var startDate = TestData.Clock.Today.AddDays(-50);
+        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
+        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
+        var alertId = person.Alerts.Single().AlertId;
+        var journeyInstance = await CreateJourneyInstance(
+            alertId,
+            new CloseAlertState()
+            {
+                EndDate = journeyEndDate
+            });
+
+        var reason = CloseAlertReasonOption.AlertPeriodHasEnded;
+        var HasAdditionalReasonDetail = false;
+        var evidenceFileName = "evidence.pdf";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder()
+            {
+                { "ChangeReason", reason },
+                { "HasAdditionalReasonDetail", HasAdditionalReasonDetail },
+                { "UploadEvidence", bool.TrueString },
+                { "EvidenceFile", CreateEvidenceFileBinaryContent(), evidenceFileName }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/{alertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(reason, journeyInstance.State.ChangeReason);
+        Assert.False(journeyInstance.State.HasAdditionalReasonDetail);
+        Assert.Null(journeyInstance.State.ChangeReasonDetail);
+        Assert.Equal(evidenceFileName, journeyInstance.State.EvidenceFileName);
+        Assert.NotNull(journeyInstance.State.EvidenceFileId);
+        Assert.NotNull(journeyInstance.State.EvidenceFileSizeDescription);
     }
 
     [Fact]
     public async Task Post_Cancel_DeletesJourneyAndRedirects()
     {
+        // Arrange
         var startDate = Clock.Today.AddDays(-50);
         var journeyEndDate = TestData.Clock.Today.AddDays(-5);
         var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
@@ -292,18 +545,13 @@ public class ReasonTests : TestBase
         Assert.Null(journeyInstance);
     }
 
-    private MultipartFormDataContent CreateFormFileUpload(string fileExtension)
+    private static HttpContent CreateEvidenceFileBinaryContent()
     {
-        var byteArrayContent = new ByteArrayContent(new byte[] { });
+        var byteArrayContent = new ByteArrayContent([]);
         byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
-
-        var multipartContent = new MultipartFormDataContent
-        {
-            { byteArrayContent, "EvidenceFile", $"evidence{fileExtension}" }
-        };
-
-        return multipartContent;
+        return byteArrayContent;
     }
+
     private async Task<JourneyInstance<CloseAlertState>> CreateJourneyInstance(Guid alertId, CloseAlertState? state = null) =>
         await CreateJourneyInstance(
             JourneyNames.CloseAlert,


### PR DESCRIPTION
### Context

The designs for the Close alert journey have evolved since they were first built.

### Changes proposed in this pull request

Aligned the implementation with the latest Figma designs +
fixed an issue where navigating from check answers to the reason page lost any uploaded files 

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
