### PR TITLE
Rename TestData.WithInduction to WithDqtInduction

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -90,7 +90,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithSanction("A21B")
-            .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
+            .WithDqtInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
             .WithQts(qtsDate: new(2021, 7, 1))
             .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -84,7 +84,7 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
             .WithTrn()
             .WithDateOfBirth(dateOfBirth)
             .WithSanction("G1")
-            .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
+            .WithDqtInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
             .WithQts(qtsDate: new(2021, 7, 1))
             .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
 
@@ -126,7 +126,7 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
             .WithTrn()
             .WithDateOfBirth(dateOfBirth)
             .WithSanction("A21B")
-            .WithInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
+            .WithDqtInduction(dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionStartDate: new(2022, 1, 1), completedDate: new DateOnly(2023, 1, 1))
             .WithQts(qtsDate: new(2021, 7, 1))
             .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240912/SetQtlsDateRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240912/SetQtlsDateRequestTests.cs
@@ -151,7 +151,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
 
 
@@ -183,7 +183,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -211,7 +211,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)); ;
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)); ;
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -245,7 +245,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -275,7 +275,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate)
             .WithSanction("G1"));
 
@@ -310,7 +310,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingqtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -343,7 +343,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithSanction("G1"));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -377,7 +377,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -409,7 +409,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -440,7 +440,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, Clock.Today.AddMonths(-1), Clock.Today.AddDays(-1), account.AccountId));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, Clock.Today.AddMonths(-1), Clock.Today.AddDays(-1), account.AccountId));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -472,7 +472,7 @@ public class SetQtlsDateRequestTests : TestBase
             .WithTrn()
             .WithQts(existingQtsDate)
             .WithQtlsDate(existingQtlsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, account.AccountId));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, account.AccountId));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -502,7 +502,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, account.AccountId));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, account.AccountId));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -532,7 +532,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -564,7 +564,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -596,7 +596,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -628,7 +628,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -660,7 +660,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -695,7 +695,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -730,7 +730,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -762,7 +762,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: dfeta_InductionExemptionReason.Exempt, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -794,7 +794,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -829,7 +829,7 @@ public class SetQtlsDateRequestTests : TestBase
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
             .WithQts(existingQtsDate)
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: null, null, null, null, null, null)
             .WithQtlsDate(existingQtlsDate));
 
         var requestBody = CreateJsonContent(new { qtsDate = incomingqtlsDate });
