### PR TITLE
Ensure alert links are pointing at appropriate endpoints

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
@@ -16,6 +16,15 @@
         <govuk-summary-list-row-value use-empty-fallback>@Model.Alert.Details</govuk-summary-list-row-value>
     </govuk-summary-list-row>
     <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Link</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value use-empty-fallback>
+            @if (Model.Alert.ExternalLink is not null)
+            {
+                <a href="@Model.Alert.ExternalLink" rel="noopener noreferrer" class="govuk-link">@Model.Alert.ExternalLink</a>
+            }
+        </govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
         <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
         <govuk-summary-list-row-value use-empty-fallback>@Model.Alert.StartDate?.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
     </govuk-summary-list-row>
@@ -30,4 +39,22 @@
             </govuk-summary-list-row-actions>
         }
     </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Reason for closing alert</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value use-empty-fallback>@Model.ChangeReason</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Reason details</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>
+            @if (Model.ChangeReasonDetail is not null)
+            {
+                <multi-line-text text="@Model.ChangeReasonDetail" />
+            }
+            else
+            {
+                <span use-empty-fallback></span>
+            }
+        </govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+
 </govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
@@ -9,19 +9,48 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts;
 
 [CheckAlertExistsFilterFactory(requiredPermission: Permissions.Alerts.Read), ServiceFilter(typeof(RequireClosedAlertFilter))]
-public class AlertDetailModel(IAuthorizationService authorizationService) : PageModel
+public class AlertDetailModel(
+    IAuthorizationService authorizationService,
+    TrsDbContext dbContext) : PageModel
 {
     public Alert? Alert { get; set; }
+
+    public string? ChangeReason { get; set; }
+
+    public string? ChangeReasonDetail { get; set; }
 
     public bool CanEdit { get; set; }
 
     public async Task OnGet()
     {
-        Alert = HttpContext.Features.GetRequiredFeature<CurrentAlertFeature>().Alert;
+        Alert = HttpContext.GetCurrentAlertFeature().Alert;
+        var personId = HttpContext.GetCurrentPersonFeature().PersonId;
+        var changeReasonInfo = await dbContext.Database
+            .SqlQuery<ChangeReasonInfo>(
+            $"""
+            SELECT
+            	payload ->> 'ChangeReason' as change_reason,
+            	payload ->> 'ChangeReasonDetail' as change_reason_detail
+            FROM
+            	events
+            WHERE
+            	person_id = {personId}
+            	AND event_name = 'AlertUpdatedEvent'
+            	AND (payload #>> Array['Alert', 'AlertId'])::uuid = {Alert.AlertId}
+            	AND payload #>> Array['Alert', 'EndDate'] is not null
+            	AND payload #>> Array['OldAlert', 'EndDate'] is null
+            ORDER BY
+            	created DESC
+            """)
+            .FirstOrDefaultAsync();
 
+        ChangeReason = changeReasonInfo?.ChangeReason;
+        ChangeReasonDetail = changeReasonInfo?.ChangeReasonDetail;
         CanEdit = (await authorizationService.AuthorizeForAlertTypeAsync(
             User,
             Alert.AlertTypeId,
             Permissions.Alerts.Write)) is { Succeeded: true };
     }
+
+    private record ChangeReasonInfo(string ChangeReason, string ChangeReasonDetail);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.AlertDetail(Model.AlertId)">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.AlertReopenCheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.AlertDetail(Model.AlertId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -50,7 +50,7 @@
                         @if (canWrite)
                         {
                             <govuk-summary-list-row-actions>
-                                <govuk-summary-list-row-action href="#" visually-hidden-text="details">Change</govuk-summary-list-row-action>
+                                <govuk-summary-list-row-action href="@LinkGenerator.AlertEditDetails(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="details">Change</govuk-summary-list-row-action>
                             </govuk-summary-list-row-actions>
                         }
                     </govuk-summary-list-row>
@@ -65,7 +65,7 @@
                         @if (canWrite)
                         {
                             <govuk-summary-list-row-actions>
-                                <govuk-summary-list-row-action href="#" visually-hidden-text="link">Change</govuk-summary-list-row-action>
+                                <govuk-summary-list-row-action href="@LinkGenerator.AlertEditLink(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="link">Change</govuk-summary-list-row-action>
                             </govuk-summary-list-row-actions>
                         }
                     </govuk-summary-list-row>
@@ -81,7 +81,13 @@
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value use-empty-fallback>@alert.EndDate?.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value use-empty-fallback></govuk-summary-list-row-value>
+                        @if (canWrite)
+                        {
+                            <govuk-summary-list-row-actions>
+                                <govuk-summary-list-row-action href="@LinkGenerator.AlertClose(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="end date">Add</govuk-summary-list-row-action>
+                            </govuk-summary-list-row-actions>
+                        }                        
                     </govuk-summary-list-row>
                 </govuk-summary-list>
             </govuk-summary-card>


### PR DESCRIPTION
### Context

The person alerts (for open alerts) and alert details (for closed alerts) pages currently have dummy links to the various journeys to edit / close / re-open / delete alerts.

### Changes proposed in this pull request

Ensure all links related to alert journeys point to the appropriate “real” URLs.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
