### PR TITLE
Remove unused basic auth package

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -35,7 +35,6 @@
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.10" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="IdentityModel" Version="6.2.0" />
-    <PackageVersion Include="idunno.Authentication.Basic" Version="2.3.1" />
     <PackageVersion Include="Joonasw.AspNetCore.SecurityHeaders" Version="5.0.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="LinqKit" Version="1.2.5" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -3,7 +3,6 @@ using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using FluentValidation;
 using FluentValidation.AspNetCore;
-using idunno.Authentication.Basic;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -71,41 +70,6 @@ public class Program
                 options.Authority = configuration.GetRequiredValue("AuthorizeAccessIssuer");
                 options.MapInboundClaims = false;
                 options.TokenValidationParameters.ValidateAudience = false;
-            })
-            .AddBasic(options =>
-            {
-                options.Realm = "TeachingRecordSystem.Api";
-                options.Events = new BasicAuthenticationEvents
-                {
-                    OnValidateCredentials = static context =>
-                    {
-                        var configuration = context.HttpContext.RequestServices.GetRequiredService<IConfiguration>();
-                        var username = configuration.GetRequiredValue("AdminCredentials:Username");
-                        var password = configuration.GetRequiredValue("AdminCredentials:Password");
-
-                        if (context.Username == username && context.Password == password)
-                        {
-                            var claims = new[]
-                            {
-                                new Claim(
-                                    ClaimTypes.NameIdentifier,
-                                    context.Username,
-                                    ClaimValueTypes.String,
-                                    context.Options.ClaimsIssuer),
-                                new Claim(
-                                    ClaimTypes.Name,
-                                    context.Username,
-                                    ClaimValueTypes.String,
-                                    context.Options.ClaimsIssuer)
-                            };
-
-                            context.Principal = new ClaimsPrincipal(new ClaimsIdentity(claims, context.Scheme.Name));
-                            context.Success();
-                        }
-
-                        return Task.CompletedTask;
-                    }
-                };
             });
 
         services.AddAuthorization(options =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/TeachingRecordSystem.Api.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/TeachingRecordSystem.Api.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.Redis" />
     <PackageReference Include="AutoMapper" />
     <PackageReference Include="FluentValidation.AspNetCore" />
-    <PackageReference Include="idunno.Authentication.Basic" />
     <PackageReference Include="MediatR" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
@@ -2,14 +2,5 @@
   "AllowVNextEndpoints": true,
   "AuthorizeAccessIssuer": "https://localhost:7236",
   "DetailedErrors": true,
-  "ApiClients": {
-    "developer": {
-      "ApiKey": [ "developer" ]
-    }
-  },
-  "AdminCredentials": {
-    "Username": "admin",
-    "Password": "test"
-  },
   "StorageConnectionString": "UseDevelopmentStorage=true"
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/packages.lock.json
@@ -31,12 +31,6 @@
           "FluentValidation.DependencyInjectionExtensions": "11.5.1"
         }
       },
-      "idunno.Authentication.Basic": {
-        "type": "Direct",
-        "requested": "[2.3.1, )",
-        "resolved": "2.3.1",
-        "contentHash": "99EoiqTy6hYDvHehG1JLlprkB08ioR/hsnCpPhvDJJeZ0JOKNpoL+7C2jLC1r5vo0G5kerOPqdhdSHF3Ss2blw=="
-      },
       "MediatR": {
         "type": "Direct",
         "requested": "[12.2.0, )",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/packages.lock.json
@@ -2429,8 +2429,7 @@
           "Swashbuckle.AspNetCore": "[6.6.2, )",
           "Swashbuckle.AspNetCore.Annotations": "[6.6.2, )",
           "TeachingRecordSystem.Core": "[1.0.0, )",
-          "TeachingRecordSystem.ServiceDefaults": "[1.0.0, )",
-          "idunno.Authentication.Basic": "[2.3.1, )"
+          "TeachingRecordSystem.ServiceDefaults": "[1.0.0, )"
         }
       },
       "teachingrecordsystem.core": {
@@ -2750,12 +2749,6 @@
         "requested": "[6.2.0, )",
         "resolved": "6.2.0",
         "contentHash": "4AXZ6Tp+DNwrSSeBziiX/231i8ZpD77A9nEMyc68gLSCWG0kgWsIBeFquYcBebiIPkfB7GEXzCYuuLeR1QZJIQ=="
-      },
-      "idunno.Authentication.Basic": {
-        "type": "CentralTransitive",
-        "requested": "[2.3.1, )",
-        "resolved": "2.3.1",
-        "contentHash": "99EoiqTy6hYDvHehG1JLlprkB08ioR/hsnCpPhvDJJeZ0JOKNpoL+7C2jLC1r5vo0G5kerOPqdhdSHF3Ss2blw=="
       },
       "MediatR": {
         "type": "CentralTransitive",


### PR DESCRIPTION
We've still got the basic auth configuration hanging around from when we used to host the Hangfire dashboard from the API. This removes it all.