### PR TITLE
Refactored tests to cleaner consistent approach

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Conventions.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
+
+public class Conventions : IConfigureFolderConventions
+{
+    public void Configure(RazorPagesOptions options)
+    {
+        options.Conventions.AddFolderApplicationModelConvention(
+            this.GetFolderPathFromNamespace(),
+            model =>
+            {
+                model.Filters.Add(new ServiceFilterAttribute<RequireClosedAlertFilter>());
+            });
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml.cs
@@ -73,12 +73,6 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IClock clock) : PageMode
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
-        if (alertInfo.Alert.EndDate is null)
-        {
-            context.Result = BadRequest();
-            return;
-        }
-
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         JourneyInstance!.State.EnsureInitialized(alertInfo);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/AddAlertTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/AddAlertTestBase.cs
@@ -1,0 +1,100 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.AddAlert;
+
+public abstract class AddAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<JourneyInstance<AddAlertState>> CreateEmptyJourneyInstance(Guid personId) =>
+        CreateJourneyInstance(personId, new());
+
+    protected async Task<JourneyInstance<AddAlertState>> CreateJourneyInstanceForAllStepsCompleted(Guid personId, bool populateOptional = true)
+    {
+        var alertType = await GetKnownAlertType();
+
+        return await CreateJourneyInstance(personId, new AddAlertState()
+        {
+            AlertTypeId = alertType.AlertTypeId,
+            AlertTypeName = alertType.Name,
+            Details = "Alert Details",
+            AddLink = populateOptional,
+            Link = populateOptional ? "https://www.example.com" : null,
+            StartDate = Clock.Today.AddDays(-30),
+            AddReason = AddAlertReasonOption.AnotherReason,
+            HasAdditionalReasonDetail = populateOptional ? true : false,
+            AddReasonDetail = populateOptional ? "More details" : null,
+            UploadEvidence = populateOptional ? true : false,
+            EvidenceFileId = populateOptional ? Guid.NewGuid() : null,
+            EvidenceFileName = populateOptional ? "evidence.jpeg" : null,
+            EvidenceFileSizeDescription = populateOptional ? "5MB" : null
+        });
+    }
+
+    protected async Task<JourneyInstance<AddAlertState>> CreateJourneyInstanceForCompletedStep(string step, Guid personId, bool populateOptional = true)
+    {
+        var alertType = await GetKnownAlertType();
+
+        return await
+            (step switch
+            {
+                JourneySteps.New or JourneySteps.Index =>
+                    CreateEmptyJourneyInstance(personId),
+                JourneySteps.AlertType =>
+                    CreateJourneyInstance(personId, new AddAlertState()
+                    {
+                        AlertTypeId = alertType.AlertTypeId,
+                        AlertTypeName = alertType.Name
+                    }),
+                JourneySteps.Details =>
+                    CreateJourneyInstance(personId, new AddAlertState()
+                    {
+                        AlertTypeId = alertType.AlertTypeId,
+                        AlertTypeName = alertType.Name,
+                        Details = "Alert Details"
+                    }),
+                JourneySteps.Link =>
+                    CreateJourneyInstance(personId, new AddAlertState()
+                    {
+                        AlertTypeId = alertType.AlertTypeId,
+                        AlertTypeName = alertType.Name,
+                        Details = "Alert Details",
+                        AddLink = populateOptional,
+                        Link = populateOptional ? "https://www.example.com" : null
+                    }),
+                JourneySteps.StartDate =>
+                    CreateJourneyInstance(personId, new AddAlertState()
+                    {
+                        AlertTypeId = alertType.AlertTypeId,
+                        AlertTypeName = alertType.Name,
+                        Details = "Alert Details",
+                        AddLink = populateOptional,
+                        Link = populateOptional ? "https://www.example.com" : null,
+                        StartDate = Clock.Today.AddDays(-30)
+                    }),
+                JourneySteps.Reason or JourneySteps.CheckAnswers =>
+                    CreateJourneyInstanceForAllStepsCompleted(personId, populateOptional: true),
+                _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
+            });
+    }
+
+    protected Task<AlertType> GetKnownAlertType(bool isDbsAlertType = false) =>
+        isDbsAlertType ? TestData.ReferenceDataCache.GetAlertTypeByDqtSanctionCode("") : TestData.ReferenceDataCache.GetAlertTypeByDqtSanctionCode("T1");
+
+    private Task<JourneyInstance<AddAlertState>> CreateJourneyInstance(Guid personId, AddAlertState state) =>
+        CreateJourneyInstance(
+            JourneyNames.AddAlert,
+            state ?? new AddAlertState(),
+            new KeyValuePair<string, object>("personId", personId));
+
+    public static class JourneySteps
+    {
+        public const string New = nameof(New);
+        public const string Index = nameof(Index);
+        public const string AlertType = nameof(AlertType);
+        public const string Details = nameof(Details);
+        public const string Link = nameof(Link);
+        public const string StartDate = nameof(StartDate);
+        public const string Reason = nameof(Reason);
+        public const string CheckAnswers = nameof(CheckAnswers);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/DetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/DetailsTests.cs
@@ -1,23 +1,24 @@
-using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
-
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.AddAlert;
 
-public class DetailsTests : TestBase
+public class DetailsTests : AddAlertTestBase
 {
+    private const string PreviousStep = JourneySteps.AlertType;
+    private const string ThisStep = JourneySteps.Details;
+
     public DetailsTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
-    [Fact]
-    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -33,13 +34,7 @@ public class DetailsTests : TestBase
     {
         // Arrange        
         var personId = Guid.NewGuid();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(personId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, personId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/details?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -55,8 +50,7 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -73,14 +67,7 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -96,15 +83,7 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-        var details = "My details";
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = details
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -113,23 +92,18 @@ public class DetailsTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
-        Assert.Equal(details, doc.GetElementById("Details")?.TextContent);
+        Assert.Equal(journeyInstance.State.Details, doc.GetElementById("Details")?.TextContent);
     }
 
-    [Fact]
-    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -143,15 +117,9 @@ public class DetailsTests : TestBase
     [Fact]
     public async Task Post_WithPersonIdForNonExistentPerson_ReturnsNotFound()
     {
-        // Arrange
+        // Arrange        
         var personId = Guid.NewGuid();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(personId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, personId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/details?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -167,8 +135,7 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -185,13 +152,7 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -207,20 +168,12 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
+        var details = new string('x', 4001);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "Details", new string('x', 4001) }
-            }
+            Content = CreatePostContent(details)
         };
 
         // Act
@@ -235,22 +188,12 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
-
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
         var details = "My details";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/details?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "Details", details }
-            }
+            Content = CreatePostContent(details)
         };
 
         // Act
