### PR TITLE
[2148] Add missing permission for google auth on manual deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
         type: environment
         required: true
 
+permissions:
+  packages: write
+  id-token: write
+
 concurrency: deploy_${{ inputs.environment }}
 jobs:
   package:


### PR DESCRIPTION
### Context
Failing manual deployment workflow: https://github.com/DFE-Digital/teaching-record-system/actions/runs/11891562537/job/33132567400

### Changes proposed in this pull request
Add the missing permission

### Guidance to review
Succesful run: https://github.com/DFE-Digital/teaching-record-system/actions/runs/11891998183/job/33134093047

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
