### PR TITLE
Add editorconfig naming styles for const fields

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,10 @@ dotnet_diagnostic.VSTHRD003.severity = none
 dotnet_diagnostic.VSTHRD103.severity = none
 dotnet_diagnostic.VSTHRD105.severity = none
 
+dotnet_naming_rule.const_fields.symbols = const_fields
+dotnet_naming_rule.const_fields.style = pascal_case
+dotnet_naming_rule.const_fields.severity = suggestion
+
 dotnet_naming_rule.private_members_with_underscore.symbols = private_fields
 dotnet_naming_rule.private_members_with_underscore.style = prefix_underscore
 dotnet_naming_rule.private_members_with_underscore.severity = suggestion
@@ -38,8 +42,13 @@ dotnet_naming_rule.private_members_with_underscore.severity = suggestion
 dotnet_naming_symbols.private_fields.applicable_kinds = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 
+dotnet_naming_symbols.const_fields.applicable_kinds = field
+dotnet_naming_symbols.const_fields.required_modifiers = const
+
 dotnet_naming_style.prefix_underscore.capitalization = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_sort_system_directives_first = true
 


### PR DESCRIPTION
This fixes the previously-added config so that we're not prompted to name const fields with underscores.