### PR TITLE
Add HTTP message signature to webhook messages

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -71,6 +71,9 @@
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+    <PackageVersion Include="NSign.AspNetCore" Version="1.1.0" />
+    <PackageVersion Include="NSign.Client" Version="1.1.0" />
+    <PackageVersion Include="NSign.SignatureProviders" Version="1.1.0" />
     <PackageVersion Include="OpenIddict.AspNetCore" Version="5.2.0" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="5.2.0" />
     <PackageVersion Include="Optional" Version="4.0.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/packages.lock.json
@@ -982,6 +982,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1200,6 +1212,11 @@
           "Pipelines.Sockets.Unofficial": "2.2.8"
         }
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
         "resolved": "6.6.2",
@@ -1277,8 +1294,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1626,8 +1643,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "5.0.1",
-        "contentHash": "qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg=="
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2479,6 +2496,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2958,6 +2977,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
@@ -945,6 +945,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1292,6 +1304,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1348,8 +1365,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1694,6 +1711,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2540,6 +2562,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -3025,6 +3049,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/packages.lock.json
@@ -668,6 +668,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -826,6 +838,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -882,8 +899,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1211,6 +1228,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2052,6 +2074,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2450,6 +2474,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookOptions.cs
@@ -6,4 +6,20 @@ public class WebhookOptions
 {
     [Required]
     public required string CanonicalDomain { get; set; }
+
+    [Required]
+    public required string SigningKeyId { get; set; }
+
+    [Required]
+    public required WebhookOptionsKey[] Keys { get; set; }
+}
+
+public class WebhookOptionsKey
+{
+    [Required]
+    public required string KeyId { get; set; }
+    [Required]
+    public required string CertificatePem { get; set; }
+    [Required]
+    public required string PrivateKeyPem { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookSender.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookSender.cs
@@ -1,15 +1,26 @@
 using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
 using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.Http;
 using CloudNative.CloudEvents.SystemTextJson;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSign;
+using NSign.Client;
+using NSign.Http;
+using NSign.Providers;
+using NSign.Signatures;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.Core.Services.Webhooks;
 
 public class WebhookSender(HttpClient httpClient, IOptions<WebhookOptions> optionsAccessor)
 {
+    public const string TagName = "trs-webhooks";
     private const string DataContentType = "application/json; charset=utf-8";
+    private const string SignatureName = "sig1";
+    private const string UserAgent = "Teaching Record System";
+    private const int TimeoutSeconds = 30;
 
     private readonly CloudEventFormatter _formatter = new JsonEventFormatter();
 
@@ -41,5 +52,83 @@ public class WebhookSender(HttpClient httpClient, IOptions<WebhookOptions> optio
 
         var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
         response.EnsureSuccessStatusCode();
+    }
+
+    public static void AddHttpClient(IServiceCollection services, Func<HttpMessageHandler>? getPrimaryHandler = null)
+    {
+        // We configure the options here manually rather than using the library-provided extension methods so that they don't 'bleed out' globally;
+        // it's feasible we could want a different configuration of, say, AddContentDigestOptions for use elsewhere.
+
+        IOptions<AddContentDigestOptions> GetAddContentDigestOptions(IServiceProvider serviceProvider) =>
+            Options.Create(new AddContentDigestOptions().WithHash(AddContentDigestOptions.Hash.Sha256));
+
+        IOptions<MessageSigningOptions> GetMessageSigningOptions(IServiceProvider serviceProvider)
+        {
+            var keyId = serviceProvider.GetRequiredService<IOptions<WebhookOptions>>().Value.SigningKeyId;
+
+            var options = new MessageSigningOptions();
+
+            options.SignatureName = SignatureName;
+
+            options
+                .WithMandatoryComponent(SignatureComponent.RequestTargetUri)
+                .WithMandatoryComponent(SignatureComponent.ContentDigest)
+                .WithMandatoryComponent(SignatureComponent.ContentLength)
+                .WithMandatoryComponent(new HttpHeaderComponent("ce-id"))
+                .WithMandatoryComponent(new HttpHeaderComponent("ce-type"))
+                .WithMandatoryComponent(new HttpHeaderComponent("ce-time"))
+                .SetParameters = signingOptions => signingOptions
+                    .WithTag(TagName)
+                    .WithCreatedNow()
+                    .WithExpires(DateTimeOffset.UtcNow.AddMinutes(5))
+                    .WithAlgorithm(SignatureAlgorithm.EcdsaP384Sha384)
+                    .WithKeyId("test")
+                    .WithNonce(Guid.NewGuid().ToString("N"));
+
+            return Options.Create(options);
+        }
+
+        // The cert is added to the container rather than being created directly in the registration for ISigner
+        // so it's tracked by the container and gets disposed with the container.
+        services.AddKeyedSingleton<X509Certificate2>(nameof(WebhookSender), (sp, _) =>
+        {
+            var options = sp.GetRequiredService<IOptions<WebhookOptions>>().Value;
+            var signingKeyId = options.SigningKeyId;
+            var key = options.Keys.SingleOrDefault(k => k.KeyId == signingKeyId) ??
+                throw new Exception($"Key with ID '{signingKeyId}' was not found.");
+
+            return X509Certificate2.CreateFromPem(key.CertificatePem, key.PrivateKeyPem);
+        });
+
+        services.AddKeyedSingleton<ISigner>(nameof(WebhookSender), (sp, k) =>
+        {
+            var options = sp.GetRequiredService<IOptions<WebhookOptions>>().Value;
+            var signingKeyId = options.SigningKeyId;
+            var cert = sp.GetRequiredKeyedService<X509Certificate2>(k);
+            return new ECDsaP382Sha384SignatureProvider(cert, signingKeyId);
+        });
+
+        var httpClientBuilder = services
+            .AddHttpClient<WebhookSender>(client =>
+            {
+                client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
+                client.DefaultRequestHeaders.ExpectContinue = false;
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
+            })
+            .AddHttpMessageHandler(sp =>
+                ActivatorUtilities.CreateInstance<AddContentDigestHandler>(
+                    sp,
+                    GetAddContentDigestOptions(sp)))
+            .AddHttpMessageHandler(sp =>
+                ActivatorUtilities.CreateInstance<SigningHandler>(
+                    sp,
+                    ActivatorUtilities.CreateInstance<DefaultMessageSigner>(sp, sp.GetRequiredKeyedService<ISigner>(nameof(WebhookSender))),
+                    Options.Create(new HttpFieldOptions()),
+                    GetMessageSigningOptions(sp)));
+
+        if (getPrimaryHandler is not null)
+        {
+            httpClientBuilder.ConfigurePrimaryHttpMessageHandler(() => getPrimaryHandler());
+        }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -177,6 +177,8 @@
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" />
     <PackageReference Include="Npgsql.DependencyInjection" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="NSign.Client" />
+    <PackageReference Include="NSign.SignatureProviders" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" />
     <PackageReference Include="Optional" />
     <PackageReference Include="Parquet.Net" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/packages.lock.json
@@ -401,6 +401,30 @@
           "Npgsql": "8.0.5"
         }
       },
+      "NSign.Client": {
+        "type": "Direct",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "Direct",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
+        }
+      },
       "OpenIddict.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.2.0, )",
@@ -1249,6 +1273,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1407,6 +1443,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1463,11 +1504,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1846,8 +1884,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "ryTgF+iFkpGZY1vRQhfCzX0xTdlV3pyaTTqRu2ETbEv+HlV7O6y7hyQURnghNIXvctl5DuZ//Dpks6HdL/Txgw=="
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/packages.lock.json
@@ -944,6 +944,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1136,6 +1148,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1192,8 +1209,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1538,6 +1555,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2384,6 +2406,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2782,6 +2806,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/packages.lock.json
@@ -1116,6 +1116,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1321,6 +1333,11 @@
         "resolved": "0.0.46",
         "contentHash": "/cCCMsB3i+MVt5LTbl236dnFd/BE4dKzzzC1teGTpAHzwPTiLIuD5hioGgtPuli/enAj8Dhmt/e9JlVUIITIgQ=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -1369,8 +1386,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1668,8 +1685,8 @@
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "5.0.1",
-        "contentHash": "qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg=="
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2500,6 +2517,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2985,6 +3004,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.UiCommon/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.UiCommon/packages.lock.json
@@ -662,6 +662,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -820,6 +832,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -876,8 +893,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1205,6 +1222,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2046,6 +2068,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2444,6 +2468,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/packages.lock.json
@@ -771,6 +771,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -938,6 +950,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -994,8 +1011,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1340,6 +1357,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2181,6 +2203,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2579,6 +2603,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/packages.lock.json
@@ -1000,6 +1000,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1209,6 +1221,11 @@
           "Pipelines.Sockets.Unofficial": "2.2.8"
         }
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
         "resolved": "6.6.2",
