### PR TITLE
Tidy induction field validation & centralise mapping from DQT statuses

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonByLastNameAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonByLastNameAndDateOfBirth.cs
@@ -5,6 +5,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using InductionStatusInfo = TeachingRecordSystem.Api.V3.Implementation.Dtos.InductionStatusInfo;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
@@ -5,6 +5,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using InductionStatusInfo = TeachingRecordSystem.Api.V3.Implementation.Dtos.InductionStatusInfo;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/MapperProfile.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/MapperProfile.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240814.Dtos;
+using InductionStatusInfo = TeachingRecordSystem.Core.ApiSchema.V3.V20240814.Dtos.InductionStatusInfo;
 
 namespace TeachingRecordSystem.Api.V3.V20240814;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonResponse.cs
@@ -1,6 +1,7 @@
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Api.V3.V20240814.Requests;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240814.Dtos;
+using InductionStatusInfo = TeachingRecordSystem.Core.ApiSchema.V3.V20240814.Dtos.InductionStatusInfo;
 
 namespace TeachingRecordSystem.Api.V3.V20240814.Responses;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonsResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Responses/FindPersonsResponse.cs
@@ -2,6 +2,7 @@ using AutoMapper.Configuration.Annotations;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240814.Dtos;
+using InductionStatusInfo = TeachingRecordSystem.Core.ApiSchema.V3.V20240814.Dtos.InductionStatusInfo;
 
 namespace TeachingRecordSystem.Api.V3.V20240814.Responses;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
@@ -1,12 +1,76 @@
+using System.Reflection;
+
 namespace TeachingRecordSystem.Core.Models;
 
 public enum InductionStatus
 {
+    [InductionStatusInfo("none", requiresStartDate: false, requiresCompletedDate: false)]
     None = 0,
+    [InductionStatusInfo("required to complete", requiresStartDate: false, requiresCompletedDate: false)]
     RequiredToComplete = 1,
+    [InductionStatusInfo("exempt", requiresStartDate: false, requiresCompletedDate: false)]
     Exempt = 2,
+    [InductionStatusInfo("in progress", requiresStartDate: true, requiresCompletedDate: false)]
     InProgress = 3,
+    [InductionStatusInfo("passed", requiresStartDate: true, requiresCompletedDate: true)]
     Passed = 4,
+    [InductionStatusInfo("failed", requiresStartDate: true, requiresCompletedDate: true)]
     Failed = 5,
+    [InductionStatusInfo("failed in Wales", requiresStartDate: true, requiresCompletedDate: true)]
     FailedInWales = 6,
+}
+
+public static class InductionStatusRegistry
+{
+    private static readonly IReadOnlyDictionary<InductionStatus, InductionStatusInfo> _info =
+        Enum.GetValues<InductionStatus>().ToDictionary(s => s, s => GetInfo(s));
+
+    public static IReadOnlyCollection<InductionStatusInfo> All => _info.Values.ToArray();
+
+    public static string GetName(this InductionStatus status) => _info[status].Name;
+
+    public static string GetTitle(this InductionStatus status) => _info[status].Title;
+
+    public static bool RequiresStartDate(this InductionStatus status) => _info[status].RequiresStartDate;
+
+    public static bool RequiresCompletedDate(this InductionStatus status) => _info[status].RequiresCompletedDate;
+
+    public static InductionStatus ToInductionStatus(this dfeta_InductionStatus? status) => status switch
+    {
+        null => InductionStatus.None,
+        dfeta_InductionStatus.RequiredtoComplete => InductionStatus.RequiredToComplete,
+        dfeta_InductionStatus.NotYetCompleted => InductionStatus.InProgress,
+        dfeta_InductionStatus.InProgress => InductionStatus.InProgress,
+        dfeta_InductionStatus.InductionExtended => InductionStatus.InProgress,
+        dfeta_InductionStatus.Pass => InductionStatus.Passed,
+        dfeta_InductionStatus.Fail => InductionStatus.Failed,
+        dfeta_InductionStatus.Exempt => InductionStatus.Exempt,
+        dfeta_InductionStatus.PassedinWales => InductionStatus.Exempt,
+        dfeta_InductionStatus.FailedinWales => InductionStatus.FailedInWales,
+        _ => throw new ArgumentException($"Failed mapping '{status}' to {nameof(InductionStatus)}.", nameof(status))
+    };
+
+    private static InductionStatusInfo GetInfo(InductionStatus status)
+    {
+        var attr = status.GetType()
+               .GetMember(status.ToString())
+               .Single()
+               .GetCustomAttribute<InductionStatusInfoAttribute>() ??
+           throw new Exception($"{nameof(InductionStatus)}.{status} is missing the {nameof(InductionStatusInfoAttribute)} attribute.");
+
+        return new InductionStatusInfo(status, attr.Name, attr.RequiresStartDate, attr.RequiresCompletedDate);
+    }
+}
+
+public sealed record InductionStatusInfo(InductionStatus Value, string Name, bool RequiresStartDate, bool RequiresCompletedDate)
+{
+    public string Title => Name[0..1].ToUpper() + Name[1..];
+}
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+file sealed class InductionStatusInfoAttribute(string name, bool requiresStartDate, bool requiresCompletedDate) : Attribute
+{
+    public string Name => name;
+    public bool RequiresStartDate => requiresStartDate;
+    public bool RequiresCompletedDate => requiresCompletedDate;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -120,48 +120,12 @@ public class TrsDataSyncHelper(
         return new InductionInfo()
         {
             PersonId = contact.ContactId!.Value,
-            InductionStatus = MapInductionStatusFromDqtInductionStatus(contact.dfeta_InductionStatus),
+            InductionStatus = contact.dfeta_InductionStatus.ToInductionStatus(),
             InductionStartDate = induction?.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             InductionCompletedDate = induction?.dfeta_CompletionDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             InductionExemptionReasons = InductionExemptionReasons.None, // this mapping will be done in a future PR
             DqtModifiedOn = induction?.ModifiedOn
         };
-    }
-
-    public static InductionStatus MapInductionStatusFromDqtInductionStatus(dfeta_InductionStatus? dqtInductionStatus)
-    {
-        var inductionStatus = InductionStatus.None;
-
-        switch (dqtInductionStatus)
-        {
-            case dfeta_InductionStatus.Exempt:
-            case dfeta_InductionStatus.PassedinWales:
-                inductionStatus = InductionStatus.Exempt;
-                break;
-            case dfeta_InductionStatus.Fail:
-                inductionStatus = InductionStatus.Failed;
-                break;
-            case dfeta_InductionStatus.FailedinWales:
-                inductionStatus = InductionStatus.FailedInWales;
-                break;
-            case dfeta_InductionStatus.InductionExtended:
-            case dfeta_InductionStatus.InProgress:
-            case dfeta_InductionStatus.NotYetCompleted:
-                inductionStatus = InductionStatus.InProgress;
-                break;
-            case dfeta_InductionStatus.Pass:
-                inductionStatus = InductionStatus.Passed;
-                break;
-            case dfeta_InductionStatus.RequiredtoComplete:
-                inductionStatus = InductionStatus.RequiredToComplete;
-                break;
-            case null:
-                break;
-            default:
-                throw new ArgumentException($"Unrecognized {nameof(dfeta_InductionStatus)}: '{dqtInductionStatus}'.", nameof(dqtInductionStatus));
-        }
-
-        return inductionStatus;
     }
 
     public async Task DeleteRecordsAsync(string modelType, IReadOnlyCollection<Guid> ids, CancellationToken cancellationToken = default)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Induction.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Induction.cs
@@ -4,7 +4,6 @@ using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Xrm.Sdk;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.Core.Tests.Services.TrsDataSync;
 
@@ -197,7 +196,7 @@ public partial class TrsDataSyncHelperTests
                 AssertInductionEventMatchesEntity(initialVersion, migratedEvent.DqtInduction);
                 Assert.Equal(initialVersion.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), migratedEvent.InductionStartDate);
                 Assert.Equal(initialVersion.dfeta_CompletionDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), migratedEvent.InductionCompletedDate);
