### PR TITLE
Amend override for Serilog to log warnings for all Worker app namespaces

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.Production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.Production.json
@@ -3,7 +3,7 @@
     "MinimumLevel": {
       "Default": "Error",
       "Override": {
-        "TeachingRecordSystem.*": "Warning"
+        "TeachingRecordSystem": "Warning"
       }
     }
   },


### PR DESCRIPTION
Correct Serilog config to log warnings for any namespace starting with `TeachingRecordSystem`