@@ -1019,7 +1019,7 @@ public class SetQtlsDateRequestTests : TestBase
         var qtlsDate = !string.IsNullOrEmpty(incomingQtls) ? DateOnly.Parse(incomingQtls) : default(DateOnly?);
         var person = await TestData.CreatePerson(p => p
             .WithTrn()
-            .WithInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: existingInductionExemptionReason, null, null, null, null, null));
+            .WithDqtInduction(inductionStatus: existingInductionStatus, inductionExemptionReason: existingInductionExemptionReason, null, null, null, null, null));
 
         var requestBody = CreateJsonContent(new { qtsDate = qtlsDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/PluginTests/UpdateInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/PluginTests/UpdateInductionStatusTests.cs
@@ -43,7 +43,7 @@ public class UpdateInductionStatusTests : IAsyncLifetime
         {
             x.WithQts(new DateOnly(2021, 01, 1));
             x.WithQtlsDate(qtlsDate);
-            x.WithInduction(inductionStatus: inductionStatus, inductionExemptionReason: exemptionReason, inductionStartDate: new DateOnly(2021, 01, 01), completedDate: new DateOnly(2022, 01, 01), inductionPeriodStartDate: new DateOnly(2021, 01, 01), inductionPeriodEndDate: new DateOnly(2022, 01, 01), appropriateBodyOrgId: establishment1.AccountId);
+            x.WithDqtInduction(inductionStatus: inductionStatus, inductionExemptionReason: exemptionReason, inductionStartDate: new DateOnly(2021, 01, 01), completedDate: new DateOnly(2022, 01, 01), inductionPeriodStartDate: new DateOnly(2021, 01, 01), inductionPeriodEndDate: new DateOnly(2022, 01, 01), appropriateBodyOrgId: establishment1.AccountId);
         });
 
         // Act
@@ -107,7 +107,7 @@ public class UpdateInductionStatusTests : IAsyncLifetime
         var createPersonResult = await _dataScope.TestData.CreatePerson(x =>
         {
             x.WithQts(qtlsDate);
-            x.WithInduction(inductionStatus, exemptionReason, null, null, null, null, null);
+            x.WithDqtInduction(inductionStatus, exemptionReason, null, null, null, null, null);
         });
 
         // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetInductionByContactIdTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetInductionByContactIdTests.cs
@@ -40,7 +40,7 @@ public class GetInductionByContactIdTests : IAsyncLifetime
         var createPersonResult = await _dataScope.TestData.CreatePerson(x =>
         {
             x.WithQts(new DateOnly(2021, 01, 1));
-            x.WithInduction(inductionStatus: dfeta_InductionStatus.Pass, inductionExemptionReason: null, null, null, null, null, null);
+            x.WithDqtInduction(inductionStatus: dfeta_InductionStatus.Pass, inductionExemptionReason: null, null, null, null, null, null);
         });
 
         // Act
@@ -65,7 +65,7 @@ public class GetInductionByContactIdTests : IAsyncLifetime
         var createPersonResult = await _dataScope.TestData.CreatePerson(x =>
         {
             x.WithQts(new DateOnly(2021, 01, 1));
-            x.WithInduction(inductionStatus: dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionPeriodStartDate: new DateOnly(2021, 01, 01), completedDate: new DateOnly(2022, 01, 01), inductionStartDate: new DateOnly(2021, 01, 01), inductionPeriodEndDate: new DateOnly(2022, 01, 01), appropriateBodyOrgId: establishment1.AccountId);
+            x.WithDqtInduction(inductionStatus: dfeta_InductionStatus.Pass, inductionExemptionReason: null, inductionPeriodStartDate: new DateOnly(2021, 01, 01), completedDate: new DateOnly(2022, 01, 01), inductionStartDate: new DateOnly(2021, 01, 01), inductionPeriodEndDate: new DateOnly(2022, 01, 01), appropriateBodyOrgId: establishment1.AccountId);
         });
 
         // Act
@@ -108,7 +108,7 @@ public class GetInductionByContactIdTests : IAsyncLifetime
         {
             x.WithQts(new DateOnly(2021, 01, 1));
             x.WithQtlsDate(qtlsDate);
-            x.WithInduction(inductionStatus: inductionStatus, inductionExemptionReason: exemptionReason, inductionStartDate: new DateOnly(2021, 01, 01), completedDate: new DateOnly(2022, 01, 01), inductionPeriodStartDate: new DateOnly(2021, 01, 01), inductionPeriodEndDate: new DateOnly(2022, 01, 01), appropriateBodyOrgId: establishment1.AccountId);
+            x.WithDqtInduction(inductionStatus: inductionStatus, inductionExemptionReason: exemptionReason, inductionStartDate: new DateOnly(2021, 01, 01), completedDate: new DateOnly(2022, 01, 01), inductionPeriodStartDate: new DateOnly(2021, 01, 01), inductionPeriodEndDate: new DateOnly(2022, 01, 01), appropriateBodyOrgId: establishment1.AccountId);
         });
 
         // Act
@@ -175,7 +175,7 @@ public class GetInductionByContactIdTests : IAsyncLifetime
         var createPersonResult = await _dataScope.TestData.CreatePerson(x =>
         {
             x.WithQts(qtlsDate);
-            x.WithInduction(inductionStatus, exemptionReason, null, null, null, null, null);
+            x.WithDqtInduction(inductionStatus, exemptionReason, null, null, null, null, null);
         });
 
         // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -39,8 +39,8 @@ public partial class TestData
         private readonly List<CreatePersonAlertBuilder> _alertBuilders = [];
         private readonly List<CreatePersonMandatoryQualificationBuilder> _mqBuilders = [];
         private DateOnly? _qtlsDate;
-        private readonly List<Induction> _inductions = [];
-        private readonly List<InductionPeriod> _inductionPeriods = [];
+        private readonly List<DqtInduction> _dqtInductions = [];
+        private readonly List<DqtInductionPeriod> _dqtInductionPeriods = [];
         private string? _trnRequestId;
         private string? _trnToken;
         private string? _slugId;
