### PR TITLE
Fix HttpClient registration for WebhookSender

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/ApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/ApplicationBuilderExtensions.cs
@@ -19,8 +19,7 @@ public static class HostApplicationBuilderExtensions
     {
         AddWebhookOptions(builder);
 
-        builder.Services.AddSingleton<IWebhookSender, WebhookSender>();
-        WebhookSender.AddHttpClient(builder.Services);
+        WebhookSender.Register(builder.Services);
 
         builder.Services.AddSingleton<IHostedService, WebhookDeliveryService>();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookSender.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookSender.cs
@@ -54,7 +54,7 @@ public class WebhookSender(HttpClient httpClient, IOptions<WebhookOptions> optio
         response.EnsureSuccessStatusCode();
     }
 
-    public static void AddHttpClient(IServiceCollection services, Func<HttpMessageHandler>? getPrimaryHandler = null)
+    public static void Register(IServiceCollection services, Func<HttpMessageHandler>? getPrimaryHandler = null)
     {
         // We configure the options here manually rather than using the library-provided extension methods so that they don't 'bleed out' globally;
         // it's feasible we could want a different configuration of, say, AddContentDigestOptions for use elsewhere.
@@ -108,8 +108,10 @@ public class WebhookSender(HttpClient httpClient, IOptions<WebhookOptions> optio
             return new ECDsaP382Sha384SignatureProvider(cert, signingKeyId);
         });
 
+        services.AddSingleton<IWebhookSender, WebhookSender>();
+
         var httpClientBuilder = services
-            .AddHttpClient<WebhookSender>(client =>
+            .AddHttpClient<IWebhookSender, WebhookSender>(client =>
             {
                 client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
                 client.DefaultRequestHeaders.ExpectContinue = false;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Webhooks/WebhookSenderTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Webhooks/WebhookSenderTests.cs
@@ -134,10 +134,8 @@ public sealed class WebhookReceiver : IDisposable
             ];
         });
 
-        builder.Services.AddSingleton<WebhookSender>();
-
         builder.Services.AddSingleton<WebhookMessageRecorder>();
-        WebhookSender.AddHttpClient(builder.Services, () => _server!.CreateHandler());
+        WebhookSender.Register(builder.Services, () => _server!.CreateHandler());
 
         builder.Services.Configure<RequestSignatureVerificationOptions>(options =>
         {
@@ -206,7 +204,7 @@ public sealed class WebhookReceiver : IDisposable
 
     public WebhookMessageRecorder WebhookMessageRecorder => Services.GetRequiredService<WebhookMessageRecorder>();
 
-    public WebhookSender GetWebhookSender() => Services.GetRequiredService<WebhookSender>();
+    public IWebhookSender GetWebhookSender() => Services.GetRequiredService<IWebhookSender>();
 
     public WebhookOptions GetWebhookOptions() => Services.GetRequiredService<IOptions<WebhookOptions>>().Value;
 


### PR DESCRIPTION
The HttpClient configuration wasn't getting picked up as it was registered against the concrete type instead of the interface. This fixes that.