@@ -269,13 +212,7 @@ public class DetailsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/details/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -289,9 +226,14 @@ public class DetailsTests : TestBase
         Assert.Null(journeyInstance);
     }
 
-    private async Task<JourneyInstance<AddAlertState>> CreateJourneyInstance(Guid personId, AddAlertState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.AddAlert,
-            state ?? new AddAlertState(),
-            new KeyValuePair<string, object>("personId", personId));
+    private static FormUrlEncodedContentBuilder CreatePostContent(string? newDetails)
+    {
+        var builder = new FormUrlEncodedContentBuilder();
+        if (newDetails is not null)
+        {
+            builder.Add("Details", newDetails);
+        }
+
+        return builder;
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/LinkTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/LinkTests.cs
@@ -1,28 +1,24 @@
-using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
-
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.AddAlert;
 
-public class LinkTests : TestBase
+public class LinkTests : AddAlertTestBase
 {
+    private const string PreviousStep = JourneySteps.Details;
+    private const string ThisStep = JourneySteps.Link;
+
     public LinkTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
-    [Fact]
-    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -38,13 +34,7 @@ public class LinkTests : TestBase
     {
         // Arrange        
         var personId = Guid.NewGuid();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(personId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, personId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/link?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -60,13 +50,7 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -83,14 +67,7 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -106,16 +83,7 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-        var link = TestData.GenerateUrl();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            Link = link
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -124,24 +92,18 @@ public class LinkTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
-        Assert.Equal(link, doc.GetElementById("Link")?.GetAttribute("value"));
+        Assert.Equal(journeyInstance.State.Link, doc.GetElementById("Link")?.GetAttribute("value"));
     }
 
-    [Fact]
-    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -157,14 +119,7 @@ public class LinkTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(personId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, personId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -180,13 +135,7 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -203,18 +152,11 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = CreatePostContent(journeyInstance.State.AddLink, journeyInstance.State.Link)
         };
 
         // Act
@@ -229,22 +171,11 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "AddLink", bool.TrueString },
-                { "Link", "bad..url" }
-            }
+            Content = CreatePostContent(true, "invalid url")
         };
 
         // Act
@@ -259,24 +190,12 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
-
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
         var link = "http://example.com";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "AddLink", bool.TrueString },
-                { "Link", link }
-            }
+            Content = CreatePostContent(true, link)
         };
 
         // Act
@@ -296,21 +215,11 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "AddLink", bool.FalseString }
-            }
+            Content = CreatePostContent(false, null)
         };
 
         // Act
@@ -330,14 +239,7 @@ public class LinkTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/link/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -351,9 +253,20 @@ public class LinkTests : TestBase
         Assert.Null(journeyInstance);
     }
 
-    private async Task<JourneyInstance<AddAlertState>> CreateJourneyInstance(Guid personId, AddAlertState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.AddAlert,
-            state ?? new AddAlertState(),
-            new KeyValuePair<string, object>("personId", personId));
+    private static FormUrlEncodedContentBuilder CreatePostContent(bool? addLink, string? newLink)
+    {
+        var builder = new FormUrlEncodedContentBuilder();
+
+        if (addLink is not null)
+        {
+            builder.Add("AddLink", addLink.Value.ToString());
+        }
+
+        if (newLink is not null)
+        {
+            builder.Add("Link", newLink);
+        }
+
+        return builder;
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
@@ -1,30 +1,24 @@
-using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
-
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.AddAlert;
 
-public class StartDateTests : TestBase
+public class StartDateTests : AddAlertTestBase
 {
+    private const string PreviousStep = JourneySteps.Link;
+    private const string ThisStep = JourneySteps.StartDate;
+
     public StartDateTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
-    [Fact]
-    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -40,15 +34,7 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(personId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, personId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/start-date?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -64,14 +50,7 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-        });
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -88,15 +67,7 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -112,17 +83,7 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-        var startDate = new DateOnly(2021, 1, 1);
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false,
-            StartDate = startDate
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -131,27 +92,20 @@ public class StartDateTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
-        Assert.Equal($"{startDate:%d}", doc.GetElementById("StartDate.Day")?.GetAttribute("value"));
-        Assert.Equal($"{startDate:%M}", doc.GetElementById("StartDate.Month")?.GetAttribute("value"));
-        Assert.Equal($"{startDate:yyyy}", doc.GetElementById("StartDate.Year")?.GetAttribute("value"));
+        Assert.Equal($"{journeyInstance.State.StartDate:%d}", doc.GetElementById("StartDate.Day")?.GetAttribute("value"));
+        Assert.Equal($"{journeyInstance.State.StartDate:%M}", doc.GetElementById("StartDate.Month")?.GetAttribute("value"));
+        Assert.Equal($"{journeyInstance.State.StartDate:yyyy}", doc.GetElementById("StartDate.Year")?.GetAttribute("value"));
     }
 
-    [Fact]
-    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -167,26 +121,9 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-        var startDate = Clock.Today;
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, personId);
 
