### PR TITLE
Allow change reason and details to be null

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml.cs
@@ -52,5 +52,5 @@ public class AlertDetailModel(
             Permissions.Alerts.Write)) is { Succeeded: true };
     }
 
-    private record ChangeReasonInfo(string ChangeReason, string ChangeReasonDetail);
+    private record ChangeReasonInfo(string? ChangeReason, string? ChangeReasonDetail);
 }


### PR DESCRIPTION
### Context

Alert details screen caused exception when change reason was null for a closed alert.

### Changes proposed in this pull request

Allow change reason and/or detail to be null
