### PR TITLE
Added tests for alert change log UI

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/AlertUpdatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/AlertUpdatedEvent.cshtml
@@ -6,7 +6,9 @@
 @{
     var updatedEvent = Model.ItemModel.Event;
     var alert = updatedEvent.Alert;
+    TrsUriHelper.TryCreateWebsiteUri(alert.ExternalLink, out var externalLinkUri);
     var oldAlert = updatedEvent.OldAlert;
+    TrsUriHelper.TryCreateWebsiteUri(oldAlert.ExternalLink, out var oldExternalLinkUri);
     var alertType = alert.AlertTypeId is not null ? await ReferenceDataCache.GetAlertTypeById(alert.AlertTypeId.Value) : null;
     var evidenceFileUrl = updatedEvent.EvidenceFile is not null ? await FileService.GetFileUrl(updatedEvent.EvidenceFile!.FileId, TimeSpan.FromMinutes(15)) : null;
     var heading = "changed";
@@ -51,9 +53,9 @@
     }
 }
 
-<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-alert-deleted-event">
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-alert-updated-event">
     <div class="moj-timeline__header">
-        <h2 class="moj-timeline__title">Alert @heading</h2>
+        <h2 class="moj-timeline__title" data-testid="heading">Alert @heading</h2>
     </div>
     <p class="moj-timeline__date">
         <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
@@ -87,7 +89,16 @@
             {
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Details</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="details" use-empty-fallback>@alert.Details</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>
+                        @if (alert.Details is not null)
+                        {
+                            <multi-line-text text="@alert.Details" data-testid="details" />
+                        }
+                        else
+                        {
+                            <span use-empty-fallback data-testid="details"></span>
+                        }
+                    </govuk-summary-list-row-value>
                 </govuk-summary-list-row>
             }
 
@@ -95,7 +106,16 @@
             {
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>External link</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="external-link" use-empty-fallback>@alert.ExternalLink</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>
+                        @if (alert.ExternalLink is not null)
+                        {
+                            <a href="@externalLinkUri" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="external-link">@($"{alert.ExternalLink} (opens in new tab)")</a>
+                        }
+                        else
+                        {
+                            <span data-testid="external-link" use-empty-fallback></span>
+                        }
+                    </govuk-summary-list-row-value>
                 </govuk-summary-list-row>
             }
 
@@ -137,11 +157,11 @@
                         <govuk-summary-list-row-value>
                             @if (updatedEvent.ChangeReasonDetail is not null)
                             {
-                                <multi-line-text text="@updatedEvent.ChangeReasonDetail" />
+                                <multi-line-text text="@updatedEvent.ChangeReasonDetail" data-testid="reason-detail" />
                             }
                             else
                             {
-                                <span use-empty-fallback></span>
+                                <span use-empty-fallback data-testid="reason-detail"></span>
                             }
                         </govuk-summary-list-row-value>
                     </govuk-summary-list-row>
@@ -172,7 +192,7 @@
                         {
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value data-testid="start-date" use-empty-fallback>@oldAlert.StartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-value data-testid="old-start-date" use-empty-fallback>@oldAlert.StartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                         }
 
@@ -180,15 +200,33 @@
                         {
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>Details</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value data-testid="details" use-empty-fallback>@oldAlert.Details</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-value>
+                                    @if (oldAlert.Details is not null)
+                                    {
+                                        <multi-line-text text="@oldAlert.Details" data-testid="old-details" />
+                                    }
+                                    else
+                                    {
+                                        <span use-empty-fallback data-testid="old-details"></span>
+                                    }
+                                </govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                         }
 
                         @if (updatedEvent.Changes.HasFlag(AlertUpdatedEventChanges.ExternalLink))
                         {
                             <govuk-summary-list-row>
-                                <govuk-summary-list-row-key>External link</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value data-testid="external-link" use-empty-fallback>@oldAlert.ExternalLink</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-key>External link</govuk-summary-list-row-key>                                
+                                <govuk-summary-list-row-value>
+                                    @if (oldAlert.ExternalLink is not null)
+                                    {
+                                        <a href="@oldExternalLinkUri" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="old-external-link">@($"{oldAlert.ExternalLink} (opens in new tab)")</a>
+                                    }
+                                    else
+                                    {
+                                        <span data-testid="old-external-link" use-empty-fallback></span>
+                                    }
+                                </govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                         }
 
@@ -196,7 +234,7 @@
                         {
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value data-testid="end-date" use-empty-fallback>@oldAlert.EndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-value data-testid="old-end-date" use-empty-fallback>@oldAlert.EndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                         }
 
@@ -204,7 +242,7 @@
                         {
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>DQT spent</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value data-testid="dqt-spent" use-empty-fallback>@oldAlert.DqtSpent</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-value data-testid="old-dqt-spent" use-empty-fallback>@oldAlert.DqtSpent</govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                         }
 
@@ -212,11 +250,11 @@
                         {
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>DQT sanction code</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value data-testid="sanction-code" use-empty-fallback>@oldAlert.DqtSanctionCode?.Value</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-value data-testid="old-sanction-code" use-empty-fallback>@oldAlert.DqtSanctionCode?.Value</govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>DQT sanction name</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value data-testid="sanction-name" use-empty-fallback>@oldAlert.DqtSanctionCode?.Name</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-value data-testid="old-sanction-name" use-empty-fallback>@oldAlert.DqtSanctionCode?.Name</govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                         }
                     </govuk-summary-list>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
