### PR TITLE
Amend GetPerson operation to use query dispatcher for Induction

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherByTrnTests.cs
@@ -1,3 +1,4 @@
+using TeachingRecordSystem.Api.V3.Implementation.Dtos;
 using static TeachingRecordSystem.TestCommon.TestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3.V20240101;
@@ -77,10 +78,59 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
     [Fact]
     public async Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
     {
-        var contact = await CreateContact();
-        var baseUrl = $"/v3/teachers/{contact.dfeta_TRN}";
+        // Arrange
+        var dqtStatus = dfeta_InductionStatus.Pass;
+        var startDate = new DateOnly(1996, 2, 3);
+        var completedDate = new DateOnly(1996, 6, 7);
+        var abName = "Test AB";
+        var appropriateBody = await TestData.CreateAccountAsync(a => a.WithName(abName));
+        var numberOfTerms = 3;
 
-        await ValidRequestWithInduction_ReturnsExpectedInductionContent(GetHttpClientWithApiKey(), baseUrl, contact);
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithTrn()
+            .WithDqtInduction(
+                dqtStatus,
+                inductionExemptionReason: null,
+                startDate,
+                completedDate,
+                inductionPeriodStartDate: startDate,
+                inductionPeriodEndDate: completedDate,
+                appropriateBodyOrgId: appropriateBody.Id,
+                numberOfTerms: numberOfTerms));
+
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}?include=Induction");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponseAsync(response);
+        var responseInduction = jsonResponse.RootElement.GetProperty("induction");
+
+        AssertEx.JsonObjectEquals(
+            new
+            {
+                startDate = startDate.ToString("yyyy-MM-dd"),
+                endDate = completedDate.ToString("yyyy-MM-dd"),
+                status = dqtStatus.ToString(),
+                statusDescription = dqtStatus.GetDescription(),
+                certificateUrl = "/v3/certificates/induction",
+                periods = new[]
+                {
+                    new
+                    {
+                        startDate = startDate.ToString("yyyy-MM-dd"),
+                        endDate = completedDate.ToString("yyyy-MM-dd"),
+                        terms = numberOfTerms,
+                        appropriateBody = new
+                        {
+                            name = abName
+                        }
+                    }
+                }
+            },
+            responseInduction);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTestBase.cs
@@ -122,51 +122,6 @@ public abstract class GetTeacherTestBase(HostFixture hostFixture) : TestBase(hos
             StatusCodes.Status200OK);
     }
 
