### PR TITLE
Add CLI commands for managing webhook endpoints

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/GlobalUsings.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/GlobalUsings.cs
@@ -1,2 +1,3 @@
 global using AutoMapper;
+global using TeachingRecordSystem.Core.ApiSchema;
 global using PostgresModels = TeachingRecordSystem.Core.DataStore.Postgres.Models;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.WebhookEndpoint.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.WebhookEndpoint.cs
@@ -1,0 +1,333 @@
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Linq.Expressions;
+using System.Text.Json;
+using TeachingRecordSystem.Core.ApiSchema;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Cli;
+
+public partial class Commands
+{
+    public static Command CreateWebhookEndpointCommand(IConfiguration configuration)
+    {
+        var jsonSerializerOptions = new JsonSerializerOptions { WriteIndented = true };
+
+        Expression<Func<WebhookEndpoint, object>> getEndpointOutputForDisplay = e =>
+            new
+            {
+                e.WebhookEndpointId,
+                e.ApplicationUserId,
+                ApplicationUserName = e.ApplicationUser.Name,
+                e.ApiVersion,
+                e.Address,
+                e.CloudEventTypes,
+                e.Enabled
+            };
+
+        var command = new Command("webhook-endpoint", "Commands for managing webhook endpoints.");
+        command.AddCommand(CreateCreateCommand());
+        command.AddCommand(CreateDeleteCommand());
+        command.AddCommand(CreateGetCommand());
+        command.AddCommand(CreateListCommand());
+        command.AddCommand(CreateUpdateCommand());
+        return command;
+
+        static string ParseApiVersionArgument(ArgumentResult result)
+        {
+            var apiVersion = NormalizeApiVersion(result.Tokens.SingleOrDefault()?.Value ?? "");
+            if (!VersionRegistry.AllV3MinorVersions.Contains(apiVersion))
+            {
+                result.ErrorMessage = $"'{apiVersion}' is not a valid API version.";
+            }
+            return apiVersion;
+        }
+
+        static string NormalizeApiVersion(string version) => version.StartsWith("V") ? version[1..] : version;
+
+        Command CreateCreateCommand()
+        {
+            var userIdOption = new Option<Guid>("--user-id") { IsRequired = true };
+            var addressOption = new Option<string>("--address") { IsRequired = true };
+            var cloudEventTypesOption = new Option<string[]>("--cloud-event-types") { IsRequired = true, AllowMultipleArgumentsPerToken = true };
+            var apiVersionOption = new Option<string>("--api-version", ParseApiVersionArgument) { IsRequired = true };
+            var enabledOption = new Option<bool>("--enabled") { IsRequired = false };
+            var connectionStringOption = new Option<string>("--connection-string") { IsRequired = true };
+
+            var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+            if (configuredConnectionString is not null)
+            {
+                connectionStringOption.SetDefaultValue(configuredConnectionString);
+            }
+
+            enabledOption.SetDefaultValue(true);
+
+            var command = new Command("create", "Creates a webhook endpoint.")
+            {
+                userIdOption,
+                addressOption,
+                cloudEventTypesOption,
+                apiVersionOption,
+                enabledOption,
+                connectionStringOption
+            };
+
+            command.SetHandler(
+                async (Guid userId, string address, string[] cloudEventTypes, string apiVersion, bool enable, string connectionString) =>
+                {
+                    await using var dbContext = TrsDbContext.Create(connectionString);
+
+                    var webhookEndpointId = Guid.NewGuid();
+                    var now = DateTime.UtcNow;
+
+                    var endpoint = new WebhookEndpoint()
+                    {
+                        WebhookEndpointId = webhookEndpointId,
+                        ApplicationUserId = userId,
+                        Address = address,
+                        ApiVersion = apiVersion,
+                        CloudEventTypes = cloudEventTypes.Order().ToList(),
+                        Enabled = enable,
+                        CreatedOn = now,
+                        UpdatedOn = now
+                    };
+
+                    dbContext.WebhookEndpoints.Add(endpoint);
+
+                    dbContext.AddEventWithoutBroadcast(new WebhookEndpointCreatedEvent
+                    {
+                        WebhookEndpoint = EventModels.WebhookEndpoint.FromModel(endpoint),
+                        EventId = Guid.NewGuid(),
+                        CreatedUtc = now,
+                        RaisedBy = SystemUser.SystemUserId
+                    });
+
+                    await dbContext.SaveChangesAsync();
+
+                    var printableEndpoint = await dbContext.WebhookEndpoints
+                        .Where(e => e.WebhookEndpointId == webhookEndpointId)
+                        .OrderBy(e => e.CreatedOn)
+                        .Select(getEndpointOutputForDisplay)
+                        .SingleAsync();
+
+                    var output = JsonSerializer.Serialize(printableEndpoint, jsonSerializerOptions);
+                    Console.WriteLine(output);
+                },
+                userIdOption,
+                addressOption,
+                cloudEventTypesOption,
+                apiVersionOption,
+                enabledOption,
+                connectionStringOption);
+
+            return command;
+        }
+
+        Command CreateDeleteCommand()
+        {
+            var webhookEndpointIdOption = new Option<Guid>(["--webhook-endpoint-id", "--id"]) { IsRequired = true };
+            var connectionStringOption = new Option<string>("--connection-string") { IsRequired = true };
+
+            var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+            if (configuredConnectionString is not null)
+            {
+                connectionStringOption.SetDefaultValue(configuredConnectionString);
+            }
+
+            var command = new Command("delete", "Deletes a webhook endpoint.")
+            {
+                webhookEndpointIdOption,
+                connectionStringOption
+            };
+
+            command.SetHandler(
+                async (Guid webhookEndpointId, string connectionString) =>
+                {
+                    await using var dbContext = TrsDbContext.Create(connectionString);
+
+                    var endpoint = await dbContext.WebhookEndpoints
+                        .SingleAsync(e => e.WebhookEndpointId == webhookEndpointId);
+
+                    var now = DateTime.UtcNow;
+                    endpoint.DeletedOn = now;
+
+                    dbContext.AddEventWithoutBroadcast(new WebhookEndpointDeletedEvent
+                    {
+                        WebhookEndpoint = EventModels.WebhookEndpoint.FromModel(endpoint),
+                        EventId = Guid.NewGuid(),
+                        CreatedUtc = now,
+                        RaisedBy = SystemUser.SystemUserId
+                    });
+
+                    await dbContext.SaveChangesAsync();
+                },
+                webhookEndpointIdOption,
+                connectionStringOption);
+
+            return command;
+        }
+
+        Command CreateGetCommand()
+        {
+            var webhookEndpointIdOption = new Option<Guid>(["--webhook-endpoint-id", "--id"]) { IsRequired = true };
+            var connectionStringOption = new Option<string>("--connection-string") { IsRequired = true };
+
+            var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+            if (configuredConnectionString is not null)
+            {
+                connectionStringOption.SetDefaultValue(configuredConnectionString);
+            }
+
+            var command = new Command("get", "Gets a webhook endpoint.")
+            {
+                webhookEndpointIdOption,
+                connectionStringOption
+            };
+
+            command.SetHandler(
+                async (Guid webhookEndpointId, string connectionString) =>
+                {
+                    await using var dbContext = TrsDbContext.Create(connectionString);
+
+                    var endpoint = await dbContext.WebhookEndpoints
+                        .Include(e => e.ApplicationUser)
+                        .SingleAsync(e => e.WebhookEndpointId == webhookEndpointId);
+
+                    var printableEndpoint = new[] { endpoint }.AsQueryable().Select(getEndpointOutputForDisplay).Single();
+
+                    var output = JsonSerializer.Serialize(printableEndpoint, jsonSerializerOptions);
+                    Console.WriteLine(output);
+                },
+                webhookEndpointIdOption,
+                connectionStringOption);
+
+            return command;
+        }
+
+        Command CreateListCommand()
+        {
+            var connectionStringOption = new Option<string>("--connection-string") { IsRequired = true };
+
+            var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+            if (configuredConnectionString is not null)
+            {
+                connectionStringOption.SetDefaultValue(configuredConnectionString);
+            }
+
+            var command = new Command("list", "Lists the webhook endpoints.")
+            {
+                connectionStringOption
+            };
+
+            command.SetHandler(
+                async (string connectionString) =>
+                {
+                    await using var dbContext = TrsDbContext.Create(connectionString);
+
+                    var endpoints = await dbContext.WebhookEndpoints
+                        .Where(e => e.ApplicationUser.Active)
+                        .OrderBy(e => e.CreatedOn)
+                        .Select(getEndpointOutputForDisplay)
+                        .ToListAsync();
+
+                    var output = JsonSerializer.Serialize(endpoints, jsonSerializerOptions);
+                    Console.WriteLine(output);
+                },
+                connectionStringOption);
+
+            return command;
+        }
+
+        Command CreateUpdateCommand()
+        {
+            var webhookEndpointIdOption = new Option<Guid>(["--webhook-endpoint-id", "--id"]) { IsRequired = true };
+            var addressOption = new Option<string>("--address") { IsRequired = false };
+            var cloudEventTypesOption = new Option<string[]>("--cloud-event-types") { IsRequired = false, AllowMultipleArgumentsPerToken = true };
+            var apiVersionOption = new Option<string>("--api-version", ParseApiVersionArgument) { IsRequired = false };
+            var enabledOption = new Option<bool>("--enabled") { IsRequired = false };
+            var connectionStringOption = new Option<string>("--connection-string") { IsRequired = true };
+
+            var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+            if (configuredConnectionString is not null)
+            {
+                connectionStringOption.SetDefaultValue(configuredConnectionString);
+            }
+
+            enabledOption.SetDefaultValue(true);
+
+            var command = new Command("update", "Updates a webhook endpoint.")
+            {
+                webhookEndpointIdOption,
+                addressOption,
+                cloudEventTypesOption,
+                apiVersionOption,
+                enabledOption,
+                connectionStringOption
+            };
+
+            command.SetHandler(
+                async (InvocationContext context) =>
+                {
+                    var webhookEndpointId = context.ParseResult.GetValueForOption(webhookEndpointIdOption);
+                    var connectionString = context.ParseResult.GetValueForOption(connectionStringOption)!;
+
+                    await using var dbContext = TrsDbContext.Create(connectionString);
+
+                    var endpoint = await dbContext.WebhookEndpoints
+                        .Include(e => e.ApplicationUser)
+                        .SingleAsync(e => e.WebhookEndpointId == webhookEndpointId);
+
+                    var changes = WebhookEndpointUpdatedChanges.None;
+
+                    if (context.ParseResult.HasOption(addressOption))
+                    {
+                        endpoint.Address = context.ParseResult.GetValueForOption(addressOption)!;
+                        changes |= WebhookEndpointUpdatedChanges.Address;
+                    }
+
+                    if (context.ParseResult.HasOption(cloudEventTypesOption))
+                    {
+                        endpoint.CloudEventTypes = context.ParseResult.GetValueForOption(cloudEventTypesOption)!.Order().ToList();
+                        changes |= WebhookEndpointUpdatedChanges.CloudEventTypes;
+                    }
+
+                    if (context.ParseResult.HasOption(apiVersionOption))
+                    {
+                        endpoint.ApiVersion = context.ParseResult.GetValueForOption(apiVersionOption)!;
+                        changes |= WebhookEndpointUpdatedChanges.ApiVersion;
+                    }
+
+                    if (context.ParseResult.HasOption(enabledOption))
+                    {
+                        endpoint.Enabled = context.ParseResult.GetValueForOption(enabledOption);
+                        changes |= WebhookEndpointUpdatedChanges.Enabled;
+                    }
+
+                    if (changes != WebhookEndpointUpdatedChanges.None)
+                    {
+                        var now = DateTime.UtcNow;
+                        endpoint.UpdatedOn = now;
+
+                        dbContext.AddEventWithoutBroadcast(new WebhookEndpointUpdatedEvent
+                        {
+                            EventId = Guid.NewGuid(),
+                            CreatedUtc = now,
+                            RaisedBy = SystemUser.SystemUserId,
+                            WebhookEndpoint = EventModels.WebhookEndpoint.FromModel(endpoint),
+                            Changes = changes
+                        });
+
+                        await dbContext.SaveChangesAsync();
+                    }
+
+                    var printableEndpoint = new[] { endpoint }.AsQueryable().Select(getEndpointOutputForDisplay).Single();
+
+                    var output = JsonSerializer.Serialize(printableEndpoint, jsonSerializerOptions);
+                    Console.WriteLine(output);
+                });
+
+            return command;
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Program.cs
@@ -17,6 +17,7 @@ var rootCommand = new RootCommand("Development tools for the Teaching Record Sys
     Commands.CreateGenerateKeyCommand(configuration),
     Commands.CreateDropDqtReportingReplicationSlotCommand(configuration),
     Commands.CreateGenerateWebhookSignatureCertificateCommand(configuration),
+    Commands.CreateWebhookEndpointCommand(configuration),
 };
 
 return await rootCommand.InvokeAsync(args);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/VersionRegistry.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/VersionRegistry.cs
@@ -1,4 +1,6 @@
-namespace TeachingRecordSystem.Api;
+using Microsoft.Extensions.Configuration;
+
+namespace TeachingRecordSystem.Core.ApiSchema;
 
 public static class VersionRegistry
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/WebhookEndpointMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/WebhookEndpointMapping.cs
@@ -7,8 +7,9 @@ public class WebhookEndpointMapping : IEntityTypeConfiguration<WebhookEndpoint>
 {
     public void Configure(EntityTypeBuilder<WebhookEndpoint> builder)
     {
+        builder.HasQueryFilter(e => EF.Property<DateTime?>(e, nameof(WebhookEndpoint.DeletedOn)) == null);
         builder.Property(e => e.Address).HasMaxLength(200);
         builder.Property(e => e.ApiVersion).HasMaxLength(50);
-        builder.HasOne<ApplicationUser>().WithMany().HasForeignKey(e => e.ApplicationUserId);
+        builder.HasOne(e => e.ApplicationUser).WithMany().HasForeignKey(e => e.ApplicationUserId);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241218104549_WebhookEndpointMetadata.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241218104549_WebhookEndpointMetadata.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241218104549_WebhookEndpointMetadata")]
+    partial class WebhookEndpointMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -3192,14 +3195,12 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.WebhookEndpoint", b =>
                 {
-                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.ApplicationUser", "ApplicationUser")
+                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("ApplicationUserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
                         .HasConstraintName("fk_webhook_endpoints_application_users_application_user_id");
-
-                    b.Navigation("ApplicationUser");
                 });
 
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.WebhookMessage", b =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241218104549_WebhookEndpointMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20241218104549_WebhookEndpointMetadata.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class WebhookEndpointMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created_on",
+                table: "webhook_endpoints",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_on",
+                table: "webhook_endpoints",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "updated_on",
+                table: "webhook_endpoints",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "created_on",
+                table: "webhook_endpoints");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_on",
+                table: "webhook_endpoints");
+
+            migrationBuilder.DropColumn(
+                name: "updated_on",
+                table: "webhook_endpoints");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/WebhookEndpoint.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/WebhookEndpoint.cs
@@ -4,8 +4,12 @@ public class WebhookEndpoint
 {
     public required Guid WebhookEndpointId { get; init; }
     public required Guid ApplicationUserId { get; init; }
+    public virtual ApplicationUser ApplicationUser { get; } = null!;
     public required string Address { get; set; }
     public required string ApiVersion { get; set; }
     public required List<string> CloudEventTypes { get; set; }
     public required bool Enabled { get; set; }
+    public required DateTime CreatedOn { get; init; }
+    public required DateTime UpdatedOn { get; set; }
+    public DateTime? DeletedOn { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/WebhookEndpoint.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/WebhookEndpoint.cs
@@ -1,0 +1,21 @@
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record WebhookEndpoint
+{
+    public required Guid WebhookEndpointId { get; init; }
+    public required Guid ApplicationUserId { get; init; }
+    public required string Address { get; init; }
+    public required string ApiVersion { get; init; }
+    public required IReadOnlyCollection<string> CloudEventTypes { get; init; }
+    public required bool Enabled { get; init; }
+
+    public static WebhookEndpoint FromModel(Core.DataStore.Postgres.Models.WebhookEndpoint model) => new()
+    {
+        WebhookEndpointId = model.WebhookEndpointId,
+        ApplicationUserId = model.ApplicationUserId,
+        Address = model.Address,
+        ApiVersion = model.ApiVersion,
+        CloudEventTypes = model.CloudEventTypes,
+        Enabled = model.Enabled
+    };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/WebhookEndpointCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/WebhookEndpointCreatedEvent.cs
@@ -1,0 +1,8 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record WebhookEndpointCreatedEvent : EventBase
+{
+    public required WebhookEndpoint WebhookEndpoint { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/WebhookEndpointDeletedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/WebhookEndpointDeletedEvent.cs
@@ -1,0 +1,8 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record WebhookEndpointDeletedEvent : EventBase
+{
+    public required WebhookEndpoint WebhookEndpoint { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/WebhookEndpointUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/WebhookEndpointUpdatedEvent.cs
@@ -1,0 +1,19 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+
+public record WebhookEndpointUpdatedEvent : EventBase
+{
+    public required WebhookEndpoint WebhookEndpoint { get; init; }
+    public required WebhookEndpointUpdatedChanges Changes { get; init; }
+}
+
+[Flags]
+public enum WebhookEndpointUpdatedChanges
+{
+    None = 0,
+    Address = 1 << 0,
+    ApiVersion = 1 << 1,
+    CloudEventTypes = 1 << 2,
+    Enabled = 1 << 3
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
@@ -35,7 +35,11 @@ public class WebhookMessageFactory(EventMapperRegistry eventMapperRegistry, IClo
             async e =>
             {
                 e.SetAbsoluteExpiration(_webhookEndpointsCacheDuration);
-                return await dbContext.WebhookEndpoints.AsNoTracking().Where(e => e.Enabled).ToArrayAsync();
+
+                return await dbContext.WebhookEndpoints
+                    .AsNoTracking()
+                    .Where(e => e.Enabled && e.ApplicationUser.Active)
+                    .ToArrayAsync();
             });
 
         var endpointCloudEventTypeVersions = endpoints!

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/GlobalUsings.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/GlobalUsings.cs
@@ -1,2 +1,3 @@
+global using TeachingRecordSystem.Core.ApiSchema;
 global using TeachingRecordSystem.Core.Dqt.Models;
 global using TeachingRecordSystem.TestCommon;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Webhooks/WebhookDeliveryServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Webhooks/WebhookDeliveryServiceTests.cs
@@ -220,6 +220,8 @@ public class WebhookDeliveryServiceTests(DbFixture dbFixture)
                 CloudEventTypes = [],
                 Enabled = true,
                 WebhookEndpointId = Guid.NewGuid(),
+                CreatedOn = DateTime.UtcNow,
+                UpdatedOn = DateTime.UtcNow
             };
             dbContext.WebhookEndpoints.Add(endpoint);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Webhooks/WebhookSenderTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Webhooks/WebhookSenderTests.cs
@@ -45,7 +45,9 @@ public class WebhookSenderTests(WebhookReceiver receiver)
                 Address = receiver.Server.BaseAddress + WebhookReceiver.Endpoint.TrimStart('/'),
                 ApiVersion = apiVersion,
                 CloudEventTypes = [cloudEventType],
-                Enabled = true
+                Enabled = true,
+                CreatedOn = DateTime.UtcNow,
+                UpdatedOn = DateTime.UtcNow
             },
             CloudEventId = cloudEventId,
             CloudEventType = cloudEventType,


### PR DESCRIPTION
These commands provide a temporary solution for managing webhook endpoints until we have some UI for doing so.

## Create an endpoint
```shell
> trscli webhook-endpoint create --user-id "0b5b4d7a-f096-493f-aaea-9771fdeaff5c" --address "https://localhost:4200/webhook" --cloud-event-types alert.created alert.updated alert.deleted --api-version Next

{
  "WebhookEndpointId": "e3809f55-71ff-41ff-8a6a-76b4b88219e1",
  "ApplicationUserId": "0b5b4d7a-f096-493f-aaea-9771fdeaff5c",
  "ApplicationUserName": "Developer",
  "ApiVersion": "Next",
  "Address": "https://localhost:4200/webhook",
  "CloudEventTypes": [
    "alert.created",
    "alert.deleted",
    "alert.updated"
  ],
  "Enabled": true
}
```

## List all endpoints
```shell
> trscli webhook-endpoint list

[
  {
    "WebhookEndpointId": "e3809f55-71ff-41ff-8a6a-76b4b88219e1",
    "ApplicationUserId": "0b5b4d7a-f096-493f-aaea-9771fdeaff5c",
    "ApplicationUserName": "Developer",
    "ApiVersion": "Next",
    "Address": "https://localhost:4200/webhook",
    "CloudEventTypes": [
      "alert.created",
      "alert.deleted",
      "alert.updated"
    ],
    "Enabled": true
  }
]
```

## Update an endpoint (e.g. disable it)
```shell
> trscli webhook-endpoint update --id "e3809f55-71ff-41ff-8a6a-76b4b88219e1" --enabled false

{
  "WebhookEndpointId": "e3809f55-71ff-41ff-8a6a-76b4b88219e1",
  "ApplicationUserId": "0b5b4d7a-f096-493f-aaea-9771fdeaff5c",
  "ApplicationUserName": "Developer",
  "ApiVersion": "Next",
  "Address": "https://localhost:4200/webhook",
  "CloudEventTypes": [
    "alert.created",
    "alert.deleted",
    "alert.updated"
  ],
  "Enabled": false
}
```

## Delete an endpoint
```shell
> trscli webhook-endpoint delete --id "e3809f55-71ff-41ff-8a6a-76b4b88219e1"
```