@@ -130,7 +129,7 @@ public class ChangeLogAlertEventsTests : TestBase
     public async Task Person_WithAlertCreatedEventGeneratedInDqt_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePerson();
@@ -147,10 +146,6 @@ public class ChangeLogAlertEventsTests : TestBase
 
         if (shouldDisplay)
         {
-            if (items.Count == 0)
-            {
-                Debug.Assert(false);
-            }
             Assert.NotEmpty(items);
         }
         else
@@ -204,7 +199,7 @@ public class ChangeLogAlertEventsTests : TestBase
     public async Task Person_WithAlertDeletedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePerson();
@@ -221,10 +216,6 @@ public class ChangeLogAlertEventsTests : TestBase
 
         if (shouldDisplay)
         {
-            if (items.Count == 0)
-            {
-                Debug.Assert(false);
-            }
             Assert.NotEmpty(items);
         }
         else
@@ -280,7 +271,7 @@ public class ChangeLogAlertEventsTests : TestBase
     public async Task Person_WithAlertDqtDeactivatedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePerson();
@@ -297,10 +288,6 @@ public class ChangeLogAlertEventsTests : TestBase
 
         if (shouldDisplay)
         {
-            if (items.Count == 0)
-            {
-                Debug.Assert(false);
-            }
             Assert.NotEmpty(items);
         }
         else
@@ -350,7 +337,7 @@ public class ChangeLogAlertEventsTests : TestBase
     public async Task Person_WithAlertDqtImportedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePerson();
@@ -367,10 +354,6 @@ public class ChangeLogAlertEventsTests : TestBase
 
         if (shouldDisplay)
         {
-            if (items.Count == 0)
-            {
-                Debug.Assert(false);
-            }
             Assert.NotEmpty(items);
         }
         else
@@ -420,7 +403,7 @@ public class ChangeLogAlertEventsTests : TestBase
     public async Task Person_WithAlertDqtReactivatedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePerson();
@@ -437,10 +420,6 @@ public class ChangeLogAlertEventsTests : TestBase
 
         if (shouldDisplay)
         {
-            if (items.Count == 0)
-            {
-                Debug.Assert(false);
-            }
             Assert.NotEmpty(items);
         }
         else
@@ -490,7 +469,7 @@ public class ChangeLogAlertEventsTests : TestBase
     public async Task Person_WithAlertMigratedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePerson();
@@ -507,10 +486,6 @@ public class ChangeLogAlertEventsTests : TestBase
 
         if (shouldDisplay)
         {
-            if (items.Count == 0)
-            {
-                Debug.Assert(false);
-            }
             Assert.NotEmpty(items);
         }
         else
@@ -707,10 +682,10 @@ public class ChangeLogAlertEventsTests : TestBase
     }
 
     [Theory]
