### PR TITLE
Add Create|Delete|Update methods to Alert and MQ

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
@@ -29,4 +29,117 @@ public class Alert
     public int? DqtState { get; set; }
     public DateTime? DqtCreatedOn { get; set; }
     public DateTime? DqtModifiedOn { get; set; }
+
+    public static Alert Create(
+        Guid alertTypeId,
+        Guid personId,
+        string? details,
+        string? externalLink,
+        DateOnly startDate,
+        DateOnly? endDate,
+        string? addReason,
+        string? addReasonDetail,
+        EventModels.File? evidenceFile,
+        EventModels.RaisedByUserInfo createdBy,
+        DateTime now,
+        out AlertCreatedEvent @event)
+    {
+        var alertId = Guid.NewGuid();
+
+        var alert = new Alert()
+        {
+            AlertId = alertId,
+            PersonId = personId,
+            AlertTypeId = alertTypeId,
+            Details = details,
+            ExternalLink = externalLink,
+            StartDate = startDate,
+            EndDate = endDate,
+            CreatedOn = now,
+            UpdatedOn = now
+        };
+
+        @event = new AlertCreatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = createdBy,
+            Alert = EventModels.Alert.FromModel(alert),
+            PersonId = personId,
+            AddReason = addReason,
+            AddReasonDetail = addReasonDetail,
+            EvidenceFile = evidenceFile
+        };
+
+        return alert;
+    }
+
+    public void Delete(
+        string? deletionReasonDetail,
+        EventModels.File? evidenceFile,
+        EventModels.RaisedByUserInfo deletedBy,
+        DateTime now,
+        out AlertDeletedEvent @event)
+    {
+        if (DeletedOn is not null)
+        {
+            throw new InvalidOperationException("Alert is already deleted.");
+        }
+
+        DeletedOn = now;
+        UpdatedOn = now;
+
+        @event = new AlertDeletedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = deletedBy,
+            PersonId = PersonId,
+            Alert = EventModels.Alert.FromModel(this),
+            DeletionReasonDetail = deletionReasonDetail,
+            EvidenceFile = evidenceFile,
+        };
+    }
+
+    public void Update(
+        Action<Alert> updateAction,
+        string? changeReason,
+        string? changeReasonDetail,
+        EventModels.File? evidenceFile,
+        EventModels.RaisedByUserInfo changedBy,
+        DateTime now,
+        out AlertUpdatedEvent? @event)
+    {
+        var oldAlertEventModel = EventModels.Alert.FromModel(this);
+
+        updateAction(this);
+
+        var changes = AlertUpdatedEventChanges.None |
+            (Details != oldAlertEventModel.Details ? AlertUpdatedEventChanges.Details : 0) |
+            (ExternalLink != oldAlertEventModel.ExternalLink ? AlertUpdatedEventChanges.ExternalLink : 0) |
+            (StartDate != oldAlertEventModel.StartDate ? AlertUpdatedEventChanges.StartDate : 0) |
+            (EndDate != oldAlertEventModel.EndDate ? AlertUpdatedEventChanges.EndDate : 0);
+
+        if (changes == AlertUpdatedEventChanges.None)
+        {
+            @event = null;
+            return;
+        }
+
+        UpdatedOn = now;
+
+        @event = new AlertUpdatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = changedBy,
+            PersonId = PersonId,
+            Alert = EventModels.Alert.FromModel(this),
+            OldAlert = oldAlertEventModel,
+            ChangeReason = changeReason,
+            ChangeReasonDetail = changeReasonDetail,
+            EvidenceFile = evidenceFile,
+            Changes = changes
+        };
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -11,4 +11,118 @@ public class MandatoryQualification : Qualification
 
     public Guid? DqtMqEstablishmentId { get; set; }
     public Guid? DqtSpecialismId { get; set; }
