### PR TITLE
Allow updating users with no roles

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
@@ -67,11 +67,6 @@ public class EditUser(
         // Sanitize roles
         var newRoles = Roles!.Where(r => UserRoles.All.Contains(r)).ToArray();
 
-        if (Roles?.Length == 0)
-        {
-            ModelState.AddModelError(nameof(Roles), "Select at least one role");
-        }
-
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUserTests.cs
@@ -184,28 +184,6 @@ public class EditUserTests : TestBase
         await AssertEx.HtmlResponseHasError(response, "Name", "Enter a name");
     }
 
-    [Fact]
-    public async Task Post_NoRolesSelected_RendersError()
-    {
-        // Arrange
-        var user = await TestData.CreateUser();
-        var newName = Faker.Name.FullName();
-
-        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(user.UserId))
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "Name", newName },
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        await AssertEx.HtmlResponseHasError(response, "Roles", "Select at least one role");
-    }
-
     [Theory]
     [InlineData(true, false, true, UserUpdatedEventChanges.Name)]
     [InlineData(false, true, true, UserUpdatedEventChanges.Roles)]


### PR DESCRIPTION
https://github.com/DFE-Digital/teaching-record-system/pull/1643 made the change to allow creating users with no roles but the Edit User page still requires at least one role. This fixes that page too.