### PR TITLE
Add private field naming rule to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,11 +25,24 @@ indent_size = 4
 
 [*.cs]
 indent_size = 4
+
 dotnet_diagnostic.IDE0005.severity = error
 dotnet_diagnostic.VSTHRD003.severity = none
 dotnet_diagnostic.VSTHRD103.severity = none
 dotnet_diagnostic.VSTHRD105.severity = none
+
+dotnet_naming_rule.private_members_with_underscore.symbols = private_fields
+dotnet_naming_rule.private_members_with_underscore.style = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
 dotnet_sort_system_directives_first = true
+
 csharp_style_namespace_declarations = file_scoped:warning
 csharp_prefer_braces = true:warning
 


### PR DESCRIPTION
This adds our convention for naming private fields with an underscore (and camel case) to .editorconfig. VS will pick this up and its suggested actions like 'Create and assign field ...' will take the naming into account.