-                Assert.Equal(TrsDataSyncHelper.MapInductionStatusFromDqtInductionStatus(initialVersion.dfeta_InductionStatus).ToString(), migratedEvent.InductionStatus);
+                Assert.Equal(initialVersion.dfeta_InductionStatus.ToInductionStatus().ToString(), migratedEvent.InductionStatus);
                 Assert.Equal(InductionExemptionReasons.None.ToString(), migratedEvent.InductionExemptionReason);
                 return Task.CompletedTask;
             });
@@ -245,7 +244,7 @@ public partial class TrsDataSyncHelperTests
                 AssertInductionEventMatchesEntity(initialVersion, migratedEvent.DqtInduction);
                 Assert.Equal(initialVersion.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), migratedEvent.InductionStartDate);
                 Assert.Equal(initialVersion.dfeta_CompletionDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), migratedEvent.InductionCompletedDate);
-                Assert.Equal(TrsDataSyncHelper.MapInductionStatusFromDqtInductionStatus(initialVersion.dfeta_InductionStatus).ToString(), migratedEvent.InductionStatus);
+                Assert.Equal(initialVersion.dfeta_InductionStatus.ToInductionStatus().ToString(), migratedEvent.InductionStatus);
                 Assert.Equal(InductionExemptionReasons.None.ToString(), migratedEvent.InductionExemptionReason);
                 return Task.CompletedTask;
             });
@@ -319,7 +318,7 @@ public partial class TrsDataSyncHelperTests
                 AssertInductionEventMatchesEntity(updatedVersion, migratedEvent.DqtInduction);
                 Assert.Equal(updatedVersion.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), migratedEvent.InductionStartDate);
                 Assert.Equal(updatedVersion.dfeta_CompletionDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true), migratedEvent.InductionCompletedDate);
-                Assert.Equal(TrsDataSyncHelper.MapInductionStatusFromDqtInductionStatus(updatedVersion.dfeta_InductionStatus).ToString(), migratedEvent.InductionStatus);
+                Assert.Equal(updatedVersion.dfeta_InductionStatus.ToInductionStatus().ToString(), migratedEvent.InductionStatus);
                 Assert.Equal(InductionExemptionReasons.None.ToString(), migratedEvent.InductionExemptionReason);
                 return Task.CompletedTask;
             });


### PR DESCRIPTION
This adds a `ValidateInductionData` method onto `Person` and uses that everywhere for checking the right induction fields are provided for a particular status. It doesn't currently do the check for QTS (since we don't have that in TRS yet and it would complicate this method).

The status-specific rules are defined on attributes on the `InductionStatus` enum itself, in the same way we do for `MandatoryQualificationStatus`.

I've also moved the mapping from DQT statuses to TRS statuses onto this class.