### PR TITLE
Added SQL Server tools to docker image

### DIFF
--- a/TeachingRecordSystem/Dockerfile
+++ b/TeachingRecordSystem/Dockerfile
@@ -34,4 +34,14 @@ RUN apk --no-cache add msttcorefonts-installer fontconfig && \
     update-ms-fonts && \
     fc-cache -f
 
+# Install SQL Server tools needed to be able to query the reporting DB to help debugging
+RUN apk add curl
+
+RUN curl -O https://download.microsoft.com/download/b/9/f/b9f3cce4-3925-46d4-9f46-da08869c6486/msodbcsql18_18.0.1.1-1_amd64.apk && \
+	curl -O https://download.microsoft.com/download/b/9/f/b9f3cce4-3925-46d4-9f46-da08869c6486/mssql-tools18_18.0.1.1-1_amd64.apk
+
+RUN apk add --allow-untrusted msodbcsql18_18.0.1.1-1_amd64.apk && \
+	apk add --allow-untrusted mssql-tools18_18.0.1.1-1_amd64.apk && \
+	rm -f msodbcsql18_18.0.1.1-1_amd64.apk mssql-tools18_18.0.1.1-1_amd64.apk
+
 ENV PATH="${PATH}:/Apps/TrsCli"


### PR DESCRIPTION
### Context

Being able to query the reporting database in SQL server is a massive help in supporting any issues in TRS / DQT.
This change to add SQL server tools to the docker image allows us to do that from with an interactive session within a Kubernetes pod.