-        var journeyInstance = await CreateJourneyInstance(personId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "StartDate.Day", startDate.Day },
-                { "StartDate.Month", startDate.Month },
-                { "StartDate.Year", startDate.Year }
-            }
-        };
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -200,25 +137,9 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-        var startDate = Clock.Today;
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details"
-        });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "StartDate.Day", startDate.Day },
-                { "StartDate.Month", startDate.Month },
-                { "StartDate.Year", startDate.Year }
-            }
-        };
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -233,15 +154,7 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -257,25 +170,12 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
         var startDate = Clock.Today.AddDays(2);
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "StartDate.Day", startDate.Day },
-                { "StartDate.Month", startDate.Month },
-                { "StartDate.Year", startDate.Year }
-            }
+            Content = CreatePostContent(startDate)
         };
 
         // Act
@@ -290,25 +190,12 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
         var startDate = Clock.Today;
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "StartDate.Day", startDate.Day },
-                { "StartDate.Month", startDate.Month },
-                { "StartDate.Year", startDate.Year }
-            }
+            Content = CreatePostContent(startDate)
         };
 
         // Act
@@ -327,15 +214,7 @@ public class StartDateTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState()
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name,
-            Details = "Details",
-            AddLink = false
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -349,9 +228,17 @@ public class StartDateTests : TestBase
         Assert.Null(journeyInstance);
     }
 
-    private async Task<JourneyInstance<AddAlertState>> CreateJourneyInstance(Guid personId, AddAlertState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.AddAlert,
-            state ?? new AddAlertState(),
-            new KeyValuePair<string, object>("personId", personId));
+    private static FormUrlEncodedContentBuilder CreatePostContent(DateOnly? startDate)
+    {
+        var builder = new FormUrlEncodedContentBuilder();
+
+        if (startDate is DateOnly date)
+        {
+            builder.Add("StartDate.Day", date.Day);
+            builder.Add("StartDate.Month", date.Month);
+            builder.Add("StartDate.Year", date.Year);
+        }
+
+        return builder;
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/TypeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/TypeTests.cs
@@ -1,24 +1,26 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.AddAlert;
 
-public class TypeTests : TestBase
+public class TypeTests : AddAlertTestBase
 {
+    private const string PreviousStep = JourneySteps.Index;
+    private const string ThisStep = JourneySteps.AlertType;
+
     public TypeTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
-    [Fact]
-    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -34,8 +36,7 @@ public class TypeTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
-
-        var journeyInstance = await CreateJourneyInstance(personId);
+        var journeyInstance = await CreateEmptyJourneyInstance(personId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -51,8 +52,7 @@ public class TypeTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -70,8 +70,7 @@ public class TypeTests : TestBase
         SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -91,8 +90,7 @@ public class TypeTests : TestBase
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -112,8 +110,7 @@ public class TypeTests : TestBase
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite));
 
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -134,8 +131,7 @@ public class TypeTests : TestBase
         SetCurrentUser(TestUsers.GetUser(UserRoles.DbsAlertsReadWrite));
 
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -154,13 +150,7 @@ public class TypeTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId, new AddAlertState
-        {
-            AlertTypeId = alertType.AlertTypeId,
-            AlertTypeName = alertType.Name
-        });
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -171,18 +161,18 @@ public class TypeTests : TestBase
         var doc = await AssertEx.HtmlResponse(response);
         var radioButtons = doc.GetElementsByName("AlertTypeId");
         var selectedRadioButton = radioButtons.Single(r => r.HasAttribute("checked"));
-        Assert.Equal(alertType.AlertTypeId.ToString(), selectedRadioButton.GetAttribute("value"));
+        Assert.Equal(journeyInstance.State.AlertTypeId.ToString(), selectedRadioButton.GetAttribute("value"));
     }
 
-    [Fact]
-    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -198,17 +188,9 @@ public class TypeTests : TestBase
     {
         // Arrange
         var personId = Guid.NewGuid();
-        var alertType = (await TestData.ReferenceDataCache.GetAlertTypes()).RandomOne();
+        var journeyInstance = await CreateEmptyJourneyInstance(personId);
 
-        var journeyInstance = await CreateJourneyInstance(personId);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/type?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "AlertTypeId", alertType.AlertTypeId }
-            }
-        };
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/type?personId={personId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -222,8 +204,7 @@ public class TypeTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -239,16 +220,12 @@ public class TypeTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
-        var alertType = await TestData.ReferenceDataCache.GetAlertTypeById(Guid.Parse("ed0cd700-3fb2-4db0-9403-ba57126090ed")); // Prohibition by the Secretary of State - misconduct
-
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
+        var alertType = await GetKnownAlertType();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/type?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "AlertTypeId", alertType.AlertTypeId }
-            }
+            Content = CreatePostContent(alertType.AlertTypeId)
         };
 
         // Act
@@ -267,10 +244,9 @@ public class TypeTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePerson();
+        var journeyInstance = await CreateEmptyJourneyInstance(person.PersonId);
 
-        var journeyInstance = await CreateJourneyInstance(person.PersonId);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/type/CANCEL?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/type/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -282,9 +258,15 @@ public class TypeTests : TestBase
         Assert.Null(journeyInstance);
     }
 
