### PR TITLE
Add methods to Person for changing induction

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241129152408_CpdInduction.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241129152408_CpdInduction.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241129152408_CpdInduction")]
+    partial class CpdInduction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241129152408_CpdInduction.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241129152408_CpdInduction.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class CpdInduction : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "induction_exemption_reason",
+                table: "persons",
+                newName: "cpd_induction_status");
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "cpd_induction_completed_date",
+                table: "persons",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "cpd_induction_cpd_modified_on",
+                table: "persons",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "cpd_induction_first_modified_on",
+                table: "persons",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "cpd_induction_modified_on",
+                table: "persons",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "cpd_induction_start_date",
+                table: "persons",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "induction_exemption_reasons",
+                table: "persons",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "induction_modified_on",
+                table: "persons",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_completed_date",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_cpd_modified_on",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_first_modified_on",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_modified_on",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_start_date",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "induction_exemption_reasons",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "induction_modified_on",
+                table: "persons");
+
+            migrationBuilder.RenameColumn(
+                name: "cpd_induction_status",
+                table: "persons",
+                newName: "induction_exemption_reason");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Optional;
 
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
@@ -16,9 +18,16 @@ public class Person
     public string? EmailAddress { get; set; }
     public string? NationalInsuranceNumber { get; set; }
     public InductionStatus InductionStatus { get; private set; }
-    public InductionExemptionReason? InductionExemptionReason { get; private set; }
+    public InductionExemptionReasons InductionExemptionReasons { get; private set; }
     public DateOnly? InductionStartDate { get; private set; }
     public DateOnly? InductionCompletedDate { get; private set; }
+    public DateTime? InductionModifiedOn { get; private set; }
+    public InductionStatus? CpdInductionStatus { get; private set; }
+    public DateOnly? CpdInductionStartDate { get; private set; }
+    public DateOnly? CpdInductionCompletedDate { get; private set; }
+    public DateTime? CpdInductionModifiedOn { get; private set; }
+    public DateTime? CpdInductionFirstModifiedOn { get; private set; }
+    public DateTime? CpdInductionCpdModifiedOn { get; private set; }
     public ICollection<Qualification> Qualifications { get; } = new List<Qualification>();
     public ICollection<Alert> Alerts { get; } = new List<Alert>();
 
@@ -34,55 +43,186 @@ public class Person
     public DateTime? DqtInductionLastSync { get; set; }
     public DateTime? DqtInductionModifiedOn { get; set; }
 
