### PR TITLE
Add support for CRM query handlers that run inside a transaction

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmQueryDispatcher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmQueryDispatcher.cs
@@ -50,6 +50,13 @@ public class CrmQueryDispatcher(IServiceProvider serviceProvider, string? servic
         }
     }
 
+    public CrmTransactionScope CreateTransactionRequestBuilder()
+    {
+        var scope = serviceProvider.CreateScope();
+        var organizationService = GetOrganizationService(scope.ServiceProvider);
+        return new CrmTransactionScope(RequestBuilder.CreateTransaction(organizationService), scope);
+    }
+
     public IOrganizationServiceAsync GetOrganizationService(IServiceProvider serviceProvider) =>
         serviceProvider.GetRequiredKeyedService<IOrganizationServiceAsync>(serviceClientName);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmTransactionScope.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/CrmTransactionScope.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TeachingRecordSystem.Core.Dqt;
+
+public sealed class CrmTransactionScope(RequestBuilder requestBuilder, IServiceScope scope) : IDisposable
+{
+    public void Dispose() => scope.Dispose();
+
+    public Task Execute() => requestBuilder.Execute();
+
+    public Func<TResult> AppendQuery<TResult>(ICrmTransactionalQuery<TResult> query)
+    {
+        var handlerType = typeof(ICrmTransactionalQueryHandler<,>).MakeGenericType(query.GetType(), typeof(TResult));
+        var handler = scope.ServiceProvider.GetRequiredService(handlerType);
+
+        var wrapperHandlerType = typeof(TransactionalQueryHandler<,>).MakeGenericType(query.GetType(), typeof(TResult));
+        var wrappedHandler = (TransactionalQueryHandler<TResult>)Activator.CreateInstance(wrapperHandlerType, handler)!;
+
+        return wrappedHandler.AppendQuery(query, requestBuilder);
+    }
+
+    private abstract class TransactionalQueryHandler<T>
+    {
+        public abstract Func<T> AppendQuery(ICrmTransactionalQuery<T> query, RequestBuilder requestBuilder);
+    }
+
+    private class TransactionalQueryHandler<TQuery, TResult>(ICrmTransactionalQueryHandler<TQuery, TResult> innerHandler) : TransactionalQueryHandler<TResult>
+        where TQuery : ICrmTransactionalQuery<TResult>
+    {
+        public override Func<TResult> AppendQuery(ICrmTransactionalQuery<TResult> query, RequestBuilder requestBuilder)
+        {
+            return innerHandler.AppendQuery((TQuery)query, requestBuilder);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmQueryDispatcher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmQueryDispatcher.cs
@@ -4,4 +4,5 @@ public interface ICrmQueryDispatcher
 {
     Task<TResult> ExecuteQuery<TResult>(ICrmQuery<TResult> query);
     IAsyncEnumerable<TResult> ExecuteQuery<TResult>(IEnumerableCrmQuery<TResult> query, CancellationToken cancellationToken = default);
+    CrmTransactionScope CreateTransactionRequestBuilder();
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmTransactionalQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmTransactionalQuery.cs
@@ -1,0 +1,5 @@
+namespace TeachingRecordSystem.Core.Dqt;
+
+public interface ICrmTransactionalQuery<TResult>
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmTransactionalQueryHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ICrmTransactionalQueryHandler.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Dqt;
+
+public interface ICrmTransactionalQueryHandler<TQuery, TResult>
+    where TQuery : ICrmTransactionalQuery<TResult>
+{
+    Func<TResult> AppendQuery(TQuery query, RequestBuilder requestBuilder);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/ServiceCollectionExtensions.cs
@@ -16,6 +16,9 @@ public static partial class ServiceCollectionExtensions
                 .WithTransientLifetime()
             .AddClasses(classes => classes.AssignableTo(typeof(IEnumerableCrmQueryHandler<,>)))
                 .AsImplementedInterfaces()
+                .WithTransientLifetime()
+            .AddClasses(classes => classes.AssignableTo(typeof(ICrmTransactionalQueryHandler<,>)))
+                .AsImplementedInterfaces()
                 .WithTransientLifetime());
 
         return services;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/CrmQueryDispatcherExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/CrmQueryDispatcherExtensions.cs
@@ -16,6 +16,9 @@ public static class CrmQueryDispatcherExtensions
         public IAsyncEnumerable<TResult> ExecuteQuery<TResult>(IEnumerableCrmQuery<TResult> query, CancellationToken cancellationToken = default) =>
             innerDispatcher.ExecuteQuery(GetOrganizationService, query, cancellationToken);
 
+        public CrmTransactionScope CreateTransactionRequestBuilder() =>
+            throw new NotSupportedException();
+
         private IOrganizationServiceAsync GetOrganizationService(IServiceProvider serviceProvider)
         {
             var organizationService = innerDispatcher.GetOrganizationService(serviceProvider);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmQueryDispatcherSpy.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/CrmQueryDispatcherSpy.cs
@@ -52,4 +52,9 @@ public class CrmQueryDispatcherDecorator(ICrmQueryDispatcher innerDispatcher, Cr
     {
         return innerDispatcher.ExecuteQuery(query, cancellationToken);
     }
+
+    public CrmTransactionScope CreateTransactionRequestBuilder()
+    {
+        return innerDispatcher.CreateTransactionRequestBuilder();
+    }
 }


### PR DESCRIPTION
Currently all our CRM query handlers run in their own transaction but we need to be able to support queries being part of a larger transaction that's managed at a higher level.

This change introduces new query and handler types: `ICrmTransactionalQuery` and `ICrmTransactionalQueryHandler`. The latter doesn't actually execute the query; it instead appends the query to a `RequestBuilder` and returns a delegate that can be executed by the caller once the transaction has been executed.

```cs
public record CreateContactTransactionalQuery(string FirstName, string LastName) : ICrmTransactionalQuery<Guid>
{
}

public class CreateContactTransactionalHandler : ICrmTransactionalQueryHandler<CreateContactQuery, Guid>
{
    public Func<Guid> AppendQuery(CreateContactQuery query, RequestBuilder requestBuilder)
    {
        var createResponse = requestBuilder.AddRequest<CreateResponse>(new CreateRequest()
        {
            Target = new Contact()
            {
                FirstName = query.FirstName,
                LastName = query.LastName
            }
        });

        return () => createResponse.GetResponse().id;
    }
}


ICrmQueryDispatcher crmQueryDispatcher;

using var txn = crmQueryDispatcher.CreateTransactionRequestBuilder();

var getContactId = txn.AppendQuery(new CreateContactTransactionalQuery("Joe", "Bloggs"));

// Add more requests here

await txn.Execute();

var contactId = getContactId();
```