-    private async Task<JourneyInstance<AddAlertState>> CreateJourneyInstance(Guid personId, AddAlertState? state = null) =>
-        await CreateJourneyInstance(
-             JourneyNames.AddAlert,
-             state ?? new AddAlertState(),
-             new KeyValuePair<string, object>("personId", personId));
+    private static FormUrlEncodedContentBuilder CreatePostContent(Guid? alertTypeId)
+    {
+        var builder = new FormUrlEncodedContentBuilder();
+        if (alertTypeId is not null)
+        {
+            builder.Add("AlertTypeId", alertTypeId);
+        }
+
+        return builder;
+    }
+
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CloseAlertTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CloseAlertTestBase.cs
@@ -1,0 +1,52 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.CloseAlert;
+
+public abstract class CloseAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<JourneyInstance<CloseAlertState>> CreateEmptyJourneyInstance(Guid alertId) =>
+        CreateJourneyInstance(alertId, new());
+
+    protected Task<JourneyInstance<CloseAlertState>> CreateJourneyInstanceForAllStepsCompleted(Alert alert, bool populateOptional = true) =>
+        CreateJourneyInstance(alert.AlertId, new CloseAlertState()
+        {
+            EndDate = alert.StartDate!.Value.AddDays(2),
+            ChangeReason = CloseAlertReasonOption.AnotherReason,
+            HasAdditionalReasonDetail = populateOptional ? true : false,
+            ChangeReasonDetail = populateOptional ? "More details" : null,
+            UploadEvidence = populateOptional ? true : false,
+            EvidenceFileId = populateOptional ? Guid.NewGuid() : null,
+            EvidenceFileName = populateOptional ? "evidence.jpeg" : null,
+            EvidenceFileSizeDescription = populateOptional ? "5MB" : null
+        });
+
+    protected Task<JourneyInstance<CloseAlertState>> CreateJourneyInstanceForCompletedStep(string step, Alert alert) =>
+        step switch
+        {
+            JourneySteps.New =>
+                CreateEmptyJourneyInstance(alert.AlertId),
+            JourneySteps.Index =>
+                CreateJourneyInstance(alert.AlertId, new CloseAlertState()
+                {
+                    EndDate = alert.StartDate!.Value.AddDays(2)
+                }),
+            JourneySteps.Reason or JourneySteps.CheckAnswers =>
+                CreateJourneyInstanceForAllStepsCompleted(alert, populateOptional: true),
+            _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
+        };
+
+    private Task<JourneyInstance<CloseAlertState>> CreateJourneyInstance(Guid alertId, CloseAlertState state) =>
+        CreateJourneyInstance(
+            JourneyNames.CloseAlert,
+            state,
+            new KeyValuePair<string, object>("alertId", alertId));
+
+    public static class JourneySteps
+    {
+        public const string New = nameof(New);
+        public const string Index = nameof(Index);
+        public const string Reason = nameof(Reason);
+        public const string CheckAnswers = nameof(CheckAnswers);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
@@ -1,27 +1,26 @@
-using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
-
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.CloseAlert;
 
-public class IndexTests : TestBase
+public class IndexTests : CloseAlertTestBase
 {
+    private const string PreviousStep = JourneySteps.New;
+    private const string ThisStep = JourneySteps.Index;
+
     public IndexTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
-    [Fact]
-    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
-        var startDate = Clock.Today.AddDays(-50);
-        var endDate = Clock.Today.AddDays(-10);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -34,9 +33,8 @@ public class IndexTests : TestBase
     public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
         var alertId = Guid.NewGuid();
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var journeyInstance = await CreateEmptyJourneyInstance(alertId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -51,13 +49,10 @@ public class IndexTests : TestBase
     public async Task Get_WithClosedAlert_ReturnsBadRequest()
     {
         // Arrange
-        var startDate = Clock.Today.AddDays(-50);
-        var endDate = Clock.Today.AddDays(-10);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -70,12 +65,10 @@ public class IndexTests : TestBase
     public async Task Get_ValidRequestWithUninitializedJourneyState_ReturnsOK()
     {
         // Arrange
-        var startDate = Clock.Today.AddDays(-50);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -88,49 +81,35 @@ public class IndexTests : TestBase
     public async Task Get_ValidRequestWithInitializedJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
-        var startDate = Clock.Today.AddDays(-50);
-        var journeyEndDate = Clock.Today.AddDays(-10);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(null)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(
-            alertId,
-            state: new()
-            {
-                EndDate = journeyEndDate
-            });
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(ThisStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
-        Assert.Equal($"{journeyEndDate:%d}", doc.GetElementById("EndDate.Day")?.GetAttribute("value"));
-        Assert.Equal($"{journeyEndDate:%M}", doc.GetElementById("EndDate.Month")?.GetAttribute("value"));
-        Assert.Equal($"{journeyEndDate:yyyy}", doc.GetElementById("EndDate.Year")?.GetAttribute("value"));
+        Assert.Equal($"{journeyInstance.State.EndDate:%d}", doc.GetElementById("EndDate.Day")?.GetAttribute("value"));
+        Assert.Equal($"{journeyInstance.State.EndDate:%M}", doc.GetElementById("EndDate.Month")?.GetAttribute("value"));
+        Assert.Equal($"{journeyInstance.State.EndDate:yyyy}", doc.GetElementById("EndDate.Year")?.GetAttribute("value"));
     }
 
-    [Fact]
-    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
-        var startDate = Clock.Today.AddDays(-50);
-        var newEndDate = Clock.Today.AddDays(-5);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(JourneySteps.New, alert);
+        var endDate = alert.StartDate!.Value.AddDays(5);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "EndDate.Day", $"{newEndDate:%d}" },
-                { "EndDate.Month", $"{newEndDate:%M}" },
-                { "EndDate.Year", $"{newEndDate:yyyy}" },
-            }
+            Content = CreatePostContent(endDate)
         };
 
         // Act
@@ -144,9 +123,8 @@ public class IndexTests : TestBase
     public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
         var alertId = Guid.NewGuid();
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var journeyInstance = await CreateEmptyJourneyInstance(alertId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -161,13 +139,10 @@ public class IndexTests : TestBase
     public async Task Post_WithClosedAlert_ReturnsBadRequest()
     {
         // Arrange
-        var startDate = Clock.Today.AddDays(-50);
-        var endDate = Clock.Today.AddDays(-10);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(endDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -179,12 +154,11 @@ public class IndexTests : TestBase
     [Fact]
     public async Task Post_WhenNoEndDateIsEntered_ReturnsError()
     {
-        var startDate = Clock.Today.AddDays(-50);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        // Arrange
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -196,20 +170,14 @@ public class IndexTests : TestBase
     [Fact]
     public async Task Post_WhenEndDateIsInTheFuture_ReturnsError()
     {
-        var startDate = Clock.Today.AddDays(-50);
+        // Arrange
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
         var futureDate = Clock.Today.AddDays(2);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "EndDate.Day", $"{futureDate:%d}" },
-                { "EndDate.Month", $"{futureDate:%M}" },
-                { "EndDate.Year", $"{futureDate:yyyy}" },
-            }
+            Content = CreatePostContent(futureDate)
         };
 
         // Act
@@ -222,20 +190,14 @@ public class IndexTests : TestBase
     [Fact]
     public async Task Post_WhenEndDateIsBeforeStartDate_ReturnsError()
     {
-        var startDate = Clock.Today.AddDays(-50);
-        var newEndDate = Clock.Today.AddDays(-51);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        // Arrange
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
+        var newEndDate = alert.StartDate!.Value.AddDays(-2);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "EndDate.Day", $"{newEndDate:%d}" },
-                { "EndDate.Month", $"{newEndDate:%M}" },
-                { "EndDate.Year", $"{newEndDate:yyyy}" },
-            }
+            Content = CreatePostContent(newEndDate)
         };
 
         // Act
@@ -248,20 +210,14 @@ public class IndexTests : TestBase
     [Fact]
     public async Task Post_WhenEndDateIsEntered_UpdatesStateAndRedirectsToChangeReasonPage()
     {
-        var startDate = Clock.Today.AddDays(-50);
-        var newEndDate = Clock.Today.AddDays(-5);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        // Arrange
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
+        var newEndDate = alert.StartDate!.Value.AddDays(2);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "EndDate.Day", $"{newEndDate:%d}" },
-                { "EndDate.Month", $"{newEndDate:%M}" },
-                { "EndDate.Year", $"{newEndDate:yyyy}" },
-            }
+            Content = CreatePostContent(newEndDate)
         };
 
         // Act
