### PR TITLE
Added new storage container for dqt integrations

### DIFF
--- a/terraform/aks/storage.tf
+++ b/terraform/aks/storage.tf
@@ -42,3 +42,9 @@ resource "azurerm_storage_container" "uploads" {
   storage_account_name  = azurerm_storage_account.app_storage.name
   container_access_type = "private"
 }
+
+resource "azurerm_storage_container" "dqt-integrations" {
+  name                  = "dqt-integrations"
+  storage_account_name  = azurerm_storage_account.app_storage.name
+  container_access_type = "private"
+}


### PR DESCRIPTION
https://trello.com/c/jZuPIctz/459-move-ewc-wales-integration-logic-into-trs

GTCWalesImport  import job is being moved from the SSIS import into TRS as a background job. This requires a storage container for processing the import files.