### PR TITLE
Match authentication cookie lifetime to access token lifetime

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -63,7 +63,6 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
     builder.Services.Configure<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme, options =>
     {
         options.Cookie.Name = "trs-auth";
-        options.Cookie.MaxAge = TimeSpan.FromHours(8);
 
         options.Events.OnSigningOut = ctx =>
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.json
@@ -10,7 +10,8 @@
     "Instance": "https://login.microsoftonline.com/",
     "TenantId": "fad277c9-c60a-4da1-b5f3-b3b8b34a82f9",
     "CallbackPath": "/signin-oidc",
-    "SignedOutCallbackPath": "/signout-oidc"
+    "SignedOutCallbackPath": "/signout-oidc",
+    "UseTokenLifetime": true
   },
   "AllowedHosts": "*",
   "ConcurrentNameChangeWindowSeconds": 5


### PR DESCRIPTION
Hopefully this removes the `MsalUiRequiredException` we see when calling the graph API with an 'old' session.