### PR TITLE
Tidy Test.CreatePerson w.r.t. specifying a TRN

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetOrCreateTrnRequestTests.cs
@@ -86,7 +86,7 @@ public class GetOrCreateTrnRequestTests : TestBase
         var requestId = Guid.NewGuid().ToString();
         var slugId = Guid.NewGuid().ToString();
         var trnRequestId = TrnRequestHelper.GetCrmTrnRequestId(ClientId, requestId);
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn().WithTrnRequestId(trnRequestId));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn().WithTrnRequestId(trnRequestId));
 
         DataverseAdapterMock
             .Setup(mock => mock.GetTeacher(createPersonResult.ContactId, /* resolveMerges: */ It.IsAny<string[]>(), true))
@@ -163,7 +163,7 @@ public class GetOrCreateTrnRequestTests : TestBase
         var requestId = Guid.NewGuid().ToString();
         var slugId = Guid.NewGuid().ToString();
         var trnRequestId = TrnRequestHelper.GetCrmTrnRequestId(ClientId, requestId);
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn(false).WithTrnRequestId(trnRequestId).WithSlugId(slugId));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithoutTrn().WithTrnRequestId(trnRequestId).WithSlugId(slugId));
 
         DataverseAdapterMock
             .Setup(mock => mock.GetTeacher(createPersonResult.ContactId, /* resolveMerges: */ It.IsAny<string[]>(), true))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V2/Operations/GetTrnRequestTests.cs
@@ -122,7 +122,7 @@ public class GetTrnRequestTests : TestBase
         var requestId = Guid.NewGuid().ToString();
         var slugId = Guid.NewGuid().ToString();
         var trnRequestId = TrnRequestHelper.GetCrmTrnRequestId(ClientId, requestId);
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn(false).WithTrnRequestId(trnRequestId).WithSlugId(slugId));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithoutTrn().WithTrnRequestId(trnRequestId).WithSlugId(slugId));
 
         DataverseAdapterMock
             .Setup(mock => mock.GetTeacher(createPersonResult.ContactId, /* resolveMerges: */ It.IsAny<string[]>(), true))
@@ -206,7 +206,7 @@ public class GetTrnRequestTests : TestBase
         var requestId = Guid.NewGuid().ToString();
         var slugId = Guid.NewGuid().ToString();
         var trnRequestId = TrnRequestHelper.GetCrmTrnRequestId(ClientId, requestId);
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn().WithTrnRequestId(trnRequestId));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn().WithTrnRequestId(trnRequestId));
 
         DataverseAdapterMock
             .Setup(mock => mock.GetTeacher(createPersonResult.ContactId, /* resolveMerges: */ It.IsAny<string[]>(), true))
@@ -296,7 +296,7 @@ public class GetTrnRequestTests : TestBase
         var trnToken = "ABCDEFG1234567";
         var qtsDate = new DateOnly(2020, 10, 03);
         var trnRequestId = TrnRequestHelper.GetCrmTrnRequestId(ClientId, requestId);
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn().WithTrnRequestId(trnRequestId).WithQts(qtsDate).WithTrnToken(trnToken));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn().WithTrnRequestId(trnRequestId).WithQts(qtsDate).WithTrnToken(trnToken));
 
         DataverseAdapterMock
             .Setup(mock => mock.GetTeacher(createPersonResult.ContactId, /* resolveMerges: */ It.IsAny<string[]>(), true))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/CreateDateOfBirthChangeTests.cs
@@ -11,7 +11,7 @@ public class CreateDateOfBirthChangeTests : TestBase
     public CreateDateOfBirthChangeTests(HostFixture hostFixture)
         : base(hostFixture)
     {
-        SetCurrentApiClient(new[] { ApiRoles.UpdatePerson });
+        SetCurrentApiClient([ApiRoles.UpdatePerson]);
     }
 
     [Theory, RoleNamesData(except: [ApiRoles.UpdatePerson])]
@@ -73,7 +73,7 @@ public class CreateDateOfBirthChangeTests : TestBase
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
 
         var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
 
@@ -145,7 +145,7 @@ public class CreateDateOfBirthChangeTests : TestBase
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";
@@ -173,7 +173,7 @@ public class CreateDateOfBirthChangeTests : TestBase
     public async Task Post_ValidRequest_CreatesIncident()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/CreateNameChangeTests.cs
@@ -80,7 +80,7 @@ public class CreateNameChangeTests : TestBase
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/v3/teachers/name-changes")
         {
@@ -156,7 +156,7 @@ public class CreateNameChangeTests : TestBase
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();
@@ -188,7 +188,7 @@ public class CreateNameChangeTests : TestBase
     public async Task Post_ValidRequest_CreatesIncident()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/FindTeachersTests.cs
@@ -9,7 +9,7 @@ public class FindTeachersTests : TestBase
         : base(hostFixture)
     {
         XrmFakedContext.DeleteAllEntities<Contact>();
-        SetCurrentApiClient(new[] { ApiRoles.GetPerson });
+        SetCurrentApiClient([ApiRoles.GetPerson]);
     }
 
     [Theory, RoleNamesData(except: [ApiRoles.GetPerson])]
@@ -22,8 +22,8 @@ public class FindTeachersTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -85,8 +85,8 @@ public class FindTeachersTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -155,9 +155,9 @@ public class FindTeachersTests : TestBase
         var lastName = TestData.GenerateLastName();
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
-        var person3 = await TestData.CreatePerson(b => b.WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person3 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
         var updatedLastName = TestData.GenerateChangedLastName(lastName);
         await TestData.UpdatePerson(b => b.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
 
@@ -238,7 +238,7 @@ public class FindTeachersTests : TestBase
 
         var sanctionCode = "A17";
         Debug.Assert(!TeachingRecordSystem.Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
-        var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherByTrnTests.cs
@@ -112,7 +112,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
     public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
             .WithTrn()
             // MQ with no EndDate
             .WithMandatoryQualification(b => b.WithStatus(MandatoryQualificationStatus.InProgress))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTests.cs
@@ -195,7 +195,7 @@ public class GetTeacherTests : GetTeacherTestBase
     public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
             .WithTrn()
             // MQ with no EndDate
             .WithMandatoryQualification(b => b.WithStatus(MandatoryQualificationStatus.InProgress))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240307/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240307/GetTrnRequestTests.cs
@@ -27,7 +27,7 @@ public class GetTrnRequestTests : TestBase
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var existingContact = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)
@@ -80,7 +80,7 @@ public class GetTrnRequestTests : TestBase
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var masterContact = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)
@@ -89,7 +89,7 @@ public class GetTrnRequestTests : TestBase
             .WithNationalInsuranceNumber(nationalInsuranceNumber: nationalInsuranceNumber));
 
         var existingContact = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: false)