-    [InlineData(EndDateChangeType.Change)]
-    [InlineData(EndDateChangeType.Close)]
-    [InlineData(EndDateChangeType.Reopen)]
-    public async Task Person_WithAlertUpdatedEventEndDateChangedFromDqt_RendersExpectedContent(EndDateChangeType changeType)
+    [InlineData(EndDateChangeType.Change, "Alert end date changed")]
+    [InlineData(EndDateChangeType.Close, "Alert closed")]
+    [InlineData(EndDateChangeType.Reopen, "Alert re-opened")]
+    public async Task Person_WithAlertUpdatedEventEndDateChangedFromDqt_RendersExpectedContent(EndDateChangeType changeType, string expectedHeading)
     {
         // Arrange
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
@@ -732,16 +707,6 @@ public class ChangeLogAlertEventsTests : TestBase
             doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
                 item =>
                 {
-                    var expectedHeading = "Alert end date changed";
-                    if (alertUpdatedEvent.Alert.EndDate is null)
-                    {
-                        expectedHeading = "Alert re-opened";
-                    }
-                    else if (alertUpdatedEvent.OldAlert.EndDate is null)
-                    {
-                        expectedHeading = "Alert closed";
-                    }
-
                     Assert.Equal(expectedHeading, item.GetElementByTestId("heading")?.TextContent.Trim());
                     Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
                     Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
@@ -754,10 +719,10 @@ public class ChangeLogAlertEventsTests : TestBase
     }
 
     [Theory]
-    [InlineData(EndDateChangeType.Change)]
-    [InlineData(EndDateChangeType.Close)]
-    [InlineData(EndDateChangeType.Reopen)]
-    public async Task Person_WithAlertUpdatedEventEndDateChangedFromTrs_RendersExpectedContent(EndDateChangeType changeType)
+    [InlineData(EndDateChangeType.Change, "Alert end date changed")]
+    [InlineData(EndDateChangeType.Close, "Alert closed")]
+    [InlineData(EndDateChangeType.Reopen, "Alert re-opened")]
+    public async Task Person_WithAlertUpdatedEventEndDateChangedFromTrs_RendersExpectedContent(EndDateChangeType changeType, string expectedHeading)
     {
         // Arrange
         var createdByUser = await TestData.CreateUser();
@@ -780,16 +745,6 @@ public class ChangeLogAlertEventsTests : TestBase
             doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
                 item =>
                 {
-                    var expectedHeading = "Alert end date changed";
-                    if (alertUpdatedEvent.Alert.EndDate is null)
-                    {
-                        expectedHeading = "Alert re-opened";
-                    }
-                    else if (alertUpdatedEvent.OldAlert.EndDate is null)
-                    {
-                        expectedHeading = "Alert closed";
-                    }
-
                     Assert.Equal(expectedHeading, item.GetElementByTestId("heading")?.TextContent.Trim());
                     Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
                     Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
@@ -883,7 +838,7 @@ public class ChangeLogAlertEventsTests : TestBase
     public async Task Person_WithAlertUpdatedEventFromDqt_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePerson();
@@ -903,10 +858,6 @@ public class ChangeLogAlertEventsTests : TestBase
 
         if (shouldDisplay)
         {
-            if (items.Count == 0)
-            {
-                Debug.Assert(false);
-            }
             Assert.NotEmpty(items);
         }
         else
@@ -1205,7 +1156,12 @@ public class ChangeLogAlertEventsTests : TestBase
     private async Task<EventModels.Alert> CreateEventAlertFromDqt(Guid personId, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
     {
         var dbsAlertType = await TestData.ReferenceDataCache.GetAlertTypeById(AlertType.DbsAlertTypeId);
-        var dqtSanctionCode = (await TestData.ReferenceDataCache.GetSanctionCodes(activeOnly: false)).Where(s => isDbsAlertType ? s.dfeta_Value == dbsAlertType.DqtSanctionCode : s.dfeta_Value != dbsAlertType.DqtSanctionCode).RandomOne();
+        var migratedSanctionCodes = (await TestData.ReferenceDataCache.GetAlertTypes())
+            .Where(t => t.DqtSanctionCode is not null)
+            .Select(c => c.DqtSanctionCode);
+        var dqtSanctionCode = (await TestData.ReferenceDataCache.GetSanctionCodes(activeOnly: false))
+            .Where(s => migratedSanctionCodes.Contains(s.dfeta_Value) && (isDbsAlertType ? s.dfeta_Value == dbsAlertType.DqtSanctionCode : s.dfeta_Value != dbsAlertType.DqtSanctionCode))
+            .RandomOne();
         var alertDqtSanctionCode = new AlertDqtSanctionCode
         {
             SanctionCodeId = dqtSanctionCode!.Id,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
@@ -1,0 +1,1242 @@
+using System.Diagnostics;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Events.Models;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
+
+public class ChangeLogAlertEventsTests : TestBase
+{
+    public ChangeLogAlertEventsTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        // Toggle between GMT and BST to ensure we're testing rendering dates in local time
+        var nows = new[]
+        {
+            new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
+            new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
+        };
+        Clock.UtcNow = nows.RandomOne();
+        SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertCreatedEventGeneratedInTrs_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByUser = await TestData.CreateUser();
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertCreatedEventFromTrs(person.PersonId, createdByUser.UserId, populateOptional, isOpenAlert: true);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alertCreatedEvent.Alert.AlertTypeId!.Value);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-created-event"),
+                item =>
+                {
+                    Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertType!.Name, item.GetElementByTestId("alert-type")?.TextContent.Trim());
+                    Assert.Equal(alertCreatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertCreatedEvent.AddReason : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertCreatedEvent.AddReasonDetail : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason-detail")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? $"{alertCreatedEvent.EvidenceFile!.Name} (opens in new tab)" : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("uploaded-evidence-link")?.TextContent);
+                });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertCreatedEventGeneratedInTrs_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByUser = await TestData.CreateUser();
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertCreatedEventFromTrs(person.PersonId, createdByUser.UserId, populateOptional: true, isOpenAlert: true, isDbsAlertType: isDbsAlertType);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-created-event");
+
+        if (shouldDisplay)
+        {
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertCreatedEventGeneratedInDqt_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertCreatedEventFromDqt(person.PersonId, createdByDqtUser, populateOptional: populateOptional, isOpenAlert: true);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-created-event"),
+                item =>
+                {
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertCreatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertCreatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertCreatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertCreatedEventGeneratedInDqt_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertCreatedEventFromDqt(person.PersonId, createdByDqtUser, populateOptional: true, isOpenAlert: true, isDbsAlertType: isDbsAlertType);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-created-event");
+
+        if (shouldDisplay)
+        {
+            if (items.Count == 0)
+            {
+                Debug.Assert(false);
+            }
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public async Task Person_WithAlertDeletedEvent_RendersExpectedContent(bool populateOptional, bool isOpenAlert)
+    {
+        // Arrange
+        var createdByUser = await TestData.CreateUser();
+        var person = await TestData.CreatePerson();
+        var alertDeletedEvent = await CreateAlertDeletedEvent(person.PersonId, createdByUser.UserId, populateOptional, isOpenAlert);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alertDeletedEvent.Alert.AlertTypeId!.Value);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-deleted-event"),
+             item =>
+             {
+                 Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                 Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                 Assert.Equal(alertType!.Name, item.GetElementByTestId("alert-type")?.TextContent.Trim());
+                 Assert.Equal(alertDeletedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                 Assert.Equal(populateOptional ? alertDeletedEvent.DeletionReasonDetail : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason-detail")?.TextContent.Trim());
+                 Assert.Equal(populateOptional ? $"{alertDeletedEvent.EvidenceFile!.Name} (opens in new tab)" : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("uploaded-evidence-link")?.TextContent);
+             });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertDeletedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertDeletedEvent(person.PersonId, createdByDqtUser, populateOptional: true, isOpenAlert: true, isDbsAlertType: isDbsAlertType);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-deleted-event");
+
+        if (shouldDisplay)
+        {
+            if (items.Count == 0)
+            {
+                Debug.Assert(false);
+            }
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public async Task Person_WithAlertDqtDeactivatedEvent_RendersExpectedContent(bool populateOptional, bool isOpenAlert)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertDqtDeactivatedEvent = await CreateAlertDqtDeactivatedEvent(person.PersonId, createdByDqtUser, populateOptional, isOpenAlert);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        var all = doc.GetAllElementsByTestId("timeline-item-alert-dqt-deactivated-event").ToArray();
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-dqt-deactivated-event"),
+             item =>
+             {
+                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                 Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                 Assert.Equal(alertDqtDeactivatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                 Assert.Equal(alertDqtDeactivatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                 Assert.Equal(populateOptional ? alertDqtDeactivatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                 Assert.Equal(populateOptional ? alertDqtDeactivatedEvent.Alert.Details : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("details")?.TextContent.Trim());
+                 Assert.Equal(isOpenAlert ? UiDefaults.EmptyDisplayContent : alertDqtDeactivatedEvent.Alert.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("end-date")?.TextContent.Trim());
+             });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertDqtDeactivatedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertDqtDeactivatedEvent(person.PersonId, createdByDqtUser, populateOptional: true, isOpenAlert: true, isDbsAlertType: isDbsAlertType);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-dqt-deactivated-event");
+
+        if (shouldDisplay)
+        {
+            if (items.Count == 0)
+            {
+                Debug.Assert(false);
+            }
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertDqtImportedEvent_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertDqtImportedEvent = await CreateAlertDqtImportedEvent(person.PersonId, createdByDqtUser, populateOptional);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-dqt-imported-event"),
+                item =>
+                {
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertDqtImportedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertDqtImportedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertDqtImportedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertDqtImportedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertDqtImportedEvent(person.PersonId, createdByDqtUser, populateOptional: true, isDbsAlertType: isDbsAlertType);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-dqt-imported-event");
+
+        if (shouldDisplay)
+        {
+            if (items.Count == 0)
+            {
+                Debug.Assert(false);
+            }
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertDqtReactivatedEvent_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertDqtImportedEvent = await CreateAlertDqtReactivatedEvent(person.PersonId, createdByDqtUser, populateOptional);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-dqt-reactivated-event"),
+                item =>
+                {
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertDqtImportedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertDqtImportedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertDqtImportedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertDqtReactivatedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertDqtReactivatedEvent(person.PersonId, createdByDqtUser, populateOptional: true, isDbsAlertType: isDbsAlertType);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-dqt-reactivated-event");
+
+        if (shouldDisplay)
+        {
+            if (items.Count == 0)
+            {
+                Debug.Assert(false);
+            }
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+    [Fact]
+    public async Task Person_WithAlertMigratedEvent_RendersExpectedContent()
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertMigratedEvent = await CreateAlertMigratedEvent(person.PersonId, createdByDqtUser, populateOptional: true);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alertMigratedEvent.Alert.AlertTypeId!.Value);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-migrated-event"),
+                item =>
+                {
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertType!.Name, item.GetElementByTestId("alert-type")?.TextContent.Trim());
+                    Assert.Equal(alertMigratedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(alertMigratedEvent!.OldAlert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertMigratedEvent!.OldAlert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertMigratedEvent_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alertCreatedEvent = await CreateAlertMigratedEvent(person.PersonId, createdByDqtUser, populateOptional: true, isDbsAlertType: isDbsAlertType);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-migrated-event");
+
+        if (shouldDisplay)
+        {
+            if (items.Count == 0)
+            {
+                Debug.Assert(false);
+            }
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventStartChangedFromDqt_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromDqt(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { StartDate = populateOptional ? null : Clock.Today.AddDays(-30) };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.StartDate, createdByDqtUser, hasReason: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert start date changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());                    
+                    Assert.Equal(populateOptional ? UiDefaults.EmptyDisplayContent : alertUpdatedEvent.OldAlert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("old-start-date")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventStartChangedFromTrs_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByUser = await TestData.CreateUser();
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromTrs(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { StartDate = Clock.Today.AddDays(-31) };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.StartDate, createdByUser.UserId, hasReason: populateOptional);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alertUpdatedEvent.Alert.AlertTypeId!.Value);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert start date changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertType!.Name, item.GetElementByTestId("alert-type")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.OldAlert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("old-start-date")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.ChangeReason : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.ChangeReasonDetail : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason-detail")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? $"{alertUpdatedEvent.EvidenceFile!.Name} (opens in new tab)" : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("uploaded-evidence-link")?.TextContent);
+                });
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventDetailsChangedFromDqt_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromDqt(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { Details = populateOptional ? null : "Old details" };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.Details, createdByDqtUser, hasReason: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert details changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.Details : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("details")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? UiDefaults.EmptyDisplayContent : alertUpdatedEvent.OldAlert.Details, item.GetElementByTestId("old-details")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventDetailsChangedFromTrs_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByUser = await TestData.CreateUser();
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromTrs(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { StartDate = Clock.Today.AddDays(-31) };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.Details, createdByUser.UserId, hasReason: populateOptional);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alertUpdatedEvent.Alert.AlertTypeId!.Value);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert details changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertType!.Name, item.GetElementByTestId("alert-type")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.Alert.Details!, item.GetElementByTestId("details")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.OldAlert.Details!, item.GetElementByTestId("old-details")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.ChangeReason : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.ChangeReasonDetail : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason-detail")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? $"{alertUpdatedEvent.EvidenceFile!.Name} (opens in new tab)" : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("uploaded-evidence-link")?.TextContent);
+                });
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventExternalLinkChangedFromTrs_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByUser = await TestData.CreateUser();
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromTrs(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { ExternalLink = populateOptional ? null : TestData.GenerateUrl() };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.ExternalLink, createdByUser.UserId, hasReason: populateOptional);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alertUpdatedEvent.Alert.AlertTypeId!.Value);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert link changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertType!.Name, item.GetElementByTestId("alert-type")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? $"{alertUpdatedEvent.Alert!.ExternalLink} (opens in new tab)" : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("external-link")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? UiDefaults.EmptyDisplayContent : $"{alertUpdatedEvent.OldAlert!.ExternalLink} (opens in new tab)", item.GetElementByTestId("old-external-link")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.ChangeReason : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.ChangeReasonDetail : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("reason-detail")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? $"{alertUpdatedEvent.EvidenceFile!.Name} (opens in new tab)" : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("uploaded-evidence-link")?.TextContent);
+                });
+    }
+
+    [Theory]
+    [InlineData(EndDateChangeType.Change)]
+    [InlineData(EndDateChangeType.Close)]
+    [InlineData(EndDateChangeType.Reopen)]
+    public async Task Person_WithAlertUpdatedEventEndDateChangedFromDqt_RendersExpectedContent(EndDateChangeType changeType)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromDqt(person.PersonId, populateOptional: true, isOpenAlert: changeType == EndDateChangeType.Reopen);
+        var oldAlert = alert with { EndDate = changeType == EndDateChangeType.Close ? null : Clock.Today.AddDays(-6) };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.EndDate, createdByDqtUser, hasReason: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    var expectedHeading = "Alert end date changed";
+                    if (alertUpdatedEvent.Alert.EndDate is null)
+                    {
+                        expectedHeading = "Alert re-opened";
+                    } 
+                    else if (alertUpdatedEvent.OldAlert.EndDate is null)
+                    {
+                        expectedHeading = "Alert closed";
+                    }
+
+                    Assert.Equal(expectedHeading, item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(changeType != EndDateChangeType.Reopen ? alertUpdatedEvent.Alert.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("end-date")?.TextContent.Trim());
+                    Assert.Equal(changeType != EndDateChangeType.Close ? alertUpdatedEvent.OldAlert.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : null, item.GetElementByTestId("old-end-date")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(EndDateChangeType.Change)]
+    [InlineData(EndDateChangeType.Close)]
+    [InlineData(EndDateChangeType.Reopen)]
+    public async Task Person_WithAlertUpdatedEventEndDateChangedFromTrs_RendersExpectedContent(EndDateChangeType changeType)
+    {
+        // Arrange
+        var createdByUser = await TestData.CreateUser();
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromTrs(person.PersonId, populateOptional: true, isOpenAlert: changeType == EndDateChangeType.Reopen);
+        var oldAlert = alert with { EndDate = changeType == EndDateChangeType.Close ? null : Clock.Today.AddDays(-6) };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.EndDate, createdByUser.UserId, hasReason: false);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alertUpdatedEvent.Alert.AlertTypeId!.Value);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    var expectedHeading = "Alert end date changed";
+                    if (alertUpdatedEvent.Alert.EndDate is null)
+                    {
+                        expectedHeading = "Alert re-opened";
+                    }
+                    else if (alertUpdatedEvent.OldAlert.EndDate is null)
+                    {
+                        expectedHeading = "Alert closed";
+                    }
+
+                    Assert.Equal(expectedHeading, item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertType!.Name, item.GetElementByTestId("alert-type")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(changeType != EndDateChangeType.Reopen ? alertUpdatedEvent.Alert.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("end-date")?.TextContent.Trim());
+                    Assert.Equal(changeType != EndDateChangeType.Close ? alertUpdatedEvent.OldAlert.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : null, item.GetElementByTestId("old-end-date")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventDqtSpentChanged_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromDqt(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { DqtSpent = populateOptional ? null : true };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.DqtSpent, createdByDqtUser, hasReason: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert DQT spent changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? bool.TrueString : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("dqt-spent")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? UiDefaults.EmptyDisplayContent : bool.TrueString, item.GetElementByTestId("old-dqt-spent")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventDqtSanctionCodeChanged_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromDqt(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { DqtSpent = populateOptional ? null : true };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.DqtSanctionCode, createdByDqtUser, hasReason: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert DQT sanction code changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.OldAlert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.OldAlert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                });
+    }
+
+    [Theory]
+    [InlineData(false, null, true)]
+    [InlineData(false, UserRoles.AlertsReadWrite, true)]
+    [InlineData(true, null, false)]
+    [InlineData(true, UserRoles.AlertsReadWrite, false)]
+    [InlineData(true, UserRoles.DbsAlertsReadWrite, true)]
+    [InlineData(true, UserRoles.DbsAlertsReadOnly, true)]
+    [InlineData(true, UserRoles.Administrator, true)]
+    public async Task Person_WithAlertUpdatedEventFromDqt_DisplaysAsExpectedForUserRole(bool isDbsAlertType, string? role, bool shouldDisplay)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role is not null ? [role!] : []));
+
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromDqt(person.PersonId, populateOptional: true, isOpenAlert: true, isDbsAlertType);
+        var oldAlert = alert with { Details = "Old details" };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.Details, createdByDqtUser, hasReason: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+        var items = doc.GetAllElementsByTestId("timeline-item-alert-updated-event");
+
+        if (shouldDisplay)
+        {
+            if (items.Count == 0)
+            {
+                Debug.Assert(false);
+            }
+            Assert.NotEmpty(items);
+        }
+        else
+        {
+            Assert.Empty(items);
+        }
+    }
+
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Person_WithAlertUpdatedEventMultipleChanges_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
+        var person = await TestData.CreatePerson();
+        var alert = await CreateEventAlertFromDqt(person.PersonId, populateOptional, isOpenAlert: true);
+        var oldAlert = alert with { Details = populateOptional ? null : "Old details", DqtSpent = populateOptional ? null : true };
+
+        var alertUpdatedEvent = await CreateAlertUpdatedEvent(person.PersonId, alert, oldAlert, AlertUpdatedEventChanges.Details | AlertUpdatedEventChanges.DqtSpent, createdByDqtUser, hasReason: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponse(response);
+
+        Assert.Collection(
+            doc.GetAllElementsByTestId("timeline-item-alert-updated-event"),
+                item =>
+                {
+                    Assert.Equal("Alert changed", item.GetElementByTestId("heading")?.TextContent.Trim());
+                    Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+                    Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
+                    Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.Details : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("details")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? UiDefaults.EmptyDisplayContent : alertUpdatedEvent.OldAlert.Details, item.GetElementByTestId("old-details")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? bool.TrueString : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("dqt-spent")?.TextContent.Trim());
+                    Assert.Equal(populateOptional ? UiDefaults.EmptyDisplayContent : bool.TrueString, item.GetElementByTestId("old-dqt-spent")?.TextContent.Trim());
+                });
+    }
+
+    private async Task<AlertCreatedEvent> CreateAlertCreatedEventFromDqt(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
+    {
+        var alert = await CreateEventAlertFromDqt(personId, populateOptional, isOpenAlert, isDbsAlertType);
+
+        var alertCreatedEvent = new AlertCreatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,
+            AddReason = null,
+            AddReasonDetail = null,
+            EvidenceFile = null,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertCreatedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertCreatedEvent;
+    }
+
+    private async Task<AlertCreatedEvent> CreateAlertCreatedEventFromTrs(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
+    {
+        var alert = await CreateEventAlertFromTrs(personId, populateOptional, isOpenAlert, isDbsAlertType);
+        var reason = populateOptional ? AddAlertReasonOption.RoutineNotificationFromStakeholder.GetDisplayName() : null;
+        var reasonDetail = populateOptional ? "Reason detail" : null;
+        var evidenceFile = populateOptional ? new EventModels.File
+        {
+            FileId = Guid.NewGuid(),
+            Name = "evidence.jpg"
+        }
+        : null;
+
+        var alertCreatedEvent = new AlertCreatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,
+            AddReason = reason,
+            AddReasonDetail = reasonDetail,
+            EvidenceFile = evidenceFile,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertCreatedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertCreatedEvent;
+    }
+
+    private async Task<AlertDeletedEvent> CreateAlertDeletedEvent(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
+    {
+        var alert = await CreateEventAlertFromTrs(personId, populateOptional, isOpenAlert, isDbsAlertType);
+        var reasonDetail = populateOptional ? "Reason detail" : null;
+        var evidenceFile = populateOptional ? new EventModels.File
+        {
+            FileId = Guid.NewGuid(),
+            Name = "evidence.jpg"
+        }
+        : null;
+
+        var alertDeletedEvent = new AlertDeletedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,            
+            DeletionReasonDetail = reasonDetail,
+            EvidenceFile = evidenceFile,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertDeletedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertDeletedEvent;
+    }
+
+    private async Task<AlertDqtDeactivatedEvent> CreateAlertDqtDeactivatedEvent(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
+    {
+        var alert = await CreateEventAlertFromDqt(personId, populateOptional, isOpenAlert, isDbsAlertType);        
+
+        var alertDqtDeactivatedEvent = new AlertDqtDeactivatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertDqtDeactivatedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertDqtDeactivatedEvent;
+    }
+
+    private async Task<AlertDqtImportedEvent> CreateAlertDqtImportedEvent(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isDbsAlertType = false)
+    {
+        var alert = await CreateEventAlertFromDqt(personId, populateOptional, isOpenAlert: true, isDbsAlertType);
+
+        var alertDqtImportedEvent = new AlertDqtImportedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow,
+            DqtState = 1
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertDqtImportedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertDqtImportedEvent;
+    }
+
+    private async Task<AlertDqtReactivatedEvent> CreateAlertDqtReactivatedEvent(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isDbsAlertType = false)
+    {
+        var alert = await CreateEventAlertFromDqt(personId, populateOptional, isOpenAlert: true, isDbsAlertType);
+
+        var alertDqtReactivatedEvent = new AlertDqtReactivatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertDqtReactivatedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertDqtReactivatedEvent;
+    }
+
+    private async Task<AlertMigratedEvent> CreateAlertMigratedEvent(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isDbsAlertType = false)
+    {
+        var alert = await CreateEventAlertFromTrs(personId, populateOptional, isOpenAlert: true, isDbsAlertType);
+        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(alert.AlertTypeId!.Value);
+        var dqtSanctionCode = await TestData.ReferenceDataCache.GetSanctionCodeByValue(alertType.DqtSanctionCode!);
+        var oldAlert = alert with
+        {
+            AlertId = Guid.NewGuid(),
+            DqtSanctionCode = populateOptional ? new AlertDqtSanctionCode
+            {
+                SanctionCodeId = dqtSanctionCode!.Id,
+                Name = dqtSanctionCode.dfeta_name,
+                Value = dqtSanctionCode.dfeta_Value
+            }
+            : null,
+            DqtSpent = populateOptional ? true : (bool?)null,
+        };
+
+        var alertMigratedEvent = new AlertMigratedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,
+            OldAlert = oldAlert,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertMigratedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertMigratedEvent;
+    }
+
+    private async Task<AlertUpdatedEvent> CreateAlertUpdatedEvent(Guid personId, EventModels.Alert alert, EventModels.Alert oldAlert, AlertUpdatedEventChanges changes, EventModels.RaisedByUserInfo createdByUser, bool hasReason)
+    {
+        var alertUpdatedEvent = new AlertUpdatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            PersonId = personId,
+            Alert = alert,
+            OldAlert = oldAlert,
+            RaisedBy = createdByUser,
+            CreatedUtc = Clock.UtcNow,
+            Changes = changes,
+            ChangeReason = hasReason ? "Change reason" : null,
+            ChangeReasonDetail = hasReason ? "Change reason detail" : null,
+            EvidenceFile = hasReason ? new EventModels.File
+            {
+                FileId = Guid.NewGuid(),
+                Name = "evidence.jpg"
+            }
+        : null
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEvent(alertUpdatedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return alertUpdatedEvent;
+    }
+
+    private async Task<EventModels.Alert> CreateEventAlertFromTrs(Guid personId, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
+    {
+        var dbsAlertType = await TestData.ReferenceDataCache.GetAlertTypeById(AlertType.DbsAlertTypeId);
+        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).Where(t => t.IsDbsAlertType == isDbsAlertType).RandomOne();
+        
+        var alertDetails = "My alert details";
+        var externalLink = populateOptional ? TestData.GenerateUrl() : null;
+        var startDate = Clock.Today.AddDays(-30);
+        var endDate = isOpenAlert ? (DateOnly?)null : Clock.Today.AddDays(-5);
+
+        var alert = new EventModels.Alert
+        {
+            AlertId = Guid.NewGuid(),
+            AlertTypeId = alertType?.AlertTypeId,
+            Details = alertDetails,
+            ExternalLink = externalLink,
+            StartDate = startDate,
+            EndDate = endDate,
+            DqtSpent = null,
+            DqtSanctionCode = null
+        };
+
+        return alert;
+    }
+
+    private async Task<EventModels.Alert> CreateEventAlertFromDqt(Guid personId, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
+    {
+        var dbsAlertType = await TestData.ReferenceDataCache.GetAlertTypeById(AlertType.DbsAlertTypeId);
+        var dqtSanctionCode = (await TestData.ReferenceDataCache.GetSanctionCodes(activeOnly: false)).Where(s => isDbsAlertType ? s.dfeta_Value == dbsAlertType.DqtSanctionCode : s.dfeta_Value != dbsAlertType.DqtSanctionCode).RandomOne();
+        var alertDqtSanctionCode = new AlertDqtSanctionCode
+        {
+            SanctionCodeId = dqtSanctionCode!.Id,
+            Name = dqtSanctionCode.dfeta_name,
+            Value = dqtSanctionCode.dfeta_Value
+        };
+
+        var dqtSpent = populateOptional ? true : (bool?)null;
+        var alertDetails = populateOptional ? "My alert details" : null;
+        var startDate = populateOptional ? Clock.Today.AddDays(-30) : (DateOnly?)null;
+        var endDate = isOpenAlert ? (DateOnly?)null : Clock.Today.AddDays(-5);
+
+        var alert = new EventModels.Alert
+        {
+            AlertId = Guid.NewGuid(),
+            AlertTypeId = null,
+            Details = alertDetails,
+            ExternalLink = null,
+            StartDate = startDate,
+            EndDate = endDate,
+            DqtSpent = dqtSpent,
+            DqtSanctionCode = alertDqtSanctionCode
+        };
+
+        return alert;
+    }
+
+    public enum EndDateChangeType
+    {
+        Change,
+        Close,
+        Reopen
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
@@ -549,7 +549,7 @@ public class ChangeLogAlertEventsTests : TestBase
                     Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
                     Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Value, item.GetElementByTestId("sanction-code")?.TextContent.Trim());
                     Assert.Equal(alertUpdatedEvent!.Alert.DqtSanctionCode!.Name, item.GetElementByTestId("sanction-name")?.TextContent.Trim());
-                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());                    
+                    Assert.Equal(populateOptional ? alertUpdatedEvent.Alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, item.GetElementByTestId("start-date")?.TextContent.Trim());
                     Assert.Equal(populateOptional ? UiDefaults.EmptyDisplayContent : alertUpdatedEvent.OldAlert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("old-start-date")?.TextContent.Trim());
                 });
     }
@@ -736,7 +736,7 @@ public class ChangeLogAlertEventsTests : TestBase
                     if (alertUpdatedEvent.Alert.EndDate is null)
                     {
                         expectedHeading = "Alert re-opened";
-                    } 
+                    }
                     else if (alertUpdatedEvent.OldAlert.EndDate is null)
                     {
                         expectedHeading = "Alert closed";
@@ -1027,7 +1027,7 @@ public class ChangeLogAlertEventsTests : TestBase
         {
             EventId = Guid.NewGuid(),
             PersonId = personId,
-            Alert = alert,            
+            Alert = alert,
             DeletionReasonDetail = reasonDetail,
             EvidenceFile = evidenceFile,
             RaisedBy = createdByUser,
@@ -1045,7 +1045,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
     private async Task<AlertDqtDeactivatedEvent> CreateAlertDqtDeactivatedEvent(Guid personId, EventModels.RaisedByUserInfo createdByUser, bool populateOptional, bool isOpenAlert, bool isDbsAlertType = false)
     {
-        var alert = await CreateEventAlertFromDqt(personId, populateOptional, isOpenAlert, isDbsAlertType);        
+        var alert = await CreateEventAlertFromDqt(personId, populateOptional, isOpenAlert, isDbsAlertType);
 
         var alertDqtDeactivatedEvent = new AlertDqtDeactivatedEvent()
         {
@@ -1181,7 +1181,7 @@ public class ChangeLogAlertEventsTests : TestBase
     {
         var dbsAlertType = await TestData.ReferenceDataCache.GetAlertTypeById(AlertType.DbsAlertTypeId);
         var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).Where(t => t.IsDbsAlertType == isDbsAlertType).RandomOne();
-        
+
         var alertDetails = "My alert details";
         var externalLink = populateOptional ? TestData.GenerateUrl() : null;
         var startDate = Clock.Today.AddDays(-30);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -124,15 +124,30 @@ public abstract class TestBase : IDisposable
             return 0;
         });
 
-    protected async Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithOpenAlert(bool populateOptional = true)
+    protected Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithOpenAlert(bool populateOptional = true, EventModels.RaisedByUserInfo? createdByUser = null)
     {
-        var person = await TestData.CreatePerson(p => p.WithAlert(a => a.WithStartDate(Clock.Today.AddDays(-30)).WithEndDate(null).WithExternalLink(populateOptional ? TestData.GenerateUrl() : null)));
-        return (person, person.Alerts.Single());
+        return CreatePersonWithAlert(isOpenAlert: true, populateOptional: populateOptional, createdByUser: createdByUser);
     }
 
-    protected async Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithClosedAlert(bool populateOptional = true)
+    protected Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithClosedAlert(bool populateOptional = true, EventModels.RaisedByUserInfo ? createdByUser = null)
     {
-        var person = await TestData.CreatePerson(p => p.WithAlert(a => a.WithStartDate(Clock.Today.AddDays(-30)).WithEndDate(Clock.Today.AddDays(-1)).WithExternalLink(populateOptional ? TestData.GenerateUrl() : null)));
+        return CreatePersonWithAlert(isOpenAlert: false, populateOptional: populateOptional, createdByUser: createdByUser);
+    }
+
+    protected async Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithAlert(bool isOpenAlert, bool populateOptional = true, EventModels.RaisedByUserInfo? createdByUser = null)
+    {
+        var person = await TestData.CreatePerson(p => p
+            .WithAlert(a =>
+            {
+                a.WithStartDate(Clock.Today.AddDays(-30));
+                a.WithEndDate(isOpenAlert ? null: Clock.Today.AddDays(-1));
+                a.WithExternalLink(populateOptional ? TestData.GenerateUrl() : null);
+                if (createdByUser is not null)
+                {
+                    a.WithCreatedByUser(createdByUser);
+                }
+            }));
+
         return (person, person.Alerts.Single());
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -129,7 +129,7 @@ public abstract class TestBase : IDisposable
         return CreatePersonWithAlert(isOpenAlert: true, populateOptional: populateOptional, createdByUser: createdByUser);
     }
 
-    protected Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithClosedAlert(bool populateOptional = true, EventModels.RaisedByUserInfo ? createdByUser = null)
+    protected Task<(TestData.CreatePersonResult, Alert)> CreatePersonWithClosedAlert(bool populateOptional = true, EventModels.RaisedByUserInfo? createdByUser = null)
     {
         return CreatePersonWithAlert(isOpenAlert: false, populateOptional: populateOptional, createdByUser: createdByUser);
     }
@@ -140,7 +140,7 @@ public abstract class TestBase : IDisposable
             .WithAlert(a =>
             {
                 a.WithStartDate(Clock.Today.AddDays(-30));
-                a.WithEndDate(isOpenAlert ? null: Clock.Today.AddDays(-1));
+                a.WithEndDate(isOpenAlert ? null : Clock.Today.AddDays(-1));
                 a.WithExternalLink(populateOptional ? TestData.GenerateUrl() : null);
                 if (createdByUser is not null)
                 {


### PR DESCRIPTION
### Context

The change history page now shows details of events related to Alerts and has been manually tested.

The automated tests were split out into this separate PR in order to get the TRS Console deployed ASAP with alert change log events.