+
+    public static MandatoryQualification Create(
+        Guid personId,
+        Guid providerId,
+        MandatoryQualificationSpecialism specialism,
+        MandatoryQualificationStatus status,
+        DateOnly startDate,
+        DateOnly? endDate,
+        EventModels.RaisedByUserInfo createdBy,
+        DateTime now,
+        out MandatoryQualificationCreatedEvent @event)
+    {
+        var qualificationId = Guid.NewGuid();
+
+        var qualification = new MandatoryQualification()
+        {
+            QualificationId = qualificationId,
+            CreatedOn = now,
+            UpdatedOn = now,
+            PersonId = personId,
+            ProviderId = providerId,
+            Status = status,
+            Specialism = specialism,
+            StartDate = startDate,
+            EndDate = endDate
+        };
+
+        @event = new MandatoryQualificationCreatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = createdBy,
+            PersonId = personId,
+            MandatoryQualification = EventModels.MandatoryQualification.FromModel(
+                qualification,
+                providerNameHint: MandatoryQualificationProvider.GetById(providerId).Name)
+        };
+
+        return qualification;
+    }
+
+    public void Delete(
+        string? deletionReason,
+        string? deletionReasonDetail,
+        EventModels.File? evidenceFile,
+        EventModels.RaisedByUserInfo deletedBy,
+        DateTime now,
+        out MandatoryQualificationDeletedEvent @event)
+    {
+        if (DeletedOn is not null)
+        {
+            throw new InvalidOperationException("MandatoryQualification is already deleted.");
+        }
+
+        DeletedOn = now;
+        UpdatedOn = now;
+
+        @event = new MandatoryQualificationDeletedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = deletedBy,
+            PersonId = PersonId,
+            MandatoryQualification = EventModels.MandatoryQualification.FromModel(this),
+            DeletionReason = deletionReason,
+            DeletionReasonDetail = deletionReasonDetail,
+            EvidenceFile = evidenceFile,
+        };
+    }
+
+    public void Update(
+        Action<MandatoryQualification> updateAction,
+        string? changeReason,
+        string? changeReasonDetail,
+        EventModels.File? evidenceFile,
+        EventModels.RaisedByUserInfo updatedBy,
+        DateTime now,
+        out MandatoryQualificationUpdatedEvent? @event)
+    {
+        var oldMqEventModel = EventModels.MandatoryQualification.FromModel(this);
+
+        updateAction(this);
+
+        var changes = MandatoryQualificationUpdatedEventChanges.None |
+            (ProviderId != oldMqEventModel.Provider?.MandatoryQualificationProviderId ? MandatoryQualificationUpdatedEventChanges.Provider : 0) |
+            (Specialism != oldMqEventModel.Specialism ? MandatoryQualificationUpdatedEventChanges.Specialism : 0) |
+            (Status != oldMqEventModel.Status ? MandatoryQualificationUpdatedEventChanges.Status : 0) |
+            (StartDate != oldMqEventModel.StartDate ? MandatoryQualificationUpdatedEventChanges.StartDate : 0) |
+            (EndDate != oldMqEventModel.EndDate ? MandatoryQualificationUpdatedEventChanges.EndDate : 0);
+
+        if (changes == MandatoryQualificationUpdatedEventChanges.None)
+        {
+            @event = null;
+            return;
+        }
+
+        UpdatedOn = now;
+
+        @event = new MandatoryQualificationUpdatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = updatedBy,
+            PersonId = PersonId,
+            MandatoryQualification = EventModels.MandatoryQualification.FromModel(
+                this,
+                providerNameHint: ProviderId is Guid providerId ? MandatoryQualificationProvider.GetById(providerId).Name : null),
+            OldMandatoryQualification = oldMqEventModel,
+            ChangeReason = changeReason,
+            ChangeReasonDetail = changeReasonDetail,
+            EvidenceFile = evidenceFile,
+            Changes = changes
+        };
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
@@ -41,44 +41,26 @@ public class CheckAnswersModel(
 
     public async Task<IActionResult> OnPostAsync()
     {
-        var now = clock.UtcNow;
+        var alert = HttpContext.GetCurrentAlertFeature().Alert;
 
-        var alert = await dbContext.Alerts
-            .SingleAsync(a => a.AlertId == AlertId);
+        alert.Update(
+            a => a.EndDate = NewEndDate,
+            ChangeReason.GetDisplayName(),
+            ChangeReasonDetail,
+            evidenceFile: JourneyInstance!.State.EvidenceFileId is Guid fileId
+                ? new EventModels.File()
+                {
+                    FileId = fileId,
+                    Name = JourneyInstance.State.EvidenceFileName!
+                }
+                : null,
+            User.GetUserId(),
+            clock.UtcNow,
+            out var updatedEvent);
 
-        var changes = NewEndDate != alert.EndDate ?
-            AlertUpdatedEventChanges.EndDate :
-            AlertUpdatedEventChanges.None;
-
-        if (changes != AlertUpdatedEventChanges.None)
+        if (updatedEvent is not null)
         {
-            var oldAlertEventModel = EventModels.Alert.FromModel(alert);
-
-            alert.EndDate = NewEndDate;
-            alert.UpdatedOn = now;
-
-            var updatedEvent = new AlertUpdatedEvent()
-            {
-                EventId = Guid.NewGuid(),
-                CreatedUtc = now,
-                RaisedBy = User.GetUserId(),
-                PersonId = PersonId,
-                Alert = EventModels.Alert.FromModel(alert),
-                OldAlert = oldAlertEventModel,
-                ChangeReason = ChangeReason.GetDisplayName(),
-                ChangeReasonDetail = ChangeReasonDetail,
-                EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
-                    new EventModels.File()
-                    {
-                        FileId = fileId,
-                        Name = JourneyInstance.State.EvidenceFileName!
-                    } :
-                    null,
-                Changes = changes
-            };
-
             dbContext.AddEvent(updatedEvent);
-
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
@@ -41,44 +41,26 @@ public class CheckAnswersModel(
 
     public async Task<IActionResult> OnPostAsync()
     {
-        var now = clock.UtcNow;
+        var alert = HttpContext.GetCurrentAlertFeature().Alert;
 
-        var alert = await dbContext.Alerts
-            .SingleAsync(a => a.AlertId == AlertId);
+        alert.Update(
+            a => a.StartDate = NewStartDate,
+            ChangeReason.GetDisplayName(),
+            ChangeReasonDetail,
+            evidenceFile: JourneyInstance!.State.EvidenceFileId is Guid fileId
+                ? new EventModels.File()
+                {
+                    FileId = fileId,
+                    Name = JourneyInstance.State.EvidenceFileName!
+                }
+                : null,
+            User.GetUserId(),
+            clock.UtcNow,
+            out var updatedEvent);
 
-        var changes = NewStartDate != alert.StartDate ?
-            AlertUpdatedEventChanges.StartDate :
-            AlertUpdatedEventChanges.None;
-
-        if (changes != AlertUpdatedEventChanges.None)
+        if (updatedEvent is not null)
         {
-            var oldAlertEventModel = EventModels.Alert.FromModel(alert);
-
-            alert.StartDate = NewStartDate;
-            alert.UpdatedOn = now;
-
-            var updatedEvent = new AlertUpdatedEvent()
-            {
-                EventId = Guid.NewGuid(),
-                CreatedUtc = now,
-                RaisedBy = User.GetUserId(),
-                PersonId = PersonId,
-                Alert = EventModels.Alert.FromModel(alert),
-                OldAlert = oldAlertEventModel,
-                ChangeReason = ChangeReason.GetDisplayName(),
-                ChangeReasonDetail = ChangeReasonDetail,
-                EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
-                    new EventModels.File()
-                    {
-                        FileId = fileId,
-                        Name = JourneyInstance.State.EvidenceFileName!
-                    } :
-                    null,
-                Changes = changes
-            };
-
             dbContext.AddEvent(updatedEvent);
-
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
@@ -30,30 +30,19 @@ public class CheckAnswersModel(TrsDbContext dbContext, TrsLinkGenerator linkGene
 
     public async Task<IActionResult> OnPostAsync()
     {
-        var qualification = new MandatoryQualification()
-        {
-            QualificationId = Guid.NewGuid(),
-            CreatedOn = clock.UtcNow,
-            UpdatedOn = clock.UtcNow,
-            PersonId = PersonId,
-            ProviderId = ProviderId,
-            Status = Status,
-            Specialism = Specialism,
-            StartDate = StartDate,
-            EndDate = EndDate
-        };
+        var qualification = MandatoryQualification.Create(
+            PersonId,
+            ProviderId,
+            Specialism,
+            Status,
+            StartDate,
+            EndDate,
+            User.GetUserId(),
+            clock.UtcNow,
+            out var createdEvent);
+
         dbContext.MandatoryQualifications.Add(qualification);
-
-        var createdEvent = new MandatoryQualificationCreatedEvent()
-        {
-            EventId = Guid.NewGuid(),
-            CreatedUtc = clock.UtcNow,
-            RaisedBy = User.GetUserId(),
-            PersonId = PersonId,
-            MandatoryQualification = EventModels.MandatoryQualification.FromModel(qualification, providerNameHint: ProviderName)
-        };
         dbContext.AddEvent(createdEvent);
-
         await dbContext.SaveChangesAsync();
 
         await JourneyInstance!.CompleteAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
@@ -45,44 +45,26 @@ public class ConfirmModel(
 
     public async Task<IActionResult> OnPostAsync()
     {
-        var now = clock.UtcNow;
+        var qualification = HttpContext.GetCurrentMandatoryQualificationFeature().MandatoryQualification;
 
-        var qualification = await dbContext.MandatoryQualifications
-            .Include(q => q.Provider)
-            .SingleAsync(q => q.QualificationId == QualificationId);
+        qualification.Update(
+            q => q.ProviderId = ProviderId,
+            ChangeReason.GetDisplayName(),
+            ChangeReasonDetail,
+            evidenceFile: JourneyInstance!.State.EvidenceFileId is Guid fileId ?
+                new EventModels.File()
+                {
+                    FileId = fileId,
+                    Name = JourneyInstance.State.EvidenceFileName!
+                } :
+                null,
+            User.GetUserId(),
+            clock.UtcNow,
+            out var updatedEvent);
 
-        var changes = ProviderId != qualification.ProviderId ?
-            MandatoryQualificationUpdatedEventChanges.Provider :
-            MandatoryQualificationUpdatedEventChanges.None;
-
-        if (changes != MandatoryQualificationUpdatedEventChanges.None)
+        if (updatedEvent is not null)
         {
-            var oldMqEventModel = EventModels.MandatoryQualification.FromModel(qualification);
-
-            qualification.ProviderId = ProviderId;
-            qualification.UpdatedOn = now;
-
-            var updatedEvent = new MandatoryQualificationUpdatedEvent()
-            {
-                EventId = Guid.NewGuid(),
-                CreatedUtc = now,
-                RaisedBy = User.GetUserId(),
-                PersonId = PersonId,
-                MandatoryQualification = EventModels.MandatoryQualification.FromModel(qualification, providerNameHint: ProviderName),
-                OldMandatoryQualification = oldMqEventModel,
-                ChangeReason = ChangeReason!.GetDisplayName(),
-                ChangeReasonDetail = ChangeReasonDetail,
-                EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
-                    new EventModels.File()
-                    {
-                        FileId = fileId,
-                        Name = JourneyInstance.State.EvidenceFileName!
-                    } :
-                    null,
-                Changes = changes
-            };
             dbContext.AddEvent(updatedEvent);
-
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
@@ -40,44 +40,26 @@ public class ConfirmModel(
 
     public async Task<IActionResult> OnPostAsync()
     {
-        var now = clock.UtcNow;
+        var qualification = HttpContext.GetCurrentMandatoryQualificationFeature().MandatoryQualification;
 
-        var qualification = await dbContext.MandatoryQualifications
-            .Include(q => q.Provider)
-            .SingleAsync(q => q.QualificationId == QualificationId);
+        qualification.Update(
+            q => q.StartDate = NewStartDate,
+            ChangeReason.GetDisplayName(),
+            ChangeReasonDetail,
+            evidenceFile: JourneyInstance!.State.EvidenceFileId is Guid fileId ?
+                new EventModels.File()
+                {
+                    FileId = fileId,
+                    Name = JourneyInstance.State.EvidenceFileName!
+                } :
+                null,
+            User.GetUserId(),
+            clock.UtcNow,
+            out var updatedEvent);
 
-        var changes = NewStartDate != qualification.StartDate ?
-            MandatoryQualificationUpdatedEventChanges.StartDate :
-            MandatoryQualificationUpdatedEventChanges.None;
-
-        if (changes != MandatoryQualificationUpdatedEventChanges.None)
+        if (updatedEvent is not null)
         {
-            var oldMqEventModel = EventModels.MandatoryQualification.FromModel(qualification);
-
-            qualification.StartDate = NewStartDate;
-            qualification.UpdatedOn = now;
-
-            var updatedEvent = new MandatoryQualificationUpdatedEvent()
-            {
-                EventId = Guid.NewGuid(),
-                CreatedUtc = now,
-                RaisedBy = User.GetUserId(),
-                PersonId = PersonId,
-                MandatoryQualification = EventModels.MandatoryQualification.FromModel(qualification),
-                OldMandatoryQualification = oldMqEventModel,
-                ChangeReason = ChangeReason!.GetDisplayName(),
-                ChangeReasonDetail = ChangeReasonDetail,
-                EvidenceFile = JourneyInstance!.State.EvidenceFileId is Guid fileId ?
-                    new EventModels.File()
-                    {
-                        FileId = fileId,
-                        Name = JourneyInstance.State.EvidenceFileName!
-                    } :
-                    null,
-                Changes = changes
-            };
             dbContext.AddEvent(updatedEvent);
-
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml
@@ -15,18 +15,18 @@
             <h1 class="govuk-heading-l" data-testid="title">@ViewBag.Title</h1>
 
             <govuk-summary-list data-testid="change-summary">
-                @if (Model.IsStatusChange!.Value)
+                @if (Model.IsStatusChange)
                 {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Current status</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value data-testid="current-status">@(Model.CurrentStatus.HasValue ? Model.CurrentStatus.Value.GetTitle() : "None")</govuk-summary-list-row-value>
-                    </govuk-summary-list-row>                
+                    </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>New status</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value data-testid="new-status">@(Model.NewStatus.HasValue ? Model.NewStatus.Value.GetTitle() : "None")</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                 }
-                @if (Model.IsEndDateChange!.Value)
+                @if (Model.IsEndDateChange)
                 {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Current end date</govuk-summary-list-row-key>
@@ -37,7 +37,7 @@
                         <govuk-summary-list-row-value data-testid="new-end-date">@(Model.NewEndDate.HasValue ? Model.NewEndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : "None")</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                 }
-                @if (Model.IsEndDateChange!.Value && !Model.IsStatusChange!.Value)
+                @if (Model.IsEndDateChange && !Model.IsStatusChange)
                 {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>


### PR DESCRIPTION
We're starting to get some repetition particularly around creating events and it will be compounded when we start adding more API endpoints that have corresponding UI.

This adds `Create`, `Update` and `Delete` methods to `Alert` and `MandatoryQualification` which all output events.