+            .WithoutTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)
@@ -143,7 +143,7 @@ public class GetTrnRequestTests : TestBase
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var existingContact = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)
@@ -189,7 +189,7 @@ public class GetTrnRequestTests : TestBase
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var existingContact = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: false)
+            .WithoutTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240412/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240412/CreateDateOfBirthChangeTests.cs
@@ -19,7 +19,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
 
         var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
 
@@ -90,7 +90,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";
@@ -117,7 +117,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240412/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240412/CreateNameChangeTests.cs
@@ -21,7 +21,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/v3/teacher/name-changes")
         {
@@ -46,7 +46,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();
@@ -77,7 +77,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240416/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240416/GetTeacherByTrnTests.cs
@@ -11,7 +11,7 @@ public class GetTeacherByTrnTests : TestBase
     public async Task Get_DateOfBirthDoesNotMatchTeachingRecord_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var dateOfBirth = person.DateOfBirth.AddDays(1);
 
         var httpClient = GetHttpClientWithApiKey();
@@ -28,7 +28,7 @@ public class GetTeacherByTrnTests : TestBase
     public async Task Get_DateOfBirthMatchesTeachingRecord_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
 
         var httpClient = GetHttpClientWithApiKey();
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}");
@@ -44,7 +44,7 @@ public class GetTeacherByTrnTests : TestBase
     public async Task Get_DateOfBirthNotProvided_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
 
         var httpClient = GetHttpClientWithApiKey();
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateDateOfBirthChangeTests.cs
@@ -19,7 +19,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
 
         var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
 
@@ -90,7 +90,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";
@@ -117,7 +117,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson();
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateNameChangeTests.cs
@@ -21,7 +21,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/name-changes")
         {
@@ -46,7 +46,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();
@@ -77,7 +77,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePerson(p => p.WithTrn());
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -22,8 +22,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -85,8 +85,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -155,11 +155,11 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = TestData.GenerateLastName();
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
-        var person3 = await TestData.CreatePerson(b => b.WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("A21B"));
+        var person3 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
         var updatedLastName = TestData.GenerateChangedLastName(lastName);
-        await TestData.UpdatePerson(b => b.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
+        await TestData.UpdatePerson(p => p.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -238,7 +238,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
 
         var sanctionCode = "A17";
         Debug.Assert(!Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
-        var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonByTrnTests.cs
@@ -111,7 +111,7 @@ public class GetPersonByTrnTests : GetPersonTestBase
     public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
             .WithTrn()
             // MQ with no EndDate
             .WithMandatoryQualification(b => b.WithStatus(MandatoryQualificationStatus.InProgress))
@@ -214,7 +214,7 @@ public class GetPersonByTrnTests : GetPersonTestBase
     public async Task Get_DateOfBirthDoesNotMatchTeachingRecord_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var dateOfBirth = person.DateOfBirth.AddDays(1);
 
         var httpClient = GetHttpClientWithApiKey();
@@ -231,7 +231,7 @@ public class GetPersonByTrnTests : GetPersonTestBase
     public async Task Get_DateOfBirthMatchesTeachingRecord_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
 
         var httpClient = GetHttpClientWithApiKey();
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}");
@@ -247,7 +247,7 @@ public class GetPersonByTrnTests : GetPersonTestBase
     public async Task Get_DateOfBirthNotProvided_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
 
         var httpClient = GetHttpClientWithApiKey();
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTests.cs
@@ -190,7 +190,7 @@ public class GetPersonTests(HostFixture hostFixture) : GetPersonTestBase(hostFix
     public async Task Get_ValidRequestWithMandatoryQualifications_ReturnsExpectedMandatoryQualificationsContent()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
             .WithTrn()
             // MQ with no EndDate
             .WithMandatoryQualification(b => b.WithStatus(MandatoryQualificationStatus.InProgress))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -22,8 +22,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction("G1"));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -85,7 +85,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b
+        var person1 = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithSanction("A21B")
@@ -93,7 +94,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
             .WithQts(qtsDate: new(2021, 7, 1))
             .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
 
-        var person2 = await TestData.CreatePerson(b => b
+        var person2 = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithSanction("A21B"));
@@ -183,10 +185,10 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = TestData.GenerateLastName();
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person2 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person2 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
         var updatedLastName = TestData.GenerateChangedLastName(lastName);
-        await TestData.UpdatePerson(b => b.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
+        await TestData.UpdatePerson(p => p.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -230,7 +232,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
 
         var sanctionCode = "A17";
         Debug.Assert(!Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
-        var person = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithSanction(sanctionCode));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -20,7 +20,8 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
 
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithDateOfBirth(dateOfBirth));
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
@@ -79,7 +80,8 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         // Arrange
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithDateOfBirth(dateOfBirth)
             .WithSanction("G1")
             .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
@@ -120,7 +122,8 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         // Arrange
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithDateOfBirth(dateOfBirth)
             .WithSanction("A21B")
             .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
@@ -197,7 +200,8 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
 
         var sanctionCode = "A17";
         Debug.Assert(!Api.V3.Constants.LegacyExposableSanctionCodes.Contains(sanctionCode));
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithDateOfBirth(dateOfBirth)
             .WithSanction(sanctionCode));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240912/GetQtlsDateRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240912/GetQtlsDateRequestTests.cs
@@ -16,7 +16,7 @@ public class GetQtlsDateRequestTests : TestBase
         // Arrange
         SetCurrentApiClient(roles);
         var existingContact = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true));
+            .WithTrn());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"v3/persons/{existingContact.Trn}/qtls");
 