@@ -83,7 +83,7 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithInduction(
+        public CreatePersonBuilder WithDqtInduction(
             dfeta_InductionStatus inductionStatus,
             dfeta_InductionExemptionReason? inductionExemptionReason,
             DateOnly? inductionStartDate,
@@ -99,7 +99,7 @@ public partial class TestData
             {
                 throw new InvalidOperationException("WithInduction must provide InductionExemptionReason if InductionStatus is Exempt");
             }
-            _inductions.Add(new Induction(inductionId, inductionStatus, inductionExemptionReason, inductionStartDate, completedDate));
+            _dqtInductions.Add(new DqtInduction(inductionId, inductionStatus, inductionExemptionReason, inductionStartDate, completedDate));
 
             //inductionPeriod is optional
             if (!appropriateBodyOrgId.HasValue && inductionPeriodStartDate.HasValue || !appropriateBodyOrgId.HasValue && inductionPeriodEndDate.HasValue)
@@ -108,7 +108,7 @@ public partial class TestData
             }
             if (appropriateBodyOrgId.HasValue)
             {
-                _inductionPeriods.Add(new InductionPeriod(inductionId, inductionPeriodStartDate, inductionPeriodEndDate, appropriateBodyOrgId!.Value));
+                _dqtInductionPeriods.Add(new DqtInductionPeriod(inductionId, inductionPeriodStartDate, inductionPeriodEndDate, appropriateBodyOrgId!.Value));
             }
             return this;
         }
@@ -178,7 +178,7 @@ public partial class TestData
         public CreatePersonBuilder WithoutTrn()
         {
             if (_alertBuilders.Any() ||
-                _inductions.Any() ||
+                _dqtInductions.Any() ||
                 _mqBuilders.Any() ||
                 _qtlsDate.HasValue ||
                 _qtsRegistrations.Any() ||
@@ -482,7 +482,7 @@ public partial class TestData
                 }
             }
 
-            foreach (var induction in _inductions)
+            foreach (var induction in _dqtInductions)
             {
                 txnRequestBuilder.AddRequest(new CreateRequest()
                 {
@@ -498,9 +498,9 @@ public partial class TestData
                 });
             }
 
-            foreach (var inductionperiod in _inductionPeriods)
+            foreach (var inductionperiod in _dqtInductionPeriods)
             {
-                var induction = _inductions.First();
+                var induction = _dqtInductions.First();
                 txnRequestBuilder.AddRequest(new CreateRequest()
                 {
                     Target = new dfeta_inductionperiod()
@@ -629,8 +629,8 @@ public partial class TestData
                 EytsDate = getEytsRegistationTask != null ? getEytsRegistationTask.GetResponse().Entity.ToEntity<dfeta_qtsregistration>().dfeta_EYTSDate.ToDateOnlyWithDqtBstFix(true) : null,
                 Sanctions = [.. _sanctions],
                 MandatoryQualifications = mqs,
-                Inductions = [.. _inductions],
-                InductionPeriods = [.. _inductionPeriods],
+                DqtInductions = [.. _dqtInductions],
+                DqtInductionPeriods = [.. _dqtInductionPeriods],
                 Alerts = alerts
             };
         }
@@ -988,14 +988,14 @@ public partial class TestData
         public required DateOnly? EytsDate { get; init; }
         public required IReadOnlyCollection<Sanction> Sanctions { get; init; }
         public required IReadOnlyCollection<MandatoryQualification> MandatoryQualifications { get; init; }
-        public required IReadOnlyCollection<Induction> Inductions { get; init; }
-        public required IReadOnlyCollection<InductionPeriod> InductionPeriods { get; init; }
+        public required IReadOnlyCollection<DqtInduction> DqtInductions { get; init; }
+        public required IReadOnlyCollection<DqtInductionPeriod> DqtInductionPeriods { get; init; }
         public required IReadOnlyCollection<Alert> Alerts { get; init; }
     }
 
-    public record Induction(Guid InductionId, dfeta_InductionStatus inductionStatus, dfeta_InductionExemptionReason? inductionExemptionReason, DateOnly? StartDate, DateOnly? CompletetionDate);
+    public record DqtInduction(Guid InductionId, dfeta_InductionStatus inductionStatus, dfeta_InductionExemptionReason? inductionExemptionReason, DateOnly? StartDate, DateOnly? CompletetionDate);
 
-    public record InductionPeriod(Guid InductionId, DateOnly? startDate, DateOnly? endDate, Guid AppropriateBodyOrgId);
+    public record DqtInductionPeriod(Guid InductionId, DateOnly? startDate, DateOnly? endDate, Guid AppropriateBodyOrgId);
 
     public record Sanction(Guid SanctionId, string SanctionCode, DateOnly? StartDate, DateOnly? EndDate, DateOnly? ReviewDate, bool Spent, string? Details, string? DetailsLink, bool IsActive);
 


### PR DESCRIPTION
We will shortly be adding the data model for induction to TRS for migration. We'll need a way to control whether induction data is written to CRM or TRS in tests. This renames the current `WithInduction()` method on `CreatePersonBuilder` to `WithDqtInduction()`; when we get the TRS version that can then take the `WithInduction()` name.