### PR TITLE
Use ApiResult instead of exceptions for API error messages

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiError.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiError.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api;
+
+public sealed record ApiError(int ErrorCode, string Title, string? Detail = null)
+{
+    public static class ErrorCodes
+    {
+        public static int PersonNotFound => 10001;
+        public static int SpecifiedResourceUrlDoesNotExist => 10028;
+        public static int TrnRequestAlreadyCreated => 10029;
+        public static int TrnRequestDoesNotExist => 10031;
+    }
+
+    public static ApiError PersonNotFound(string trn, DateOnly? dateOfBirth = null, string? nationalInsuranceNumber = null)
+    {
+        var title = $"Person not found.";
+
+        var detail = $"TRN: '{trn}'";
+        if (dateOfBirth is not null)
+        {
+            detail += $"\nDate of birth: '{dateOfBirth:yyyy-MM-dd}'";
+        }
+        if (!string.IsNullOrEmpty(nationalInsuranceNumber))
+        {
+            detail += $"\nNational insurance number: '{nationalInsuranceNumber}'";
+        }
+
+        return new ApiError(ErrorCodes.PersonNotFound, title, detail);
+    }
+
+    public static ApiError SpecifiedResourceUrlDoesNotExist(string url) =>
+        new(ErrorCodes.SpecifiedResourceUrlDoesNotExist, "The specified resource does not exist.", $"URL: '{url}'");
+
+    public static ApiError TrnRequestAlreadyCreated(string requestId) =>
+        new(ErrorCodes.TrnRequestAlreadyCreated, "TRN request has already been created.", $"TRN request ID: '{requestId}'");
+
+    public static ApiError TrnRequestDoesNotExist(string requestId) =>
+        new(ErrorCodes.TrnRequestDoesNotExist, "TRN request does not exist.", $"TRN request ID: '{requestId}'");
+
+    public IActionResult ToActionResult(int statusCode = 400)
+    {
+        var problemDetails = new ProblemDetails()
+        {
+            Title = Title,
+            Detail = Detail,
+            Status = statusCode,
+            Extensions =
+            {
+                { "errorCode", ErrorCode }
+            }
+        };
+
+        return new ObjectResult(problemDetails)
+        {
+            StatusCode = statusCode
+        };
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiResult.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api;
+
+public sealed class ApiResult<TResult> where TResult : notnull
+{
+    private readonly TResult? _result;
+    private readonly ApiError? _error;
+
+    public ApiResult(TResult result) : this(result, null)
+    {
+    }
+
+    public ApiResult(ApiError error) : this(default, error)
+    {
+    }
+
+    private ApiResult(TResult? result, ApiError? error)
+    {
+        Debug.Assert(result is not null ^ error is not null);
+        _result = result;
+        _error = error;
+    }
+
+    public bool IsError => _error is not null;
+
+    public static implicit operator ApiResult<TResult>(ApiError error) => new(error);
+
+    public static implicit operator ApiResult<TResult>(TResult result) => new(result);
+
+    public ApiError GetError() =>
+        _error ?? throw new InvalidOperationException("ApiResult is not in an error state.");
+
+    public TResult GetSuccess() =>
+        _result ?? throw new InvalidOperationException("ApiResult is not in a success state.");
+
+    public ApiResultActionResultBuilder<TResult> ToActionResult(Func<TResult, IActionResult> mapSuccess) => new(this, mapSuccess);
+}
+
+public class ApiResultActionResultBuilder<TResult>(ApiResult<TResult> result, Func<TResult, IActionResult> mapSuccess) : IActionResult
+    where TResult : notnull
+{
+    private readonly Dictionary<int, int> _errorCodeStatusCodeMappings = [];
+
+    public Task ExecuteResultAsync(ActionContext context)
+    {
+        if (result.IsError)
+        {
+            var error = result.GetError();
+            var statusCode = _errorCodeStatusCodeMappings.TryGetValue(error.ErrorCode, out var sc) ? sc : StatusCodes.Status400BadRequest;
+            return error.ToActionResult(statusCode).ExecuteResultAsync(context);
+        }
+
+        return mapSuccess(result.GetSuccess()).ExecuteResultAsync(context);
+    }
+
+    public ApiResultActionResultBuilder<TResult> MapErrorCode(int errorCode, int statusCode)
+    {
+        _errorCodeStatusCodeMappings[errorCode] = statusCode;
+        return this;
+    }
+}
+
+public sealed class Unit
+{
+    private Unit() { }
+
+    public static Unit Instance { get; } = new();
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonByLastNameAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonByLastNameAndDateOfBirth.cs
@@ -33,7 +33,7 @@ public class FindPersonByLastNameAndDateOfBirthHandler(
     PreviousNameHelper previousNameHelper,
     ReferenceDataCache referenceDataCache)
 {
-    public async Task<FindPersonByLastNameAndDateOfBirthResult> HandleAsync(FindPersonByLastNameAndDateOfBirthCommand command)
+    public async Task<ApiResult<FindPersonByLastNameAndDateOfBirthResult>> HandleAsync(FindPersonByLastNameAndDateOfBirthCommand command)
     {
         var matched = await crmQueryDispatcher.ExecuteQueryAsync(
             new GetActiveContactsByLastNameAndDateOfBirthQuery(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
@@ -33,7 +33,7 @@ public class FindPersonsByTrnAndDateOfBirthHandler(
     PreviousNameHelper previousNameHelper,
     ReferenceDataCache referenceDataCache)
 {
-    public async Task<FindPersonsByTrnAndDateOfBirthResult> HandleAsync(FindPersonsByTrnAndDateOfBirthCommand command)
+    public async Task<ApiResult<FindPersonsByTrnAndDateOfBirthResult>> HandleAsync(FindPersonsByTrnAndDateOfBirthCommand command)
     {
         var contacts = await crmQueryDispatcher.ExecuteQueryAsync(
             new GetActiveContactsByTrnsQuery(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetQtls.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetQtls.cs
@@ -10,19 +10,18 @@ public record GetQtlsCommand(string Trn);
 
 public class GetQtlsHandler(ICrmQueryDispatcher crmQueryDispatcher)
 {
-    public async Task<QtlsResult?> HandleAsync(GetQtlsCommand command)
+    public async Task<ApiResult<QtlsResult>> HandleAsync(GetQtlsCommand command)
     {
-        var contact = (await crmQueryDispatcher.ExecuteQueryAsync(
+        var contact = await crmQueryDispatcher.ExecuteQueryAsync(
             new GetActiveContactByTrnQuery(
                 command.Trn,
                 new ColumnSet(
                     Contact.Fields.dfeta_TRN,
-                    Contact.Fields.dfeta_qtlsdate))
-            ))!;
+                    Contact.Fields.dfeta_qtlsdate)));
 
         if (contact is null)
         {
-            return null;
+            return ApiError.PersonNotFound(command.Trn);
         }
 
         return new QtlsResult()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
@@ -8,14 +8,14 @@ public record GetTrnRequestCommand(string RequestId);
 
 public class GetTrnRequestHandler(TrnRequestHelper trnRequestHelper, ICurrentUserProvider currentUserProvider)
 {
-    public async Task<TrnRequestInfo?> HandleAsync(GetTrnRequestCommand command)
+    public async Task<ApiResult<TrnRequestInfo>> HandleAsync(GetTrnRequestCommand command)
     {
         var (currentApplicationUserId, _) = currentUserProvider.GetCurrentApplicationUser();
 
         var trnRequest = await trnRequestHelper.GetTrnRequestInfoAsync(currentApplicationUserId, command.RequestId);
         if (trnRequest is null)
         {
-            return null;
+            return ApiError.TrnRequestDoesNotExist(command.RequestId);
         }
 
         var contact = trnRequest.Contact;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetDeceasedRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetDeceasedRequest.cs
@@ -1,5 +1,4 @@
 using Microsoft.Xrm.Sdk.Query;
-using TeachingRecordSystem.Api.Validation;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Queries;
 
@@ -9,18 +8,20 @@ public record SetDeceasedCommand(string Trn, DateOnly DateOfDeath);
 
 public class SetDeceasedHandler(ICrmQueryDispatcher crmQueryDispatcher)
 {
-    public async Task HandleAsync(SetDeceasedCommand command)
+    public async Task<ApiResult<Unit>> HandleAsync(SetDeceasedCommand command)
     {
         var contact = await crmQueryDispatcher.ExecuteQueryAsync(
             new GetActiveContactByTrnQuery(
                 command.Trn,
                 new ColumnSet()));
 
-        if (contact == null)
+        if (contact is null)
         {
-            throw new ErrorException(ErrorRegistry.TeacherWithSpecifiedTrnNotFound());
+            return ApiError.PersonNotFound(command.Trn);
         }
 
         await crmQueryDispatcher.ExecuteQueryAsync(new SetDeceasedQuery(contact.Id, command.DateOfDeath))!;
+
+        return Unit.Instance;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Controllers/TeacherController.cs
@@ -10,7 +10,7 @@ using TeachingRecordSystem.Api.V3.V20240412.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240412.Controllers;
 
 [Route("teacher")]
-public class TeacherController : ControllerBase
+public class TeacherController(IMapper mapper) : ControllerBase
 {
     [HttpPost("name-changes")]
     [SwaggerOperation(
@@ -35,9 +35,9 @@ public class TeacherController : ControllerBase
             EmailAddress = request.Email
         };
 
-        var caseNumber = await handler.HandleAsync(command);
-        var response = new CreateNameChangeResponse() { CaseNumber = caseNumber };
-        return Ok(response);
+        var result = await handler.HandleAsync(command);
+
+        return result.ToActionResult(r => Ok(mapper.Map<CreateNameChangeResponse>(r)));
     }
 
     [HttpPost("date-of-birth-changes")]
@@ -61,8 +61,8 @@ public class TeacherController : ControllerBase
             EmailAddress = request.Email
         };
 
-        var caseNumber = await handler.HandleAsync(command);
-        var response = new CreateNameChangeResponse() { CaseNumber = caseNumber };
-        return Ok(response);
+        var result = await handler.HandleAsync(command);
+
+        return result.ToActionResult(r => Ok(mapper.Map<CreateDateOfBirthChangeResponse>(r)));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Responses/CreateDateOfBirthChangeResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Responses/CreateDateOfBirthChangeResponse.cs
@@ -1,5 +1,8 @@
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+
 namespace TeachingRecordSystem.Api.V3.V20240412.Responses;
 
+[AutoMap(typeof(CreateDateOfBirthChangeRequestResult))]
 public record CreateDateOfBirthChangeResponse
 {
     public required string CaseNumber { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Responses/CreateNameChangeResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Responses/CreateNameChangeResponse.cs
@@ -1,5 +1,8 @@
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+
 namespace TeachingRecordSystem.Api.V3.V20240412.Responses;
 
+[AutoMap(typeof(CreateNameChangeRequestResult))]
 public record CreateNameChangeResponse
 {
     public required string CaseNumber { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
@@ -19,7 +19,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
         Description = "Gets the details of the teacher corresponding to the given TRN.")]
     [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> GetAsync(
         [FromRoute] string trn,
@@ -35,12 +35,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
 
         var result = await handler.HandleAsync(command);
 
-        if (result is null)
-        {
-            return NotFound();
-        }
-
-        var response = mapper.Map<GetTeacherResponse>(result);
-        return Ok(response);
+        return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
@@ -32,8 +32,9 @@ public class PersonController(IMapper mapper) : ControllerBase
             ApplyLegacyAlertsBehavior: true);
 
         var result = await handler.HandleAsync(command);
-        var response = mapper.Map<GetPersonResponse?>(result);
-        return response is null ? Forbid() : Ok(response);
+
+        return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
     }
 
     [HttpPost("name-changes")]
@@ -59,9 +60,9 @@ public class PersonController(IMapper mapper) : ControllerBase
             EmailAddress = request.EmailAddress
         };
 
-        var caseNumber = await handler.HandleAsync(command);
-        var response = new CreateNameChangeResponse() { CaseNumber = caseNumber };
-        return Ok(response);
+        var result = await handler.HandleAsync(command);
+
+        return result.ToActionResult(r => Ok(mapper.Map<CreateNameChangeResponse>(r)));
     }
 
     [HttpPost("date-of-birth-changes")]
@@ -85,8 +86,8 @@ public class PersonController(IMapper mapper) : ControllerBase
             EmailAddress = request.EmailAddress
         };
 
-        var caseNumber = await handler.HandleAsync(command);
-        var response = new CreateNameChangeResponse() { CaseNumber = caseNumber };
-        return Ok(response);
+        var result = await handler.HandleAsync(command);
+
+        return result.ToActionResult(r => Ok(mapper.Map<CreateDateOfBirthChangeResponse>(r)));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TrnRequestsController.cs
@@ -24,7 +24,6 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(TrnRequestInfo), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
-    [MapError(10029, statusCode: StatusCodes.Status409Conflict)]
     public async Task<IActionResult> CreateTrnRequestAsync(
         [FromBody] CreateTrnRequestRequest request,
         [FromServices] CreateTrnRequestHandler handler)
@@ -50,8 +49,8 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
         };
         var result = await handler.HandleAsync(command);
 
-        var response = mapper.Map<TrnRequestInfo>(result);
-        return Ok(response);
+        return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.TrnRequestAlreadyCreated, StatusCodes.Status409Conflict);
     }
 
     [HttpGet("")]
@@ -71,12 +70,7 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
         var command = new GetTrnRequestCommand(requestId);
         var result = await handler.HandleAsync(command);
 
-        if (result is null)
-        {
-            return NotFound();
-        }
-
-        var response = mapper.Map<TrnRequestInfo>(result);
-        return Ok(response);
+        return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.TrnRequestDoesNotExist, StatusCodes.Status404NotFound);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateDateOfBirthChangeResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateDateOfBirthChangeResponse.cs
@@ -1,4 +1,7 @@
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+
 namespace TeachingRecordSystem.Api.V3.V20240606.Responses;
 
+[AutoMap(typeof(CreateDateOfBirthChangeRequestResult))]
 [GenerateVersionedDto(typeof(V20240412.Responses.CreateDateOfBirthChangeResponse))]
 public partial record CreateDateOfBirthChangeResponse;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateNameChangeResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/CreateNameChangeResponse.cs
@@ -1,4 +1,7 @@
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+
 namespace TeachingRecordSystem.Api.V3.V20240606.Responses;
 
+[AutoMap(typeof(CreateNameChangeRequestResult))]
 [GenerateVersionedDto(typeof(V20240412.Responses.CreateNameChangeResponse))]
 public partial record CreateNameChangeResponse;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Controllers/PersonsController.cs
@@ -25,8 +25,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     {
         var command = new FindPersonsByTrnAndDateOfBirthCommand(request.Persons.Select(p => (p.Trn, p.DateOfBirth)));
         var result = await handler.HandleAsync(command);
-        var response = mapper.Map<FindPersonsResponse>(result);
-        return Ok(response);
+        return result.ToActionResult(r => Ok(mapper.Map<FindPersonsResponse>(r)));
     }
 
     [HttpGet("")]
@@ -44,13 +43,12 @@ public class PersonsController(IMapper mapper) : ControllerBase
         var command = new FindPersonByLastNameAndDateOfBirthCommand(request.LastName!, request.DateOfBirth!.Value);
         var result = await handler.HandleAsync(command);
 
-        var response = new FindPersonResponse()
-        {
-            Total = result.Total,
-            Query = request,
-            Results = result.Items.Select(mapper.Map<FindPersonResponseResult>).AsReadOnly()
-        };
-
-        return Ok(response);
+        return result.ToActionResult(r =>
+            Ok(new FindPersonResponse()
+            {
+                Total = r.Total,
+                Query = request,
+                Results = r.Items.Select(mapper.Map<FindPersonResponseResult>).AsReadOnly()
+            }));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
@@ -32,7 +32,8 @@ public class PersonController(IMapper mapper) : ControllerBase
             ApplyLegacyAlertsBehavior: false);
 
         var result = await handler.HandleAsync(command);
-        var response = mapper.Map<GetPersonResponse?>(result);
-        return response is null ? Forbid() : Ok(response);
+
+        return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
@@ -71,12 +71,8 @@ public class PersonsController(IMapper mapper) : ControllerBase
 
         var result = await handler.HandleAsync(command);
 
-        if (result is null)
-        {
-            return NotFound();
-        }
-
-        var response = GetPersonResponse.Map(result, mapper, User.IsInRole(ApiRoles.AppropriateBody));
-        return Ok(response);
+        return result
+            .ToActionResult(r => Ok(GetPersonResponse.Map(r, mapper, User.IsInRole(ApiRoles.AppropriateBody))))
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/TrnRequestsController.cs
@@ -48,9 +48,10 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
             Postcode = request.Person.Address?.Postcode,
             Country = request.Person.Address?.Country,
         };
+
         var result = await handler.HandleAsync(command);
 
-        var response = mapper.Map<TrnRequestInfo>(result);
-        return Ok(response);
+        return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.TrnRequestAlreadyCreated, StatusCodes.Status409Conflict);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -27,20 +27,9 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
 
         var alert = person.Alerts.Single();
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
-        {
-            Content = JsonContent.Create(new
-            {
-                persons = new[]
-                {
-                    new
-                    {
-                        trn = person.Trn,
-                        dateOfBirth = person.DateOfBirth
-                    }
-                }
-            })
-        };
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/v3/persons?findBy=LastNameAndDateOfBirth&lastName={lastName}&dateOfBirth={dateOfBirth:yyyy-MM-dd}");
 
         // Act
         var response = await GetHttpClientWithApiKey().SendAsync(request);


### PR DESCRIPTION
This begins to move away from exceptions and the old `ErrorRegistry` towards an `ApiResult<T>` result type and a new `ApiError` class. I've moved most of the V3 operations to use this; the remaining operations will follow separately.