### PR TITLE
Link One Login user when TRN request is Completed

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/TrnRequestHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/TrnRequestHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
@@ -6,7 +7,7 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Api;
 
-public class TrnRequestHelper(TrsDbContext dbContext, ICrmQueryDispatcher crmQueryDispatcher)
+public class TrnRequestHelper(TrsDbContext dbContext, ICrmQueryDispatcher crmQueryDispatcher, IClock clock)
 {
     public async Task<GetTrnRequestResult?> GetTrnRequestInfo(Guid currentApplicationUserId, string requestId)
     {
@@ -16,14 +17,20 @@ public class TrnRequestHelper(TrsDbContext dbContext, ICrmQueryDispatcher crmQue
         var getContactByTrnRequestIdTask = crmQueryDispatcher.ExecuteQuery(
             new GetContactByTrnRequestIdQuery(crmTrnRequestId, new Microsoft.Xrm.Sdk.Query.ColumnSet(Contact.Fields.ContactId, Contact.Fields.dfeta_TrnToken)));
 
+        // We can't have this running in parallel with getDbTrnRequestTask since they share a connection so make it continuation
+        var metadata = await getDbTrnRequestTask
+            .ContinueWith(_ => dbContext.TrnRequestMetadata
+                .SingleOrDefaultAsync(m => m.ApplicationUserId == currentApplicationUserId && m.RequestId == requestId))
+            .Unwrap();
+
         if (await getDbTrnRequestTask is TrnRequest dbTrnRequest)
         {
-            return new(dbTrnRequest.TeacherId, dbTrnRequest.TrnToken);
+            return new(dbTrnRequest.TeacherId, dbTrnRequest.TrnToken, metadata, currentApplicationUserId);
         }
 
         if (await getContactByTrnRequestIdTask is Contact contact)
         {
-            return new(contact.ContactId!.Value, contact.dfeta_TrnToken);
+            return new(contact.ContactId!.Value, contact.dfeta_TrnToken, metadata, currentApplicationUserId);
         }
 
         return null;
@@ -31,6 +38,45 @@ public class TrnRequestHelper(TrsDbContext dbContext, ICrmQueryDispatcher crmQue
 
     public static string GetCrmTrnRequestId(Guid currentApplicationUserId, string requestId) =>
         $"{currentApplicationUserId}::{requestId}";
+
+    public async Task EnsureOneLoginUserIsConnected(GetTrnRequestResult trnRequest, Contact contact)
+    {
+        if (trnRequest.Metadata?.VerifiedOneLoginUserSubject is not string oneLoginUserSubject)
+        {
+            return;
+        }
+
+        if (await dbContext.OneLoginUsers.AnyAsync(u => u.Subject == oneLoginUserSubject))
+        {
+            return;
+        }
+
+        Debug.Assert(contact.dfeta_TRN is not null);
+
+        var oneLoginUser = new OneLoginUser() { Subject = oneLoginUserSubject };
+
+        var verifiedName = new string[]
+        {
+            contact.HasStatedNames() ? contact.dfeta_StatedFirstName : contact.FirstName,
+            contact.HasStatedNames() ? contact.dfeta_StatedMiddleName : contact.MiddleName,
+            contact.HasStatedNames() ? contact.dfeta_StatedLastName : contact.LastName
+        };
+
+        var verifiedDateOfBirth = contact.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false);
+
+        oneLoginUser.SetVerified(
+            verifiedOn: clock.UtcNow,
+            OneLoginUserVerificationRoute.External,
+            verifiedByApplicationUserId: trnRequest.ApplicationUserId,
+            verifiedNames: [[.. verifiedName]],
+            verifiedDatesOfBirth: [verifiedDateOfBirth]);
+
+        oneLoginUser.SetMatched(contact.Id, OneLoginUserMatchRoute.TrnAllocation, matchedAttributes: null);
+
+        dbContext.OneLoginUsers.Add(oneLoginUser);
+
+        await dbContext.SaveChangesAsync();
+    }
 }
 
-public record GetTrnRequestResult(Guid ContactId, string? TrnToken);
+public record GetTrnRequestResult(Guid ContactId, string? TrnToken, TrnRequestMetadata? Metadata, Guid ApplicationUserId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Core/Operations/GetTrnRequest.cs
@@ -32,6 +32,9 @@ public class GetTrnRequestHandler(
                     Contact.Fields.FirstName,
                     Contact.Fields.MiddleName,
                     Contact.Fields.LastName,
+                    Contact.Fields.dfeta_StatedFirstName,
+                    Contact.Fields.dfeta_StatedMiddleName,
+                    Contact.Fields.dfeta_StatedLastName,
                     Contact.Fields.EMailAddress1,
                     Contact.Fields.dfeta_NINumber,
                     Contact.Fields.BirthDate,
@@ -39,6 +42,13 @@ public class GetTrnRequestHandler(
                     Contact.Fields.MasterId))))!;
 
         var status = !string.IsNullOrEmpty(contact.dfeta_TRN) ? TrnRequestStatus.Completed : TrnRequestStatus.Pending;
+
+        // If we have metadata for the One Login user, ensure they're added to the OneLoginUsers table.
+        // FUTURE: when TRN requests are handled exclusively in TRS this should be done at the point the task is resolved instead of here.
+        if (status == TrnRequestStatus.Completed)
+        {
+            await trnRequestHelper.EnsureOneLoginUserIsConnected(trnRequest, contact);
+        }
 
         return new TrnRequestInfo()
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
@@ -157,7 +157,7 @@ public class OAuth2Controller(
 
         if (User.HasScope(Scopes.Email))
         {
-            claims.Add(ClaimTypes.Email, oneLoginUser.Email);
+            claims.Add(ClaimTypes.Email, oneLoginUser.Email!);
         }
 
         if (oneLoginUser.VerificationRoute == OneLoginUserVerificationRoute.OneLogin)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
@@ -116,7 +116,7 @@ public class DebugIdentityModel(
 
         if (_oneLoginUser!.PersonId is not null && DetachPerson)
         {
-            _oneLoginUser.PersonId = null;
+            _oneLoginUser.ClearMatchedPerson();
         }
 
         if (IdentityVerified)
@@ -125,10 +125,7 @@ public class DebugIdentityModel(
         }
         else
         {
-            _oneLoginUser!.VerifiedOn = null;
-            _oneLoginUser.VerificationRoute = null;
-            _oneLoginUser.VerifiedNames = null;
-            _oneLoginUser.VerifiedDatesOfBirth = null;
+            _oneLoginUser.ClearVerifiedInfo();
 
             await JourneyInstance!.UpdateStateAsync(state => state.ClearVerified());
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
@@ -33,6 +33,7 @@ public class OneLoginUserMapping : IEntityTypeConfiguration<OneLoginUser>
             new ValueComparer<KeyValuePair<OneLoginUserMatchedAttribute, string>[]>(
                 (a, b) => a == b,  // Reference equality is fine here; we'll always replace the entire collection
                 v => v.GetHashCode()));
+        builder.HasOne<ApplicationUser>().WithMany().HasForeignKey(o => o.VerifiedByApplicationUserId);
     }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class TrnRequestMetadataMapping : IEntityTypeConfiguration<TrnRequestMetadata>
+{
+    public void Configure(EntityTypeBuilder<TrnRequestMetadata> builder)
+    {
+        builder.HasKey(r => new { r.ApplicationUserId, r.RequestId });
+        builder.Property(r => r.RequestId).IsRequired().HasMaxLength(TrnRequest.RequestIdMaxLength);
+        builder.Property(o => o.VerifiedOneLoginUserSubject).HasMaxLength(255);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107113402_TrnRequestMetadata.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107113402_TrnRequestMetadata.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241107113402_TrnRequestMetadata")]
+    partial class TrnRequestMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1676,11 +1679,12 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnName("subject");
 
                     b.Property<string>("Email")
+                        .IsRequired()
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)")
                         .HasColumnName("email");
 
-                    b.Property<DateTime?>("FirstOneLoginSignIn")
+                    b.Property<DateTime>("FirstOneLoginSignIn")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("first_one_login_sign_in");
 
@@ -1692,7 +1696,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("jsonb")
                         .HasColumnName("last_core_identity_vc");
 
-                    b.Property<DateTime?>("LastOneLoginSignIn")
+                    b.Property<DateTime>("LastOneLoginSignIn")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("last_one_login_sign_in");
 
@@ -1700,7 +1704,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("last_sign_in");
 
-                    b.Property<int?>("MatchRoute")
+                    b.Property<int>("MatchRoute")
                         .HasColumnType("integer")
                         .HasColumnName("match_route");
 
@@ -1715,10 +1719,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Property<int?>("VerificationRoute")
                         .HasColumnType("integer")
                         .HasColumnName("verification_route");
-
-                    b.Property<Guid?>("VerifiedByApplicationUserId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("verified_by_application_user_id");
 
                     b.Property<string>("VerifiedDatesOfBirth")
                         .HasColumnType("jsonb")
@@ -3106,11 +3106,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .WithOne()
                         .HasForeignKey("TeachingRecordSystem.Core.DataStore.Postgres.Models.OneLoginUser", "PersonId")
                         .HasConstraintName("fk_one_login_users_persons_person_id");
-
-                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.ApplicationUser", null)
-                        .WithMany()
-                        .HasForeignKey("VerifiedByApplicationUserId")
-                        .HasConstraintName("fk_one_login_users_application_users_verified_by_application_u");
 
                     b.Navigation("Person");
                 });

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107113402_TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107113402_TrnRequestMetadata.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnRequestMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "trn_request_metadata",
+                columns: table => new
+                {
+                    application_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    request_id = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    verified_one_login_user_subject = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_trn_request_metadata", x => new { x.application_user_id, x.request_id });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "trn_request_metadata");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107123546_NullableOneLoginUserFields.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107123546_NullableOneLoginUserFields.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241107123546_NullableOneLoginUserFields")]
+    partial class NullableOneLoginUserFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1716,10 +1719,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("integer")
                         .HasColumnName("verification_route");
 
-                    b.Property<Guid?>("VerifiedByApplicationUserId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("verified_by_application_user_id");
-
                     b.Property<string>("VerifiedDatesOfBirth")
                         .HasColumnType("jsonb")
                         .HasColumnName("verified_dates_of_birth");
@@ -3106,11 +3105,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .WithOne()
                         .HasForeignKey("TeachingRecordSystem.Core.DataStore.Postgres.Models.OneLoginUser", "PersonId")
                         .HasConstraintName("fk_one_login_users_persons_person_id");
-
-                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.ApplicationUser", null)
-                        .WithMany()
-                        .HasForeignKey("VerifiedByApplicationUserId")
-                        .HasConstraintName("fk_one_login_users_application_users_verified_by_application_u");
 
                     b.Navigation("Person");
                 });

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107123546_NullableOneLoginUserFields.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107123546_NullableOneLoginUserFields.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class NullableOneLoginUserFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "match_route",
+                table: "one_login_users",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "last_one_login_sign_in",
+                table: "one_login_users",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "first_one_login_sign_in",
+                table: "one_login_users",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "email",
+                table: "one_login_users",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "match_route",
+                table: "one_login_users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "last_one_login_sign_in",
+                table: "one_login_users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "first_one_login_sign_in",
+                table: "one_login_users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "email",
+                table: "one_login_users",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200,
+                oldNullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107134330_OneLoginUserVerifiedByApplicationUserId.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107134330_OneLoginUserVerifiedByApplicationUserId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241107134330_OneLoginUserVerifiedByApplicationUserId")]
+    partial class OneLoginUserVerifiedByApplicationUserId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107134330_OneLoginUserVerifiedByApplicationUserId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241107134330_OneLoginUserVerifiedByApplicationUserId.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class OneLoginUserVerifiedByApplicationUserId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "verified_by_application_user_id",
+                table: "one_login_users",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_one_login_users_application_users_verified_by_application_u",
+                table: "one_login_users",
+                column: "verified_by_application_user_id",
+                principalTable: "users",
+                principalColumn: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_one_login_users_application_users_verified_by_application_u",
+                table: "one_login_users");
+
+            migrationBuilder.DropColumn(
+                name: "verified_by_application_user_id",
+                table: "one_login_users");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
@@ -1,20 +1,80 @@
+using System.Diagnostics;
+
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class OneLoginUser
 {
     public required string Subject { get; init; }
-    public required string Email { get; set; }
-    public required DateTime FirstOneLoginSignIn { get; init; }
-    public required DateTime LastOneLoginSignIn { get; set; }
+    public string? Email { get; set; }
+    public DateTime? FirstOneLoginSignIn { get; set; }
+    public DateTime? LastOneLoginSignIn { get; set; }
     public DateTime? FirstSignIn { get; set; }
     public DateTime? LastSignIn { get; set; }
-    public Guid? PersonId { get; set; }
+    public Guid? PersonId { get; private set; }
     public Person? Person { get; }
-    public DateTime? VerifiedOn { get; set; }
-    public OneLoginUserVerificationRoute? VerificationRoute { get; set; }
-    public string[][]? VerifiedNames { get; set; }
-    public DateOnly[]? VerifiedDatesOfBirth { get; set; }
+    public DateTime? VerifiedOn { get; private set; }
+    public OneLoginUserVerificationRoute? VerificationRoute { get; private set; }
+    public string[][]? VerifiedNames { get; private set; }
+    public DateOnly[]? VerifiedDatesOfBirth { get; private set; }
     public string? LastCoreIdentityVc { get; set; }
-    public OneLoginUserMatchRoute MatchRoute { get; set; }
-    public KeyValuePair<OneLoginUserMatchedAttribute, string>[]? MatchedAttributes { get; set; }
+    public OneLoginUserMatchRoute? MatchRoute { get; private set; }
+    public KeyValuePair<OneLoginUserMatchedAttribute, string>[]? MatchedAttributes { get; private set; }
+    public Guid? VerifiedByApplicationUserId { get; private set; }
+
+    public void SetVerified(
+        DateTime verifiedOn,
+        OneLoginUserVerificationRoute route,
+        Guid? verifiedByApplicationUserId,
+        string[][] verifiedNames,
+        DateOnly[] verifiedDatesOfBirth)
+    {
+        if (route == OneLoginUserVerificationRoute.External && !verifiedByApplicationUserId.HasValue)
+        {
+            throw new ArgumentException(
+                $"{nameof(verifiedByApplicationUserId)} must be non-null when {nameof(route)} is {OneLoginUserVerificationRoute.External}.",
+                nameof(verifiedByApplicationUserId));
+        }
+
+        if (route != OneLoginUserVerificationRoute.External && verifiedByApplicationUserId.HasValue)
+        {
+            throw new ArgumentException(
+                $"{nameof(verifiedByApplicationUserId)} must be null when {nameof(route)} is not {OneLoginUserVerificationRoute.External}.",
+                nameof(verifiedByApplicationUserId));
+        }
+
+        VerifiedOn = verifiedOn;
+        VerificationRoute = route;
+        VerifiedByApplicationUserId = verifiedByApplicationUserId;
+        VerifiedNames = verifiedNames;
+        VerifiedDatesOfBirth = verifiedDatesOfBirth;
+    }
+
+    public void SetMatched(
+        Guid personId,
+        OneLoginUserMatchRoute route,
+        KeyValuePair<OneLoginUserMatchedAttribute, string>[]? matchedAttributes)
+    {
+        Debug.Assert(VerifiedOn is not null);
+
+        PersonId = personId;
+        MatchRoute = route;
+        MatchedAttributes = matchedAttributes;
+    }
+
+    public void ClearVerifiedInfo()
+    {
+        // Used for testing only
+        VerifiedOn = null;
+        VerificationRoute = null;
+        VerifiedNames = null;
+        VerifiedDatesOfBirth = null;
+    }
+
+    public void ClearMatchedPerson()
+    {
+        // Used for testing only
+        PersonId = null;
+        MatchRoute = null;
+        MatchedAttributes = null;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class TrnRequestMetadata
+{
+    public required Guid ApplicationUserId { get; init; }
+    public required string RequestId { get; init; }
+    public required string? VerifiedOneLoginUserSubject { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -99,6 +99,8 @@ public class TrsDbContext : DbContext
 
     public DbSet<WebhookMessage> WebhookMessages => Set<WebhookMessage>();
 
+    public DbSet<TrnRequestMetadata> TrnRequestMetadata => Set<TrnRequestMetadata>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string? connectionString = null, int? commandTimeout = null)
     {
         Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o.CommandTimeout(commandTimeout);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchRoute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserMatchRoute.cs
@@ -7,4 +7,5 @@ public enum OneLoginUserMatchRoute
     TrnToken = 3,
     Support = 4,
     GetAnIdentityUser = 5,
+    TrnAllocation = 6,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserVerificationRoute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/OneLoginUserVerificationRoute.cs
@@ -3,5 +3,6 @@ namespace TeachingRecordSystem.Core.Models;
 public enum OneLoginUserVerificationRoute
 {
     OneLogin = 1,
-    Support = 2
+    Support = 2,
+    External = 3,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml.cs
@@ -37,14 +37,17 @@ public class ConnectModel(TrsDbContext dbContext, IPersonMatchingService personM
         };
         _supportTask.Status = SupportTaskStatus.Closed;
 
-        var oneLoginUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == data.OneLoginUserSubject);
-        oneLoginUser.PersonId = PersonDetail!.PersonId;
-        oneLoginUser.MatchedAttributes = (await personMatchingService
+        var matchedAttributes = (await personMatchingService
             .GetMatchedAttributes(
                 new(data.VerifiedNames!, data.VerifiedDatesOfBirth!, data.StatedNationalInsuranceNumber, data.StatedTrn, data.TrnTokenTrn),
                 PersonDetail.PersonId))
             .ToArray();
-        oneLoginUser.MatchRoute = OneLoginUserMatchRoute.Support;
+
+        var oneLoginUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == data.OneLoginUserSubject);
+        oneLoginUser.SetMatched(
+            PersonDetail!.PersonId,
+            OneLoginUserMatchRoute.Support,
+            matchedAttributes);
 
         await dbContext.SaveChangesAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/TestBase.cs
@@ -13,8 +13,6 @@ namespace TeachingRecordSystem.Api.Tests;
 
 public abstract class TestBase
 {
-    private static readonly Guid _defaultApplicationUserId = new Guid("c0c8c511-e8e4-4b8e-96e3-55085dafc05d");
-
     private readonly TestScopedServices _testServices;
 
     protected TestBase(HostFixture hostFixture)
@@ -28,7 +26,9 @@ public abstract class TestBase
 
     public Mock<ICertificateGenerator> CertificateGeneratorMock => _testServices.CertificateGeneratorMock;
 
-    public Guid ApplicationUserId { get; } = _defaultApplicationUserId;
+    public Guid DefaultApplicationUserId => HostFixture.DefaultApplicationUserId;
+
+    public Guid ApplicationUserId { get; } = HostFixture.DefaultApplicationUserId;
 
     public CrmQueryDispatcherSpy CrmQueryDispatcherSpy => _testServices.CrmQueryDispatcherSpy;
 
@@ -102,7 +102,7 @@ public abstract class TestBase
     protected void SetCurrentApiClient(IEnumerable<string> roles, Guid? applicationUserId = null)
     {
         var currentUserProvider = HostFixture.Services.GetRequiredService<CurrentApiClientProvider>();
-        currentUserProvider.CurrentApiUserId = applicationUserId ?? _defaultApplicationUserId;
+        currentUserProvider.CurrentApiUserId = applicationUserId ?? DefaultApplicationUserId;
         currentUserProvider.Roles = roles.ToArray();
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/VNext/GetTrnRequestTests.cs
@@ -1,0 +1,87 @@
+namespace TeachingRecordSystem.Api.Tests.V3.VNext;
+
+public class GetTrnRequestTests : TestBase
+{
+    public GetTrnRequestTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        SetCurrentApiClient(roles: [ApiRoles.CreateTrn]);
+    }
+
+    [Fact]
+    public async Task Get_CompletedRequestWithOneLoginUserMetadata_AddsOneLoginUserToDb()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+
+        var person = await TestData.CreatePerson(p => p
+            .WithTrn()
+            .WithTrnRequestId(TrnRequestHelper.GetCrmTrnRequestId(ApplicationUserId, requestId)));
+
+        var oneLoginUserSubject = TestData.CreateOneLoginUserSubject();
+
+        await WithDbContext(dbContext =>
+        {
+            dbContext.TrnRequestMetadata.Add(new Core.DataStore.Postgres.Models.TrnRequestMetadata()
+            {
+                ApplicationUserId = ApplicationUserId,
+                RequestId = requestId,
+                VerifiedOneLoginUserSubject = oneLoginUserSubject
+            });
+
+            return dbContext.SaveChangesAsync();
+        });
+
+        // Act
+        var response = await GetHttpClientWithApiKey().GetAsync($"v3/trn-requests?requestId={requestId}");
+
+        // Assert
+        await AssertEx.JsonResponse(response, expectedStatusCode: 200);
+
+        await WithDbContext(async dbContext =>
+        {
+            var oneLoginUser = await dbContext.OneLoginUsers.SingleOrDefaultAsync(u => u.Subject == oneLoginUserSubject);
+            Assert.NotNull(oneLoginUser);
+            Assert.Equal(person.PersonId, oneLoginUser.PersonId);
+            Assert.Equal(Clock.UtcNow, oneLoginUser.VerifiedOn);
+            Assert.Equal(OneLoginUserVerificationRoute.External, oneLoginUser.VerificationRoute);
+            Assert.Equal(ApplicationUserId, oneLoginUser.VerifiedByApplicationUserId);
+        });
+    }
+
+    [Fact]
+    public async Task Get_PendingRequestWithOneLoginUserMetadata_DoesNotAddOneLoginUserToDb()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+
+        var person = await TestData.CreatePerson(p => p
+            .WithoutTrn()
+            .WithTrnRequestId(TrnRequestHelper.GetCrmTrnRequestId(ApplicationUserId, requestId)));
+
+        var oneLoginUserSubject = TestData.CreateOneLoginUserSubject();
+
+        await WithDbContext(dbContext =>
+        {
+            dbContext.TrnRequestMetadata.Add(new Core.DataStore.Postgres.Models.TrnRequestMetadata()
+            {
+                ApplicationUserId = ApplicationUserId,
+                RequestId = requestId,
+                VerifiedOneLoginUserSubject = oneLoginUserSubject
+            });
+
+            return dbContext.SaveChangesAsync();
+        });
+
+        // Act
+        var response = await GetHttpClientWithApiKey().GetAsync($"v3/trn-requests?requestId={requestId}");
+
+        // Assert
+        await AssertEx.JsonResponse(response, expectedStatusCode: 200);
+
+        await WithDbContext(async dbContext =>
+        {
+            var oneLoginUser = await dbContext.OneLoginUsers.SingleOrDefaultAsync(u => u.Subject == oneLoginUserSubject);
+            Assert.Null(oneLoginUser);
+        });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
@@ -11,7 +11,7 @@ public class OidcTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var coreIdentityVc = TestData.CreateOneLoginCoreIdentityVc(person.FirstName, person.LastName, person.DateOfBirth);
-        SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email, coreIdentityVc));
+        SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email!, coreIdentityVc));
 
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
@@ -345,7 +345,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUser(person);
 
         var coreIdentityVc = TestData.CreateOneLoginCoreIdentityVc(person.FirstName, person.LastName, person.DateOfBirth);
-        SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email, coreIdentityVc));
+        SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email!, coreIdentityVc));
 
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateConnectOneLoginUserSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateConnectOneLoginUserSupportTask.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTaskData;
 
