### PR TITLE
Prevent a null email address from being submitted

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/CreateTrnRequestRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Validators/CreateTrnRequestRequestValidator.cs
@@ -38,6 +38,8 @@ public class CreateTrnRequestRequestValidator : AbstractValidator<CreateTrnReque
             });
 
         RuleForEach(r => r.Person.EmailAddresses)
+            .NotNull()
+                .WithMessage("Email address cannot be null.")
             .EmailAddress()
             .MaximumLength(AttributeConstraints.Contact.EMailAddress1MaxLength);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/CreateTrnRequestTests.cs
@@ -106,6 +106,41 @@ public class CreateTrnRequestTests : TestBase
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
+    [Fact]
+    public async Task Post_RequestWithNullEmail_ReturnsError()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+        var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = new DateOnly(1990, 01, 01);
+
+        var requestBody = CreateJsonContent(CreateDummyRequest() with
+        {
+            RequestId = requestId,
+            Person = new()
+            {
+                FirstName = firstName,
+                MiddleName = middleName,
+                LastName = lastName,
+                DateOfBirth = dateOfBirth,
+                EmailAddresses = new[] { (string?)null }!
+            }
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "v3/trn-requests")
+        {
+            Content = requestBody
+        };
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseHasValidationErrorForPropertyAsync(response, "person.emailAddresses[0]", "Email address cannot be null.");
+    }
+
     private static CreateTrnRequestRequest CreateDummyRequest() => new()
     {
         RequestId = Guid.NewGuid().ToString(),


### PR DESCRIPTION
We've got a Sentry error caused by a `null` email address that's crept in with a TRN request (in the `emailAddresses` array). This adds validation to prevent requests getting through.

https://dfe-teacher-services.sentry.io/share/issue/15136e5da672401b94c3e6661426f9b2/