### PR TITLE
Create webhook messages when events are saved

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetCpdInductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetCpdInductionStatus.cs
@@ -103,7 +103,7 @@ public class SetCpdInductionStatusHandler(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
         }
 
         await dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetWelshInductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetWelshInductionStatus.cs
@@ -65,7 +65,7 @@ public class SetWelshInductionStatusHandler(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
         }
 
         await dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/CheckAnswers.cshtml.cs
@@ -57,7 +57,7 @@ public class CheckAnswersModel(SignInJourneyHelper helper, TrsDbContext dbContex
         };
         dbContext.SupportTasks.Add(supportTask);
 
-        dbContext.AddEvent(new SupportTaskCreatedEvent()
+        await dbContext.AddEventAndBroadcastAsync(new SupportTaskCreatedEvent()
         {
             EventId = Guid.NewGuid(),
             CreatedUtc = clock.UtcNow,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/CacheKeys.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/CacheKeys.cs
@@ -29,4 +29,6 @@ public static class CacheKeys
     public static object GetSubjectTitleKey(string title) => $"subjects_{title}";
 
     public static object PersonInfo(Guid personId) => $"person_info:{personId}";
+
+    public static object EnabledWebhookEndpoints() => "webhook_endpoints";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDesignTimeDbContextFactory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDesignTimeDbContextFactory.cs
@@ -13,9 +13,6 @@ public class TrsDesignTimeDbContextFactory : IDesignTimeDbContextFactory<TrsDbCo
 
         var connectionString = configuration.GetPostgresConnectionString();
 
-        var optionsBuilder = new DbContextOptionsBuilder<TrsDbContext>();
-        TrsDbContext.ConfigureOptions(optionsBuilder, connectionString);
-
-        return new TrsDbContext(optionsBuilder.Options);
+        return TrsDbContext.Create(connectionString);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Extensions.cs
@@ -3,12 +3,14 @@ using Hangfire.PostgreSql;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Npgsql;
 using Serilog;
 using Serilog.Formatting.Compact;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
+using TeachingRecordSystem.Core.Services.Webhooks;
 
 namespace TeachingRecordSystem.Core;
 
@@ -68,6 +70,15 @@ public static class Extensions
                         UseSlidingInvisibilityTimeout = true
                     }));
         }
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddWebhookMessageFactory(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddSingleton<WebhookMessageFactory>();
+        builder.Services.AddSingleton<EventMapperRegistry>();
+        builder.Services.TryAddSingleton<PersonInfoCache>();
 
         return builder;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendEytsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendEytsAwardedEmailJob.cs
@@ -49,7 +49,7 @@ public class SendEytsAwardedEmailJob
         await _notificationSender.SendEmailAsync(EytsAwardedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
         item.EmailSent = true;
 
-        _dbContext.AddEvent(new EytsAwardedEmailSentEvent
+        _dbContext.AddEventWithoutBroadcast(new EytsAwardedEmailSentEvent
         {
             EventId = Guid.NewGuid(),
             EytsAwardedEmailsJobId = eytsAwardedEmailsJobId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
@@ -49,7 +49,7 @@ public class SendInductionCompletedEmailJob
         await _notificationSender.SendEmailAsync(InductionCompletedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
         item.EmailSent = true;
 
-        _dbContext.AddEvent(new InductionCompletedEmailSentEvent
+        _dbContext.AddEventWithoutBroadcast(new InductionCompletedEmailSentEvent
         {
             EventId = Guid.NewGuid(),
             InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInternationalQtsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInternationalQtsAwardedEmailJob.cs
@@ -49,7 +49,7 @@ public class SendInternationalQtsAwardedEmailJob
         await _notificationSender.SendEmailAsync(InternationalQtsAwardedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
         item.EmailSent = true;
 
-        _dbContext.AddEvent(new InternationalQtsAwardedEmailSentEvent
+        _dbContext.AddEventWithoutBroadcast(new InternationalQtsAwardedEmailSentEvent
         {
             EventId = Guid.NewGuid(),
             InternationalQtsAwardedEmailsJobId = internationalQtsAwardedEmailsJobId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendQtsAwardedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendQtsAwardedEmailJob.cs
@@ -49,7 +49,7 @@ public class SendQtsAwardedEmailJob
         await _notificationSender.SendEmailAsync(QtsAwardedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
         item.EmailSent = true;
 
-        _dbContext.AddEvent(new QtsAwardedEmailSentEvent
+        _dbContext.AddEventWithoutBroadcast(new QtsAwardedEmailSentEvent
         {
             EventId = Guid.NewGuid(),
             QtsAwardedEmailsJobId = qtsAwardedEmailsJobId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/EventMapperRegistry.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/EventMapperRegistry.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.CodeAnalysis;
+using TeachingRecordSystem.Core.ApiSchema.V3;
+
+namespace TeachingRecordSystem.Core.Services.Webhooks;
+
+public class EventMapperRegistry
+{
+    private sealed record MapperKey(Type EventType, string CloudEventType, string ApiVersion);
+
+    private sealed record MapperValue(Type MapperType, Type DataType);
+
+    private readonly Dictionary<MapperKey, MapperValue> _mappers = DiscoverMappers();
+
+    public Type? GetMapperType(Type eventType, string cloudEventType, string apiVersion, [MaybeNull] out Type dataType)
+    {
+        if (_mappers.TryGetValue(new(eventType, cloudEventType, apiVersion), out var result))
+        {
+            dataType = result.DataType;
+            return result.MapperType;
+        }
+
+        dataType = null;
+        return null;
+    }
+
+    private static Dictionary<MapperKey, MapperValue> DiscoverMappers()
+    {
+        var mapperTypes = typeof(EventMapperRegistry).Assembly.GetTypes()
+            .Where(t => t.IsPublic && !t.IsAbstract && t.GetInterfaces().Any(i =>
+                i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableTo(typeof(IEventMapper<,>))));
+
+        var mappers = new Dictionary<MapperKey, MapperValue>();
+
+        foreach (var type in mapperTypes)
+        {
+            var mapperTypeArgs = type.GetInterface(typeof(IEventMapper<,>).Name)!.GetGenericArguments();
+            var eventType = mapperTypeArgs[0];
+            var dataType = mapperTypeArgs[1];
+
+            var cloudEventType = (string)dataType.GetProperty("CloudEventType")!.GetValue(null)!;
+
+            var version = type.Namespace!.Split('.').SkipWhile(ns => ns != "V3").Skip(1).First().TrimStart('V');
+
+            mappers.Add(new MapperKey(eventType, cloudEventType, version), new MapperValue(type, dataType));
+        }
+
+        return mappers;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using TeachingRecordSystem.Core.ApiSchema.V3;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Infrastructure.Json;
+
+namespace TeachingRecordSystem.Core.Services.Webhooks;
+
+public class WebhookMessageFactory(EventMapperRegistry eventMapperRegistry, IClock clock, IMemoryCache memoryCache)
+{
+    private static readonly TimeSpan _webhookEndpointsCacheDuration = TimeSpan.FromMinutes(1);
+
+    private static readonly JsonSerializerOptions _serializerOptions =
+        new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+            {
+                Modifiers =
+                {
+                    Modifiers.OptionProperties
+                }
+            }
+        };
+
+    public async Task<IEnumerable<WebhookMessage>> CreateMessagesAsync(
+        TrsDbContext dbContext,
+        EventBase @event,
+        IServiceProvider serviceProvider)
+    {
+        var endpoints = await memoryCache.GetOrCreateAsync(
+            CacheKeys.EnabledWebhookEndpoints(),
+            async e =>
+            {
+                e.SetAbsoluteExpiration(_webhookEndpointsCacheDuration);
+                return await dbContext.WebhookEndpoints.AsNoTracking().Where(e => e.Enabled).ToArrayAsync();
+            });
+
+        var endpointCloudEventTypeVersions = endpoints!
+            .SelectMany(e =>
+                e.CloudEventTypes.Select(t => (Version: e.ApiVersion, CloudEventType: t, e.WebhookEndpointId)))
+            .GroupBy(t => (t.Version, t.CloudEventType), t => t.WebhookEndpointId)
+            .ToDictionary(g => g.Key, g => g.AsEnumerable());
+
+        var messages = new List<WebhookMessage>();
+
+        foreach (var (version, cloudEventType) in endpointCloudEventTypeVersions.Keys)
+        {
+            var mapperType = eventMapperRegistry.GetMapperType(@event.GetType(), cloudEventType, version, out var dataType);
+            if (mapperType is null)
+            {
+                continue;
+            }
+
+            var payload = await MapEventAsync(mapperType, dataType!);
+            if (payload is null)
+            {
+                continue;
+            }
+
+            var serializedPayload = JsonSerializer.SerializeToElement(payload, _serializerOptions);
+
+            messages.AddRange(endpointCloudEventTypeVersions[(version, cloudEventType)].Select(epId =>
+            {
+                var id = Guid.NewGuid();
+
+                return new WebhookMessage
+                {
+                    WebhookMessageId = id,
+                    WebhookEndpointId = epId,
+                    CloudEventId = id.ToString(),
+                    CloudEventType = cloudEventType,
+                    Timestamp = clock.UtcNow,
+                    ApiVersion = version,
+                    Data = serializedPayload,
+                    NextDeliveryAttempt = clock.UtcNow,
+                    Delivered = null,
+                    DeliveryAttempts = [],
+                    DeliveryErrors = []
+                };
+            }));
+        }
+
+        return messages;
+
+        Task<object?> MapEventAsync(Type mapperType, Type dataType)
+        {
+            var mapper = ActivatorUtilities.CreateInstance(serviceProvider, mapperType);
+
+            var eventType = @event.GetType();
+
+            var wrappedMapper = (IEventMapper)ActivatorUtilities.CreateInstance(
+                serviceProvider,
+                typeof(WrappedMapper<,>).MakeGenericType(eventType, dataType),
+                mapper);
+
+            return wrappedMapper.MapEventAsync(@event);
+        }
+    }
+
+    private interface IEventMapper
+    {
+        Task<object?> MapEventAsync(EventBase @event);
+    }
+
+    private class WrappedMapper<TEvent, TData>(IEventMapper<TEvent, TData> innerMapper) : IEventMapper
+        where TEvent : EventBase
+        where TData : IWebhookMessageData
+    {
+        public async Task<object?> MapEventAsync(EventBase @event) =>
+            await innerMapper.MapEventAsync((TEvent)@event);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.ServiceDefaults/Extensions.cs
@@ -23,6 +23,7 @@ public static class Extensions
         builder.AddDatabase();
         builder.AddHangfire();
         builder.AddBackgroundWorkScheduler();
+        builder.AddWebhookMessageFactory();
 
         builder.Services.AddHealthChecks().AddNpgSql(sp => sp.GetRequiredService<NpgsqlDataSource>());
         builder.Services.AddDatabaseDeveloperPageExceptionFilter();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
@@ -71,7 +71,7 @@ public class CheckAnswersModel(
             out var createdEvent);
 
         dbContext.Alerts.Add(alert);
-        dbContext.AddEvent(createdEvent);
+        await dbContext.AddEventAndBroadcastAsync(createdEvent);
         await dbContext.SaveChangesAsync();
 
         await JourneyInstance!.CompleteAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -78,7 +78,7 @@ public class CheckAnswersModel(
             Changes = AlertUpdatedEventChanges.EndDate
         };
 
-        dbContext.AddEvent(updatedEvent);
+        await dbContext.AddEventAndBroadcastAsync(updatedEvent);
 
         await dbContext.SaveChangesAsync();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
@@ -59,7 +59,7 @@ public class CheckAnswersModel(
             clock.UtcNow,
             out var deletedEvent);
 
-        dbContext.AddEvent(deletedEvent);
+        await dbContext.AddEventAndBroadcastAsync(deletedEvent);
         await dbContext.SaveChangesAsync();
 
         await JourneyInstance!.CompleteAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
@@ -60,7 +60,7 @@ public class CheckAnswersModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
@@ -60,7 +60,7 @@ public class CheckAnswersModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
@@ -64,7 +64,7 @@ public class CheckAnswersModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
@@ -60,7 +60,7 @@ public class CheckAnswersModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
@@ -66,7 +66,7 @@ public class CheckAnswersModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey.cshtml.cs
@@ -54,7 +54,7 @@ public class AddApiKeyModel(TrsDbContext dbContext, IClock clock, TrsLinkGenerat
             RaisedBy = User.GetUserId(),
             ApiKey = Core.Events.Models.ApiKey.FromModel(apiKey)
         };
-        dbContext.AddEvent(@event);
+        await dbContext.AddEventAndBroadcastAsync(@event);
 
         try
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey.cshtml.cs
@@ -48,7 +48,7 @@ public class EditApiKeyModel(TrsDbContext dbContext, TrsLinkGenerator linkGenera
             OldApiKey = oldApiKey,
             Changes = ApiKeyUpdatedEventChanges.Expires
         };
-        dbContext.AddEvent(@event);
+        await dbContext.AddEventAndBroadcastAsync(@event);
 
         await dbContext.SaveChangesAsync();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser.cshtml.cs
@@ -37,7 +37,7 @@ public class AddApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator li
 
         dbContext.ApplicationUsers.Add(newUser);
 
-        dbContext.AddEvent(new ApplicationUserCreatedEvent()
+        await dbContext.AddEventAndBroadcastAsync(new ApplicationUserCreatedEvent()
         {
             EventId = Guid.NewGuid(),
             ApplicationUser = Core.Events.Models.ApplicationUser.FromModel(newUser),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
@@ -229,7 +229,7 @@ public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator l
                 OldApplicationUser = oldApplicationUser,
                 Changes = changes
             };
-            dbContext.AddEvent(@event);
+            await dbContext.AddEventAndBroadcastAsync(@event);
 
             await dbContext.SaveChangesAsync();
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
@@ -42,7 +42,7 @@ public class CheckAnswersModel(TrsDbContext dbContext, TrsLinkGenerator linkGene
             out var createdEvent);
 
         dbContext.MandatoryQualifications.Add(qualification);
-        dbContext.AddEvent(createdEvent);
+        await dbContext.AddEventAndBroadcastAsync(createdEvent);
         await dbContext.SaveChangesAsync();
 
         await JourneyInstance!.CompleteAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Confirm.cshtml.cs
@@ -60,7 +60,7 @@ public class ConfirmModel(
             clock.UtcNow,
             out var deletedEvent);
 
-        dbContext.AddEvent(deletedEvent);
+        await dbContext.AddEventAndBroadcastAsync(deletedEvent);
         await dbContext.SaveChangesAsync();
 
         await JourneyInstance!.CompleteAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Confirm.cshtml.cs
@@ -64,7 +64,7 @@ public class ConfirmModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Confirm.cshtml.cs
@@ -59,7 +59,7 @@ public class ConfirmModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Confirm.cshtml.cs
@@ -59,7 +59,7 @@ public class ConfirmModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Confirm.cshtml.cs
@@ -73,7 +73,7 @@ public class ConfirmModel(
 
         if (updatedEvent is not null)
         {
-            dbContext.AddEvent(updatedEvent);
+            await dbContext.AddEventAndBroadcastAsync(updatedEvent);
             await dbContext.SaveChangesAsync();
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
@@ -80,7 +80,7 @@ public class ConfirmModel(
 
         dbContext.Users.Add(newUser);
 
-        dbContext.AddEvent(new UserAddedEvent()
+        await dbContext.AddEventAndBroadcastAsync(new UserAddedEvent()
         {
             EventId = Guid.NewGuid(),
             User = Core.Events.Models.User.FromModel(newUser),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
@@ -83,7 +83,7 @@ public class EditUser(
             user.Roles = newRoles;
             user.Name = Name!;
 
-            dbContext.AddEvent(new UserUpdatedEvent
+            await dbContext.AddEventAndBroadcastAsync(new UserUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
                 User = Core.Events.Models.User.FromModel(user),
@@ -110,7 +110,7 @@ public class EditUser(
 
         user.Active = false;
 
-        dbContext.AddEvent(new UserDeactivatedEvent
+        await dbContext.AddEventAndBroadcastAsync(new UserDeactivatedEvent
         {
             EventId = Guid.NewGuid(),
             User = Core.Events.Models.User.FromModel(user),
@@ -135,7 +135,7 @@ public class EditUser(
 
         user.Active = true;
 
-        dbContext.AddEvent(new UserActivatedEvent
+        await dbContext.AddEventAndBroadcastAsync(new UserActivatedEvent
         {
             EventId = Guid.NewGuid(),
             User = Core.Events.Models.User.FromModel(user),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
@@ -44,7 +44,8 @@ builder
     .AddIdentityApi()
     .AddNameSynonyms()
     .AddDqtOutboxMessageProcessorService()
-    .AddWebhookDeliveryService();
+    .AddWebhookDeliveryService()
+    .AddWebhookMessageFactory();
 
 var crmServiceClient = new ServiceClient(builder.Configuration.GetRequiredValue("ConnectionStrings:Crm"))
 {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogAlertEventsTests.cs
@@ -923,7 +923,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertCreatedEvent);
+            dbContext.AddEventWithoutBroadcast(alertCreatedEvent);
             await dbContext.SaveChangesAsync();
         });
 
@@ -956,7 +956,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertCreatedEvent);
+            dbContext.AddEventWithoutBroadcast(alertCreatedEvent);
             await dbContext.SaveChangesAsync();
         });
 
@@ -987,7 +987,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertDeletedEvent);
+            dbContext.AddEventWithoutBroadcast(alertDeletedEvent);
             await dbContext.SaveChangesAsync();
         });
 
@@ -1009,7 +1009,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertDqtDeactivatedEvent);
+            dbContext.AddEventWithoutBroadcast(alertDqtDeactivatedEvent);
             await dbContext.SaveChangesAsync();
         });
 
@@ -1032,7 +1032,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertDqtImportedEvent);
+            dbContext.AddEventWithoutBroadcast(alertDqtImportedEvent);
             await dbContext.SaveChangesAsync();
         });
 
@@ -1054,7 +1054,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertDqtReactivatedEvent);
+            dbContext.AddEventWithoutBroadcast(alertDqtReactivatedEvent);
             await dbContext.SaveChangesAsync();
         });
 
@@ -1091,7 +1091,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertMigratedEvent);
+            dbContext.AddEventWithoutBroadcast(alertMigratedEvent);
             await dbContext.SaveChangesAsync();
         });
 
@@ -1121,7 +1121,7 @@ public class ChangeLogAlertEventsTests : TestBase
 
         await WithDbContext(async dbContext =>
         {
-            dbContext.AddEvent(alertUpdatedEvent);
+            dbContext.AddEventWithoutBroadcast(alertUpdatedEvent);
             await dbContext.SaveChangesAsync();
         });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMandatoryQualificationEventsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMandatoryQualificationEventsTests.cs
@@ -342,7 +342,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                     EndDate = qualification.EndDate
                 }
             };
-            dbContext.AddEvent(reactivatedEvent);
+            dbContext.AddEventWithoutBroadcast(reactivatedEvent);
 
             await dbContext.SaveChangesAsync();
         });
@@ -388,7 +388,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 MandatoryQualification = EventModels.MandatoryQualification.FromModel(mq),
                 Changes = MandatoryQualificationMigratedEventChanges.None
             };
-            dbContext.AddEvent(migratedEvent);
+            dbContext.AddEventWithoutBroadcast(migratedEvent);
 
             await dbContext.SaveChangesAsync();
         });
@@ -434,7 +434,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 MandatoryQualification = EventModels.MandatoryQualification.FromModel(mq),
                 Changes = MandatoryQualificationMigratedEventChanges.None
             };
-            dbContext.AddEvent(migratedEvent);
+            dbContext.AddEventWithoutBroadcast(migratedEvent);
 
             await dbContext.SaveChangesAsync();
         });
@@ -483,7 +483,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 MandatoryQualification = EventModels.MandatoryQualification.FromModel(mq),
                 Changes = MandatoryQualificationMigratedEventChanges.Provider
             };
-            dbContext.AddEvent(migratedEvent);
+            dbContext.AddEventWithoutBroadcast(migratedEvent);
 
             await dbContext.SaveChangesAsync();
 
@@ -539,7 +539,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 MandatoryQualification = EventModels.MandatoryQualification.FromModel(mq),
                 Changes = MandatoryQualificationMigratedEventChanges.Specialism
             };
-            dbContext.AddEvent(migratedEvent);
+            dbContext.AddEventWithoutBroadcast(migratedEvent);
 
             await dbContext.SaveChangesAsync();
 
@@ -1015,7 +1015,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 EndDate = qualification.EndDate
             }
         };
-        dbContext.AddEvent(deletedEvent);
+        dbContext.AddEventWithoutBroadcast(deletedEvent);
 
         await dbContext.SaveChangesAsync();
     });
@@ -1105,7 +1105,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                     null,
                 Changes = changes
             };
-            dbContext.AddEvent(updatedEvent);
+            dbContext.AddEventWithoutBroadcast(updatedEvent);
 
             await dbContext.SaveChangesAsync();
         });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiKey.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiKey.cs