@@ -14,12 +15,13 @@ public partial class TestData
         WithDbContext(async dbContext =>
         {
             var user = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLoginUserSubject);
+            Debug.Assert(user.Email is not null);
 
             var data = new ConnectOneLoginUserData()
             {
                 Verified = user.VerificationRoute is not null,
                 OneLoginUserSubject = user.Subject,
-                OneLoginUserEmail = user.Email,
+                OneLoginUserEmail = user.Email!,
                 VerifiedNames = user.VerifiedNames,
                 VerifiedDatesOfBirth = user.VerifiedDatesOfBirth,
                 StatedNationalInsuranceNumber = statedNationalInsuranceNumber,


### PR DESCRIPTION
Apply for QTS need to be able to pass us a One Login User ID with a TRN allocation request so that we can associate the One Login user with the resolved teaching record. This means that the user won't have to go through verification or matching when they sign in to AYTQ (with One Login).

This change adds a `trn_request_metadata` table in which we will stash the One Login user ID for a given request, if we have one. (This isn't going into the `trn_requests` table since we're not using that for new requests.)

Ideally we would link the One Login User to the teaching record at the point the support task is resolved but we don't have a simple and reliable way of doing that while support tasks are still managed in DQT. This puts the logic into our Get TRN request endpoint so that we can guarantee the link will have been made at the point we return the TRN to the calling service. Once support tasks are moved to TRS we can move the work to happen on support task completion.

A follow-up PR will make the change to actually write to the `trn_request_metadata` table. That same PR will cover the case where the TRN request is immediately resolved (since the calling service won't ever poll the `GET` endpoint in those cases and we still need the link to have been made).