### PR TITLE
Consider NINO when looking for duplicates

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTeacherQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTeacherQuery.cs
@@ -11,7 +11,7 @@ public class CreateContactQuery : ICrmQuery<Guid>
     public required DateOnly DateOfBirth { get; init; }
     public required string? EmailAddress { get; init; }
     public required string? NationalInsuranceNumber { get; init; }
-    public required FindPotentialDuplicateContactsResult[] PotentialDuplicates { get; init; }
+    public required IReadOnlyCollection<FindPotentialDuplicateContactsResult> PotentialDuplicates { get; init; }
     public required string? Trn { get; init; }
     public required string? TrnRequestId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/FindPotentialDuplicateContactsQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/FindPotentialDuplicateContactsQuery.cs
@@ -7,18 +7,27 @@ public record FindPotentialDuplicateContactsQuery : ICrmQuery<FindPotentialDupli
     public required string LastName { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public required IEnumerable<string> EmailAddresses { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
+
+    // A collection of contact IDs that have already been identified to match on NINO (through workforce data)
+    public required Guid[] MatchedOnNationalInsuranceNumberContactIds { get; init; }
 }
 
 public record FindPotentialDuplicateContactsResult
 {
     public required Guid ContactId { get; init; }
-    public required string[] MatchedAttributes { get; init; }
+    public required string Trn { get; init; }
+    public required IReadOnlyCollection<string> MatchedAttributes { get; init; }
     public required bool HasActiveSanctions { get; init; }
     public required bool HasQtsDate { get; init; }
     public required bool HasEytsDate { get; init; }
     public required string FirstName { get; init; }
     public required string MiddleName { get; init; }
     public required string LastName { get; init; }
+    public required string? StatedFirstName { get; init; }
+    public required string? StatedMiddleName { get; init; }
+    public required string? StatedLastName { get; init; }
     public required DateOnly? DateOfBirth { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
     public required string? EmailAddress { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/INameSynonymProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/NameSynonyms/INameSynonymProvider.cs
@@ -1,4 +1,3 @@
-
 namespace TeachingRecordSystem.Core.Services.NameSynonyms;
 
 public interface INameSynonymProvider

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateTrnRequestTests.cs
@@ -26,6 +26,7 @@ public class CreateTrnRequestTests : TestBase
         var email2 = Faker.Internet.Email();
 
         await TestData.CreatePerson(p => p
+            .WithTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
@@ -155,6 +155,7 @@ public class CreateContactTests : IAsyncLifetime
                 new FindPotentialDuplicateContactsResult()
                 {
                     ContactId = createdTeacherId1,
+                    Trn = trn1,
                     MatchedAttributes = [Contact.Fields.FirstName, Contact.Fields.MiddleName, Contact.Fields.LastName],
                     HasActiveSanctions = false,
                     HasEytsDate = false,
@@ -162,8 +163,12 @@ public class CreateContactTests : IAsyncLifetime
                     FirstName = firstName,
                     MiddleName = middleName,
                     LastName = lastName,
+                    StatedFirstName = firstName,
+                    StatedMiddleName = middleName,
+                    StatedLastName = lastName,
                     DateOfBirth = dob,
-                    EmailAddress = email
+                    EmailAddress = email,
+                    NationalInsuranceNumber = ni
                 }
             ]
         };

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/FindPotentialDuplicateContactsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/FindPotentialDuplicateContactsTests.cs
@@ -38,7 +38,9 @@ public class FindPotentialDuplicateContactsTests : IAsyncLifetime
             MiddleName = middleName,
             LastName = lastName,
             DateOfBirth = dob.ToDateOnlyWithDqtBstFix(isLocalTime: false),
-            EmailAddresses = []
+            EmailAddresses = [],
+            NationalInsuranceNumber = null,
+            MatchedOnNationalInsuranceNumberContactIds = []
         };
 
         // Act
@@ -61,7 +63,7 @@ public class FindPotentialDuplicateContactsTests : IAsyncLifetime
         // Arrange
         var email = $"{Guid.NewGuid()}@test.com";
 
-        var person = await _dataScope.TestData.CreatePerson(p => p.WithEmail(email));
+        var person = await _dataScope.TestData.CreatePerson(p => p.WithTrn().WithEmail(email));
 
         var query = new FindPotentialDuplicateContactsQuery()
         {
@@ -69,7 +71,9 @@ public class FindPotentialDuplicateContactsTests : IAsyncLifetime
             MiddleName = "",
             LastName = Faker.Name.Last(),
             DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-            EmailAddresses = [email]
+            EmailAddresses = [email],
+            NationalInsuranceNumber = null,
+            MatchedOnNationalInsuranceNumberContactIds = []
         };
 
         // Act


### PR DESCRIPTION
Updates the duplicate checking process to include NINO. If NINO alone is matched it's flagged as a potential duplicate (for manual review). If NINO and DOB match it's considered a definite duplicate and we return the record's TRN and mark the request as Completed.