@@ -1278,8 +1295,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2448,6 +2465,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -3007,6 +3026,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/packages.lock.json
@@ -986,6 +986,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1324,6 +1336,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -1372,8 +1389,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2538,6 +2555,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -3130,6 +3149,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.AspNetCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
@@ -975,6 +975,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1313,6 +1325,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -1361,8 +1378,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2522,6 +2539,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -3114,6 +3133,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.AspNetCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/packages.lock.json
@@ -765,6 +765,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -914,6 +926,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -962,8 +979,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1241,6 +1258,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2087,6 +2109,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2499,6 +2523,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TeachingRecordSystem.Core.Tests.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TeachingRecordSystem.Core.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="NSign.AspNetCore" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Xunit.DependencyInjection" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/packages.lock.json
@@ -32,6 +32,16 @@
           "Castle.Core": "5.1.1"
         }
       },
+      "NSign.AspNetCore": {
+        "type": "Direct",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "w+D5EdMYd2eNmVTtSShYC16hDHrhNyhu1eZRTCnpCXjpjjDjjL7z7aZf7gDu+fMpns8mtsd8wCcKRCyV2ETM5g==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.6.2, )",
@@ -753,6 +763,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -902,6 +924,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -950,8 +977,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2080,6 +2107,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2523,6 +2552,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
@@ -1168,6 +1168,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1373,6 +1385,11 @@
         "resolved": "0.0.46",
         "contentHash": "/cCCMsB3i+MVt5LTbl236dnFd/BE4dKzzzC1teGTpAHzwPTiLIuD5hioGgtPuli/enAj8Dhmt/e9JlVUIITIgQ=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -1421,8 +1438,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2594,6 +2611,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -3233,6 +3252,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
@@ -1178,6 +1178,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -1383,6 +1395,11 @@
         "resolved": "0.0.46",
         "contentHash": "/cCCMsB3i+MVt5LTbl236dnFd/BE4dKzzzC1teGTpAHzwPTiLIuD5hioGgtPuli/enAj8Dhmt/e9JlVUIITIgQ=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -1431,8 +1448,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2599,6 +2616,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -3224,6 +3243,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/packages.lock.json
@@ -728,6 +728,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -877,6 +889,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -925,8 +942,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1204,6 +1221,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -2008,6 +2030,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2415,6 +2439,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiCommon.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiCommon.Tests/packages.lock.json
@@ -733,6 +733,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -891,6 +903,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.AppContext": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -947,8 +964,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2164,6 +2181,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2577,6 +2596,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
@@ -671,6 +671,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0"
         }
       },