-    protected async Task ValidRequestWithInduction_ReturnsExpectedInductionContent(
-        HttpClient httpClient,
-        string baseUrl,
-        Contact contact)
-    {
-        // Arrange
-        var induction = CreateInduction();
-        var inductionPeriods = CreateInductionPeriods();
-
-        await ConfigureMocks(contact, induction: induction, inductionPeriods: inductionPeriods);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"{baseUrl}?include=Induction");
-
-        // Act
-        var response = await httpClient.SendAsync(request);
-
-        // Assert
-        var expectedJson = JsonSerializer.SerializeToNode(new
-        {
-            startDate = induction.dfeta_StartDate?.ToString("yyyy-MM-dd"),
-            endDate = induction.dfeta_CompletionDate?.ToString("yyyy-MM-dd"),
-            status = contact.dfeta_InductionStatus?.ToString(),
-            statusDescription = contact.dfeta_InductionStatus?.GetDescription(),
-            certificateUrl = "/v3/certificates/induction",
-            periods = new[]
-            {
-                new
-                {
-                    startDate = inductionPeriods[0].dfeta_StartDate?.ToString("yyyy-MM-dd"),
-                    endDate = inductionPeriods[0].dfeta_EndDate?.ToString("yyyy-MM-dd"),
-                    terms = inductionPeriods[0].dfeta_Numberofterms,
-                    appropriateBody = new
-                    {
-                        name = inductionPeriods[0].GetAttributeValue<AliasedValue>($"appropriatebody.{Account.Fields.Name}").Value
-                    }
-                }
-            }
-        })!;
-
-        var jsonResponse = await AssertEx.JsonResponseAsync(response);
-        var responseInduction = jsonResponse.RootElement.GetProperty("induction");
-
-        AssertEx.JsonObjectEquals(expectedJson, responseInduction);
-    }
-
     protected async Task ValidRequestWithInitialTeacherTraining_ReturnsExpectedInitialTeacherTrainingContent(
         HttpClient httpClient,
         string baseUrl,
@@ -617,43 +572,6 @@ public abstract class GetTeacherTestBase(HostFixture hostFixture) : TestBase(hos
         itt.Attributes.Add($"subject3.{dfeta_ittsubject.Fields.dfeta_name}", new AliasedValue(dfeta_ittsubject.EntityLogicalName, dfeta_ittsubject.Fields.dfeta_name, ittSubject3Name));
 
         return itt;
-    }
-
-    private static dfeta_induction CreateInduction()
-    {
-        var inductionStartDate = new DateOnly(1996, 2, 3);
-        var inductionEndDate = new DateOnly(1996, 6, 7);
-        var inductionStatus = dfeta_InductionStatus.Pass;
-
-        return new dfeta_induction()
-        {
-            dfeta_StartDate = inductionStartDate.ToDateTime(),
-            dfeta_CompletionDate = inductionEndDate.ToDateTime(),
-            dfeta_InductionStatus = inductionStatus
-        };
-    }
-
-    private static dfeta_inductionperiod[] CreateInductionPeriods()
-    {
-        var inductionPeriodStartDate = new DateOnly(1996, 2, 3);
-        var inductionPeriodEndDate = new DateOnly(1996, 6, 7);
-        var inductionPeriodTerms = 3;
-        var inductionPeriodAppropriateBodyName = "My appropriate body";
-
-        var inductionPeriod = new dfeta_inductionperiod()
-        {
-            dfeta_StartDate = inductionPeriodStartDate.ToDateTime(),
-            dfeta_EndDate = inductionPeriodEndDate.ToDateTime(),
-            dfeta_Numberofterms = inductionPeriodTerms
-        };
-
-        inductionPeriod.Attributes.Add($"appropriatebody.{Account.PrimaryIdAttribute}", new AliasedValue(Account.EntityLogicalName, Account.PrimaryIdAttribute, Guid.NewGuid()));
-        inductionPeriod.Attributes.Add($"appropriatebody.{Account.Fields.Name}", new AliasedValue(Account.EntityLogicalName, Account.Fields.Name, inductionPeriodAppropriateBodyName));
-
-        return new[]
-        {
-            inductionPeriod
-        };
     }
 
     private static dfeta_qualification CreateQualification(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240101/GetTeacherTests.cs
@@ -1,3 +1,4 @@
+using TeachingRecordSystem.Api.V3.Implementation.Dtos;
 using static TeachingRecordSystem.TestCommon.TestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3.V20240101;
@@ -157,11 +158,59 @@ public class GetTeacherTests : GetTeacherTestBase
     [Fact]
     public async Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
     {
-        var contact = await CreateContact();
-        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
-        var baseUrl = "/v3/teacher";
+        // Arrange
+        var dqtStatus = dfeta_InductionStatus.Pass;
+        var startDate = new DateOnly(1996, 2, 3);
+        var completedDate = new DateOnly(1996, 6, 7);
+        var abName = "Test AB";
+        var appropriateBody = await TestData.CreateAccountAsync(a => a.WithName(abName));
+        var numberOfTerms = 3;
 
-        await ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, contact);
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithTrn()
+            .WithDqtInduction(
+                dqtStatus,
+                inductionExemptionReason: null,
+                startDate,
+                completedDate,
+                inductionPeriodStartDate: startDate,
+                inductionPeriodEndDate: completedDate,
+                appropriateBodyOrgId: appropriateBody.Id,
+                numberOfTerms: numberOfTerms));
+
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/v3/teacher?include=Induction");
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(person.Trn!).SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponseAsync(response);
+        var responseInduction = jsonResponse.RootElement.GetProperty("induction");
+
+        AssertEx.JsonObjectEquals(
+            new
+            {
+                startDate = startDate.ToString("yyyy-MM-dd"),
+                endDate = completedDate.ToString("yyyy-MM-dd"),
+                status = dqtStatus.ToString(),
+                statusDescription = dqtStatus.GetDescription(),
+                certificateUrl = "/v3/certificates/induction",
+                periods = new[]
+                {
+                    new
+                    {
+                        startDate = startDate.ToString("yyyy-MM-dd"),
+                        endDate = completedDate.ToString("yyyy-MM-dd"),
+                        terms = numberOfTerms,
+                        appropriateBody = new
+                        {
+                            name = abName
+                        }
+                    }
+                }
+            },
+            responseInduction);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/V3/V20240606/GetPersonTests.cs
@@ -1,3 +1,4 @@
+using TeachingRecordSystem.Api.V3.Implementation.Dtos;
 using static TeachingRecordSystem.TestCommon.TestData;
 
 namespace TeachingRecordSystem.Api.Tests.V3.V20240606;
@@ -152,11 +153,59 @@ public class GetPersonTests(HostFixture hostFixture) : GetPersonTestBase(hostFix
     [Fact]
     public async Task Get_ValidRequestWithInduction_ReturnsExpectedInductionContent()
     {
-        var contact = await CreateContact();
-        var httpClient = GetHttpClientWithIdentityAccessToken(contact.dfeta_TRN);
-        var baseUrl = "/v3/person";
+        // Arrange
+        var dqtStatus = dfeta_InductionStatus.Pass;
+        var startDate = new DateOnly(1996, 2, 3);
+        var completedDate = new DateOnly(1996, 6, 7);
+        var abName = "Test AB";
+        var appropriateBody = await TestData.CreateAccountAsync(a => a.WithName(abName));
+        var numberOfTerms = 3;
 
-        await ValidRequestWithInduction_ReturnsExpectedInductionContent(httpClient, baseUrl, contact);
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithTrn()
+            .WithDqtInduction(
+                dqtStatus,
+                inductionExemptionReason: null,
+                startDate,
+                completedDate,
+                inductionPeriodStartDate: startDate,
+                inductionPeriodEndDate: completedDate,
+                appropriateBodyOrgId: appropriateBody.Id,
+                numberOfTerms: numberOfTerms));
+
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person?include=Induction");
+
+        // Act
+        var response = await GetHttpClientWithIdentityAccessToken(person.Trn!).SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponseAsync(response);
+        var responseInduction = jsonResponse.RootElement.GetProperty("induction");
+
+        AssertEx.JsonObjectEquals(
+            new
+            {
+                startDate = startDate.ToString("yyyy-MM-dd"),
+                endDate = completedDate.ToString("yyyy-MM-dd"),
+                status = dqtStatus.ToString(),
+                statusDescription = dqtStatus.GetDescription(),
+                certificateUrl = "/v3/certificates/induction",
+                periods = new[]
+                {
+                    new
+                    {
+                        startDate = startDate.ToString("yyyy-MM-dd"),
+                        endDate = completedDate.ToString("yyyy-MM-dd"),
+                        terms = numberOfTerms,
+                        appropriateBody = new
+                        {
+                            name = abName
+                        }
+                    }
+                }
+            },
+            responseInduction);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -97,7 +97,8 @@ public partial class TestData
             DateOnly? completedDate,
             DateOnly? inductionPeriodStartDate = null,
             DateOnly? inductionPeriodEndDate = null,
-            Guid? appropriateBodyOrgId = null)
+            Guid? appropriateBodyOrgId = null,
+            int? numberOfTerms = null)
         {
             EnsureTrn();
 
@@ -115,7 +116,7 @@ public partial class TestData
             }
             if (appropriateBodyOrgId.HasValue)
             {
-                _dqtInductionPeriods.Add(new DqtInductionPeriod(inductionId, inductionPeriodStartDate, inductionPeriodEndDate, appropriateBodyOrgId!.Value));
+                _dqtInductionPeriods.Add(new DqtInductionPeriod(inductionId, inductionPeriodStartDate, inductionPeriodEndDate, appropriateBodyOrgId!.Value, numberOfTerms));
             }
             return this;
         }