@@ -28,7 +28,7 @@ public partial class TestData
             RaisedBy = SystemUser.SystemUserId,
             ApiKey = Core.Events.Models.ApiKey.FromModel(apiKey)
         };
-        dbContext.AddEvent(@event);
+        dbContext.AddEventWithoutBroadcast(@event);
 
         await dbContext.SaveChangesAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
@@ -64,7 +64,7 @@ public partial class TestData
                 CreatedUtc = Clock.UtcNow,
                 ApplicationUser = EventModels.ApplicationUser.FromModel(user)
             };
-            dbContext.AddEvent(@event);
+            dbContext.AddEventWithoutBroadcast(@event);
 
             await dbContext.SaveChangesAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -850,7 +850,7 @@ public partial class TestData
                 out var @createdEvent);
 
             dbContext.Alerts.Add(alert);
-            dbContext.AddEvent(createdEvent);
+            dbContext.AddEventWithoutBroadcast(createdEvent);
 
             return (alert.AlertId, [createdEvent]);
         }
@@ -1023,7 +1023,7 @@ public partial class TestData
                     DqtState = 0
                 };
 
-                dbContext.AddEvent(createdEvent);
+                dbContext.AddEventWithoutBroadcast(createdEvent);
                 events.Add(createdEvent);
             }
             else
