### PR TITLE
Add a mechanism for overriding features in a test

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/IFeatureProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/IFeatureProvider.cs
@@ -1,6 +1,11 @@
 namespace TeachingRecordSystem.SupportUi;
 
-public class FeatureProvider(IConfiguration configuration)
+public interface IFeatureProvider
+{
+    bool IsEnabled(string featureName);
+}
+
+public class ConfigurationFeatureProvider(IConfiguration configuration) : IFeatureProvider
 {
     private readonly HashSet<string> _features = new(configuration.GetSection("EnabledFeatures").Get<string[]>() ?? [], StringComparer.OrdinalIgnoreCase);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireFeatureEnabledFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireFeatureEnabledFilter.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
-public class RequireFeatureEnabledFilter(FeatureProvider featureProvider, string featureName) : IResourceFilter
+public class RequireFeatureEnabledFilter(IFeatureProvider featureProvider, string featureName) : IResourceFilter
 {
     public void OnResourceExecuting(ResourceExecutingContext context)
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/_ViewImports.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/_ViewImports.cshtml
@@ -7,4 +7,4 @@
 @addTagHelper *, GovUk.Frontend.AspNetCore
 @addTagHelper *, TeachingRecordSystem.SupportUi
 @inject TeachingRecordSystem.SupportUi.TrsLinkGenerator LinkGenerator
-@inject TeachingRecordSystem.SupportUi.FeatureProvider FeatureProvider
+@inject TeachingRecordSystem.SupportUi.IFeatureProvider FeatureProvider

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -162,7 +162,7 @@ builder.Services
     .AddFormFlowJourneyDescriptors(typeof(Program).Assembly)
     .AddFileService()
     .AddTransient<TrsLinkGenerator>()
-    .AddSingleton<FeatureProvider>()
+    .AddSingleton<IFeatureProvider, ConfigurationFeatureProvider>()
     .AddTransient<ICurrentUserIdProvider, HttpContextCurrentUserIdProvider>()
     .AddTransient<CheckMandatoryQualificationExistsFilter>()
     .AddTransient<CheckUserExistsFilter>()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -51,6 +51,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddTestScoped<IClock>(tss => tss.Clock);
             services.AddTestScoped<IDataverseAdapter>(tss => tss.DataverseAdapterMock.Object);
             services.AddTestScoped<IAadUserService>(tss => tss.AzureActiveDirectoryUserServiceMock.Object);
+            services.AddTestScoped<IFeatureProvider>(tss => tss.FeatureProvider);
             services.AddSingleton<TestData>(
                 sp => ActivatorUtilities.CreateInstance<TestData>(
                     sp,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Infrastructure/TestableFeatureProvider.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Infrastructure/TestableFeatureProvider.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.SupportUi.Tests.Infrastructure;
+
+public class TestableFeatureProvider(IConfiguration configuration) : IFeatureProvider
+{
+    public ICollection<string> Features { get; } =
+        new HashSet<string>(configuration.GetSection("EnabledFeatures").Get<string[]>() ?? [], StringComparer.OrdinalIgnoreCase);
+
+    public bool IsEnabled(string featureName) => Features.Contains(featureName);
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
@@ -12,7 +12,7 @@ public class IndexTests : TestBase
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
     {
-        // Arrange        
+        // Arrange
         var nonExistentPersonId = Guid.NewGuid().ToString();
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{nonExistentPersonId}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -6,6 +6,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
+using TeachingRecordSystem.SupportUi.Tests.Infrastructure;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure.Security;
 using TeachingRecordSystem.UiCommon.FormFlow.State;
 
@@ -20,7 +21,7 @@ public abstract class TestBase : IDisposable
     {
         HostFixture = hostFixture;
 
-        _testServices = TestScopedServices.Reset();
+        _testServices = TestScopedServices.Reset(hostFixture.Services);
         SetCurrentUser(TestUsers.GetUser(UserRoles.Administrator));
 
         HttpClient = hostFixture.CreateClient(new()
@@ -56,6 +57,8 @@ public abstract class TestBase : IDisposable
     public TestUsers TestUsers => HostFixture.Services.GetRequiredService<TestUsers>();
 
     public IXrmFakedContext XrmFakedContext => HostFixture.Services.GetRequiredService<IXrmFakedContext>();
+
+    public TestableFeatureProvider FeatureProvider => _testServices.FeatureProvider;
 
     public async Task<JourneyInstance<TState>> CreateJourneyInstance<TState>(
             string journeyName,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
+using TeachingRecordSystem.SupportUi.Tests.Infrastructure;
 
 namespace TeachingRecordSystem.SupportUi.Tests;
 
@@ -7,25 +8,26 @@ public class TestScopedServices
 {
     private static readonly AsyncLocal<TestScopedServices> _current = new();
 
-    public TestScopedServices()
+    public TestScopedServices(IServiceProvider serviceProvider)
     {
         Clock = new();
         DataverseAdapterMock = new();
         AzureActiveDirectoryUserServiceMock = new();
         EventObserver = new();
+        FeatureProvider = ActivatorUtilities.CreateInstance<TestableFeatureProvider>(serviceProvider);
     }
 
     public static TestScopedServices GetCurrent() =>
         _current.Value ?? throw new InvalidOperationException("No current instance has been set.");
 
-    public static TestScopedServices Reset()
+    public static TestScopedServices Reset(IServiceProvider serviceProvider)
     {
         if (_current.Value is not null)
         {
             throw new InvalidOperationException("Current instance has already been set.");
         }
 
-        return _current.Value = new();
+        return _current.Value = new(serviceProvider);
     }
 
     public TestableClock Clock { get; }
@@ -35,4 +37,6 @@ public class TestScopedServices
     public Mock<IAadUserService> AzureActiveDirectoryUserServiceMock { get; }
 
     public CaptureEventObserver EventObserver { get; }
+
+    public TestableFeatureProvider FeatureProvider { get; }
 }


### PR DESCRIPTION
Currently feature flags cannot be overridden in a test; this adds an implementation of `IFeatureProvider` that's test-scoped that allows amending features:

```cs
FeatureProvider.Features.Add(FeatureNames.Alerts);
```