### PR TITLE
Use local dotnet-format version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Lint
         run: |
           git fetch origin main --quiet --depth=1
+
           CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA | { grep -oP '^TeachingRecordSystem\/\K.*\.cs(proj)?$' || true; })
 
           if [ "$CHANGED_FILES" == "" ]; then
@@ -46,7 +47,7 @@ jobs:
             echo "::notice::Linting changed files only"
           fi
 
-          dotnet format --verify-no-changes $INCLUDE_ARG
+          dotnet dotnet-format --verify-no-changes $INCLUDE_ARG
         working-directory: TeachingRecordSystem
 
   validate_terraform:

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ test:
 
 # Format the .NET solution and Terraform code
 format:
-  @cd {{solution-root}} && dotnet format
+  @cd {{solution-root}} && dotnet dotnet-format
   @terraform fmt terraform/aks
 
 # Format any un-committed .tf or .cs files
@@ -64,7 +64,7 @@ format-changed:
 
   $changedCsFiles = (Get-ChangedFiles "{{solution-root}}/**/*.cs") | foreach { $_ -Replace "^{{solution-root}}/", "" }
   if ($changedCsFiles.Length -gt 0) {
-    $dotnetArgs = @("format", "--no-restore", "--include") + $changedCsFiles
+    $dotnetArgs = @("dotnet-format", "--no-restore", "--include") + $changedCsFiles
     cd {{solution-root}} && dotnet $dotnetArgs
   }
 


### PR DESCRIPTION
We have a specific version of `dotnet-format` specified in local tools but our commands have been using the version in the current SDK.