### PR TITLE
Schedule database backup at 2am

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -22,7 +22,7 @@ on:
           Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
 
   schedule:
-    - cron: "0 4 * * *" # 04:00 UTC
+    - cron: "0 2 * * *" # 02:00 UTC
 
 env:
   SERVICE_SHORT: trs


### PR DESCRIPTION
### Context
There is an error almost everyday around 4am and we haven't been able to identify the issue:
https://github.com/DFE-Digital/teaching-record-system/actions/runs/12289591518/job/34295330947

### Changes proposed in this pull request
Move to 2am to see if the problem persists.

### Guidance to review
Code review

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