@@ -46,7 +46,7 @@ public class GetQtlsDateRequestTests : TestBase
     public async Task Get_NoQtls_ReturnsExpectedResult()
     {
         // Arrange
-        var person = await TestData.CreatePerson(p => p.WithTrn(hasTrn: true));
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var request = new HttpRequestMessage(HttpMethod.Get, $"v3/persons/{person.Trn}/qtls");
 
         // Act
@@ -70,7 +70,7 @@ public class GetQtlsDateRequestTests : TestBase
         // Arrange
         var qtlsDate = new DateOnly(2020, 01, 01);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQtlsDate(qtlsDate));
         var request = new HttpRequestMessage(HttpMethod.Get, $"v3/persons/{person.Trn}/qtls");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240912/SetQtlsDateRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240912/SetQtlsDateRequestTests.cs
@@ -111,7 +111,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var qtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQtlsDate(new DateOnly(2020, 01, 01)));
 
         var requestBody = CreateJsonContent(new { qtsDate = qtlsDate });
@@ -149,7 +149,7 @@ public class SetQtlsDateRequestTests : TestBase
         var expectedInductionStatus = dfeta_InductionStatus.RequiredtoComplete;
         var expectedHttpStatus = HttpStatusCode.OK;
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
@@ -181,7 +181,7 @@ public class SetQtlsDateRequestTests : TestBase
         var expectedInductionStatus = dfeta_InductionStatus.Exempt;
         var expectedHttpStatus = HttpStatusCode.OK;
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
@@ -209,7 +209,7 @@ public class SetQtlsDateRequestTests : TestBase
         var incomingqtlsDate = DateOnly.Parse("01/07/1997");
         var expectedInductionStatus = dfeta_InductionStatus.InProgress;
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)); ;
 
@@ -243,7 +243,7 @@ public class SetQtlsDateRequestTests : TestBase
         var incomingqtlsDate = DateOnly.Parse("01/07/1997");
         var expectedInductionStatus = dfeta_InductionStatus.Exempt;
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
@@ -273,7 +273,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate)
@@ -308,7 +308,7 @@ public class SetQtlsDateRequestTests : TestBase
         var incomingqtlsDate = DateOnly.Parse("04/04/2002");
         var existingqtlsDate = DateOnly.Parse("04/04/2002");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingqtlsDate));
@@ -341,7 +341,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("04/04/2001");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithSanction("G1"));
@@ -375,7 +375,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
@@ -407,7 +407,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("01/07/1997");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
@@ -438,7 +438,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("01/07/1997");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, Clock.Today.AddMonths(-1), Clock.Today.AddDays(-1), account.AccountId));
 
@@ -469,7 +469,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithQtlsDate(existingQtlsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, account.AccountId));
@@ -500,7 +500,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("04/04/2011");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, account.AccountId));
 
@@ -530,7 +530,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("01/07/1997");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
 
@@ -562,7 +562,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
@@ -594,7 +594,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("01/07/1997");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
 
@@ -626,7 +626,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
@@ -658,7 +658,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("01/01/1992");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
@@ -693,7 +693,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtlsDate = DateOnly.Parse("04/04/1991");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
@@ -728,7 +728,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("01/07/1997");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
 
@@ -760,7 +760,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
@@ -792,7 +792,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtsDate = DateOnly.Parse("04/04/2016");
         var incomingqtlsDate = DateOnly.Parse("01/01/1992");
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
@@ -827,7 +827,7 @@ public class SetQtlsDateRequestTests : TestBase
         var existingQtlsDate = DateOnly.Parse("04/04/1991");
         var incomingqtlsDate = default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(existingQtsDate)
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
@@ -861,7 +861,7 @@ public class SetQtlsDateRequestTests : TestBase
         var qtlsDate = new DateOnly(2010, 01, 01);
         var incommingQtlsDate = new DateOnly(2009, 01, 01);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQtlsDate(qtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incommingQtlsDate });
@@ -888,7 +888,7 @@ public class SetQtlsDateRequestTests : TestBase
         var qtlsDate = new DateOnly(2010, 01, 01);
         var qtsDate = new DateOnly(2008, 01, 01);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(qtsDate)
             .WithQtlsDate(qtlsDate));
 
@@ -917,7 +917,7 @@ public class SetQtlsDateRequestTests : TestBase
         var qtsDate1 = new DateOnly(2010, 01, 01);
         var earliestQTSDate = new DateOnly(2008, 01, 01);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(qtsDate1)
             .WithQts(earliestQTSDate));
 
@@ -944,7 +944,7 @@ public class SetQtlsDateRequestTests : TestBase
         var qtsDate1 = new DateOnly(2010, 01, 01);
         var qtsDate2 = new DateOnly(2008, 01, 01);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(qtsDate1)
             .WithQts(qtsDate2));
 
@@ -976,7 +976,7 @@ public class SetQtlsDateRequestTests : TestBase
         var qtsDate2 = DateOnly.Parse(qts2);
         var expectedQTSDate = DateOnly.Parse(expectedQTS);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithQts(qtsDate1)
             .WithQts(qtsDate2)
             .WithQtlsDate(qtlsDate));
@@ -1018,7 +1018,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var qtlsDate = !string.IsNullOrEmpty(incomingQtls) ? DateOnly.Parse(incomingQtls) : default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
-            .WithTrn(hasTrn: true)
+            .WithTrn()
             .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: existingInductionExemptionReason, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = qtlsDate });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -23,7 +23,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var alertType = await ReferenceDataCache.GetAlertTypeByDqtSanctionCode(sanctionCode);
         var alertCategory = await ReferenceDataCache.GetAlertCategoryById(alertType.AlertCategoryId);
 
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithSanction(sanctionCode, startDate, endDate, details: details));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -24,7 +24,8 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var alertType = await ReferenceDataCache.GetAlertTypeByDqtSanctionCode(sanctionCode);
         var alertCategory = await ReferenceDataCache.GetAlertCategoryById(alertType.AlertCategoryId);
 
