### PR TITLE
Sync induction changes in real time from dqt

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
@@ -52,6 +52,8 @@ public partial class Commands
                 }
 
                 await syncHelper.SyncPersonAsync(contact, ignoreInvalid: false, dryRun: false);
+
+                await syncHelper.SyncInductionsAsync([contact], ignoreInvalid: false, createMigratedEvent: false, dryRun: false);
                 //return 0;
             },
             connectionStringOption,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -17,7 +17,7 @@ public class Person
     public required DateOnly? DateOfBirth { get; set; }  // A few DQT records in prod have a null DOB
     public string? EmailAddress { get; set; }
     public string? NationalInsuranceNumber { get; set; }
-    public InductionStatus InductionStatus { get; private set; }
+    public InductionStatus InductionStatus { get; set; }
     public InductionExemptionReasons InductionExemptionReasons { get; private set; }
     public DateOnly? InductionStartDate { get; private set; }
     public DateOnly? InductionCompletedDate { get; private set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -61,6 +61,7 @@ public class TrsDataSyncService(
         var modelTypesToSync = optionsAccessor.Value.ModelTypes;
 
         // Order is important here; the dependees should come before dependents
+        await SyncIfEnabledAsync(TrsDataSyncHelper.ModelTypes.Induction);
         await SyncIfEnabledAsync(TrsDataSyncHelper.ModelTypes.Person);
         await SyncIfEnabledAsync(TrsDataSyncHelper.ModelTypes.Event);
         await SyncIfEnabledAsync(TrsDataSyncHelper.ModelTypes.Alert);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Induction.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Induction.cs
@@ -1,0 +1,115 @@
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Tests.Services.TrsDataSync;
+
+public partial class TrsDataSyncServiceTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Induction_NewRecord_WritesUpdatedPersonRecordToDatabase(bool personAlreadySynced)
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithSyncOverride(personAlreadySynced));
+        var contactId = createPersonResult.ContactId;
+
+        var inductionStartDate = Clock.Today.AddYears(-1);
+        var inductionEndDate = Clock.Today.AddDays(-10);
+        var induction = new dfeta_induction()
+        {
+            Id = Guid.NewGuid(),
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, contactId),
+            dfeta_InductionStatus = dfeta_InductionStatus.Pass,
+            dfeta_StartDate = inductionStartDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
+            dfeta_CompletionDate = inductionEndDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
+            CreatedOn = Clock.UtcNow,
+            ModifiedOn = Clock.UtcNow
+        };
+
+        // Keep the contact induction status in sync with dfeta_induction otherwise the sync will fail
+        await TestData.OrganizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = contactId,
+                dfeta_InductionStatus = dfeta_InductionStatus.Pass
+            }
+        });
+
+        var newItem = new NewOrUpdatedItem(ChangeType.NewOrUpdated, induction);
+
+        // Act
+        await fixture.PublishChangedItemAndConsumeAsync(TrsDataSyncHelper.ModelTypes.Induction, newItem);
+
+        // Assert
+        await fixture.DbFixture.WithDbContextAsync(async dbContext =>
+        {
+            var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.DqtContactId == contactId);
+            Assert.NotNull(person);
+            Assert.Equal(InductionStatus.Passed, person.InductionStatus);
+            Assert.Equal(inductionStartDate, person.InductionStartDate);
+            Assert.Equal(inductionEndDate, person.InductionCompletedDate);
+        });
+    }
+
+    [Fact]
+    public async Task Induction_UpdatedRecord_WritesUpdatedPersonRecordToDatabase()
+    {
+        // Arrange
+        var originalInductionStatus = dfeta_InductionStatus.InProgress;
+        var originalInductionStartDate = Clock.Today.AddYears(-1);
+        var originalInductionEndDate = Clock.Today.AddDays(-10);
+
+        var createPersonResult = await TestData.CreatePersonAsync(
+            p => p.WithSyncOverride(true)
+                .WithDqtInduction(originalInductionStatus, null, originalInductionStartDate, null));
+        var contactId = createPersonResult.ContactId;
+        var existingInduction = createPersonResult.DqtInductions.Single();
+
+        var updatedInductionStatus = dfeta_InductionStatus.Pass;
+        var updatedInductionStartDate = Clock.Today.AddYears(-2);
+        var updatedInductionEndDate = Clock.Today.AddDays(-20);
+        var createdOn = Clock.UtcNow;
+        var modifiedOn = Clock.Advance();
+        var updatedInduction = new dfeta_induction()
+        {
+            Id = existingInduction.InductionId,
+            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, contactId),
+            dfeta_InductionStatus = updatedInductionStatus,
+            dfeta_StartDate = updatedInductionStartDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
+            dfeta_CompletionDate = updatedInductionEndDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
+            CreatedOn = Clock.UtcNow,
+            ModifiedOn = modifiedOn
+        };
+
+        // Keep the contact induction status in sync with dfeta_induction otherwise the sync will fail
+        await TestData.OrganizationService.ExecuteAsync(new UpdateRequest()
+        {
+            Target = new Contact()
+            {
+                Id = contactId,
+                dfeta_InductionStatus = dfeta_InductionStatus.Pass
+            }
+        });
+
+        var updatedItem = new NewOrUpdatedItem(ChangeType.NewOrUpdated, updatedInduction);
+
+        // Act
+        await fixture.PublishChangedItemAndConsumeAsync(TrsDataSyncHelper.ModelTypes.Induction, updatedItem);
+
+        // Assert
+        await fixture.DbFixture.WithDbContextAsync(async dbContext =>
+        {
+            var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.DqtContactId == contactId);
+            Assert.NotNull(person);
+            Assert.Equal(InductionStatus.Passed, person.InductionStatus);
+            Assert.Equal(updatedInductionStartDate, person.InductionStartDate);
+            Assert.Equal(updatedInductionEndDate, person.InductionCompletedDate);
+            Assert.Equal(Clock.UtcNow, person.DqtInductionModifiedOn);
+        });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.cs
@@ -1,9 +1,14 @@
+
 namespace TeachingRecordSystem.Core.Tests.Services.TrsDataSync;
 
 [Collection(nameof(TrsDataSyncTestCollection))]
-public partial class TrsDataSyncServiceTests(TrsDataSyncServiceFixture fixture) : IClassFixture<TrsDataSyncServiceFixture>
+public partial class TrsDataSyncServiceTests(TrsDataSyncServiceFixture fixture) : IClassFixture<TrsDataSyncServiceFixture>, IAsyncLifetime
 {
     private TestableClock Clock => fixture.Clock;
 
     private TestData TestData => fixture.TestData;
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
+
+    Task IAsyncLifetime.InitializeAsync() => fixture.DbFixture.DbHelper.ClearDataAsync();
 }


### PR DESCRIPTION
### Context

Induction data is moving from DQT to TRS and we want to ensure TRS data is kept up to date with what’s in DQT.

### Changes proposed in this pull request

Amend TrsDataSyncService to include induction data.
Also, extended sync-person CLI command to also sync induction data.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
