### PR TITLE
Give migrations more time to run

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241030104414_BackfillQualificationIdAndAlertId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241030104414_BackfillQualificationIdAndAlertId.cs
@@ -12,9 +12,11 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
         {
             migrationBuilder.Sql(
                 """
-                update events set qualification_id = (payload #>> Array['MandatoryQualification', 'QualificationId'])::uuid;
+                update events set qualification_id = (payload #>> Array['MandatoryQualification', 'QualificationId'])::uuid
+                where (payload #>> Array['MandatoryQualification', 'QualificationId'])::uuid is not null;
 
-                update events set alert_id = (payload #>> Array['Alert', 'AlertId'])::uuid;
+                update events set alert_id = (payload #>> Array['Alert', 'AlertId'])::uuid
+                where (payload #>> Array['Alert', 'AlertId'])::uuid is not null;
                 """);
         }
 

--- a/terraform/aks/app.tf
+++ b/terraform/aks/app.tf
@@ -43,8 +43,8 @@ resource "kubernetes_job" "migrations" {
   wait_for_completion = true
 
   timeouts {
-    create = "11m"
-    update = "11m"
+    create = "15m"
+    update = "15m"
   }
 }
 


### PR DESCRIPTION
The last migration is timing out in prod. This increase the timeout and tweaks the migration a little (which may speed it up).