@@ -1053,7 +1053,7 @@ public partial class TestData
                     }
                 };
 
-                dbContext.AddEvent(createdEvent);
+                dbContext.AddEventWithoutBroadcast(createdEvent);
                 events.Add(createdEvent);
             }
 
@@ -1138,7 +1138,7 @@ public partial class TestData
 
             if (@event is not null)
             {
-                dbContext.AddEvent(@event);
+                dbContext.AddEventWithoutBroadcast(@event);
                 return [@event];
             }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.DeleteMandatoryQualification.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.DeleteMandatoryQualification.cs
@@ -60,7 +60,7 @@ public partial class TestData
                     } :
                     null
             };
-            dbContext.AddEvent(deletedEvent);
+            dbContext.AddEventWithoutBroadcast(deletedEvent);
 
             await dbContext.SaveChangesAsync();
         });


### PR DESCRIPTION
This updates our code paths that create events to also generate corresponding webhook messages, where appropriate. The `AddEvent` method on `TrsDbContext` is replaced with `AddEventAndBroadcastAsync`, which does the mapping to webhook messages and adds them to the `DbContext` to be saved.

There's a corresponding `AddEventWithoutBroadcast` method for use where we don't need to generate webhook messages.

All this does is write messages to the DB; the existing `WebhookDeliveryService` run by the worker is the thing that actually sends the messages.