### PR TITLE
Add initial models for routes & QTS

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/CountryMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/CountryMapping.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class CountryMapping : IEntityTypeConfiguration<Country>
+{
+    public void Configure(EntityTypeBuilder<Country> builder)
+    {
+        builder.HasKey(c => c.CountryId);
+        builder.Property(c => c.CountryId).HasMaxLength(4);
+        builder.Property(c => c.Name).HasMaxLength(200);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EarlyYearsTeacherStatusQualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EarlyYearsTeacherStatusQualificationMapping.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class EarlyYearsTeacherStatusQualificationMapping : IEntityTypeConfiguration<EarlyYearsTeacherStatusQualification>
+{
+    public void Configure(EntityTypeBuilder<EarlyYearsTeacherStatusQualification> builder)
+    {
+        builder.Property(q => q.AwardedDate).HasColumnName("awarded_date");
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
@@ -11,7 +11,9 @@ public class QualificationMapping : IEntityTypeConfiguration<Qualification>
         builder.HasKey(q => q.QualificationId);
         builder.HasQueryFilter(q => EF.Property<DateTime?>(q, nameof(Qualification.DeletedOn)) == null);
         builder.HasDiscriminator(q => q.QualificationType)
-            .HasValue<MandatoryQualification>(QualificationType.MandatoryQualification);
+            .HasValue<MandatoryQualification>(QualificationType.MandatoryQualification)
+            .HasValue<QualifiedTeacherStatusQualification>(QualificationType.QualifiedTeacherStatus)
+            .HasValue<EarlyYearsTeacherStatusQualification>(QualificationType.EarlyYearsTeacherStatus);
         builder.HasOne<Person>(q => q.Person).WithMany(p => p.Qualifications).HasForeignKey(q => q.PersonId).HasConstraintName(Qualification.PersonForeignKeyName);
         builder.HasIndex(q => q.PersonId);
         builder.HasIndex(q => q.DqtQualificationId).HasFilter("dqt_qualification_id is not null").IsUnique();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualifiedTeacherStatusQualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualifiedTeacherStatusQualificationMapping.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class QualifiedTeacherStatusQualificationMapping : IEntityTypeConfiguration<QualifiedTeacherStatusQualification>
+{
+    public void Configure(EntityTypeBuilder<QualifiedTeacherStatusQualification> builder)
+    {
+        builder.Property(q => q.AwardedDate).HasColumnName("awarded_date");
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/RouteMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/RouteMapping.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class RouteMapping : IEntityTypeConfiguration<Route>
+{
+    public void Configure(EntityTypeBuilder<Route> builder)
+    {
+        builder.HasKey(r => r.RouteId);
+        builder.HasOne<Person>().WithMany(p => p.Routes).HasForeignKey(r => r.PersonId);
+        builder.HasOne<Qualification>(r => r.Qualification).WithOne(q => q.Route).HasForeignKey<Route>(r => r.QualificationId);
+        builder.HasOne<Country>().WithMany().HasForeignKey(r => r.CountryId);
+        builder.HasIndex(r => r.PersonId);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029120016_AddQtsAndEytsQualificationTypes.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029120016_AddQtsAndEytsQualificationTypes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241029120016_AddQtsAndEytsQualificationTypes")]
+    partial class AddQtsAndEytsQualificationTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1027,25 +1030,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.ToTable("api_keys", (string)null);
                 });
 
-            modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.Country", b =>
-                {
-                    b.Property<string>("CountryId")
-                        .HasMaxLength(4)
-                        .HasColumnType("character varying(4)")
-                        .HasColumnName("country_id");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("name");
-
-                    b.HasKey("CountryId")
-                        .HasName("pk_countries");
-
-                    b.ToTable("countries", (string)null);
-                });
-
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.EntityChangesJournal", b =>
                 {
                     b.Property<string>("Key")
@@ -2025,79 +2009,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.UseTphMappingStrategy();
                 });
 
-            modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.Route", b =>
-                {
-                    b.Property<Guid>("RouteId")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("route_id");
-
-                    b.Property<int?>("AgeRangeFrom")
-                        .HasColumnType("integer")
-                        .HasColumnName("age_range_from");
-
-                    b.Property<int?>("AgeRangeTo")
-                        .HasColumnType("integer")
-                        .HasColumnName("age_range_to");
-
-                    b.Property<string>("CountryId")
-                        .HasColumnType("character varying(4)")
-                        .HasColumnName("country_id");
-
-                    b.Property<string>("ExternalReference")
-                        .HasColumnType("text")
-                        .HasColumnName("external_reference");
-
-                    b.Property<int?>("InductionExemptionReason")
-                        .HasColumnType("integer")
-                        .HasColumnName("induction_exemption_reason");
-
-                    b.Property<Guid?>("IttProviderId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("itt_provider_id");
-
-                    b.Property<Guid>("PersonId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("person_id");
-
-                    b.Property<DateOnly?>("ProgrammeEndDate")
-                        .HasColumnType("date")
-                        .HasColumnName("programme_end_date");
-
-                    b.Property<DateOnly?>("ProgrammeStartDate")
-                        .HasColumnType("date")
-                        .HasColumnName("programme_start_date");
-
-                    b.Property<Guid?>("QualificationId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("qualification_id");
-
-                    b.Property<int>("QualificationType")
-                        .HasColumnType("integer")
-                        .HasColumnName("qualification_type");
-
-                    b.Property<int>("RouteStatus")
-                        .HasColumnType("integer")
-                        .HasColumnName("route_status");
-
-                    b.Property<int>("RouteType")
-                        .HasColumnType("integer")
-                        .HasColumnName("route_type");
-
-                    b.Property<List<Guid>>("Subjects")
-                        .IsRequired()
-                        .HasColumnType("uuid[]")
-                        .HasColumnName("subjects");
-
-                    b.HasKey("RouteId")
-                        .HasName("pk_routes");
-
-                    b.HasIndex("PersonId")
-                        .HasDatabaseName("ix_routes_person_id");
-
-                    b.ToTable("routes", (string)null);
-                });
-
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.SupportTask", b =>
                 {
                     b.Property<string>("SupportTaskReference")
@@ -2994,28 +2905,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Navigation("Person");
                 });
 
-            modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.Route", b =>
-                {
-                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.Country", null)
-                        .WithMany()
-                        .HasForeignKey("CountryId")
-                        .HasConstraintName("fk_routes_countries_country_id");
-
-                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.Person", null)
-                        .WithMany("Routes")
-                        .HasForeignKey("PersonId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_routes_persons_person_id");
-
-                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.Qualification", "Qualification")
-                        .WithOne("Route")
-                        .HasForeignKey("TeachingRecordSystem.Core.DataStore.Postgres.Models.Route", "QualificationId")
-                        .HasConstraintName("fk_routes_qualifications_qualification_id");
-
-                    b.Navigation("Qualification");
-                });
-
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.SupportTask", b =>
                 {
                     b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.OneLoginUser", null)
@@ -3120,18 +3009,11 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Navigation("Alerts");
 
                     b.Navigation("Qualifications");
-
-                    b.Navigation("Routes");
                 });
 
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.QtsAwardedEmailsJob", b =>
                 {
                     b.Navigation("JobItems");
-                });
-
-            modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.Qualification", b =>
-                {
-                    b.Navigation("Route");
                 });
 
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.ApplicationUser", b =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029120016_AddQtsAndEytsQualificationTypes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029120016_AddQtsAndEytsQualificationTypes.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQtsAndEytsQualificationTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "awarded_date",
+                table: "qualifications",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "dqt_qts_registration_id",
+                table: "qualifications",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "awarded_date",
+                table: "qualifications");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_qts_registration_id",
+                table: "qualifications");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029131635_Route.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029131635_Route.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241029131635_Route")]
+    partial class Route
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029131635_Route.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241029131635_Route.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class Route : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "countries",
+                columns: table => new
+                {
+                    country_id = table.Column<string>(type: "character varying(4)", maxLength: 4, nullable: false),
+                    name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_countries", x => x.country_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "routes",
+                columns: table => new
+                {
+                    route_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    person_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    external_reference = table.Column<string>(type: "text", nullable: true),
+                    qualification_type = table.Column<int>(type: "integer", nullable: false),
+                    qualification_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    route_type = table.Column<int>(type: "integer", nullable: false),
+                    route_status = table.Column<int>(type: "integer", nullable: false),
+                    country_id = table.Column<string>(type: "character varying(4)", nullable: true),
+                    induction_exemption_reason = table.Column<int>(type: "integer", nullable: true),
+                    itt_provider_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    programme_start_date = table.Column<DateOnly>(type: "date", nullable: true),
+                    programme_end_date = table.Column<DateOnly>(type: "date", nullable: true),
+                    age_range_from = table.Column<int>(type: "integer", nullable: true),
+                    age_range_to = table.Column<int>(type: "integer", nullable: true),
+                    subjects = table.Column<List<Guid>>(type: "uuid[]", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_routes", x => x.route_id);
+                    table.ForeignKey(
+                        name: "fk_routes_countries_country_id",
+                        column: x => x.country_id,
+                        principalTable: "countries",
+                        principalColumn: "country_id");
+                    table.ForeignKey(
+                        name: "fk_routes_persons_person_id",
+                        column: x => x.person_id,
+                        principalTable: "persons",
+                        principalColumn: "person_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_routes_qualifications_qualification_id",
+                        column: x => x.qualification_id,
+                        principalTable: "qualifications",
+                        principalColumn: "qualification_id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_routes_person_id",
+                table: "routes",
+                column: "person_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "routes");
+
+            migrationBuilder.DropTable(
+                name: "countries");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Country.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Country.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class Country
+{
+    public required string CountryId { get; init; }
+    public required string Name { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EarlyYearsTeacherStatusQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/EarlyYearsTeacherStatusQualification.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class EarlyYearsTeacherStatusQualification : Qualification
+{
+    public required DateOnly AwardedDate { get; set; }
+
+    public Guid? DqtQtsRegistrationId { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -15,6 +15,7 @@ public class Person
     public string? NationalInsuranceNumber { get; set; }
     public ICollection<Qualification> Qualifications { get; } = new List<Qualification>();
     public ICollection<Alert> Alerts { get; } = new List<Alert>();
+    public ICollection<Route> Routes { get; } = new List<Route>();
 
     public Guid? DqtContactId { get; init; }
     public DateTime? DqtFirstSync { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
@@ -11,6 +11,7 @@ public abstract class Qualification
     public QualificationType QualificationType { get; }
     public required Guid PersonId { get; init; }
     public Person Person { get; } = null!;
+    public Route? Route { get; }
 
     public Guid? DqtQualificationId { get; set; }
     public DateTime? DqtFirstSync { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/QualifiedTeacherStatusQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/QualifiedTeacherStatusQualification.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class QualifiedTeacherStatusQualification : Qualification
+{
+    public required DateOnly AwardedDate { get; set; }
+
+    public Guid? DqtQtsRegistrationId { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Route.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Route.cs
@@ -1,0 +1,21 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class Route
+{
+    public required Guid RouteId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string? ExternalReference { get; init; }  // e.g. Register's slug
+    public required QualificationType QualificationType { get; init; }
+    public Guid? QualificationId { get; set; }
+    public Qualification? Qualification { get; }
+    public required RouteType RouteType { get; init; }
+    public required RouteStatus RouteStatus { get; set; }
+    public required string? CountryId { get; set; }
+    public required InductionExemptionReason? InductionExemptionReason { get; set; }
+    public required Guid? IttProviderId { get; set; }
+    public required DateOnly? ProgrammeStartDate { get; set; }
+    public required DateOnly? ProgrammeEndDate { get; set; }
+    public required int? AgeRangeFrom { get; set; }
+    public required int? AgeRangeTo { get; set; }
+    public required List<Guid> Subjects { get; set; } = [];
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -87,6 +87,14 @@ public class TrsDbContext : DbContext
 
     public DbSet<AlertCategory> AlertCategories => Set<AlertCategory>();
 
+    public DbSet<QualifiedTeacherStatusQualification> QualifiedTeacherStatusQualifications => Set<QualifiedTeacherStatusQualification>();
+
+    public DbSet<EarlyYearsTeacherStatusQualification> EarlyYearsTeacherStatusQualifications => Set<EarlyYearsTeacherStatusQualification>();
+
+    public DbSet<Country> Countries => Set<Country>();
+
+    public DbSet<Route> Routes => Set<Route>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string? connectionString = null, int? commandTimeout = null)
     {
         Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o.CommandTimeout(commandTimeout);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/InductionExemptionReason.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/InductionExemptionReason.cs
@@ -1,0 +1,5 @@
+namespace TeachingRecordSystem.Core;
+
+public enum InductionExemptionReason
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/QualificationType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/QualificationType.cs
@@ -2,5 +2,7 @@ namespace TeachingRecordSystem.Core.Models;
 
 public enum QualificationType
 {
-    MandatoryQualification = 0
+    MandatoryQualification = 0,
+    QualifiedTeacherStatus = 1,
+    EarlyYearsTeacherStatus = 2
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/RouteStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/RouteStatus.cs
@@ -1,0 +1,18 @@
+namespace TeachingRecordSystem.Core;
+
+public enum RouteStatus
+{
+    // TBD - copied from DQT for now
+    Pass = 1,
+    Fail = 2,
+    Withdrawn = 3,
+    Deferred = 4,
+    DeferredForSkillsTests = 5,
+    ApplicationReceived = 6,
+    ApplicationUnsuccessful = 7,
+    Approved = 8,
+    Info = 9,
+    InTraining = 10,
+    NoResultSubmitted = 11,
+    UnderAssessment = 12
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/RouteToProfessionalStatusType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/RouteToProfessionalStatusType.cs
@@ -1,0 +1,11 @@
+namespace TeachingRecordSystem.Core;
+
+public enum RouteType
+{
+    InitialTeacherTraining = 0,
+    AssessmentOnly = 1,
+    InternationalQualifiedTeacherStatus = 2,
+    OverseasQualified = 3,
+    Qtls = 4,
+    Other = 5
+}


### PR DESCRIPTION
This roughs out the `Route` type and extends `Qualification` to include QTS and EYTS. I've added a few dependent enums too, though many are currently empty.

I'm not wild about the `Route` naming but don't have anything better yet.