### PR TITLE
Add a webhook-jwks endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/GetAnIdentityEndpoints.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/GetAnIdentityEndpoints.cs
@@ -41,9 +41,9 @@ public static class GetAnIdentityEndpoints
 
     public static IEndpointConventionBuilder MapIdentityEndpoints(this IEndpointRouteBuilder builder)
     {
-        return builder.MapGroup("/identity")
+        return builder
             .MapPost(
-                "",
+                "/webhooks/identity",
                 async (
                     HttpContext context,
                     IOptions<GetAnIdentityOptions> identityOptions,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/WebHookEndpoints.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/IdentityWebHooks/WebHookEndpoints.cs
@@ -4,7 +4,6 @@ public static class WebHookEndpoints
 {
     public static IEndpointConventionBuilder MapWebHookEndpoints(this IEndpointRouteBuilder builder)
     {
-        return builder.MapGroup("/webhooks")
-            .MapIdentityEndpoints();
+        return builder.MapIdentityEndpoints();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/WebhookJwks.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Endpoints/WebhookJwks.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Options;
+using TeachingRecordSystem.Core.Services.Webhooks;
+
+namespace TeachingRecordSystem.Api.Endpoints;
+
+public static class WebhookJwks
+{
+    public static IEndpointConventionBuilder MapWebhookJwks(this IEndpointRouteBuilder endpoints)
+    {
+        return endpoints.MapGet("/webhook-jwks", async ctx =>
+        {
+            var webhookOptions = ctx.RequestServices.GetRequiredService<IOptions<WebhookOptions>>();
+            var jsonWebKeySet = webhookOptions.Value.GetJsonWebKeySet();
+            await ctx.Response.WriteAsJsonAsync(jsonWebKeySet);
+        });
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Optional;
+using TeachingRecordSystem.Api.Endpoints;
 using TeachingRecordSystem.Api.Endpoints.IdentityWebHooks;
 using TeachingRecordSystem.Api.Infrastructure.ApplicationModel;
 using TeachingRecordSystem.Api.Infrastructure.Filters;
@@ -30,6 +31,7 @@ using TeachingRecordSystem.Core.Services.DqtOutbox;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.NameSynonyms;
 using TeachingRecordSystem.Core.Services.TrnGenerationApi;
+using TeachingRecordSystem.Core.Services.Webhooks;
 using TeachingRecordSystem.ServiceDefaults;
 using TeachingRecordSystem.ServiceDefaults.Infrastructure.Logging;
 
@@ -221,7 +223,8 @@ public class Program
             .AddDistributedLocks()
             .AddIdentityApi()
             .AddNameSynonyms()
-            .AddDqtOutboxMessageSerializer();
+            .AddDqtOutboxMessageSerializer()
+            .AddWebhookOptions();
 
         services.AddAccessYourTeachingQualificationsOptions(configuration, env);
         services.AddCertificateGeneration();
@@ -274,6 +277,7 @@ public class Program
         });
 
         app.MapWebHookEndpoints();
+        app.MapWebhookJwks();
 
         app.MapControllers();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
@@ -11,5 +11,8 @@
     "Username": "admin",
     "Password": "test"
   },
-  "StorageConnectionString": "UseDevelopmentStorage=true"
+  "StorageConnectionString": "UseDevelopmentStorage=true",
+  "Webhooks": {
+    "CanonicalDomain": "https://localhost:5001"
+  }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/ApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/ApplicationBuilderExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace TeachingRecordSystem.Core.Services.Webhooks;
+
+public static class HostApplicationBuilderExtensions
+{
+    public static IHostApplicationBuilder AddWebhookOptions(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddOptions<WebhookOptions>()
+            .Bind(builder.Configuration.GetSection("Webhooks"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        return builder;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookOptions.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.IdentityModel.Tokens;
 
 namespace TeachingRecordSystem.Core.Services.Webhooks;
 
@@ -12,6 +14,35 @@ public class WebhookOptions
 
     [Required]
     public required WebhookOptionsKey[] Keys { get; set; }
+
+    public JsonWebKeySet GetJsonWebKeySet()
+    {
+        // FUTURE memoize this
+
+        var keySet = new JsonWebKeySet();
+
+        foreach (var key in Keys)
+        {
+            using var certificate = X509Certificate2.CreateFromPem(key.CertificatePem);
+            var securityKey = new ECDsaSecurityKey(certificate.GetECDsaPublicKey());
+
+            var jsonWebKey = JsonWebKeyConverter.ConvertFromECDsaSecurityKey(securityKey);
+            jsonWebKey.Use = "sig";
+            jsonWebKey.Alg = "ES384";
+            jsonWebKey.KeyId = key.KeyId;
+
+            var certChain = certificate.ExportCertificatePem().Split("\n")
+                .Skip(1)  // Remove -----BEGIN CERTIFICATE-----
+                .SkipLast(1)  // Remove -----END CERTIFICATE-----
+                .Aggregate((l, r) => l + r);
+
+            jsonWebKey.X5c.Add(certChain);
+
+            keySet.Keys.Add(jsonWebKey);
+        }
+
+        return keySet;
+    }
 }
 
 public class WebhookOptionsKey

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookSender.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookSender.cs
@@ -82,7 +82,7 @@ public class WebhookSender(HttpClient httpClient, IOptions<WebhookOptions> optio
                     .WithCreatedNow()
                     .WithExpires(DateTimeOffset.UtcNow.AddMinutes(5))
                     .WithAlgorithm(SignatureAlgorithm.EcdsaP384Sha384)
-                    .WithKeyId("test")
+                    .WithKeyId(keyId)
                     .WithNonce(Guid.NewGuid().ToString("N"));
 
             return Options.Create(options);


### PR DESCRIPTION
Receivers of webhook messages need to verify they've come from us. To do that they need access to our public keys so they can check messages have been signed by us. This exposes a `/webhook-jwks` endpoint to allow just that. The `kid` parameter here aligns with the key ID uses in the HTTP message signature.