### PR TITLE
Add QualificationId and AlertId to Event table

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -18,5 +18,7 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.HasIndex(e => e.Payload).HasMethod("gin");
         builder.HasIndex(e => e.Key).IsUnique().HasFilter("key is not null").HasDatabaseName(Event.KeyUniqueIndexName);
         builder.HasIndex(e => new { e.PersonId, e.EventName }).HasFilter("person_id is not null");
+        builder.HasIndex(e => new { e.QualificationId, e.EventName }).HasFilter("qualification_id is not null");
+        builder.HasIndex(e => new { e.AlertId, e.EventName }).HasFilter("alert_id is not null");
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241030101833_EventQualificationAndAlertIds.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241030101833_EventQualificationAndAlertIds.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241030101833_EventQualificationAndAlertIds")]
+    partial class EventQualificationAndAlertIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241030101833_EventQualificationAndAlertIds.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241030101833_EventQualificationAndAlertIds.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EventQualificationAndAlertIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "alert_id",
+                table: "events",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "qualification_id",
+                table: "events",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_events_alert_id_event_name",
+                table: "events",
+                columns: new[] { "alert_id", "event_name" },
+                filter: "alert_id is not null");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_events_qualification_id_event_name",
+                table: "events",
+                columns: new[] { "qualification_id", "event_name" },
+                filter: "qualification_id is not null");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_events_alert_id_event_name",
+                table: "events");
+
+            migrationBuilder.DropIndex(
+                name: "ix_events_qualification_id_event_name",
+                table: "events");
+
+            migrationBuilder.DropColumn(
+                name: "alert_id",
+                table: "events");
+
+            migrationBuilder.DropColumn(
+                name: "qualification_id",
+                table: "events");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
@@ -12,6 +12,8 @@ public class Event
     public string? Key { get; init; }
     public bool Published { get; set; }
     public Guid? PersonId { get; init; }
+    public Guid? QualificationId { get; init; }
+    public Guid? AlertId { get; init; }
 
     public static Event FromEventBase(EventBase @event, DateTime? inserted)
     {
@@ -26,7 +28,9 @@ public class Event
             Inserted = inserted ?? @event.CreatedUtc,
             Payload = payload,
             Key = (@event as IEventWithKey)?.Key,
-            PersonId = (@event as IEventWithPersonId)?.PersonId
+            PersonId = (@event as IEventWithPersonId)?.PersonId,
+            QualificationId = (@event as IEventWithMandatoryQualification)?.MandatoryQualification.QualificationId,
+            AlertId = (@event as IEventWithAlert)?.Alert.AlertId
         };
     }
 


### PR DESCRIPTION
We've had a couple of needs arise in the last day or so to be able to query the `events` table for a specific alert. Today, that requires diving into the JSON `payload` and that's a little painful and not as quick as it could be.

This adds an `alert_id` column to `events` and adds an index. For symmetry, I've done the same for `qualification_id` too.

More PRs will follow to back-fill the data for these columns and to add the `events` table to the reporting DB.