### PR TITLE
Added missing induction sync columns to reporting db

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0038_TrsPersonsInductionSync.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0038_TrsPersonsInductionSync.sql
@@ -1,0 +1,2 @@
+alter table trs_persons add dqt_induction_last_sync datetime
+alter table trs_persons add dqt_induction_modified_on datetime

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -70,6 +70,7 @@
     <None Remove="Services\DqtReporting\Migrations\0035_TrsEventsSyncMetadata.sql" />
     <None Remove="Services\DqtReporting\Migrations\0036_TrsPersonsInduction.sql" />
     <None Remove="Services\DqtReporting\Migrations\0037_RenameSanctionTable.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0038_TrsPersonsInductionSync.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -138,6 +139,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0035_TrsEventsSyncMetadata.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0036_TrsPersonsInduction.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0037_RenameSanctionTable.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0038_TrsPersonsInductionSync.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context

Forgot to add some new Persons table columns to the reporting db schema.
The migrations here fix that.
