### PR TITLE
Sync audit details to blob storage

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -189,6 +189,16 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<SyncAllDqtContactAuditsJob>(
+                    nameof(SyncAllDqtContactAuditsJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<SyncAllDqtInductionAuditsJob>(
+                    nameof(SyncAllDqtInductionAuditsJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllDqtContactAuditsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllDqtContactAuditsJob.cs
@@ -1,0 +1,63 @@
+using System.ServiceModel;
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+[AutomaticRetry(Attempts = 0)]
+public class SyncAllDqtContactAuditsJob(
+    [FromKeyedServices(TrsDataSyncService.CrmClientName)] IOrganizationServiceAsync2 organizationService,
+    TrsDataSyncHelper trsDataSyncHelper)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        const int pageSize = 1000;
+
+        var query = new QueryExpression(Contact.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(),
+            Orders =
+            {
+                new OrderExpression(Contact.PrimaryIdAttribute, OrderType.Ascending)
+            },
+            PageInfo = new PagingInfo()
+            {
+                Count = pageSize,
+                PageNumber = 1
+            }
+        };
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            EntityCollection result;
+            try
+            {
+                result = await organizationService.RetrieveMultipleAsync(query);
+            }
+            catch (FaultException<OrganizationServiceFault> fex) when (fex.IsCrmRateLimitException(out var retryAfter))
+            {
+                await Task.Delay(retryAfter, cancellationToken);
+                continue;
+            }
+
+            await trsDataSyncHelper.SyncAuditAsync(Contact.EntityLogicalName, result.Entities.Select(e => e.Id), cancellationToken);
+
+            if (result.MoreRecords)
+            {
+                query.PageInfo.PageNumber++;
+                query.PageInfo.PagingCookie = result.PagingCookie;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllDqtInductionAuditsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllDqtInductionAuditsJob.cs
@@ -1,0 +1,63 @@
+using System.ServiceModel;
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+[AutomaticRetry(Attempts = 0)]
+public class SyncAllDqtInductionAuditsJob(
+    [FromKeyedServices(TrsDataSyncService.CrmClientName)] IOrganizationServiceAsync2 organizationService,
+    TrsDataSyncHelper trsDataSyncHelper)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        const int pageSize = 1000;
+
+        var query = new QueryExpression(dfeta_induction.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(),
+            Orders =
+            {
+                new OrderExpression(dfeta_induction.PrimaryIdAttribute, OrderType.Ascending)
+            },
+            PageInfo = new PagingInfo()
+            {
+                Count = pageSize,
+                PageNumber = 1
+            }
+        };
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            EntityCollection result;
+            try
+            {
+                result = await organizationService.RetrieveMultipleAsync(query);
+            }
+            catch (FaultException<OrganizationServiceFault> fex) when (fex.IsCrmRateLimitException(out var retryAfter))
+            {
+                await Task.Delay(retryAfter, cancellationToken);
+                continue;
+            }
+
+            await trsDataSyncHelper.SyncAuditAsync(dfeta_induction.EntityLogicalName, result.Entities.Select(e => e.Id), cancellationToken);
+
+            if (result.MoreRecords)
+            {
+                query.PageInfo.PageNumber++;
+                query.PageInfo.PagingCookie = result.PagingCookie;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/BlobStorageAuditRepository.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/BlobStorageAuditRepository.cs
@@ -1,0 +1,51 @@
+using System.Runtime.Serialization;
+using Azure;
+using Azure.Storage.Blobs;
+using Microsoft.Crm.Sdk.Messages;
+
+namespace TeachingRecordSystem.Core.Services.TrsDataSync;
+
+public class BlobStorageAuditRepository(BlobServiceClient blobServiceClient) : IAuditRepository
+{
+    private const string ContainerName = "dqtaudits";
+
+    private static readonly DataContractSerializer _serializer =
+        new DataContractSerializer(
+            typeof(AuditDetailCollection),
+            knownTypes: [
+                typeof(Audit),
+                typeof(Contact),
+                typeof(dfeta_induction)
+            ]);
+
+    public async Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, Guid id)
+    {
+        var containerClient = blobServiceClient.GetBlobContainerClient(ContainerName);
+        var blobClient = containerClient.GetBlobClient(GetBlobName(entityLogicalName, id));
+
+        try
+        {
+            var response = await blobClient.DownloadContentAsync();
+            await using var contentStream = response.Value.Content.ToStream();
+            return (AuditDetailCollection)_serializer.ReadObject(contentStream)!;
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return null;
+        }
+    }
+
+    public async Task SetAuditDetailAsync(string entityLogicalName, Guid id, AuditDetailCollection auditDetailCollection)
+    {
+        var containerClient = blobServiceClient.GetBlobContainerClient(ContainerName);
+        var blobClient = containerClient.GetBlobClient(GetBlobName(entityLogicalName, id));
+
+        using var ms = new MemoryStream();
+        _serializer.WriteObject(ms, auditDetailCollection);
+        ms.Seek(0L, SeekOrigin.Begin);
+
+        await blobClient.UploadAsync(ms);
+    }
+
+    private static string GetBlobName(string entityLogicalName, Guid id) => $"{entityLogicalName}/{id:N}.xml";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/HostApplicationBuilderExtensions.cs
@@ -39,6 +39,8 @@ public static class HostApplicationBuilderExtensions
                     .GetRequiredValue("TrsSyncService:CrmConnectionString")));
 
             builder.Services.AddCrmEntityChangesService(name: TrsDataSyncService.CrmClientName);
+
+            builder.Services.AddSingleton<IAuditRepository, BlobStorageAuditRepository>();
         }
 
         builder.Services.TryAddSingleton<TrsDataSyncHelper>();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/IAuditRepository.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/IAuditRepository.cs
@@ -1,0 +1,9 @@
+using Microsoft.Crm.Sdk.Messages;
+
+namespace TeachingRecordSystem.Core.Services.TrsDataSync;
+
+public interface IAuditRepository
+{
+    Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, Guid id);
+    Task SetAuditDetailAsync(string entityLogicalName, Guid id, AuditDetailCollection auditDetailCollection);
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/HostFixture.cs
@@ -82,6 +82,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddFakeXrm();
             services.AddSingleton<FakeTrnGenerator>();
             services.AddSingleton<TrsDataSyncHelper>();
+            services.AddSingleton<IAuditRepository, TestableAuditRepository>();
             services.AddSingleton<ITrnGenerationApiClient, FakeTrnGenerationApiClient>();
             services.Decorate<ICrmQueryDispatcher>(
                 inner => new CrmQueryDispatcherDecorator(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
@@ -89,6 +89,7 @@ public sealed class HostFixture(IConfiguration configuration) : IAsyncDisposable
                     services.AddFakeXrm();
                     services.AddSingleton<FakeTrnGenerator>();
                     services.AddSingleton<TrsDataSyncHelper>();
+                    services.AddSingleton<IAuditRepository, TestableAuditRepository>();
                     services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
                     services.AddSingleton(GetMockFileService());
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
@@ -61,6 +61,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddFakeXrm();
             services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
             services.AddSingleton<FakeTrnGenerator>();
+            services.AddSingleton<IAuditRepository, TestableAuditRepository>();
             services.AddSingleton<TrsDataSyncHelper>();
             services.AddSingleton(GetMockFileService());
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
@@ -65,7 +65,7 @@ public sealed class CrmClientFixture : IDisposable
                 _referenceDataCache,
                 Clock,
                 () => _trnGenerationApiClient.GenerateTrnAsync(),
-                withSync ? TestDataSyncConfiguration.Sync(new(DbFixture.GetDataSource(), orgService, _referenceDataCache, Clock)) : TestDataSyncConfiguration.NoSync()),
+                withSync ? TestDataSyncConfiguration.Sync(new(DbFixture.GetDataSource(), orgService, _referenceDataCache, Clock, new TestableAuditRepository())) : TestDataSyncConfiguration.NoSync()),
             _memoryCache,
             onAsyncDispose);
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/EventMapperTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/EventMapperTestBase.cs
@@ -40,7 +40,8 @@ public class EventMapperFixture
             dbFixture.GetDataSource(),
             organizationService,
             ReferenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/DqtOutbox/OutboxMessageHandlerTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/DqtOutbox/OutboxMessageHandlerTests.cs
@@ -97,7 +97,8 @@ public class OutboxMessageHandlerFixture
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
@@ -20,7 +20,8 @@ public class EstablishmentRefresherTests
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
@@ -37,7 +37,8 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -21,7 +21,8 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),
@@ -198,7 +199,7 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             // Person who matches on last name & DOB
             var person1 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
-            // Person who matches on NINO            
+            // Person who matches on NINO
             var person2 = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
             var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var personEmployment = await TestData.CreateTpsEmploymentAsync(person2, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), usePersonNino ? alternativeNationalInsuranceNumber : nationalInsuranceNumber);