-        var person = await TestData.CreatePerson(b => b
+        var person = await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithSanction(sanctionCode, startDate, endDate, details: details));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
@@ -97,7 +97,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -236,7 +236,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -256,7 +256,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequest_CreatesSupportTicketAndRedirectsToSupportRequestedSubmitted()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var trnToken = await CreateTrnToken(person.Trn!);
         var applicationUser = await TestData.CreateApplicationUser(isOidcClient: true);
         var state = CreateNewState(clientApplicationUserId: applicationUser.UserId, trnToken: trnToken);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
@@ -44,7 +44,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -122,7 +122,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
@@ -34,7 +34,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -79,7 +79,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
@@ -44,7 +44,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -148,7 +148,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -335,7 +335,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUser(
             personId: null,
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
@@ -48,7 +48,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
@@ -25,7 +25,7 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
@@ -95,7 +95,7 @@ public class SupportRequestSubmittedTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
@@ -46,7 +46,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -184,7 +184,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn());
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -418,7 +418,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
 
-        var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUser(
             personId: null,
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
@@ -18,7 +18,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(person);
             Clock.Advance();
 
@@ -233,7 +233,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -292,7 +292,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -351,7 +351,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -410,7 +410,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -459,7 +459,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -508,7 +508,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -557,7 +557,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -616,7 +616,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -666,7 +666,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -716,7 +716,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -762,7 +762,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -812,7 +812,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePerson(b => b.WithTrn(true));
+            var person = await TestData.CreatePerson(p => p.WithTrn());
             var user = await TestData.CreateOneLoginUser(personId: null);
             Clock.Advance();
 
@@ -918,7 +918,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var firstName = Faker.Name.Last();
             var lastName = Faker.Name.Last();
             var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-            var person = await TestData.CreatePerson(b => b.WithTrn(false).WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
+            var person = await TestData.CreatePerson(p => p.WithoutTrn().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
 
             var user = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([firstName, lastName], dateOfBirth));
             Clock.Advance();
@@ -977,7 +977,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var firstName = Faker.Name.Last();
             var lastName = Faker.Name.Last();
             var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-            var person = await TestData.CreatePerson(b => b.WithTrn().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
+            var person = await TestData.CreatePerson(p => p.WithTrn().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
 
             var user = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([firstName, lastName], dateOfBirth));
             Clock.Advance();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/FindPotentialDuplicateContactsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/FindPotentialDuplicateContactsTests.cs
@@ -25,7 +25,8 @@ public class FindPotentialDuplicateContactsTests : IAsyncLifetime
         var lastName = Faker.Name.Last();
         var dob = new DateTime(1987, 01, 01);
 
-        var person = await _dataScope.TestData.CreatePerson(b => b
+        var person = await _dataScope.TestData.CreatePerson(p => p
+            .WithTrn()
             .WithFirstName(firstNameSynonym)
             .WithLastName(lastName)
             .WithMiddleName(middleName)
@@ -60,7 +61,7 @@ public class FindPotentialDuplicateContactsTests : IAsyncLifetime
         // Arrange
         var email = $"{Guid.NewGuid()}@test.com";
 
-        var person = await _dataScope.TestData.CreatePerson(b => b.WithEmail(email));
+        var person = await _dataScope.TestData.CreatePerson(p => p.WithEmail(email));
 
         var query = new FindPotentialDuplicateContactsQuery()
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactByTrnTests.cs
@@ -34,7 +34,7 @@ public class GetActiveContactByTrnTests : IAsyncLifetime
     public async Task WhenCalled_WithTrnForExistingContact_ReturnsContactDetail()
     {
         // Arrange        
-        var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
+        var person = await _dataScope.TestData.CreatePerson(p => p.WithTrn());
 
         // Act
         var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactByTrnQuery(person.Trn!, new ColumnSet()));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactDetailByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactDetailByTrnTests.cs
@@ -34,7 +34,7 @@ public class GetActiveContactDetailByTrnTests : IAsyncLifetime
     public async Task WhenCalled_WithTrnForExistingContact_ReturnsContactDetail()
     {
         // Arrange
-        var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
+        var person = await _dataScope.TestData.CreatePerson(p => p.WithTrn());
 
         // Act
         var result = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
@@ -52,7 +52,7 @@ public class GetActiveContactDetailByTrnTests : IAsyncLifetime
         var updatedFirstName = _dataScope.TestData.GenerateFirstName();
         var updatedMiddleName = _dataScope.TestData.GenerateMiddleName();
         var updatedLastName = _dataScope.TestData.GenerateLastName();
-        var person = await _dataScope.TestData.CreatePerson(b => b.WithTrn());
+        var person = await _dataScope.TestData.CreatePerson(p => p.WithTrn());
         await _dataScope.TestData.UpdatePerson(b => b.WithPersonId(person.ContactId).WithUpdatedName(updatedFirstName, updatedMiddleName, updatedLastName));
 
         // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactsByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactsByLastNameAndDateOfBirthTests.cs
@@ -24,8 +24,8 @@ public class GetActiveContactsByLastNameAndDateOfBirthTests : IAsyncLifetime
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await _dataScope.TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person2 = await _dataScope.TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person1 = await _dataScope.TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person2 = await _dataScope.TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
         // Act
         var results = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactsByLastNameAndDateOfBirthQuery(lastName, dateOfBirth, new ColumnSet()));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactByTrnRequestIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactByTrnRequestIdTests.cs
@@ -35,7 +35,7 @@ public class GetContactByTrnRequestIdTests : IAsyncLifetime
     {
         // Arrange
         var requestId = Guid.NewGuid().ToString();
-        var person = await _dataScope.TestData.CreatePerson(b => b.WithTrnRequestId(requestId));
+        var person = await _dataScope.TestData.CreatePerson(p => p.WithTrn().WithTrnRequestId(requestId));
 
         // Act
         var result = await _crmQueryDispatcher.ExecuteQuery(new GetContactByTrnRequestIdQuery(requestId, new ColumnSet()));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetContactsByDateOfBirthTests.cs
@@ -76,9 +76,9 @@ public class GetContactsByDateOfBirthTests : IAsyncLifetime
             Contact.Fields.FullName);
 
 
-        var person1 = await _dataScope.TestData.CreatePerson(b => b.WithDateOfBirth(dateOfBirth));
-        var person2 = await _dataScope.TestData.CreatePerson(b => b.WithDateOfBirth(dateOfBirth));
-        var person3 = await _dataScope.TestData.CreatePerson(b => b.WithDateOfBirth(dateOfBirth));
+        var person1 = await _dataScope.TestData.CreatePerson(p => p.WithTrn().WithDateOfBirth(dateOfBirth));
+        var person2 = await _dataScope.TestData.CreatePerson(p => p.WithTrn().WithDateOfBirth(dateOfBirth));
+        var person3 = await _dataScope.TestData.CreatePerson(p => p.WithTrn().WithDateOfBirth(dateOfBirth));
 
         // Act
         var results = await _crmQueryDispatcher.ExecuteQuery(new GetActiveContactsByDateOfBirthQuery(dateOfBirth, testScenarioData.SortBy, maxRecordCount, columnSet));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -67,7 +67,7 @@ public class PersonMatchingServiceTests : IAsyncLifetime
                 await dbContext.SaveChangesAsync();
             }
 
-            var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName));
+            var person = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName));
             var establishment = await TestData.CreateEstablishment(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var employmentNino = TestData.GenerateChangedNationalInsuranceNumber(person.NationalInsuranceNumber!);
             var personEmployment = await TestData.CreateTpsEmployment(person, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), employmentNino);
