### PR TITLE
Align reopen alert journey with designs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -11,8 +11,7 @@ public class CheckAnswersModel(
     TrsDbContext dbContext,
     TrsLinkGenerator linkGenerator,
     IFileService fileService,
-    IClock clock,
-    ReferenceDataCache referenceDataCache) : PageModel
+    IClock clock) : PageModel
 {
     private static readonly TimeSpan _fileUrlExpiresAfter = TimeSpan.FromMinutes(15);
 
@@ -105,11 +104,10 @@ public class CheckAnswersModel(
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
-        var alertType = await referenceDataCache.GetAlertTypeById(alertInfo.Alert.AlertTypeId);
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        AlertTypeName = alertType.Name;
+        AlertTypeName = alertInfo.Alert.AlertType.Name;
         Details = alertInfo.Alert.Details;
         Link = alertInfo.Alert.ExternalLink;
         StartDate = alertInfo.Alert.StartDate;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
@@ -1,4 +1,4 @@
-@page "/alerts/{alertId}/reopen/check-answers/{handler?}"
+@page "/alerts/{alertId}/re-open/check-answers/{handler?}"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert.CheckAnswersModel
 @{
     ViewBag.Title = "Check details and confirm change";
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
         <form action="@LinkGenerator.AlertReopenCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post">
-            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <span class="govuk-caption-l">Change closed alert - @Model.PersonName</span>
             <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
             <govuk-summary-list>
@@ -42,9 +42,25 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value><multi-line-text text="@Model.ChangeReason" data-testid="change-reason" /></govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@Model.ChangeReason.GetDisplayName()</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.AlertReopen(Model.AlertId, Model.JourneyInstance!.InstanceId)">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Reason details</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @if (Model.ChangeReasonDetail is not null)
+                        {
+                            <multi-line-text text="@Model.ChangeReasonDetail" />
+                        }
+                        else
+                        {
+                            <span use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AlertCloseReason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Conventions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
@@ -12,6 +13,7 @@ public class Conventions : IConfigureFolderConventions
             model =>
             {
                 model.Filters.Add(new CheckAlertExistsFilterFactory(requiredPermission: Permissions.Alerts.Write));
+                model.Filters.Add(new ServiceFilterAttribute<RequireClosedAlertFilter>());
             });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
@@ -1,4 +1,4 @@
-@page "/alerts/{alertId}/reopen/{handler?}"
+@page "/alerts/{alertId}/re-open/{handler?}"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert.IndexModel
 @{
     ViewBag.Title = "Why are you removing the end date?";
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.AlertReopen(Model.AlertId, Model.JourneyInstance!.InstanceId)" method="post" enctype="multipart/form-data">
-            <span class="govuk-caption-l">Change previous alert - @Model.PersonName</span>
+            <span class="govuk-caption-l">Change closed alert - @Model.PersonName</span>
             <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
             <govuk-radios asp-for="ChangeReason" data-testid="change-reason-options">
@@ -22,9 +22,21 @@
                     </govuk-radios-item>                    
                     <govuk-radios-item value="@ReopenAlertReasonOption.AnotherReason">
                         @ReopenAlertReasonOption.AnotherReason.GetDisplayName()
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-radios asp-for="HasAdditionalReasonDetail">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-item value="@true">
+                        Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="4000" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="@IndexModel.ChangeReasonDetailMaxLength" />
                         </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertState.cs
@@ -13,6 +13,8 @@ public class ReopenAlertState : IRegisterJourney
 
     public ReopenAlertReasonOption? ChangeReason { get; set; }
 
+    public bool? HasAdditionalReasonDetail { get; set; }
+
     public string? ChangeReasonDetail { get; set; }
 
     public bool? UploadEvidence { get; set; }
@@ -24,9 +26,11 @@ public class ReopenAlertState : IRegisterJourney
     public string? EvidenceFileSizeDescription { get; set; }
 
     [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(ChangeReason), nameof(UploadEvidence), nameof(EvidenceFileId))]
-    public bool IsComplete => ChangeReason.HasValue &&
-        (ChangeReason.Value == ReopenAlertReasonOption.AnotherReason ? !string.IsNullOrWhiteSpace(ChangeReasonDetail) : true) &&
+    [MemberNotNullWhen(true, nameof(ChangeReason), nameof(HasAdditionalReasonDetail), nameof(UploadEvidence), nameof(EvidenceFileId))]
+    public bool IsComplete =>
+        ChangeReason.HasValue &&
+        HasAdditionalReasonDetail.HasValue &&
+        (!HasAdditionalReasonDetail.Value || (HasAdditionalReasonDetail.Value && !string.IsNullOrWhiteSpace(ChangeReasonDetail))) &&
         UploadEvidence.HasValue &&
         (!UploadEvidence.Value || (UploadEvidence.Value && EvidenceFileId.HasValue));
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/AlertTests.cs
@@ -5,6 +5,7 @@ using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
@@ -361,7 +362,8 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePerson(b => b.WithAlert(a => a.WithStartDate(startDate).WithEndDate(endDate)));
         var personId = person.PersonId;
         var alertId = person.Alerts.First().AlertId;
-        var changeReason = TestData.GenerateLoremIpsum();
+        var changeReason = ReopenAlertReasonOption.ClosedInError;
+        var changeReasonDetail = TestData.GenerateLoremIpsum();
         var evidenceFileName = "evidence.jpg";
         var evidenceFileMimeType = "image/jpeg";
 
@@ -372,10 +374,10 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnReopenAlertPage(alertId);
 
-        await page.CheckAsync("label:text-is('Another reason')");
-        await page.FillAsync("label:text-is('Enter details')", changeReason);
-
-        await page.CheckAsync("label:text-is('Yes')");
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{changeReason.GetDisplayName()}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re removing the end date?')").Locator("label:text-is('Yes')").CheckAsync();
+        await page.FillAsync("label:text-is('Add additional detail')", changeReasonDetail);
+        await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
         await page
             .GetByLabel("Upload a file")
             .SetInputFilesAsync(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -63,7 +63,7 @@ public static class PageExtensions
 
     public static async Task GoToReopenAlertPage(this IPage page, Guid alertId)
     {
-        await page.GotoAsync($"/alerts/{alertId}/reopen");
+        await page.GotoAsync($"/alerts/{alertId}/re-open");
     }
 
     public static async Task GoToDeleteAlertPage(this IPage page, Guid alertId)
@@ -274,12 +274,12 @@ public static class PageExtensions
 
     public static async Task AssertOnReopenAlertPage(this IPage page, Guid alertId)
     {
-        await page.WaitForUrlPathAsync($"/alerts/{alertId}/reopen");
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/re-open");
     }
 
     public static async Task AssertOnReopenAlertCheckAnswersPage(this IPage page, Guid alertId)
     {
-        await page.WaitForUrlPathAsync($"/alerts/{alertId}/reopen/check-answers");
+        await page.WaitForUrlPathAsync($"/alerts/{alertId}/re-open/check-answers");
     }
 
     public static async Task AssertOnDeleteAlertPage(this IPage page, Guid alertId)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/ReopenAlertTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/ReopenAlertTestBase.cs
@@ -1,0 +1,45 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.ReopenAlert;
+
+public abstract class ReopenAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<JourneyInstance<ReopenAlertState>> CreateEmptyJourneyInstance(Guid alertId) =>
+        CreateJourneyInstance(alertId, new());
+
+    protected Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstanceForAllStepsCompleted(Alert alert, bool populateOptional = true) =>
+        CreateJourneyInstance(alert.AlertId, new ReopenAlertState()
+        {
+            ChangeReason = ReopenAlertReasonOption.ClosedInError,
+            HasAdditionalReasonDetail = populateOptional ? true : false,
+            ChangeReasonDetail = populateOptional ? "More details" : null,
+            UploadEvidence = populateOptional ? true : false,
+            EvidenceFileId = populateOptional ? Guid.NewGuid() : null,
+            EvidenceFileName = populateOptional ? "evidence.jpeg" : null,
+            EvidenceFileSizeDescription = populateOptional ? "5MB" : null
+        });
+
+    protected Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstanceForCompletedStep(string step, Alert alert) =>
+        step switch
+        {
+            JourneySteps.New =>
+                CreateEmptyJourneyInstance(alert.AlertId),
+            JourneySteps.Index or JourneySteps.CheckAnswers =>
+                CreateJourneyInstanceForAllStepsCompleted(alert, populateOptional: true),
+            _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
+        };
+
+    private Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstance(Guid alertId, ReopenAlertState state) =>
+        CreateJourneyInstance(
+            JourneyNames.ReopenAlert,
+            state,
+            new KeyValuePair<string, object>("alertId", alertId));
+
+    public static class JourneySteps
+    {
+        public const string New = nameof(New);
+        public const string Index = nameof(Index);
+        public const string CheckAnswers = nameof(CheckAnswers);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -124,15 +124,15 @@ public abstract class TestBase : IDisposable
             return 0;
         });
 
-    protected async Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithOpenAlert()
+    protected async Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithOpenAlert(bool populateOptional = true)
     {
-        var person = await TestData.CreatePerson(p => p.WithAlert(a => a.WithStartDate(Clock.Today.AddDays(-30)).WithEndDate(null)));
+        var person = await TestData.CreatePerson(p => p.WithAlert(a => a.WithStartDate(Clock.Today.AddDays(-30)).WithEndDate(null).WithExternalLink(populateOptional ? TestData.GenerateUrl() : null)));
         return (person, person.Alerts.Single());
     }
 
-    protected async Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithClosedAlert()
+    protected async Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithClosedAlert(bool populateOptional = true)
     {
-        var person = await TestData.CreatePerson(p => p.WithAlert(a => a.WithStartDate(Clock.Today.AddDays(-30)).WithEndDate(Clock.Today.AddDays(-1))));
+        var person = await TestData.CreatePerson(p => p.WithAlert(a => a.WithStartDate(Clock.Today.AddDays(-30)).WithEndDate(Clock.Today.AddDays(-1)).WithExternalLink(populateOptional ? TestData.GenerateUrl() : null)));
         return (person, person.Alerts.Single());
     }
 


### PR DESCRIPTION
### Context

The designs for the Reopen alert journey have evolved since they were first built.

### Changes proposed in this pull request

Align the implementation with the latest Figma designs.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
