### PR TITLE
Added fixes while testing against CRM build environment data

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
@@ -53,7 +53,7 @@ public partial class Commands
 
                 await syncHelper.SyncPersonAsync(contact, ignoreInvalid: false, dryRun: false);
 
-                await syncHelper.SyncInductionsAsync([contact], ignoreInvalid: false, createMigratedEvent: false, dryRun: false);
+                await syncHelper.SyncInductionsAsync([contact], syncAudit: true, ignoreInvalid: false, createMigratedEvent: false, dryRun: false);
                 //return 0;
             },
             connectionStringOption,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -1,8 +1,10 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reactive.Subjects;
 using System.ServiceModel;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
@@ -16,11 +18,12 @@ using TeachingRecordSystem.Core.Dqt;
 namespace TeachingRecordSystem.Core.Services.TrsDataSync;
 
 public class TrsDataSyncHelper(
-    NpgsqlDataSource trsDbDataSource,
-    [FromKeyedServices(TrsDataSyncService.CrmClientName)] IOrganizationServiceAsync2 organizationService,
-    ReferenceDataCache referenceDataCache,
-    IClock clock,
-    IAuditRepository auditRepository)
+        NpgsqlDataSource trsDbDataSource,
+        [FromKeyedServices(TrsDataSyncService.CrmClientName)] IOrganizationServiceAsync2 organizationService,
+        ReferenceDataCache referenceDataCache,
+        IClock clock,
+        IAuditRepository auditRepository,
+        ILogger<TrsDataSyncHelper> logger)
 {
     private delegate Task SyncEntitiesHandler(IReadOnlyCollection<Entity> entities, bool ignoreInvalid, bool dryRun, CancellationToken cancellationToken);
 
@@ -100,7 +103,7 @@ public class TrsDataSyncHelper(
         };
     }
 