@@ -374,7 +375,7 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             TrnArgumentOption.SpecifiedButDifferent,
             /*expectMatch: */ true,
             _matchNameDobAndNinoAttributes
-        },        
+        },
 
         // Single name with alias, single DOB, person NINO and TRN all match
         {
@@ -454,7 +455,7 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             TrnArgumentOption.SpecifiedButDifferent,
             /*expectMatch: */ true,
             _matchNameDobAndNinoAttributes
-        },        
+        },
 
         // Multiple names with one match, single DOB, person NINO and TRN all match
         {
@@ -534,8 +535,8 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             TrnArgumentOption.SpecifiedButDifferent,
             /*expectMatch: */ true,
             _matchNameDobAndNinoAttributes
-        },        
-        
+        },
+
 
         // *** No match cases ***
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
@@ -23,7 +23,8 @@ public partial class TrsDataSyncHelperTests : IAsyncLifetime
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
@@ -21,7 +21,8 @@ public class TrsDataSyncServiceFixture : IAsyncLifetime
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -21,7 +21,8 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -25,7 +25,8 @@ public class WorkforceDataExporterTests : IAsyncLifetime
             dbFixture.GetDataSource(),
             organizationService,
             referenceDataCache,
-            Clock);
+            Clock,
+            new TestableAuditRepository());
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -76,6 +76,7 @@ public sealed class HostFixture : IAsyncDisposable, IStartupTask
                     services.AddFakeXrm();
                     services.AddSingleton<FakeTrnGenerator>();
                     services.AddSingleton<TrsDataSyncHelper>();