-
-    public void SetInductionStatus(InductionStatus status, DateOnly? startDate, DateOnly? completedDate, InductionExemptionReason? exemptionReason)
+    public void SetCpdInductionStatus(
+        InductionStatus status,
+        DateOnly? startDate,
+        DateOnly? completedDate,
+        DateTime cpdModifiedOn,
+        EventModels.RaisedByUserInfo updatedBy,
+        DateTime now,
+        out PersonInductionUpdatedEvent? @event)
     {
-        if (status is Core.Models.InductionStatus.None or Core.Models.InductionStatus.RequiredToComplete)
+        if (status == CpdInductionStatus &&
+            startDate == CpdInductionStartDate &&
+            completedDate == CpdInductionCompletedDate)
         {
-            EnsureArgumentIsNull(startDate);
-            EnsureArgumentIsNull(completedDate);
-            EnsureArgumentIsNull(exemptionReason);
+            @event = null;
+            return;
         }
-        else if (status is Core.Models.InductionStatus.Exempt)
+
+        // FUTURE When we have QTS in TRS - assert person has QTS
+        AssertInductionChangeIsValid(status, startDate, completedDate, exemptionReason: null);
+
+        // If the CPD status is not Passed and we know the person is Exempt then the overall status is Exempt.
+        // Otherwise, the overall status is set to match the CPD status.
+        // It's important we never overwrite InductionExemptionReasons here since we're using it to remember
+        // if somebody is exempt. In future we may be able to get this from the {route to} professional status instead.
+
+        var isExempt = InductionExemptionReasons != InductionExemptionReasons.None;
+        var (newOverallStatus, newOverallStartDate, newOverallCompletedDate) = isExempt && status != InductionStatus.Passed
+            ? (InductionStatus.Exempt, null, null)
+            : (status, startDate, completedDate);
+
+        var changes = PersonInductionUpdatedEventChanges.None |
+            (InductionStatus != newOverallStatus ? PersonInductionUpdatedEventChanges.InductionStatus : 0) |
+            (InductionStartDate != newOverallStartDate ? PersonInductionUpdatedEventChanges.InductionStartDate : 0) |
+            (InductionCompletedDate != newOverallCompletedDate ? PersonInductionUpdatedEventChanges.InductionCompletedDate : 0) |
+            (CpdInductionStatus != status ? PersonInductionUpdatedEventChanges.CpdInductionStatus : 0) |
+            (CpdInductionStartDate != startDate ? PersonInductionUpdatedEventChanges.CpdInductionStartDate : 0) |
+            (CpdInductionCompletedDate != completedDate ? PersonInductionUpdatedEventChanges.CpdInductionCompletedDate : 0);
+
+        if (changes == PersonInductionUpdatedEventChanges.None)
         {
-            EnsureArgumentIsNull(startDate);
-            EnsureArgumentIsNull(completedDate);
-            EnsureArgumentIsNotNull(exemptionReason);
+            @event = null;
+            return;
         }
-        else if (status is Core.Models.InductionStatus.InProgress)
+
+        InductionStatus = newOverallStatus;
+        InductionStartDate = newOverallStartDate;
+        InductionCompletedDate = newOverallCompletedDate;
+        CpdInductionStatus = status;
+        CpdInductionStartDate = startDate;
+        CpdInductionCompletedDate = completedDate;
+        CpdInductionCpdModifiedOn = cpdModifiedOn;
+        CpdInductionModifiedOn = now;
+        CpdInductionFirstModifiedOn ??= now;
+
+        if ((changes & (
+             PersonInductionUpdatedEventChanges.InductionStatus |
+             PersonInductionUpdatedEventChanges.InductionStartDate |
+             PersonInductionUpdatedEventChanges.InductionCompletedDate))
+            != 0)
         {
-            EnsureArgumentIsNotNull(startDate);
-            EnsureArgumentIsNull(completedDate);
+            InductionModifiedOn = now;
         }
-        else if (status is Core.Models.InductionStatus.Passed)
+
+        @event = new PersonInductionUpdatedEvent()
         {
-            EnsureArgumentIsNotNull(startDate);
-            EnsureArgumentIsNotNull(completedDate);
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = updatedBy,
+            PersonId = PersonId,
+            InductionStatus = newOverallStatus,
+            InductionStartDate = newOverallStartDate,
+            InductionCompletedDate = newOverallCompletedDate,
+            InductionExemptionReasons = InductionExemptionReasons,
+            CpdInductionStatus = Option.Some(status),
+            CpdInductionStartDate = Option.Some(startDate),
+            CpdInductionCompletedDate = Option.Some(completedDate),
+            CpdInductionCpdModifiedOn = Option.Some(cpdModifiedOn),
+            ChangeReason = null,
+            ChangeReasonDetail = null,
+            EvidenceFile = null,
+            Changes = changes
+        };
+    }
+
+    public void SetInductionStatus(
+        InductionStatus status,
+        DateOnly? startDate,
+        DateOnly? completedDate,
+        InductionExemptionReasons exemptionReasons,
+        EventModels.RaisedByUserInfo updatedBy,
+        DateTime now,
+        out PersonInductionUpdatedEvent? @event)
+    {
+        // FUTURE When we have QTS in TRS - assert person has QTS
+        AssertInductionChangeIsValid(status, startDate, completedDate, exemptionReasons);
+
+        var changes = PersonInductionUpdatedEventChanges.None |
+            (InductionStatus != status ? PersonInductionUpdatedEventChanges.InductionStatus : 0) |
+            (InductionStartDate != startDate ? PersonInductionUpdatedEventChanges.InductionStartDate : 0) |
+            (InductionCompletedDate != completedDate ? PersonInductionUpdatedEventChanges.InductionCompletedDate : 0) |
+            (InductionExemptionReasons != exemptionReasons ? PersonInductionUpdatedEventChanges.InductionExemptionReasons : 0);
+
+        if (changes == PersonInductionUpdatedEventChanges.None)
+        {
+            @event = null;
+            return;
+        }
+
+        InductionStatus = status;
+        InductionStartDate = startDate;
+        InductionCompletedDate = completedDate;
+        InductionExemptionReasons = exemptionReasons;
+        InductionModifiedOn = now;
+
+        @event = new PersonInductionUpdatedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = updatedBy,
+            PersonId = PersonId,
+            InductionStatus = status,
+            InductionStartDate = startDate,
+            InductionCompletedDate = completedDate,
+            InductionExemptionReasons = InductionExemptionReasons,
+            CpdInductionStatus = default,
+            CpdInductionStartDate = default,
+            CpdInductionCompletedDate = default,
+            CpdInductionCpdModifiedOn = default,
+            ChangeReason = null,
+            ChangeReasonDetail = null,
+            EvidenceFile = null,
+            Changes = changes
+        };
+    }
+
+    private static void AssertInductionChangeIsValid(
+        InductionStatus status,
+        DateOnly? startDate,
+        DateOnly? completedDate,
+        InductionExemptionReasons? exemptionReason)
+    {
+        if (status is InductionStatus.None or InductionStatus.RequiredToComplete)
+        {
+            EnsureArgumentIsNullForInduction(startDate);
+            EnsureArgumentIsNullForInduction(completedDate);
+            EnsureArgumentIsNullForInduction(exemptionReason);
+        }
+        else if (status is InductionStatus.Exempt)
+        {
+            EnsureArgumentIsNullForInduction(startDate);
+            EnsureArgumentIsNullForInduction(completedDate);
+            EnsureArgumentIsNotNullForInduction(exemptionReason);
+        }
+        else if (status is InductionStatus.InProgress)
+        {
+            EnsureArgumentIsNotNullForInduction(startDate);
+            EnsureArgumentIsNullForInduction(completedDate);
+            EnsureArgumentIsNullForInduction(exemptionReason);
+        }
+        else if (status is InductionStatus.Passed)
+        {
+            EnsureArgumentIsNotNullForInduction(startDate);
+            EnsureArgumentIsNotNullForInduction(completedDate);
+            EnsureArgumentIsNullForInduction(exemptionReason);
+        }
+        else if (status is InductionStatus.FailedInWales)
+        {
+            EnsureArgumentIsNullForInduction(startDate);
+            EnsureArgumentIsNullForInduction(completedDate);
+            EnsureArgumentIsNullForInduction(exemptionReason);
         }
         else
         {
             throw new ArgumentException($"Unknown status: '{status}'.", nameof(status));
         }
 
-        InductionStatus = status;
-        InductionStartDate = startDate;
-        InductionCompletedDate = completedDate;
-        InductionExemptionReason = exemptionReason;
+        void EnsureArgumentIsNullForInduction(object? arg, [CallerArgumentExpression(nameof(arg))] string? paramName = "") =>
+            Debug.Assert(arg is null, $"{paramName} must be null when the status is '{status}'.");
 
-        void EnsureArgumentIsNull(object? arg, [CallerArgumentExpression(nameof(arg))] string? paramName = "")
-        {
-            if (arg is not null)
-            {
-                throw new ArgumentException($"{paramName} must be null when the status is '{status}'.", paramName);
-            }
-        }
-
-        void EnsureArgumentIsNotNull(object? arg, [CallerArgumentExpression(nameof(arg))] string? paramName = "")
-        {
-            if (arg is null)
-            {
-                throw new ArgumentException($"{paramName} cannot be null when the status is '{status}'.", paramName);
-            }
-        }
+        void EnsureArgumentIsNotNullForInduction(object? arg, [CallerArgumentExpression(nameof(arg))] string? paramName = "") =>
+            Debug.Assert(arg is not null, $"{paramName} cannot be null when the status is '{status}'.");
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonInductionUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonInductionUpdatedEvent.cs
@@ -1,0 +1,33 @@
+using Optional;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record PersonInductionUpdatedEvent : EventBase, IEventWithPersonId
+{
+    public required Guid PersonId { get; init; }
+    public required InductionStatus InductionStatus { get; init; }
+    public required DateOnly? InductionStartDate { get; init; }
+    public required DateOnly? InductionCompletedDate { get; init; }
+    public required InductionExemptionReasons InductionExemptionReasons { get; init; }
+    public required Option<InductionStatus> CpdInductionStatus { get; init; }
+    public required Option<DateOnly?> CpdInductionStartDate { get; init; }
+    public required Option<DateOnly?> CpdInductionCompletedDate { get; init; }
+    public required Option<DateTime> CpdInductionCpdModifiedOn { get; init; }
+    public required string? ChangeReason { get; init; }
+    public required string? ChangeReasonDetail { get; init; }
+    public required EventModels.File? EvidenceFile { get; init; }
+    public required PersonInductionUpdatedEventChanges Changes { get; init; }
+}
+
+[Flags]
+public enum PersonInductionUpdatedEventChanges
+{
+    None = 0,
+    InductionStatus = 1 << 0,
+    InductionStartDate = 1 << 1,
+    InductionCompletedDate = 1 << 2,
+    InductionExemptionReasons = 1 << 3,
+    CpdInductionStatus = 1 << 4,
+    CpdInductionStartDate = 1 << 5,
+    CpdInductionCompletedDate = 1 << 6
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionExemptionReason.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionExemptionReason.cs
@@ -1,5 +1,7 @@
 namespace TeachingRecordSystem.Core.Models;
 
-public enum InductionExemptionReason
+[Flags]
+public enum InductionExemptionReasons
 {
+    None = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -123,7 +123,7 @@ public class TrsDataSyncHelper(
             InductionStatus = MapInductionStatusFromDqtInductionStatus(contact.dfeta_InductionStatus),
             InductionStartDate = induction?.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             InductionCompletedDate = induction?.dfeta_CompletionDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
-            InductionExemptionReason = null, // this mapping will be done in a future PR
+            InductionExemptionReasons = InductionExemptionReasons.None, // this mapping will be done in a future PR
             DqtModifiedOn = induction?.ModifiedOn
         };
     }
@@ -971,9 +971,10 @@ public class TrsDataSyncHelper(
         {
             "person_id",
             "induction_completed_date",
-            "induction_exemption_reason",
+            "induction_exemption_reasons",
             "induction_start_date",
             "induction_status",
+            "induction_modified_on",
             "dqt_induction_modified_on"
         };
 
@@ -987,9 +988,10 @@ public class TrsDataSyncHelper(
             (
                 person_id uuid NOT NULL,
                 induction_completed_date date,
-                induction_exemption_reason integer,
+                induction_exemption_reasons integer,
                 induction_start_date date,
                 induction_status integer,
+                induction_modified_on timestamp with time zone,
                 dqt_induction_modified_on timestamp with time zone
             )
             """;
@@ -1018,9 +1020,10 @@ public class TrsDataSyncHelper(
         {
             writer.WriteValueOrNull(induction.PersonId, NpgsqlDbType.Uuid);
             writer.WriteValueOrNull(induction.InductionCompletedDate, NpgsqlDbType.Date);
-            writer.WriteValueOrNull((int?)induction.InductionExemptionReason, NpgsqlDbType.Integer);
+            writer.WriteValueOrNull((int?)induction.InductionExemptionReasons, NpgsqlDbType.Integer);
             writer.WriteValueOrNull(induction.InductionStartDate, NpgsqlDbType.Date);
             writer.WriteValueOrNull((int?)induction.InductionStatus, NpgsqlDbType.Integer);
+            writer.WriteValueOrNull(induction.DqtModifiedOn, NpgsqlDbType.TimestampTz);
             writer.WriteValueOrNull(induction.DqtModifiedOn, NpgsqlDbType.TimestampTz);
         };
 
@@ -1435,7 +1438,7 @@ public class TrsDataSyncHelper(
     {
         public required Guid PersonId { get; init; }
         public required DateOnly? InductionCompletedDate { get; init; }
-        public required InductionExemptionReason? InductionExemptionReason { get; init; }
+        public required InductionExemptionReasons InductionExemptionReasons { get; init; }
         public required DateOnly? InductionStartDate { get; init; }
         public required InductionStatus? InductionStatus { get; init; }
         public required DateTime? DqtModifiedOn { get; init; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Tests.DataStore.Postgres.Models;
+
+public class PersonTests
+{
+    public TestableClock Clock { get; } = new();
+
+    [Theory]
+    [InlineData(InductionStatus.Passed)]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.RequiredToComplete)]
+    public void SetCpdInductionStatus_SetsOverallStatusAndOutsEvent(InductionStatus status)
+    {
+        // Arrange
+        var person = new Person
+        {
+            PersonId = Guid.NewGuid(),
+            CreatedOn = Clock.UtcNow,
+            UpdatedOn = Clock.UtcNow,
+            Trn = "1234567",
+            FirstName = "Joe",
+            MiddleName = "",
+            LastName = "Bloggs",
+            DateOfBirth = new(1990, 1, 1),
+        };
+
+        // Act
+        person.SetCpdInductionStatus(
+            status,
+            startDate: status != InductionStatus.RequiredToComplete ? new(2024, 1, 1) : null,
+            completedDate: status == InductionStatus.Passed ? new(2024, 10, 1) : null,
+            cpdModifiedOn: Clock.UtcNow,
+            updatedBy: SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(status, person.InductionStatus);
+        Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
+        Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
+    }
+
+    [Fact]
+    public void SetCpdInductionStatus_PersonIsExemptAndNewStatusIsPassed_SetsOverallStatusToPassed()
+    {
+        // Arrange
+        var person = new Person
+        {
+            PersonId = Guid.NewGuid(),
+            CreatedOn = Clock.UtcNow,
+            UpdatedOn = Clock.UtcNow,
+            Trn = "1234567",
+            FirstName = "Joe",
+            MiddleName = "",
+            LastName = "Bloggs",
+            DateOfBirth = new(1990, 1, 1),
+        };
+
+        person.SetInductionStatus(
+            InductionStatus.Exempt,
+            startDate: null,
+            completedDate: null,
+            (InductionExemptionReasons)1,
+            updatedBy: SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+        Debug.Assert(person.InductionStatus == InductionStatus.Exempt);
+
+        Clock.Advance();
+
+        // Act
+        person.SetCpdInductionStatus(
+            InductionStatus.Passed,
+            startDate: new(2024, 1, 1),
+            completedDate: new(2024, 10, 1),
+            cpdModifiedOn: Clock.UtcNow,
+            updatedBy: SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.Passed, person.InductionStatus);
+        Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
+        Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.RequiredToComplete)]
+    public void SetCpdInductionStatus_PersonIsExemptAndNewStatusIsNotPassed_KeepsOverallStatusAsExempt(InductionStatus status)
+    {
+        // Arrange
+        var person = new Person
+        {
+            PersonId = Guid.NewGuid(),
+            CreatedOn = Clock.UtcNow,
+            UpdatedOn = Clock.UtcNow,
+            Trn = "1234567",
+            FirstName = "Joe",
+            MiddleName = "",
+            LastName = "Bloggs",
+            DateOfBirth = new(1990, 1, 1),
+        };
+
+        person.SetInductionStatus(
+            InductionStatus.Exempt,
+            startDate: null,
+            completedDate: null,
+            (InductionExemptionReasons)1,
+            updatedBy: SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+        Debug.Assert(person.InductionStatus == InductionStatus.Exempt);
+
+        Clock.Advance();
+
+        // Act
+        person.SetCpdInductionStatus(
+            status,
+            startDate: status == InductionStatus.InProgress ? new(2024, 1, 1) : null,
+            completedDate: null,
+            cpdModifiedOn: Clock.UtcNow,
+            updatedBy: SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.Exempt, person.InductionStatus);
+        Assert.NotEqual(Clock.UtcNow, person.InductionModifiedOn);
+        Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
+    }
+}


### PR DESCRIPTION
This updates the `Person` model to add `CpdInduction*` fields. We're tracking 'induction according to CPD' separately so that we can correctly infer the right status in all cases (since CPD doesn't know about all induction statuses).