-    private static InductionInfo? MapInductionInfoFromDqtInduction(
+    private InductionInfo? MapInductionInfoFromDqtInduction(
         dfeta_induction? induction,
         Contact contact,
         bool ignoreInvalid)
@@ -109,22 +112,26 @@ public class TrsDataSyncHelper(
         var hasQtls = contact.dfeta_qtlsdate is not null;
         if (induction is not null && induction.dfeta_InductionStatus != contact.dfeta_InductionStatus)
         {
+            var errorMessage = $"Induction status {contact.dfeta_InductionStatus} for contact {contact.ContactId} does not match induction status {induction.dfeta_InductionStatus} for induction {induction!.dfeta_inductionId}.";
             if (ignoreInvalid)
             {
+                logger.LogWarning(errorMessage);
                 return null;
             }
 
-            throw new InvalidOperationException($"Induction status {contact.dfeta_InductionStatus} for contact {contact.ContactId} does not match induction status {induction.dfeta_InductionStatus} for induction {induction!.dfeta_inductionId}.");
+            throw new InvalidOperationException(errorMessage);
         }
         // Person with QTLS should be exempt from induction
         else if (hasQtls && contact.dfeta_InductionStatus != dfeta_InductionStatus.Exempt)
         {
+            var errorMessage = $"Induction status for contact {contact.ContactId} with QTLS should be {dfeta_InductionStatus.Exempt} but is {contact.dfeta_InductionStatus}.";
             if (ignoreInvalid)
             {
+                logger.LogWarning(errorMessage);
                 return null;
             }
 
-            throw new InvalidOperationException($"Induction status for contact {contact.ContactId} with QTLS should be {dfeta_InductionStatus.Exempt} but is {contact.dfeta_InductionStatus}.");
+            throw new InvalidOperationException(errorMessage);
         }
 
         return new InductionInfo()
@@ -302,16 +309,12 @@ public class TrsDataSyncHelper(
 
     public async Task<int> SyncInductionsAsync(
         IReadOnlyCollection<dfeta_induction> inductions,
+        bool syncAudit,
         bool ignoreInvalid,
         bool dryRun,
         CancellationToken cancellationToken)
     {
-        var contactAttributeNames = new[]
-        {
-            Contact.PrimaryIdAttribute,
-            Contact.Fields.dfeta_InductionStatus,
-            Contact.Fields.dfeta_QtlsDateHasBeenSet
-        };
+        var contactAttributeNames = GetModelTypeSyncInfo(ModelTypes.Induction).AttributeNames;
 
         var contacts = await GetEntitiesAsync<Contact>(
             Contact.EntityLogicalName,
@@ -321,11 +324,12 @@ public class TrsDataSyncHelper(
             activeOnly: false,
             cancellationToken);
 
-        return await SyncInductionsAsync(contacts, inductions, ignoreInvalid, createMigratedEvent: false, dryRun, cancellationToken);
+        return await SyncInductionsAsync(contacts, inductions, syncAudit, ignoreInvalid, createMigratedEvent: false, dryRun, cancellationToken);
     }
 
     public async Task<int> SyncInductionsAsync(
         IReadOnlyCollection<Contact> contacts,
+        bool syncAudit,
         bool ignoreInvalid,
         bool createMigratedEvent,
         bool dryRun,
@@ -340,7 +344,8 @@ public class TrsDataSyncHelper(
             dfeta_induction.Fields.dfeta_InductionStatus,
             dfeta_induction.Fields.CreatedOn,
             dfeta_induction.Fields.CreatedBy,
-            dfeta_induction.Fields.ModifiedOn
+            dfeta_induction.Fields.ModifiedOn,
+            dfeta_induction.Fields.StateCode
         };
 
         var inductions = await GetEntitiesAsync<dfeta_induction>(
@@ -351,19 +356,26 @@ public class TrsDataSyncHelper(
             true,
             cancellationToken);
 
-        return await SyncInductionsAsync(contacts, inductions, ignoreInvalid, createMigratedEvent, dryRun, cancellationToken);
+        return await SyncInductionsAsync(contacts, inductions, syncAudit, ignoreInvalid, createMigratedEvent, dryRun, cancellationToken);
     }
 
     public async Task<int> SyncInductionsAsync(
         IReadOnlyCollection<Contact> contacts,
         IReadOnlyCollection<dfeta_induction> entities,
+        bool syncAudit,
         bool ignoreInvalid,
         bool createMigratedEvent,
         bool dryRun,
         CancellationToken cancellationToken)
     {
-        var contactAuditDetails = await GetAuditRecordsAsync(Contact.EntityLogicalName, contacts.Select(q => q.ContactId!.Value), cancellationToken);
-        var inductionAuditDetails = await GetAuditRecordsAsync(dfeta_induction.EntityLogicalName, entities.Select(q => q.Id), cancellationToken);
+        if (syncAudit)
+        {
+            await SyncAuditAsync(Contact.EntityLogicalName, contacts.Select(q => q.ContactId!.Value), cancellationToken);
+            await SyncAuditAsync(dfeta_induction.EntityLogicalName, entities.Select(q => q.Id), cancellationToken);
+        }
+
+        var contactAuditDetails = await GetAuditRecordsFromAuditRepositoryAsync(Contact.EntityLogicalName, contacts.Select(q => q.ContactId!.Value), cancellationToken);
+        var inductionAuditDetails = await GetAuditRecordsFromAuditRepositoryAsync(dfeta_induction.EntityLogicalName, entities.Select(q => q.Id), cancellationToken);
         var auditDetails = contactAuditDetails
             .Concat(inductionAuditDetails)
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
@@ -445,8 +457,10 @@ public class TrsDataSyncHelper(
                 var unableToSyncContactIds = unsyncedContactIds.Where(id => !personsSynced.Contains(id)).ToArray();
                 if (unableToSyncContactIds.Length > 0)
                 {
+                    var errorMessage = $"Attempted to sync Induction for persons but the Contact records with IDs [{string.Join(", ", unableToSyncContactIds)}] do not meet the sync criteria.";
                     if (ignoreInvalid)
                     {
+                        logger.LogWarning(errorMessage);
                         toSync.RemoveAll(i => unableToSyncContactIds.Contains(i.PersonId));
                         if (toSync.Count == 0)
                         {
@@ -455,8 +469,7 @@ public class TrsDataSyncHelper(
                     }
                     else
                     {
-                        throw new InvalidOperationException(
-                            $"Attempted to sync Induction for persons but the Contact records with IDs [{string.Join(", ", unableToSyncContactIds)}] do not meet the sync criteria.");
+                        throw new InvalidOperationException(errorMessage);
                     }
                 }
 
@@ -647,13 +660,19 @@ public class TrsDataSyncHelper(
     private EntityVersionInfo<TEntity>[] GetEntityVersions<TEntity>(TEntity latest, IEnumerable<AuditDetail> auditDetails, string[] attributeNames)
         where TEntity : Entity
     {
-        var created = latest.GetAttributeValue<DateTime?>("createdon")!.Value;
+        if (!latest.TryGetAttributeValue<DateTime?>("createdon", out var createdOn) || !createdOn.HasValue)
+        {
+            throw new ArgumentException($"Expected {latest.LogicalName} entity with ID {latest.Id} to have a non-null 'createdon' attribute value.", nameof(latest));
+        }
+
+        var created = createdOn.Value;
         var createdBy = latest.GetAttributeValue<EntityReference>("createdby");
 
         var ordered = auditDetails
             .OfType<AttributeAuditDetail>()
             .Select(a => (AuditDetail: a, AuditRecord: a.AuditRecord.ToEntity<Audit>()))
             .OrderBy(a => a.AuditRecord.CreatedOn)
+            .ThenBy(a => a.AuditRecord.Action == Audit_Action.Create ? 0 : 1)
             .ToArray();
 
         if (ordered.Length == 0)
@@ -812,6 +831,7 @@ public class TrsDataSyncHelper(
                     }
                     catch (FaultException fex) when (fex.IsCrmRateLimitException(out var retryAfter))
                     {
+                        logger.LogWarning("Hit CRM service limits getting {entityLogicalName} audit records; Fault exception. Retrying after {retryAfter} seconds.", entityLogicalName, retryAfter.TotalSeconds);
                         await Task.Delay(retryAfter, cancellationToken);
                         continue;
                     }
@@ -822,11 +842,13 @@ public class TrsDataSyncHelper(
 
                         if (firstFault.IsCrmRateLimitFault(out var retryAfter))
                         {
+                            logger.LogWarning("Hit CRM service limits getting {entityLogicalName} audit records; CRM rate limit fault. Retrying after {retryAfter} seconds.", entityLogicalName, retryAfter.TotalSeconds);
                             await Task.Delay(retryAfter, cancellationToken);
                             continue;
                         }
                         else if (firstFault.Message.Contains("The HTTP status code of the response was not expected (429)"))
                         {
+                            logger.LogWarning("Hit CRM service limits getting {entityLogicalName} audit records; 429 too many requests", entityLogicalName);
                             await Task.Delay(TimeSpan.FromMinutes(2), cancellationToken);
                             continue;
                         }
@@ -843,6 +865,24 @@ public class TrsDataSyncHelper(
             })))
             .SelectMany(b => b)
             .ToDictionary(t => t.Id, t => t.AuditDetailCollection));
+    }
+
+    private async Task<IReadOnlyDictionary<Guid, AuditDetailCollection>> GetAuditRecordsFromAuditRepositoryAsync(
+        string entityLogicalName,
+        IEnumerable<Guid> ids,
+        CancellationToken cancellationToken)
+    {
+        var auditRecords = new ConcurrentDictionary<Guid, AuditDetailCollection>();
+        await Parallel.ForEachAsync(
+            ids,
+            cancellationToken,
+            async (id, ct) =>
+            {
+                var audit = await auditRepository.GetAuditDetailAsync(entityLogicalName, id) ?? throw new Exception($"No audit detail for '{id}'.");
+                auditRecords[id] = audit;
+            });
+
+        return auditRecords;
     }
 
     private async Task<TEntity[]> GetEntitiesAsync<TEntity>(
@@ -862,7 +902,25 @@ public class TrsDataSyncHelper(
             query.Criteria.AddCondition("statecode", ConditionOperator.Equal, 0);
         }
 
-        var response = await organizationService.RetrieveMultipleAsync(query, cancellationToken);
+        EntityCollection response;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                response = await organizationService.RetrieveMultipleAsync(query, cancellationToken);
+            }
+            catch (FaultException<OrganizationServiceFault> fex) when (fex.IsCrmRateLimitException(out var retryAfter))
+            {
+                logger.LogWarning("Hit CRM service limits; error code: {ErrorCode}", fex.Detail.ErrorCode);
+                await Task.Delay(retryAfter, cancellationToken);
+                continue;
+            }
+
+            break;
+        }
+
         return response.Entities.Select(e => e.ToEntity<TEntity>()).ToArray();
     }
 
@@ -1022,7 +1080,21 @@ public class TrsDataSyncHelper(
         {
             Contact.PrimaryIdAttribute,
             Contact.Fields.dfeta_InductionStatus,
-            Contact.Fields.dfeta_qtlsdate
+            Contact.Fields.dfeta_qtlsdate,
+            Contact.Fields.CreatedOn,
+            Contact.Fields.CreatedBy,
+            Contact.Fields.StateCode,
+            Contact.Fields.ModifiedOn,
+            Contact.Fields.dfeta_TRN,
+            Contact.Fields.FirstName,
+            Contact.Fields.MiddleName,
+            Contact.Fields.LastName,
+            Contact.Fields.dfeta_StatedFirstName,
+            Contact.Fields.dfeta_StatedMiddleName,
+            Contact.Fields.dfeta_StatedLastName,
+            Contact.Fields.BirthDate,
+            Contact.Fields.dfeta_NINumber,
+            Contact.Fields.EMailAddress1,
         };
 
         Action<NpgsqlBinaryImporter, InductionInfo> writeRecord = (writer, induction) =>
@@ -1046,7 +1118,7 @@ public class TrsDataSyncHelper(
             EntityLogicalName = dfeta_induction.EntityLogicalName,
             AttributeNames = attributeNames,
             GetSyncHandler = helper => (entities, ignoreInvalid, dryRun, ct) =>
-                helper.SyncInductionsAsync(entities.Select(e => e.ToEntity<dfeta_induction>()).ToArray(), ignoreInvalid, dryRun, ct),
+                helper.SyncInductionsAsync(entities.Select(e => e.ToEntity<dfeta_induction>()).ToArray(), syncAudit: true, ignoreInvalid, dryRun, ct),
             WriteRecord = writeRecord
         };
     }
@@ -1215,9 +1287,17 @@ public class TrsDataSyncHelper(
                 // We shouldn't have multiple induction records for the same person in prod at all but we might in other environments
                 // so we'll just take the most recently modified one.
                 induction = personInductions.OrderByDescending(i => i.ModifiedOn).First();
-                if (personInductions.Length > 1 && !ignoreInvalid)
+                if (personInductions.Length > 1)
                 {
-                    throw new InvalidOperationException($"Contact '{contact.ContactId!.Value}' has multiple induction records.");
+                    var errorMessage = $"Contact '{contact.ContactId!.Value}' has multiple induction records.";
+                    if (ignoreInvalid)
+                    {
+                        logger.LogWarning(errorMessage);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException(errorMessage);
+                    }
                 }
             }
 
@@ -1235,7 +1315,8 @@ public class TrsDataSyncHelper(
                     dfeta_induction.Fields.dfeta_InductionExemptionReason,
                     dfeta_induction.Fields.dfeta_StartDate,
                     dfeta_induction.Fields.dfeta_InductionStatus,
-                    dfeta_induction.Fields.ModifiedOn
+                    dfeta_induction.Fields.ModifiedOn,
+                    dfeta_induction.Fields.StateCode
                 };
 
                 if (auditDetails.TryGetValue(induction!.Id, out var inductionAudits))

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.Production.json
@@ -3,7 +3,7 @@
     "MinimumLevel": {
       "Default": "Error",
       "Override": {
-        "TeachingRecordSystem.Worker": "Warning"
+        "TeachingRecordSystem.*": "Warning"
       }
     }
   },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/EventMapperTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/EventMapperTestBase.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
@@ -30,7 +31,8 @@ public class EventMapperFixture
         IOrganizationServiceAsync2 organizationService,
         ICrmQueryDispatcher crmQueryDispatcher,
         FakeTrnGenerator trnGenerator,
-        IServiceProvider serviceProvider)
+        IServiceProvider serviceProvider,
+        ILoggerFactory loggerFactory)
     {
         Clock = new TestableClock();
         DbFixture = dbFixture;
@@ -41,7 +43,8 @@ public class EventMapperFixture
             organizationService,
             ReferenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncAllInductionsFromCrmJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncAllInductionsFromCrmJobTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.Core.Jobs;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+using TeachingRecordSystem.Core.Tests.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Tests.Jobs;
+
+[CollectionDefinition(nameof(TrsDataSyncTestCollection), DisableParallelization = true)]
+public class SyncAllInductionsFromCrmJobTests : SyncFromCrmJobTestBase, IAsyncLifetime
+{
+    public SyncAllInductionsFromCrmJobTests(SyncFromCrmJobFixture jobFixture) : base(jobFixture)
+    {
+    }
+
+    [Fact(Skip = "Causes deadlock on CI for some reason")]
+    public async Task SyncInductionsAsync_WithExistingDqtInduction_UpdatesPersonRecord()
+    {
+        // Arrange
+        var inductionStatus = dfeta_InductionStatus.Pass;
+        var inductionStartDate = Clock.Today.AddYears(-1);
+        var inductionCompletedDate = Clock.Today.AddDays(-5);
+        var options = Options.Create(new TrsDataSyncServiceOptions()
+        {
+            CrmConnectionString = "dummy",
+            ModelTypes = [TrsDataSyncHelper.ModelTypes.Person],
+            PollIntervalSeconds = 60,
+            IgnoreInvalidData = false,
+            RunService = false
+        });
+
+        var person = await TestData.CreatePersonAsync(
+            p => p.WithTrn()
+                .WithQts()
+                .WithDqtInduction(inductionStatus, null, inductionStartDate, inductionCompletedDate)
+                .WithSyncOverride(false));
+
+        // Act
+        var job = new SyncAllInductionsFromCrmJob(
+            CrmServiceClientProvider,
+            Helper,
+            options,
+            LoggerFactory.CreateLogger<SyncAllInductionsFromCrmJob>());
+
+        await job.ExecuteAsync(createMigratedEvent: false, dryRun: false, CancellationToken.None);
+
+        // Assert
+        await DbFixture.WithDbContextAsync(async dbContext =>
+        {
+            var updatedPerson = await dbContext.Persons.SingleOrDefaultAsync(p => p.DqtContactId == person.ContactId);
+            Assert.Equal(inductionStatus.ToInductionStatus(), updatedPerson!.InductionStatus);
+            Assert.Equal(inductionStartDate, updatedPerson.InductionStartDate);
+            Assert.Equal(inductionCompletedDate, updatedPerson.InductionCompletedDate);
+        });
+    }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
+
+    Task IAsyncLifetime.InitializeAsync() => JobFixture.DbFixture.DbHelper.ClearDataAsync();
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncFromCrmJobFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncFromCrmJobFixture.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Tests.Jobs;
+
+public class SyncFromCrmJobFixture : IAsyncLifetime
+{
+    public SyncFromCrmJobFixture(
+        DbFixture dbFixture,
+        IOrganizationServiceAsync2 organizationService,
+        ReferenceDataCache referenceDataCache,
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
+    {
+        DbFixture = dbFixture;
+        LoggerFactory = loggerFactory;
+        Clock = new();
+        LoggerFactory = loggerFactory;
+
+        Helper = new TrsDataSyncHelper(
+            dbFixture.GetDataSource(),
+            organizationService,
+            referenceDataCache,
+            Clock,
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
+
+        TestData = new TestData(
+            dbFixture.GetDbContextFactory(),
+            organizationService,
+            referenceDataCache,
+            Clock,
+            trnGenerator,
+            TestDataSyncConfiguration.Sync(Helper));
+
+        CrmServiceClientProvider = new TestCrmServiceClientProvider(organizationService);
+    }
+
+    public TestableClock Clock { get; }
+
+    public DbFixture DbFixture { get; }
+
+    public ILoggerFactory LoggerFactory { get; }
+
+    public TrsDataSyncHelper Helper { get; }
+
+    public TestData TestData { get; }
+
+    public ICrmServiceClientProvider CrmServiceClientProvider { get; }
+
+    Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+
+    private class TestCrmServiceClientProvider : ICrmServiceClientProvider
+    {
+        private readonly IOrganizationServiceAsync2 _organizationService;
+
+        public TestCrmServiceClientProvider(IOrganizationServiceAsync2 organizationService)
+        {
+            _organizationService = organizationService;
+        }
+
+        public IOrganizationServiceAsync2 GetClient(string name)
+        {
+            return _organizationService;
+        }
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncFromCrmJobTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncFromCrmJobTestBase.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Tests.Jobs;
+
+public abstract class SyncFromCrmJobTestBase : IClassFixture<SyncFromCrmJobFixture>
+{
+    public SyncFromCrmJobTestBase(SyncFromCrmJobFixture jobFixture)
+    {
+        JobFixture = jobFixture;
+    }
+
+    public SyncFromCrmJobFixture JobFixture { get; }
+
+    protected TestableClock Clock => JobFixture.Clock;
+
+    protected ILoggerFactory LoggerFactory => JobFixture.LoggerFactory;
+
+    protected DbFixture DbFixture => JobFixture.DbFixture;
+
+    protected TrsDataSyncHelper Helper => JobFixture.Helper;
+
+    protected TestData TestData => JobFixture.TestData;
+
+    public ICrmServiceClientProvider CrmServiceClientProvider => JobFixture.CrmServiceClientProvider;
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/DqtOutbox/OutboxMessageHandlerTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/DqtOutbox/OutboxMessageHandlerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
@@ -87,7 +88,8 @@ public class OutboxMessageHandlerFixture
         IOrganizationServiceAsync2 organizationService,
         IDbContextFactory<TrsDbContext> dbContextFactory,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         Clock = new TestableClock();
         DbFixture = dbFixture;
@@ -98,7 +100,8 @@ public class OutboxMessageHandlerFixture
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Services.Establishments.Gias;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
@@ -11,7 +12,8 @@ public class EstablishmentRefresherTests
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -21,7 +23,8 @@ public class EstablishmentRefresherTests
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.Establishments.Tps;
@@ -28,7 +29,8 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -38,7 +40,8 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.PersonMatching;
@@ -12,7 +13,8 @@ public class PersonMatchingServiceTests : IAsyncLifetime
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -22,7 +24,8 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
@@ -1,5 +1,6 @@
 using FakeXrmEasy.Extensions;
 using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using TeachingRecordSystem.Core.Dqt.Models;
@@ -14,7 +15,8 @@ public partial class TrsDataSyncHelperTests : IAsyncLifetime
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -24,7 +26,8 @@ public partial class TrsDataSyncHelperTests : IAsyncLifetime
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -12,17 +13,20 @@ public class TrsDataSyncServiceFixture : IAsyncLifetime
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         DbFixture = dbFixture;
         Clock = new();
+        AuditRepository = new();
 
         Helper = new TrsDataSyncHelper(
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            AuditRepository,
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),
@@ -40,6 +44,8 @@ public class TrsDataSyncServiceFixture : IAsyncLifetime
     public TrsDataSyncHelper Helper { get; }
 
     public TestData TestData { get; }
+
+    public TestableAuditRepository AuditRepository { get; }
 
     public Task PublishChangedItemAndConsumeAsync(string modelType, IChangedItem changedItem)
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Induction.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Induction.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using FakeXrmEasy.Extensions;
+using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using TeachingRecordSystem.Core.Dqt;
@@ -14,21 +17,28 @@ public partial class TrsDataSyncServiceTests
     public async Task Induction_NewRecord_WritesUpdatedPersonRecordToDatabase(bool personAlreadySynced)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithSyncOverride(personAlreadySynced));
-        var contactId = createPersonResult.ContactId;
+        var person = await TestData.CreatePersonAsync(p => p.WithSyncOverride(personAlreadySynced));
+        var contactId = person.ContactId;
 
+        var contactAuditDetails = new AuditDetailCollection();
+        contactAuditDetails.Add(person.DqtContactAuditDetail);
+        await AuditRepository.SetAuditDetailAsync(Contact.EntityLogicalName, contactId, contactAuditDetails);
+
+        var inductionId = Guid.NewGuid();
+        var inductionStatus = dfeta_InductionStatus.Pass;
         var inductionStartDate = Clock.Today.AddYears(-1);
         var inductionEndDate = Clock.Today.AddDays(-10);
-        var induction = new dfeta_induction()
-        {
-            Id = Guid.NewGuid(),
-            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, contactId),
-            dfeta_InductionStatus = dfeta_InductionStatus.Pass,
-            dfeta_StartDate = inductionStartDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
-            dfeta_CompletionDate = inductionEndDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
-            CreatedOn = Clock.UtcNow,
-            ModifiedOn = Clock.UtcNow
-        };
+
+        var inductionAuditDetails = new AuditDetailCollection();
+        var induction = await CreateNewInductionEntityVersion(
+            inductionId,
+            person.Contact,
+            inductionAuditDetails,
+            startDate: inductionStartDate,
+            endDate: inductionEndDate,
+            status: inductionStatus);
+
+        await AuditRepository.SetAuditDetailAsync(dfeta_induction.EntityLogicalName, inductionId, inductionAuditDetails);
 
         // Keep the contact induction status in sync with dfeta_induction otherwise the sync will fail
         await TestData.OrganizationService.ExecuteAsync(new UpdateRequest()
@@ -50,7 +60,7 @@ public partial class TrsDataSyncServiceTests
         {
             var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.DqtContactId == contactId);
             Assert.NotNull(person);
-            Assert.Equal(InductionStatus.Passed, person.InductionStatus);
+            Assert.Equal(inductionStatus.ToInductionStatus(), person.InductionStatus);
             Assert.Equal(inductionStartDate, person.InductionStartDate);
             Assert.Equal(inductionEndDate, person.InductionCompletedDate);
         });
@@ -64,27 +74,44 @@ public partial class TrsDataSyncServiceTests
         var originalInductionStartDate = Clock.Today.AddYears(-1);
         var originalInductionEndDate = Clock.Today.AddDays(-10);
 
-        var createPersonResult = await TestData.CreatePersonAsync(
+        var person = await TestData.CreatePersonAsync(
             p => p.WithSyncOverride(true)
                 .WithDqtInduction(originalInductionStatus, null, originalInductionStartDate, null));
-        var contactId = createPersonResult.ContactId;
-        var existingInduction = createPersonResult.DqtInductions.Single();
+        var contactId = person.ContactId;
 
-        var updatedInductionStatus = dfeta_InductionStatus.Pass;
-        var updatedInductionStartDate = Clock.Today.AddYears(-2);
-        var updatedInductionEndDate = Clock.Today.AddDays(-20);
-        var createdOn = Clock.UtcNow;
-        var modifiedOn = Clock.Advance();
-        var updatedInduction = new dfeta_induction()
-        {
-            Id = existingInduction.InductionId,
-            dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, contactId),
-            dfeta_InductionStatus = updatedInductionStatus,
-            dfeta_StartDate = updatedInductionStartDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
-            dfeta_CompletionDate = updatedInductionEndDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
-            CreatedOn = Clock.UtcNow,
-            ModifiedOn = modifiedOn
-        };
+        var contactAuditDetails = new AuditDetailCollection();
+        contactAuditDetails.Add(person.DqtContactAuditDetail);
+        await AuditRepository.SetAuditDetailAsync(Contact.EntityLogicalName, contactId, contactAuditDetails);
+
+        var inductionId = person.DqtInductions.Single().InductionId;
+        using var ctx = new DqtCrmServiceContext(TestData.OrganizationService);
+        var induction = ctx.dfeta_inductionSet.SingleOrDefault(i => i.GetAttributeValue<Guid>(dfeta_induction.PrimaryIdAttribute) == inductionId);
+        var inductionAuditDetails = new AuditDetailCollection();
+
+        ////var existingInduction = person.DqtInductions.Single();
+
+        ////var updatedInductionStatus = dfeta_InductionStatus.Pass;
+        ////var updatedInductionStartDate = Clock.Today.AddYears(-2);
+        ////var updatedInductionEndDate = Clock.Today.AddDays(-20);
+        ////var createdOn = Clock.UtcNow;
+        ////var modifiedOn = Clock.Advance();
+        ////var updatedInduction = new dfeta_induction()
+        ////{
+        ////    Id = existingInduction.InductionId,
+        ////    dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, contactId),
+        ////    dfeta_InductionStatus = updatedInductionStatus,
+        ////    dfeta_StartDate = updatedInductionStartDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
+        ////    dfeta_CompletionDate = updatedInductionEndDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
+        ////    CreatedOn = Clock.UtcNow,
+        ////    ModifiedOn = modifiedOn
+        ////};
+
+        var updatedInduction = await CreateUpdatedInductionEntityVersion(
+            induction!,
+            inductionAuditDetails,
+            DqtInductionUpdatedEventChanges.StartDate & DqtInductionUpdatedEventChanges.CompletionDate | DqtInductionUpdatedEventChanges.Status);
+
+        await AuditRepository.SetAuditDetailAsync(dfeta_induction.EntityLogicalName, inductionId, inductionAuditDetails);
 
         // Keep the contact induction status in sync with dfeta_induction otherwise the sync will fail
         await TestData.OrganizationService.ExecuteAsync(new UpdateRequest()
@@ -92,7 +119,7 @@ public partial class TrsDataSyncServiceTests
             Target = new Contact()
             {
                 Id = contactId,
-                dfeta_InductionStatus = dfeta_InductionStatus.Pass
+                dfeta_InductionStatus = updatedInduction.dfeta_InductionStatus
             }
         });
 
@@ -106,10 +133,160 @@ public partial class TrsDataSyncServiceTests
         {
             var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.DqtContactId == contactId);
             Assert.NotNull(person);
-            Assert.Equal(InductionStatus.Passed, person.InductionStatus);
-            Assert.Equal(updatedInductionStartDate, person.InductionStartDate);
-            Assert.Equal(updatedInductionEndDate, person.InductionCompletedDate);
-            Assert.Equal(Clock.UtcNow, person.DqtInductionModifiedOn);
+            Assert.Equal(updatedInduction.dfeta_InductionStatus.ToInductionStatus(), person.InductionStatus);
+            Assert.Equal(updatedInduction.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true), person.InductionStartDate);
+            Assert.Equal(updatedInduction.dfeta_CompletionDate.ToDateOnlyWithDqtBstFix(isLocalTime: true), person.InductionCompletedDate);
+            Assert.Equal(updatedInduction.ModifiedOn, person.DqtInductionModifiedOn);
         });
+    }
+
+    private async Task<dfeta_induction> CreateNewInductionEntityVersion(
+        Guid inductionId,
+        Contact contact,
+        AuditDetailCollection auditDetailCollection,
+        DateOnly? startDate = null,
+        DateOnly? endDate = null,
+        dfeta_InductionStatus? status = null,
+        dfeta_InductionExemptionReason? exemptionReason = null,
+        bool addCreateAudit = true)
+    {
+        Debug.Assert(auditDetailCollection.Count == 0);
+
+        var currentDqtUser = await TestData.GetCurrentCrmUserAsync();
+        var createdOn = Clock.UtcNow;
+        var modifiedOn = Clock.UtcNow;
+        var state = dfeta_inductionState.Active;
+
+        var newInduction = new dfeta_induction()
+        {
+            Id = inductionId,
+            dfeta_PersonId = contact.Id.ToEntityReference(Contact.EntityLogicalName),
+            CreatedOn = createdOn,
+            CreatedBy = currentDqtUser,
+            ModifiedOn = modifiedOn,
+            StateCode = state,
+            dfeta_StartDate = startDate?.ToDateTimeWithDqtBstFix(isLocalTime: true),
+            dfeta_CompletionDate = endDate?.ToDateTimeWithDqtBstFix(isLocalTime: true),
+            dfeta_InductionStatus = status,
+            dfeta_InductionExemptionReason = exemptionReason
+        };
+
+        if (addCreateAudit)
+        {
+            var auditId = Guid.NewGuid();
+            auditDetailCollection.Add(new AttributeAuditDetail()
+            {
+                AuditRecord = new Audit()
+                {
+                    Action = Audit_Action.Create,
+                    AuditId = auditId,
+                    CreatedOn = Clock.UtcNow,
+                    Id = auditId,
+                    Operation = Audit_Operation.Create,
+                    UserId = currentDqtUser
+                },
+                OldValue = new Entity(),
+                NewValue = newInduction.Clone()
+            });
+        }
+
+        return newInduction;
+    }
+
+    private async Task<dfeta_induction> CreateUpdatedInductionEntityVersion(
+        dfeta_induction existingInduction,
+        AuditDetailCollection auditDetailCollection,
+        DqtInductionUpdatedEventChanges? changes = null)
+    {
+        if (changes == DqtInductionUpdatedEventChanges.None)
+        {
+            throw new ArgumentException("Changes cannot be None.", nameof(changes));
+        }
+
+        bool ChangeRequested(DqtInductionUpdatedEventChanges field) =>
+            changes is null || changes.Value.HasFlag(field);
+
+        var currentDqtUser = await TestData.GetCurrentCrmUserAsync();
+
+        var existingStartDate = existingInduction.dfeta_StartDate;
+        var startDate = ChangeRequested(DqtInductionUpdatedEventChanges.StartDate) ?
+            (existingInduction.dfeta_StartDate?.ToDateOnlyWithDqtBstFix(isLocalTime: true) is DateOnly existingStartDateOnly ?
+                TestData.GenerateChangedDate(existingStartDateOnly, min: new DateOnly(2020, 4, 1)) :
+                TestData.GenerateDate(min: new DateOnly(2020, 4, 1))).ToDateTimeWithDqtBstFix(isLocalTime: true) :
+            existingStartDate;
+
+        var existingCompletionDate = existingInduction.dfeta_CompletionDate;
+        DateTime? completionDate;
+
+        if (ChangeRequested(DqtInductionUpdatedEventChanges.CompletionDate))
+        {
+            if (startDate is null)
+            {
+                throw new InvalidOperationException("Cannot generate a completion date when there is no start date.");
+            }
+
+            var startDateOnly = startDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true);
+
+            completionDate = (existingCompletionDate is null ?
+                    TestData.GenerateDate(min: startDateOnly.AddDays(1)) :
+                    TestData.GenerateChangedDate(existingCompletionDate.Value.ToDateOnlyWithDqtBstFix(isLocalTime: true), min: startDateOnly.AddDays(1)))
+                .ToDateTimeWithDqtBstFix(isLocalTime: true);
+        }
+        else
+        {
+            completionDate = null;
+        }
+
+        var existingStatus = existingInduction.dfeta_InductionStatus;
+        var status = ChangeRequested(DqtInductionUpdatedEventChanges.Status) ?
+            TestData.GenerateChangedEnumValue(existingStatus) :
+            existingStatus;
+
+        var existingExemptionReason = existingInduction.dfeta_InductionExemptionReason;
+        var exemptionReason = ChangeRequested(DqtInductionUpdatedEventChanges.ExemptionReason) ?
+            TestData.GenerateChangedEnumValue(existingExemptionReason) :
+            existingExemptionReason;
+
+        var updatedInduction = existingInduction.Clone<dfeta_induction>();
+        updatedInduction.ModifiedOn = Clock.UtcNow;
+        updatedInduction.dfeta_StartDate = startDate;
+        updatedInduction.dfeta_CompletionDate = completionDate;
+        updatedInduction.dfeta_InductionStatus = status;
+        updatedInduction.dfeta_InductionExemptionReason = exemptionReason;
+
+        var changedAttrs = (
+            from newAttr in updatedInduction.Attributes
+            join oldAttr in existingInduction.Attributes on newAttr.Key equals oldAttr.Key
+            where !AttributeValuesEqual(newAttr.Value, oldAttr.Value)
+            select newAttr.Key).ToArray();
+
+        var oldValue = new Entity(dfeta_induction.EntityLogicalName, existingInduction.Id);
+        Array.ForEach(changedAttrs, a => oldValue.Attributes[a] = existingInduction.Attributes[a]);
+
+        var newValue = new Entity(dfeta_induction.EntityLogicalName, existingInduction.Id);
+        Array.ForEach(changedAttrs, a => newValue.Attributes[a] = updatedInduction.Attributes[a]);
+
+
+        var auditId = Guid.NewGuid();
+        auditDetailCollection.Add(new AttributeAuditDetail()
+        {
+            AuditRecord = new Audit()
+            {
+                Action = Audit_Action.Update,
+                AuditId = auditId,
+                CreatedOn = Clock.UtcNow,
+                Id = auditId,
+                Operation = Audit_Operation.Update,
+                UserId = currentDqtUser
+            },
+            OldValue = oldValue,
+            NewValue = newValue
+        });
+
+        return updatedInduction;
+
+        static bool AttributeValuesEqual(object? a, object? b) =>
+            a is null && b is null ||
+            (a is not null && b is not null && a.Equals(b));
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.cs
@@ -8,6 +8,8 @@ public partial class TrsDataSyncServiceTests(TrsDataSyncServiceFixture fixture) 
 
     private TestData TestData => fixture.TestData;
 
+    private TestableAuditRepository AuditRepository => fixture.AuditRepository;
+
     Task IAsyncLifetime.DisposeAsync() => Task.CompletedTask;
 
     Task IAsyncLifetime.InitializeAsync() => fixture.DbFixture.DbHelper.ClearDataAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
@@ -12,7 +13,8 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -22,7 +24,8 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -1,5 +1,6 @@
 using Google.Apis.Upload;
 using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Parquet.Serialization;
@@ -16,7 +17,8 @@ public class WorkforceDataExporterTests : IAsyncLifetime
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        FakeTrnGenerator trnGenerator)
+        FakeTrnGenerator trnGenerator,
+        ILoggerFactory loggerFactory)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -26,7 +28,8 @@ public class WorkforceDataExporterTests : IAsyncLifetime
             organizationService,
             referenceDataCache,
             Clock,