+                    services.AddSingleton<IAuditRepository, TestableAuditRepository>();
                     services.AddSingleton(GetMockFileService());
                     services.AddSingleton(GetMockAdUserService());
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -61,6 +61,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
             services.AddSingleton<FakeTrnGenerator>();
             services.AddSingleton<TrsDataSyncHelper>();
+            services.AddSingleton<IAuditRepository, TestableAuditRepository>();
             services.AddSingleton(GetMockFileService());
 
             IFileService GetMockFileService()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestableAuditRepository.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestableAuditRepository.cs
@@ -1,0 +1,19 @@
+using System.Collections.Concurrent;
+using Microsoft.Crm.Sdk.Messages;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.TestCommon;
+
+public class TestableAuditRepository : IAuditRepository
+{
+    private readonly ConcurrentDictionary<(string EntityLogicalName, Guid Id), AuditDetailCollection> _audits = new();
+
+    public Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, Guid id) =>
+        Task.FromResult(_audits.TryGetValue((entityLogicalName, id), out var audit) ? audit : null);
+
+    public Task SetAuditDetailAsync(string entityLogicalName, Guid id, AuditDetailCollection auditDetailCollection)
+    {
+        _audits[(entityLogicalName, id)] = auditDetailCollection;
+        return Task.CompletedTask;
+    }
+}

--- a/terraform/aks/storage.tf
+++ b/terraform/aks/storage.tf
@@ -48,3 +48,9 @@ resource "azurerm_storage_container" "dqt-integrations" {
   storage_account_name  = azurerm_storage_account.app_storage.name
   container_access_type = "private"
 }
+
+resource "azurerm_storage_container" "dqtaudits" {
+  name                  = "dqtaudits"
+  storage_account_name  = azurerm_storage_account.app_storage.name
+  container_access_type = "private"
+}


### PR DESCRIPTION
Pulling audit records from the API on-demand for induction syncing jobs is proving to be too slow. This adds jobs to push `contact` and `dfeta_induction` audits into blob storage. A follow-up change will amend the jobs to use this as the data source for syncing.