@@ -536,7 +537,8 @@ public partial class TestData
                         dfeta_InductionId = inductionperiod!.InductionId.ToEntityReference(dfeta_induction.EntityLogicalName),
                         dfeta_StartDate = inductionperiod.startDate.ToDateTimeWithDqtBstFix(isLocalTime: false),
                         dfeta_EndDate = inductionperiod.endDate.ToDateTimeWithDqtBstFix(isLocalTime: false),
-                        dfeta_AppropriateBodyId = inductionperiod.AppropriateBodyOrgId.ToEntityReference(Core.Dqt.Models.Account.EntityLogicalName)
+                        dfeta_AppropriateBodyId = inductionperiod.AppropriateBodyOrgId.ToEntityReference(Core.Dqt.Models.Account.EntityLogicalName),
+                        dfeta_Numberofterms = inductionperiod.NumberOfTerms
                     }
                 });
             }
@@ -1244,7 +1246,7 @@ public partial class TestData
 
     public record DqtInduction(Guid InductionId, dfeta_InductionStatus inductionStatus, dfeta_InductionExemptionReason? inductionExemptionReason, DateOnly? StartDate, DateOnly? CompletetionDate);
 
-    public record DqtInductionPeriod(Guid InductionId, DateOnly? startDate, DateOnly? endDate, Guid AppropriateBodyOrgId);
+    public record DqtInductionPeriod(Guid InductionId, DateOnly? startDate, DateOnly? endDate, Guid AppropriateBodyOrgId, int? NumberOfTerms);
 
     public record QtsRegistration(DateOnly? QtsDate, string? TeacherStatusValue, DateTime? CreatedOn, DateOnly? EytsDate, string? EytsStatusValue);
 


### PR DESCRIPTION
This removes the use of the old `DataverseAdapter` for retrieving induction information in the `Get Person` operation.