-            new TestableAuditRepository());
+            new TestableAuditRepository(),
+            loggerFactory.CreateLogger<TrsDataSyncHelper>());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/terraform/aks/config/pre-production.tfvars.json
+++ b/terraform/aks/config/pre-production.tfvars.json
@@ -9,7 +9,7 @@
   "run_dqt_reporting_service": true,
   "run_recurring_jobs": true,
   "enable_logit": true,
-  "worker_max_memory": "2Gi",
+  "worker_max_memory": "4Gi",
   "postgres_flexible_server_sku": "GP_Standard_D2ads_v5",
   "postgres_azure_storage_mb": 65536,
   "enable_dfe_analytics_federated_auth": true

--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -14,7 +14,7 @@
   "authz_replicas": 2,
   "ui_replicas": 2,
   "worker_replicas": 2,
-  "worker_max_memory": "2Gi",
+  "worker_max_memory": "4Gi",
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_azure_storage_mb": 65536,
   "postgres_enable_high_availability": true,


### PR DESCRIPTION
### Context

As the `SyncAllInductionsFromCrmJob` was run against more volumes of data, various issues came to light which needed fixing.

### Changes proposed in this pull request

Various tweaks to ensure that all induction data and related audit history for dfeta_induction and contact table get synced correctly.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
