### PR TITLE
Add TRS Console URLs to StatusCake monitoring

### DIFF
--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -21,6 +21,14 @@
   "redis_capacity": 1,
   "redis_family": "P",
   "redis_sku_name": "Premium",
-  "statuscake_extra_urls": ["https://teacher-qualifications-api.education.gov.uk/health"],
-  "ssl_urls": ["https://teacher-qualifications-api.education.gov.uk/health"]
+  "statuscake_extra_urls": [
+    "https://teacher-qualifications-api.education.gov.uk/health",
+    "https://teaching-record-system.education.gov.uk/health",
+    "https://authorise-access-to-a-teaching-record.education.gov.uk/health"
+  ],
+  "ssl_urls": [
+    "https://teacher-qualifications-api.education.gov.uk/health",
+    "https://teaching-record-system.education.gov.uk/health",
+    "https://authorise-access-to-a-teaching-record.education.gov.uk/health"
+  ]
 }


### PR DESCRIPTION
The production TRS Console certificate expired without us noticing. This adds StatusCake alerts for the production TRS Console.

We don't have monitoring for Teacher Auth either (authorise-access-to-a-teaching-record.education.gov.uk) so that's added too.