### PR TITLE
[2124] Enable Bigquery federated authentication in production

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -51,6 +51,7 @@ provider "registry.terraform.io/hashicorp/google" {
   constraints = "6.6.0"
   hashes = [
     "h1:BOwY9eXbFeMU+DC1L8RW1CfcGPIiF1rMxNAxjssqNgk=",
+    "h1:bNj7UyO9+IdcTbkZJgjULH89DrJSaBCRw89zt6g8ajg=",
     "zh:0c181f9b9f0ab81731e5c4c2d20b6d342244506687437dad94e279ef2a588f68",
     "zh:12a4c333fc0ba670e87f09eb574e4b7da90381f9929ef7c866048b6841cc8a6a",
     "zh:15c277c2052df89429051350df4bccabe4cf46068433d4d8c673820d9756fc00",

--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -30,5 +30,6 @@
     "https://teacher-qualifications-api.education.gov.uk/health",
     "https://teaching-record-system.education.gov.uk/health",
     "https://authorise-access-to-a-teaching-record.education.gov.uk/health"
-  ]
+  ],
+  "enable_dfe_analytics_federated_auth": true
 }


### PR DESCRIPTION
### Context
Use Google federated authentication in production. It's already been applied to the other environments successfully.

### Changes proposed in this pull request
Set terraform variable to true

### Guidance to review
Compare with the other environments

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