@@ -134,8 +134,8 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             var lastName = TestData.GenerateLastName();
             var dateOfBirth = TestData.GenerateDateOfBirth();
 
-            var person1 = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-            var person2 = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person1 = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person2 = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
             string[][] names = [[firstName, lastName]];
             DateOnly[] datesOfBirth = [dateOfBirth];
@@ -166,7 +166,7 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             });
             await dbContext.SaveChangesAsync();
 
-            var person = await TestData.CreatePerson(b => b.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName));
+            var person = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName));
 
             string[][] names = [[person.FirstName, person.LastName], [alias, person.LastName]];
             DateOnly[] datesOfBirth = [person.DateOfBirth];
@@ -196,19 +196,19 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             var alternativeNationalInsuranceNumber = TestData.GenerateChangedNationalInsuranceNumber(nationalInsuranceNumber);
 
             // Person who matches on last name & DOB
-            var person1 = await TestData.CreatePerson(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person1 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
             // Person who matches on NINO            
-            var person2 = await TestData.CreatePerson(b => b.WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
+            var person2 = await TestData.CreatePerson(p => p.WithTrn().WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
             var establishment = await TestData.CreateEstablishment(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var personEmployment = await TestData.CreateTpsEmployment(person2, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), usePersonNino ? alternativeNationalInsuranceNumber : nationalInsuranceNumber);
 
             // Person who matches on TRN
-            var person3 = await TestData.CreatePerson(b => b.WithTrn());
+            var person3 = await TestData.CreatePerson(p => p.WithTrn());
             var trn = person3.Trn!;
 
             // Person who matches on last name, DOB & TRN
-            var person4 = await TestData.CreatePerson(b => b.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person4 = await TestData.CreatePerson(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
             var trnTokenHintTrn = person4.Trn!;
 
             string[][] names = [[firstName, lastName]];
@@ -241,7 +241,7 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
             var alternativeNationalInsuranceNumber = TestData.GenerateChangedNationalInsuranceNumber(nationalInsuranceNumber);
 
-            var person = await TestData.CreatePerson(b => b.WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
+            var person = await TestData.CreatePerson(p => p.WithTrn().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
             var establishment = await TestData.CreateEstablishment(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var personEmployment = await TestData.CreateTpsEmployment(person, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), usePersonNino ? alternativeNationalInsuranceNumber : nationalInsuranceNumber);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Alert.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Alert.cs
@@ -15,7 +15,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_NewRecord_WritesNewRowToDb(bool personAlreadySynced)
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithSyncOverride(personAlreadySynced));
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithSyncOverride(personAlreadySynced));
         var alertId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var entity = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection);
@@ -31,7 +31,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_SanctionCodeIsRedundant_IsNotWrittenToDb()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var alertId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var entity = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection, redundantType: true);
@@ -51,7 +51,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_WithDeactivatedEvent_SetsDeletedOnAttribute()
     {
         // Arrange
-        var person = await TestData.CreatePerson(b => b.WithSyncOverride(false));
+        var person = await TestData.CreatePerson(p => p.WithTrn().WithSyncOverride(false));
         var qualificationId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var entity = await CreateNewAlertEntityVersion(qualificationId, person.ContactId, auditDetailCollection);
@@ -75,7 +75,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_WithDqtCreateAudit_CreatesExpectedEvents()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var qualificationId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var initialVersion = await CreateNewAlertEntityVersion(qualificationId, person.ContactId, auditDetailCollection, addCreateAudit: true);
@@ -111,7 +111,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_WithNoDqtAudit_CreatesExpectedEvents()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var alertId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var initialVersion = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection, addCreateAudit: false);
@@ -154,7 +154,7 @@ public partial class TrsDataSyncHelperTests
         // be reconstructed from multiple Update audits.
 
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var alertId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var initialVersion = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection, addCreateAudit: false);
@@ -209,7 +209,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_WithDqtUpdateAudit_CreatesExpectedEvents()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var alertId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var initialVersion = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection);
@@ -255,7 +255,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_WithDqtDeactivatedAudit_CreatesExpectedEvent()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var alertId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var entity = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection);
@@ -279,7 +279,7 @@ public partial class TrsDataSyncHelperTests
     public async Task SyncAlert_WithDqtReactivatedAudit_CreatesExpectedEvents()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var alertId = Guid.NewGuid();
         var auditDetailCollection = new AuditDetailCollection();
         var entity = await CreateNewAlertEntityVersion(alertId, person.ContactId, auditDetailCollection);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Person.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Person.cs
