### PR TITLE
Rename QtlsInfo

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetQtls.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetQtls.cs
@@ -10,7 +10,7 @@ public record GetQtlsCommand(string Trn);
 
 public class GetQtlsHandler(ICrmQueryDispatcher crmQueryDispatcher)
 {
-    public async Task<QtlsInfo?> Handle(GetQtlsCommand command)
+    public async Task<QtlsResult?> Handle(GetQtlsCommand command)
     {
         var contact = (await crmQueryDispatcher.ExecuteQuery(
             new GetActiveContactByTrnQuery(
@@ -25,7 +25,7 @@ public class GetQtlsHandler(ICrmQueryDispatcher crmQueryDispatcher)
             return null;
         }
 
-        return new QtlsInfo()
+        return new QtlsResult()
         {
             Trn = command.Trn,
             QtsDate = contact.dfeta_qtlsdate.ToDateOnlyWithDqtBstFix(isLocalTime: false),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/SetQtls.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/SetQtls.cs
@@ -15,9 +15,9 @@ public sealed class SetQtlsResult
 
     public bool Succeeded { get; private set; }
 
-    public QtlsInfo? QtlsInfo { get; private set; }
+    public QtlsResult? QtlsInfo { get; private set; }
 
-    public static SetQtlsResult Success(QtlsInfo qtlsInfo) => new()
+    public static SetQtlsResult Success(QtlsResult qtlsInfo) => new()
     {
         Succeeded = true,
         QtlsInfo = qtlsInfo
@@ -69,7 +69,7 @@ public class SetQtlsHandler(ICrmQueryDispatcher crmQueryDispatcher, IClock clock
         await crmQueryDispatcher.ExecuteQuery(
              new SetQtlsDateQuery(contact.Id, command.QtsDate, contact.dfeta_ActiveSanctions == true, clock.UtcNow))!;
 
-        return SetQtlsResult.Success(new QtlsInfo()
+        return SetQtlsResult.Success(new QtlsResult()
         {
             Trn = command.Trn,
             QtsDate = command.QtsDate

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/QtlsResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/SharedModels/QtlsResult.cs
@@ -1,6 +1,6 @@
 namespace TeachingRecordSystem.Api.V3.Core.SharedModels;
 
-public record QtlsInfo
+public record QtlsResult
 {
     public required DateOnly? QtsDate { get; init; }
     public required string Trn { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240912/ApiModels/QtlsResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240912/ApiModels/QtlsResponse.cs
@@ -1,7 +1,7 @@
 namespace TeachingRecordSystem.Api.V3.V20240912.ApiModels;
 
-[AutoMap(typeof(Core.SharedModels.QtlsInfo))]
-public record QtlsInfo
+[AutoMap(typeof(Core.SharedModels.QtlsResult))]
+public record QtlsResponse
 {
     public required DateOnly? QtsDate { get; init; }
     public required string Trn { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240912/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240912/Controllers/PersonsController.cs
@@ -16,7 +16,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         OperationId = "SetQtls",
         Summary = "Set QTLS status for a teacher",
         Description = "Sets the QTLS status for the teacher with the given TRN.")]
-    [ProducesResponseType(typeof(QtlsInfo), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(QtlsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status202Accepted)]
     [MapError(10001, statusCode: StatusCodes.Status404NotFound)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.AssignQtls)]
@@ -35,7 +35,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         OperationId = "GetQtls",
         Summary = "Get QTLS status for a teacher",
         Description = "Gets the QTLS status for the teacher with the given TRN.")]
-    [ProducesResponseType(typeof(QtlsInfo), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(QtlsResponse), StatusCodes.Status200OK)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.AssignQtls)]
     public async Task<IActionResult> GetQtls(
     [FromRoute] string trn,
@@ -43,7 +43,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     {
         var command = new GetQtlsCommand(trn);
         var result = await handler.Handle(command);
-        var response = mapper.Map<QtlsInfo?>(result);
+        var response = mapper.Map<QtlsResponse?>(result);
         return response is not null ? Ok(response) : NotFound();
     }
 }


### PR DESCRIPTION
This type isn't consistent with the other *Info types; every other occurrence is used within a larger response whereas this is the root object returned. It also has a `Trn`, which is inconsistent too. 