+      "NSign.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "UGgFyDoeyz0fLm7P/Qu7TqOqeLEBySIU8qCRCPKoCmn3wmp67OXLkYyxAUL4s9J1SwVhWjPc8AdvBHSJecJ+cw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options.DataAnnotations": "8.0.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
       "OpenIddict.Abstractions": {
         "type": "Transitive",
         "resolved": "5.2.0",
@@ -820,6 +832,11 @@
         "resolved": "1.1.6",
         "contentHash": "aLJu7Q0mVk0e9QwjJLEh70tXQ0Url8fHITrHXwqF+eq7N20jGMOhkmTXUUjpPim+rCm0I4fARcVBRzJPSipN+w=="
       },
+      "StructuredFieldValues": {
+        "type": "Transitive",
+        "resolved": "0.6.3",
+        "contentHash": "EgCsxEnSeXuamDL6AV8ygCI+WHNodfgARlpqBT1MQjy4Qxg8VQA7IHlH5jFbzhXKpWIL2mU8+/Ed3yW/At9vWg=="
+      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -868,8 +885,8 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "1.5.0",
-        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -1147,6 +1164,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -1951,6 +1973,8 @@
           "Microsoft.Extensions.Options.DataAnnotations": "[8.0.0, )",
           "Microsoft.PowerPlatform.Dataverse.Client": "[1.1.27, )",
           "Microsoft.PowerPlatform.Dataverse.Client.Dynamics": "[1.1.27, )",
+          "NSign.Client": "[1.1.0, )",
+          "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
@@ -2409,6 +2433,30 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "8.0.10",
           "Microsoft.EntityFrameworkCore.Relational": "8.0.10",
           "Npgsql": "8.0.5"
+        }
+      },
+      "NSign.Client": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "wfHRl6NDEc92nJXZjPqCgEBvqC8z/+uLWUOQ+YcBna5BHdb+Xx2Rr8Ixc1yjNVC6TioxjJjtqXaVpJhPVLPh/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.1",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "NSign.Abstractions": "1.1.0",
+          "StructuredFieldValues": "0.6.3",
+          "System.Collections.Immutable": "8.0.0",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "NSign.SignatureProviders": {
+        "type": "CentralTransitive",
+        "requested": "[1.1.0, )",
+        "resolved": "1.1.0",
+        "contentHash": "poa3Qez1ds4w28TWQyPzKa/Yd4WOY9Pto8qWI96wNRHp76ZfV9M2kfZ6JH7ma3uAgInwpYEoAc+2Z0h6/E/sSA==",
+        "dependencies": {
+          "NSign.Abstractions": "1.1.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {


### PR DESCRIPTION
We're adding an [HTTP message signature](https://www.rfc-editor.org/rfc/rfc9421.html) to webhook messages so that receivers can confirm the message has come from us.

This updates `WebhookSender` to add the signature and its tests to check the signature can be verified successfully.

Most of the ceremony here is around DI since the provided extension methods in NSign don't allow scoping services to a specific `HttpClient` instance; I don't want things like `AddContentDigestOptions` to be around globally.