@@ -11,7 +11,7 @@ public partial class TrsDataSyncServiceTests
     public async Task Contact_NewRecord_WritesNewPersonRecordToDatabase()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithSyncOverride(false));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithSyncOverride(false));
         var contactId = createPersonResult.ContactId;
         var contact = createPersonResult.Contact;
         contact.CreatedOn = Clock.UtcNow;
@@ -35,7 +35,7 @@ public partial class TrsDataSyncServiceTests
     public async Task Contact_UpdatedRecord_WritesUpdatedPersonRecordToDatabase()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithSyncOverride(false));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithSyncOverride(false));
         var contactId = createPersonResult.ContactId;
         var contact = createPersonResult.Contact;
         contact.CreatedOn = Clock.UtcNow;
@@ -69,7 +69,7 @@ public partial class TrsDataSyncServiceTests
     public async Task Contact_DeletedRecord_DeletesPersonRecordFromDatabase()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithSyncOverride(true));
+        var createPersonResult = await TestData.CreatePerson(p => p.WithSyncOverride(true));
         var contactId = createPersonResult.ContactId;
         var newItem = new NewOrUpdatedItem(ChangeType.NewOrUpdated, createPersonResult.Contact);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -61,7 +61,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNonMatchingEstablishments_WhenCalledWithEstablishmentsNotMatchingEstablishmentsInTrs_SetsResultToInvalidEstablishment()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "124", establishmentNumber: "1235");
         var nonExistentEstablishmentNumber = "4321";