@@ -269,7 +225,7 @@ public class IndexTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alertId}/close/change-reason", response.Headers.Location?.OriginalString);
+        Assert.StartsWith($"/alerts/{alert.AlertId}/close/change-reason", response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(newEndDate, journeyInstance.State.EndDate);
@@ -278,12 +234,11 @@ public class IndexTests : TestBase
     [Fact]
     public async Task Post_Cancel_DeletesJourneyAndRedirects()
     {
-        var startDate = Clock.Today.AddDays(-50);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        // Arrange
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/close/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -296,9 +251,17 @@ public class IndexTests : TestBase
         Assert.Null(journeyInstance);
     }
 
-    private async Task<JourneyInstance<CloseAlertState>> CreateJourneyInstance(Guid alertId, CloseAlertState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.CloseAlert,
-            state ?? new CloseAlertState(),
-            new KeyValuePair<string, object>("alertId", alertId));
+    private static FormUrlEncodedContentBuilder CreatePostContent(DateOnly? endDate)
+    {
+        var builder = new FormUrlEncodedContentBuilder();
+
+        if (endDate is not null)
+        {
+            builder.Add("EndDate.Day", $"{endDate:%d}");
+            builder.Add("EndDate.Month", $"{endDate:%M}");
+            builder.Add("EndDate.Year", $"{endDate:yyyy}");
+        }
+
+        return builder;
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/DetailsTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/DetailsTestBase.cs
@@ -1,0 +1,56 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.Details;
+
+public abstract class DetailsTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<JourneyInstance<EditAlertDetailsState>> CreateEmptyJourneyInstance(Guid alertId) =>
+        CreateJourneyInstance(alertId, new());
+
+    protected Task<JourneyInstance<EditAlertDetailsState>> CreateJourneyInstanceForAllStepsCompleted(Alert alert, bool populateOptional = true) =>
+        CreateJourneyInstance(alert.AlertId, new EditAlertDetailsState()
+        {
+            Initialized = true,
+            CurrentDetails = alert.Details,
+            Details = "New details",
+            ChangeReason = AlertChangeDetailsReasonOption.AnotherReason,
+            HasAdditionalReasonDetail = populateOptional ? true : false,
+            ChangeReasonDetail = populateOptional ? "More details" : null,
+            UploadEvidence = populateOptional ? true : false,
+            EvidenceFileId = populateOptional ? Guid.NewGuid() : null,
+            EvidenceFileName = populateOptional ? "evidence.jpeg" : null,
+            EvidenceFileSizeDescription = populateOptional ? "5MB" : null
+        });
+
+    protected Task<JourneyInstance<EditAlertDetailsState>> CreateJourneyInstanceForCompletedStep(string step, Alert alert) =>
+        step switch
+        {
+            JourneySteps.New =>
+                CreateEmptyJourneyInstance(alert.AlertId),
+            JourneySteps.Index =>
+                CreateJourneyInstance(alert.AlertId, new EditAlertDetailsState()
+                {
+                    Initialized = true,
+                    CurrentDetails = alert.Details,
+                    Details = "New details"
+                }),
+            JourneySteps.Reason or JourneySteps.CheckAnswers =>
+                CreateJourneyInstanceForAllStepsCompleted(alert, populateOptional: true),
+            _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
+        };
+
+    private Task<JourneyInstance<EditAlertDetailsState>> CreateJourneyInstance(Guid alertId, EditAlertDetailsState state) =>
+        CreateJourneyInstance(
+            JourneyNames.EditAlertDetails,
+            state,
+            new KeyValuePair<string, object>("alertId", alertId));
+
+    public static class JourneySteps
+    {
+        public const string New = nameof(New);
+        public const string Index = nameof(Index);
+        public const string Reason = nameof(Reason);
+        public const string CheckAnswers = nameof(CheckAnswers);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
@@ -48,13 +48,13 @@ public class CheckAnswersTests : EndDateTestBase
     }
 
     [Fact]
-    public async Task Get_WithClosedAlert_ReturnsBadRequest()
+    public async Task Get_WithOpenAlert_ReturnsBadRequest()
     {
         // Arrange
-        var (person, alert) = await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateJourneyInstanceForAllStepsCompleted(alert);
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -136,6 +136,22 @@ public class CheckAnswersTests : EndDateTestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_WithOpenAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var (person, alert) = await CreatePersonWithOpenAlert();
+        var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
@@ -2,42 +2,27 @@ using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.EndDate;
 
-public class CheckAnswersTests : TestBase
+public class CheckAnswersTests : EndDateTestBase
 {
+    private const string PreviousStep = JourneySteps.Reason;
+    private const string ThisStep = JourneySteps.CheckAnswers;
+
     public CheckAnswersTests(HostFixture hostFixture) : base(hostFixture)
     {
         SetCurrentUser(TestUsers.GetUser(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite));
     }
 
-    [Fact]
-    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Get_UserDoesNotHavePermission_ReturnsForbidden(string? role)
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
+        SetCurrentUser(TestUsers.GetUser(role));
 
-        var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
-        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var changeReason = AlertChangeEndDateReasonOption.AnotherReason;
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForAllStepsCompleted(alert);
 
-        var journeyInstance = await CreateJourneyInstance(
-            alertId,
-            new EditAlertEndDateState()
-            {
-                Initialized = true,
-                CurrentEndDate = databaseEndDate,
-                EndDate = journeyEndDate,
-                ChangeReason = changeReason,
-                HasAdditionalReasonDetail = false,
-                ChangeReasonDetail = null,
-                UploadEvidence = false,
-                EvidenceFileId = null,
-                EvidenceFileName = null
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -50,9 +35,8 @@ public class CheckAnswersTests : TestBase
     public async Task Get_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
         var alertId = Guid.NewGuid();
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var journeyInstance = await CreateEmptyJourneyInstance(alertId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -64,23 +48,36 @@ public class CheckAnswersTests : TestBase
     }
 
     [Fact]
+    public async Task Get_WithClosedAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForAllStepsCompleted(alert);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
     public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
     {
         // Arrange        
-        var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(JourneySteps.Index, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alertId}/end-date", response.Headers.Location?.OriginalString);
+        Assert.StartsWith($"/alerts/{alert.AlertId}/end-date", response.Headers.Location?.OriginalString);
     }
 
     [Theory]
@@ -89,51 +86,48 @@ public class CheckAnswersTests : TestBase
     public async Task Get_WithValidJourneyState_ReturnsOk(bool populateOptional)
     {
         // Arrange
-        var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
-        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
-        var changeReason = AlertChangeEndDateReasonOption.IncorrectEndDate;
-        var changeReasonDetail = populateOptional ? "Some details" : null;
-        var evidenceFileId = Guid.NewGuid();
-        var evidenceFileName = "test.pdf";
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(
-            alertId,
-            new EditAlertEndDateState()
-            {
-                Initialized = true,
-                CurrentEndDate = databaseEndDate,
-                EndDate = journeyEndDate,
-                ChangeReason = changeReason,
-                HasAdditionalReasonDetail = populateOptional,
-                ChangeReasonDetail = changeReasonDetail,
-                UploadEvidence = populateOptional ? true : false,
-                EvidenceFileId = populateOptional ? evidenceFileId : null,
-                EvidenceFileName = populateOptional ? evidenceFileName : null
-            });
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForAllStepsCompleted(alert, populateOptional);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         var doc = await AssertEx.HtmlResponse(response);
-        Assert.Equal(journeyEndDate.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("New end date"));
-        Assert.Equal(databaseEndDate.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("Current end date"));
-        Assert.Equal(changeReason.GetDisplayName(), doc.GetSummaryListValueForKey("Reason for change"));
-        Assert.Equal(populateOptional ? changeReasonDetail : UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Reason details"));
-        Assert.Equal(populateOptional ? $"{evidenceFileName} (opens in new tab)" : UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Evidence"));
+        Assert.Equal(journeyInstance.State.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("New end date"));
+        Assert.Equal(alert.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("Current end date"));
+        Assert.Equal(journeyInstance.State.ChangeReason!.Value.GetDisplayName(), doc.GetSummaryListValueForKey("Reason for change"));
+        Assert.Equal(populateOptional ? journeyInstance.State.ChangeReasonDetail : UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Reason details"));
+        Assert.Equal(populateOptional ? $"{journeyInstance.State.EvidenceFileName} (opens in new tab)" : UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Evidence"));
+    }
+
+    [Theory]
+    [RolesWithoutAlertWritePermissionData]
+    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden(string? role)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role));
+
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForAllStepsCompleted(alert);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
     [Fact]
     public async Task Post_WithAlertIdForNonExistentAlert_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePerson();
         var alertId = Guid.NewGuid();
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var journeyInstance = await CreateEmptyJourneyInstance(alertId);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -148,57 +142,32 @@ public class CheckAnswersTests : TestBase
     public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
     {
         // Arrange
-        var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(alertId);
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForCompletedStep(JourneySteps.Index, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alertId}/end-date", response.Headers.Location?.OriginalString);
+        Assert.StartsWith($"/alerts/{alert.AlertId}/end-date", response.Headers.Location?.OriginalString);
     }
 
     [Theory]
-    [InlineData(AlertChangeEndDateReasonOption.IncorrectEndDate)]
-    [InlineData(AlertChangeEndDateReasonOption.ChangeOfEndDate)]
-    [InlineData(AlertChangeEndDateReasonOption.AnotherReason)]
-    public async Task Post_Confirm_UpdatesAlertCreatesEventCompletesJourneyAndRedirectsWithFlashMessage(AlertChangeEndDateReasonOption changeReason)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_Confirm_UpdatesAlertCreatesEventCompletesJourneyAndRedirectsWithFlashMessage(bool populateOptional)
     {
         // Arrange
-        var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
-        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
-        var changeReasonDetail = "Some reason or other";
-        var evidenceFileId = Guid.NewGuid();
-        var evidenceFileName = "test.pdf";
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
-        var originalAlert = person.Alerts.Single();
-        var alertId = originalAlert.AlertId;
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForAllStepsCompleted(alert, populateOptional);
 
         EventPublisher.Clear();
 
-        var journeyInstance = await CreateJourneyInstance(
-            alertId,
-            new EditAlertEndDateState()
-            {
-                Initialized = true,
-                CurrentEndDate = databaseEndDate,
-                EndDate = journeyEndDate,
-                ChangeReason = changeReason,
-                HasAdditionalReasonDetail = true,
-                ChangeReasonDetail = changeReasonDetail,
-                UploadEvidence = true,
-                EvidenceFileId = evidenceFileId,
-                EvidenceFileName = evidenceFileName
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -212,48 +181,51 @@ public class CheckAnswersTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alertId);
-            Assert.Equal(journeyEndDate, updatedAlert!.EndDate);
+            var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alert.AlertId);
+            Assert.Equal(journeyInstance.State.EndDate, updatedAlert!.EndDate);
         });
 
         EventPublisher.AssertEventsSaved(e =>
         {
+            var actualAlertUpdatedEvent = Assert.IsType<AlertUpdatedEvent>(e);
+
             var expectedAlertUpdatedEvent = new AlertUpdatedEvent()
             {
-                EventId = Guid.Empty,
+                EventId = actualAlertUpdatedEvent.EventId,
                 CreatedUtc = Clock.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
                 Alert = new()
                 {
-                    AlertId = alertId,
-                    AlertTypeId = originalAlert.AlertTypeId,
-                    Details = originalAlert.Details,
-                    ExternalLink = originalAlert.ExternalLink,
-                    StartDate = originalAlert.StartDate,
-                    EndDate = journeyEndDate
+                    AlertId = actualAlertUpdatedEvent.EventId,
+                    AlertTypeId = alert.AlertTypeId,
+                    Details = alert.Details,
+                    ExternalLink = alert.ExternalLink,
+                    StartDate = alert.StartDate,
+                    EndDate = journeyInstance.State.EndDate
                 },
                 OldAlert = new()
                 {
-                    AlertId = alertId,
-                    AlertTypeId = originalAlert.AlertTypeId,
-                    Details = originalAlert.Details,
-                    ExternalLink = originalAlert.ExternalLink,
-                    StartDate = originalAlert.StartDate,
-                    EndDate = databaseEndDate
+                    AlertId = alert.AlertId,
+                    AlertTypeId = alert.AlertTypeId,
+                    Details = alert.Details,
+                    ExternalLink = alert.ExternalLink,
+                    StartDate = alert.StartDate,
+                    EndDate = alert.EndDate
                 },
-                ChangeReason = changeReason.GetDisplayName(),
-                ChangeReasonDetail = changeReasonDetail,
-                EvidenceFile = new()
+                ChangeReason = journeyInstance.State.ChangeReason!.GetDisplayName(),
+                ChangeReasonDetail = populateOptional ? journeyInstance.State.ChangeReasonDetail : null,
+                EvidenceFile = populateOptional ? new()
                 {
-                    FileId = evidenceFileId,
-                    Name = evidenceFileName
-                },
+                    FileId = journeyInstance.State.EvidenceFileId!.Value,
+                    Name = journeyInstance.State.EvidenceFileName!
+                }
+                : null,
                 Changes = AlertUpdatedEventChanges.EndDate
             };
 
-            var actualAlertUpdatedEvent = Assert.IsType<AlertUpdatedEvent>(e);
-            Assert.Equivalent(expectedAlertUpdatedEvent with { EventId = actualAlertUpdatedEvent.EventId }, actualAlertUpdatedEvent);
+
+            Assert.Equivalent(expectedAlertUpdatedEvent, actualAlertUpdatedEvent);
         });
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -261,78 +233,20 @@ public class CheckAnswersTests : TestBase
     }
 
     [Fact]
-    public async Task Post_UserDoesNotHavePermission_ReturnsForbidden()
-    {
-        // Arrange
-        SetCurrentUser(TestUsers.GetUser(roles: []));
-
-        var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
-        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var changeReason = AlertChangeEndDateReasonOption.AnotherReason;
-
-        var journeyInstance = await CreateJourneyInstance(
-            alertId,
-            new EditAlertEndDateState()
-            {
-                Initialized = true,
-                CurrentEndDate = databaseEndDate,
-                EndDate = journeyEndDate,
-                ChangeReason = changeReason,
-                HasAdditionalReasonDetail = false,
-                ChangeReasonDetail = null,
-                UploadEvidence = false,
-                EvidenceFileId = null,
-                EvidenceFileName = null
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
-    }
-
-    [Fact]
     public async Task Post_Cancel_DeletesJourneyAndRedirects()
     {
         // Arrange
-        var startDate = TestData.Clock.Today.AddDays(-50);
-        var databaseEndDate = TestData.Clock.Today.AddDays(-10);
-        var journeyEndDate = TestData.Clock.Today.AddDays(-5);
-        var changeReason = AlertChangeEndDateReasonOption.IncorrectEndDate;
-        var changeReasonDetail = "Some reason or other";
-        var evidenceFileId = Guid.NewGuid();
-        var evidenceFileName = "test.pdf";
-        var person = await TestData.CreatePerson(b => b.WithAlert(q => q.WithStartDate(startDate).WithEndDate(databaseEndDate)));
-        var alertId = person.Alerts.Single().AlertId;
-        var journeyInstance = await CreateJourneyInstance(
-            alertId,
-            new EditAlertEndDateState()
-            {
-                Initialized = true,
-                CurrentEndDate = databaseEndDate,
-                EndDate = journeyEndDate,
-                ChangeReason = changeReason,
-                HasAdditionalReasonDetail = true,
-                ChangeReasonDetail = changeReasonDetail,
-                UploadEvidence = true,
-                EvidenceFileId = evidenceFileId,
-                EvidenceFileName = evidenceFileName
-            });
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForAllStepsCompleted(alert, true);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alertId}/end-date/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alertId}", response.Headers.Location?.OriginalString);
+        Assert.StartsWith($"/alerts/{alert.AlertId}", response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Null(journeyInstance);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/EndDateTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/EndDateTestBase.cs
@@ -1,0 +1,60 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.EndDate;
+
+public abstract class EndDateTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<JourneyInstance<EditAlertEndDateState>> CreateEmptyJourneyInstance(Guid alertId) =>
+        CreateJourneyInstance(alertId, new());
+
+    protected Task<JourneyInstance<EditAlertEndDateState>> CreateJourneyInstanceForAllStepsCompleted(Alert alert, bool populateOptional = true) =>
+        CreateJourneyInstance(alert.AlertId, new EditAlertEndDateState()
+        {
+            Initialized = true,
+            CurrentEndDate = alert.EndDate,
+            EndDate = alert.EndDate!.Value.AddDays(-5),
+            ChangeReason = AlertChangeEndDateReasonOption.AnotherReason,
+            HasAdditionalReasonDetail = populateOptional ? true : false,
+            ChangeReasonDetail = populateOptional ? "More details" : null,
+            UploadEvidence = populateOptional ? true : false,
+            EvidenceFileId = populateOptional ? Guid.NewGuid() : null,
+            EvidenceFileName = populateOptional ? "evidence.jpeg" : null,
+            EvidenceFileSizeDescription = populateOptional ? "5MB" : null
+        });
+
+    protected Task<JourneyInstance<EditAlertEndDateState>> CreateJourneyInstanceForCompletedStep(string step, Alert alert) =>
+        step switch
+        {
+            JourneySteps.New =>
+                CreateJourneyInstance(alert.AlertId, new EditAlertEndDateState()
+                {
+                    Initialized = true,
+                    CurrentEndDate = alert.EndDate
+                }),
+            JourneySteps.Index =>
+                CreateJourneyInstance(alert.AlertId, new EditAlertEndDateState()
+                {
+                    Initialized = true,
+                    CurrentEndDate = alert.EndDate,
+                    EndDate = alert.EndDate!.Value.AddDays(-5)
+                }),
+            JourneySteps.Reason or JourneySteps.CheckAnswers =>
+                CreateJourneyInstanceForAllStepsCompleted(alert, populateOptional: true),
+            _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
+        };
+
+    private Task<JourneyInstance<EditAlertEndDateState>> CreateJourneyInstance(Guid alertId, EditAlertEndDateState state) =>
+        CreateJourneyInstance(
+            JourneyNames.EditAlertEndDate,
+            state,
+            new KeyValuePair<string, object>("alertId", alertId));
+
+    public static class JourneySteps
+    {
+        public const string New = nameof(New);
+        public const string Index = nameof(Index);
+        public const string Reason = nameof(Reason);
+        public const string CheckAnswers = nameof(CheckAnswers);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/LinkTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/LinkTestBase.cs
@@ -1,0 +1,58 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.Link;
+
+public abstract class LinkTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<JourneyInstance<EditAlertLinkState>> CreateEmptyJourneyInstance(Guid alertId) =>
+        CreateJourneyInstance(alertId, new());
+
+    protected Task<JourneyInstance<EditAlertLinkState>> CreateJourneyInstanceForAllStepsCompleted(Alert alert, bool populateOptional = true) =>
+        CreateJourneyInstance(alert.AlertId, new EditAlertLinkState()
+        {
+            Initialized = true,
+            CurrentLink = populateOptional ? null : alert.ExternalLink,
+            AddLink = populateOptional,
+            Link = populateOptional ? "https://www.example.com" : null,
+            ChangeReason = AlertChangeLinkReasonOption.AnotherReason,
+            HasAdditionalReasonDetail = populateOptional ? true : false,
+            ChangeReasonDetail = populateOptional ? "More details" : null,
+            UploadEvidence = populateOptional ? true : false,
+            EvidenceFileId = populateOptional ? Guid.NewGuid() : null,
+            EvidenceFileName = populateOptional ? "evidence.jpeg" : null,
+            EvidenceFileSizeDescription = populateOptional ? "5MB" : null
+        });
+
+    protected Task<JourneyInstance<EditAlertLinkState>> CreateJourneyInstanceForCompletedStep(string step, Alert alert, bool populateOptional = true) =>
+        step switch
+        {
+            JourneySteps.New =>
+                CreateEmptyJourneyInstance(alert.AlertId),
+            JourneySteps.Index =>
+                CreateJourneyInstance(alert.AlertId, new EditAlertLinkState()
+                {
+                    Initialized = true,
+                    CurrentLink = populateOptional ? null : alert.ExternalLink,
+                    AddLink = populateOptional,
+                    Link = populateOptional ? "https://www.example.com" : null
+                }),
+            JourneySteps.Reason or JourneySteps.CheckAnswers =>
+                CreateJourneyInstanceForAllStepsCompleted(alert, populateOptional: populateOptional),
+            _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
+        };
+
+    private Task<JourneyInstance<EditAlertLinkState>> CreateJourneyInstance(Guid alertId, EditAlertLinkState state) =>
+        CreateJourneyInstance(
+            JourneyNames.EditAlertLink,
+            state,
+            new KeyValuePair<string, object>("alertId", alertId));
+
+    public static class JourneySteps
+    {
+        public const string New = nameof(New);
+        public const string Index = nameof(Index);
+        public const string Reason = nameof(Reason);
+        public const string CheckAnswers = nameof(CheckAnswers);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
@@ -157,6 +157,7 @@ public class CheckAnswersTests : ReopenAlertTestBase
     [Fact]
     public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
     {
+        // Arrange
         var (person, alert) = await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateEmptyJourneyInstance(alert.AlertId);
 


### PR DESCRIPTION
### Context

We’ve started to refactor some of the tests for the the alert journeys. 
We should do the same for all alert journeys so they’re consistent.

### Changes proposed in this pull request

Go through tests for all the alert journeys and refactor in a similar way to the edit alert start date tests

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