@@ -86,7 +86,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithNewEmploymentHistory_InsertsNewPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishment(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -115,7 +115,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithEndDateInTheFuture_SetsLastKnownEmployedDateToExtractDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishment(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -144,7 +144,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithWithdrawalIndicatorSet_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishment(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -173,7 +173,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithLastKnownEmployedDateOlderThanFiveMonths_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishment(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -203,7 +203,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_ForLaCodeAndEstablishmentNumberWithMultipleEstablishmentEntries_MatchesToTheMostOpenEstablishment()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var laCode = "321";
         var establishmentNumber = "4321";
@@ -237,7 +237,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WithValidData_OnlyMatchesToLaCodeAndPostCodeForHigherEducationIfNoMatchOnLaCodeAndEstablishment()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var laCode1 = "322";
         var establishmentNumber1 = "4322";
@@ -271,7 +271,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithUpdatedEmploymentHistory_UpdatesPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -301,7 +301,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithEndDateInTheFuture_SetsLastKnownEmployedDateToExtractDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -329,7 +329,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithWithdrawalIndicatorSet_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -361,7 +361,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithLastKnownEmployedDateOlderThanFiveMonths_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -389,7 +389,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithWithdrawalIndicatorNowRemoved_ResetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -418,7 +418,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithUpdatedEmploymentHistoryWithNoChanges_SetsResultToValidNoChanges()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -442,7 +442,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task UpdateLatestEstablishmentVersions_WithEstablishmentChangingUrn_UpdatesPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 2); // Closed
         var establishment2 = await TestData.CreateEstablishment(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 1); // Open
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -465,7 +465,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessEndedEmployments_WithLastKnownEmployedDateGreaterThanThreeMonthsBeforeLastExtractDate_SetsEndDateOnPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "128", establishmentNumber: "1239");
         var establishment2 = await TestData.CreateEstablishment(localAuthorityCode: "128", establishmentNumber: "1240");
         var extractDate = new DateOnly(2024, 04, 25);
@@ -494,7 +494,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task BackfillNinoAndPersonPostcodeInEmploymentHistory_WhenCalledWithPersonEmploymentRecordsWithoutNinoAndPersonPostcode_SetsNinoAndPersonPostcode()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishment(localAuthorityCode: "129", establishmentNumber: "1241");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -43,7 +43,7 @@ public class WorkforceDataExporterTests : IAsyncLifetime
         var optionsAccessor = Mock.Of<IOptions<WorkforceDataExportOptions>>();
         var storageClientProvider = Mock.Of<IStorageClientProvider>();
         var storageClient = Mock.Of<StorageClient>();
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var establishment1 = await TestData.CreateEstablishment(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
         var personPostcode = Faker.Address.UkPostCode();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/SupportTaskTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/SupportTaskTests.cs
@@ -5,7 +5,7 @@ public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task ConnectOneLoginUser_WithSuggestion()
     {
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -28,7 +28,7 @@ public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task ConnectOneLoginUser_WithoutSuggestions()
     {
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([TestData.GenerateFirstName(), TestData.GenerateLastName()], TestData.GenerateDateOfBirth()));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
@@ -35,6 +35,7 @@ public class IndexTests : TestBase
         var updatedLastName = TestData.GenerateLastName();
         var previousMiddleNameChangedOn = new DateOnly(2022, 02, 02);
         var createPersonResult = await TestData.CreatePerson(b => b
+            .WithTrn()
             .WithEmail(email)
             .WithMobileNumber(mobileNumber)
             .WithNationalInsuranceNumber());
@@ -68,7 +69,7 @@ public class IndexTests : TestBase
     public async Task Get_WithPersonIdForExistingPersonWithMissingProperties_ReturnsExpectedContent()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePerson(b => b.WithTrn(hasTrn: false));
+        var createPersonResult = await TestData.CreatePerson(b => b.WithoutTrn());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}");
 
@@ -108,7 +109,7 @@ public class IndexTests : TestBase
     public async Task Get_PersonHasNoAlert_DoesNotShowAlertNotification()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         Debug.Assert(person.Alerts.Count == 0);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/ConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/ConnectTests.cs
@@ -27,7 +27,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -48,7 +48,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_TrnDoesNotExist_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -65,7 +65,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequest_ReturnsExpectedContent()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -102,7 +102,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -123,7 +123,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_TrnDoesNotExist_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -140,7 +140,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequest_ClosesTaskConnectsUserToPersonAndRedirectsToSupportTaskList()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/IndexTests.cs
@@ -27,7 +27,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -48,7 +48,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var statedNationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
         var statedTrn = person.Trn;
@@ -94,7 +94,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -121,7 +121,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_NoSuggestionChosen_RendersError()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -141,7 +141,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequestFromSuggestion_RedirectsToConnectPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 
@@ -165,7 +165,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequestWithOverridenTrn_RedirectsToConnectPage()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
+        var person = await TestData.CreatePerson(p => p.WithTrn());
         var oneLoginUser = await TestData.CreateOneLoginUser(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTask(oneLoginUser.Subject);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -55,55 +55,30 @@ public partial class TestData
 
         public CreatePersonBuilder WithDateOfBirth(DateOnly dateOfBirth)
         {
-            if (_dateOfBirth is not null && _dateOfBirth != dateOfBirth)
-            {
-                throw new InvalidOperationException("WithDateOfBirth cannot be changed after it's set.");
-            }
-
             _dateOfBirth = dateOfBirth;
             return this;
         }
 
         public CreatePersonBuilder WithFirstName(string firstName)
         {
-            if (_firstName is not null && _firstName != firstName)
-            {
-                throw new InvalidOperationException("WithFirstName cannot be changed after it's set.");
-            }
-
             _firstName = firstName;
             return this;
         }
 
-        public CreatePersonBuilder WithMiddleName(string middleName)
+        public CreatePersonBuilder WithMiddleName(string? middleName)
         {
-            if (_middleName is not null && _middleName != middleName)
-            {
-                throw new InvalidOperationException("WithMiddleName cannot be changed after it's set.");
-            }
-
             _middleName = middleName;
             return this;
         }
 
         public CreatePersonBuilder WithLastName(string lastName)
         {
-            if (_lastName is not null && _lastName != lastName)
-            {
-                throw new InvalidOperationException("WithLastName cannot be changed after it's set.");
-            }
-
             _lastName = lastName;
             return this;
         }
 
-        public CreatePersonBuilder WithEmail(string email)
+        public CreatePersonBuilder WithEmail(string? email)
         {
-            if (_email is not null && _email != email)
-            {
-                throw new InvalidOperationException("WithEmail cannot be changed after it's set.");
-            }
-
             _email = email;
             return this;
         }
@@ -117,6 +92,8 @@ public partial class TestData
             DateOnly? inductionPeriodEndDate = null,
             Guid? appropriateBodyOrgId = null)
         {
+            EnsureTrn();
+
             var inductionId = Guid.NewGuid();
             if (inductionStatus == dfeta_InductionStatus.Exempt && inductionExemptionReason == null)
             {
@@ -136,13 +113,8 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithMobileNumber(string mobileNumber)
+        public CreatePersonBuilder WithMobileNumber(string? mobileNumber)
         {
-            if (_mobileNumber is not null && _mobileNumber != mobileNumber)
-            {
-                throw new InvalidOperationException("WithMobileNumber cannot be changed after it's set.");
-            }
-
             _mobileNumber = mobileNumber;
             return this;
         }
@@ -157,15 +129,21 @@ public partial class TestData
             string? detailsLink = null,
             bool isActive = true)
         {
+            EnsureTrn();
+
             _sanctions.Add(new(Guid.NewGuid(), sanctionCode, startDate, endDate, reviewDate, spent, details, detailsLink, isActive));
+
             return this;
         }
 
         public CreatePersonBuilder WithAlert(Action<CreatePersonAlertBuilder>? configure = null)
         {
+            EnsureTrn();
+
             var alertBuilder = new CreatePersonAlertBuilder();
             configure?.Invoke(alertBuilder);
             _alertBuilders.Add(alertBuilder);
+
             return this;
         }
 
@@ -179,70 +157,76 @@ public partial class TestData
             string? heSubject2Value = null,
             string? heSubject3Value = null)
         {
+            EnsureTrn();
+
             _qualifications.Add(new(qualificationId ?? Guid.NewGuid(), type, completionOrAwardDate, isActive!.Value, heQualificationValue, heSubject1Value, heSubject2Value, heSubject3Value));
+
             return this;
         }
 
         public CreatePersonBuilder WithMandatoryQualification(Action<CreatePersonMandatoryQualificationBuilder>? configure = null)
         {
+            EnsureTrn();
+
             var mqBuilder = new CreatePersonMandatoryQualificationBuilder();
             configure?.Invoke(mqBuilder);
             _mqBuilders.Add(mqBuilder);
+
             return this;
         }
 
-        public CreatePersonBuilder WithTrn(bool hasTrn = true)
+        public CreatePersonBuilder WithoutTrn()
         {
-            if (_hasTrn is not null && _hasTrn != hasTrn)
+            if (_alertBuilders.Any() ||
+                _inductions.Any() ||
+                _mqBuilders.Any() ||
+                _qtlsDate.HasValue ||
+                _qtsRegistrations.Any() ||
+                _qualifications.Any() ||
+                _sanctions.Any())
             {
-                throw new InvalidOperationException("WithTrn cannot be changed after it's set.");
+                throw new InvalidOperationException("Person requires a TRN.");
             }
 
-            _hasTrn = hasTrn;
+            _hasTrn = false;
             return this;
         }
 
-        public CreatePersonBuilder WithGender(Contact_GenderCode gender)
+        public CreatePersonBuilder WithTrn()
         {
-            if (_gender is not null && _gender != gender)
-            {
-                throw new InvalidOperationException("WithGender cannot be changed after it's set.");
-            }
+            _hasTrn = true;
+            return this;
+        }
 
+        public CreatePersonBuilder WithGender(Contact_GenderCode? gender)
+        {
             _gender = gender;
             return this;
         }
 
-        public CreatePersonBuilder WithNationalInsuranceNumber(bool? hasNationalInsuranceNumber = true, string? nationalInsuranceNumber = null)
+        public CreatePersonBuilder WithNationalInsuranceNumber(bool hasNationalInsuranceNumber = true)
         {
-            if ((_hasNationalInsuranceNumber is not null && _hasNationalInsuranceNumber != hasNationalInsuranceNumber)
-                || (_nationalInsuranceNumber is not null && _nationalInsuranceNumber != nationalInsuranceNumber))
+            _hasNationalInsuranceNumber = hasNationalInsuranceNumber;
+
+            if (_hasNationalInsuranceNumber is false)
             {
-                throw new InvalidOperationException("WithNationalInsuranceNumber cannot be changed after it's set.");
+                _nationalInsuranceNumber = null;
             }
 
-            _hasNationalInsuranceNumber = hasNationalInsuranceNumber;
-            _nationalInsuranceNumber = nationalInsuranceNumber;
             return this;
         }
 
         public CreatePersonBuilder WithNationalInsuranceNumber(string nationalInsuranceNumber)
         {
-            var hasNationalInsuranceNumber = true;
-
-            if ((_hasNationalInsuranceNumber is not null && _hasNationalInsuranceNumber != hasNationalInsuranceNumber)
-                || (_nationalInsuranceNumber is not null && _nationalInsuranceNumber != nationalInsuranceNumber))
-            {
-                throw new InvalidOperationException("WithNationalInsuranceNumber cannot be changed after it's set.");
-            }
-
-            _hasNationalInsuranceNumber = hasNationalInsuranceNumber;
+            _hasNationalInsuranceNumber = true;
             _nationalInsuranceNumber = nationalInsuranceNumber;
             return this;
         }
 
         public CreatePersonBuilder WithQts(DateOnly? qtsDate = null)
         {
+            EnsureTrn();
+
             _qtsRegistrations.Add(
                 new QtsRegistration(
                     qtsDate ?? new DateOnly(2022, 9, 1),
@@ -256,63 +240,52 @@ public partial class TestData
 
         public CreatePersonBuilder WithQtlsDate(DateOnly? qtlsDate)
         {
-            if (_qtlsDate is not null && _qtlsDate != qtlsDate)
-            {
-                throw new InvalidOperationException("WithQtlsDate cannot be changed after it's set.");
-            }
+            EnsureTrn();
+
             _qtlsDate = qtlsDate;
+
             return this;
         }
 
         public CreatePersonBuilder WithQtsRegistration(DateOnly? qtsDate, string? teacherStatusValue, DateTime? createdDate, DateOnly? eytsDate, string? eytsTeacherStatus)
         {
+            EnsureTrn();
+
             _qtsRegistrations.Add(new QtsRegistration(qtsDate, teacherStatusValue, createdDate, eytsDate, eytsTeacherStatus));
+
             return this;
         }
 
         public CreatePersonBuilder WithEyts(DateOnly? eytsDate, string? eytsStatusValue, DateTime? createdDate = null)
         {
+            EnsureTrn();
+
             _qtsRegistrations.Add(new QtsRegistration(null, null, createdDate, eytsDate, eytsStatusValue));
+
             return this;
         }
 
         public CreatePersonBuilder WithTrnRequestId(string trnRequestId)
         {
-            if (_trnRequestId is not null && _trnRequestId != trnRequestId)
-            {
-                throw new InvalidOperationException("WithTrnRequestId cannot be changed after it's set.");
-            }
-
             _trnRequestId = trnRequestId;
             return this;
         }
 
         public CreatePersonBuilder WithTrnToken(string trnToken)
         {
-            if (_trnToken is not null && _trnToken != trnToken)
-            {
-                throw new InvalidOperationException("WithTrnToken cannot be changed after it's set.");
-            }
-
             _trnToken = trnToken;
             return this;
         }
 
         public CreatePersonBuilder WithSlugId(string slugId)
         {
-            if (_slugId is not null && _slugId != slugId)
-            {
-                throw new InvalidOperationException("WithSlugId cannot be changed after it's set.");
-            }
-
             _slugId = slugId;
             return this;
         }
 
         internal async Task<CreatePersonResult> Execute(TestData testData)
         {
-            var hasTrn = _hasTrn ?? true;
-            var trn = hasTrn ? await testData.GenerateTrn() : null;
+            var trn = _hasTrn == true ? await testData.GenerateTrn() : null;
             var statedFirstName = _firstName ?? testData.GenerateFirstName();
             var statedMiddleName = _middleName ?? testData.GenerateMiddleName();
             var firstAndMiddleNames = $"{statedFirstName} {statedMiddleName}".Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -661,6 +634,16 @@ public partial class TestData
                 Alerts = alerts
             };
         }
+
+        private void EnsureTrn()
+        {
+            _hasTrn ??= true;
+
+            if (_hasTrn != true)
+            {
+                throw new InvalidOperationException("Person requires a TRN.");
+            }
+        }
     }
 
     public class CreatePersonAlertBuilder
@@ -705,7 +688,7 @@ public partial class TestData
         {
             if (endDate.HasValue && !_startDate.HasValue)
             {
-                throw new ArgumentException($"{nameof(endDate)} cannot be specified until {nameof(WithStartDate)} has been called with a non null startDate.");
+                throw new ArgumentException($"{nameof(endDate)} cannot be specified until {nameof(WithStartDate)} has been called with a non-null startDate.");
             }
 
             if (endDate.HasValue && endDate < _startDate.ValueOrDefault())


### PR DESCRIPTION
This amends `TestData.CreatePerson()` to require that person records which need a TRN should explicitly say so by calling `WithTrn()`; tests shouldn't be depending on the defaults.

The bulk of the changes here are in `TestData.CreatePerson.cs`.