### PR TITLE
Amend person sync to be able to also optionally sync contact audit too

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetCpdInductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetCpdInductionStatus.cs
@@ -74,7 +74,7 @@ public class SetCpdInductionStatusHandler(
         if (person is null)
         {
             // The person record hasn't synced to TRS yet - force that to happen so we can assign induction status
-            var synced = await syncHelper.SyncPersonAsync(dqtContact.Id);
+            var synced = await syncHelper.SyncPersonAsync(dqtContact.Id, syncAudit: true);
             if (!synced)
             {
                 throw new Exception($"Could not sync Person with contact ID: '{dqtContact.Id}'.");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetWelshInductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetWelshInductionStatus.cs
@@ -43,7 +43,7 @@ public class SetWelshInductionStatusHandler(
         if (person is null)
         {
             // The person record hasn't synced to TRS yet - force that to happen so we can assign induction status
-            var synced = await syncHelper.SyncPersonAsync(dqtContact.Id);
+            var synced = await syncHelper.SyncPersonAsync(dqtContact.Id, syncAudit: true);
             if (!synced)
             {
                 throw new Exception($"Could not sync Person with contact ID: '{dqtContact.Id}'.");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
@@ -51,7 +51,7 @@ public partial class Commands
                     return;
                 }
 
-                await syncHelper.SyncPersonAsync(contact, ignoreInvalid: false, dryRun: false);
+                await syncHelper.SyncPersonAsync(contact, syncAudit: true, ignoreInvalid: false, dryRun: false);
 
                 await syncHelper.SyncInductionsAsync([contact], syncAudit: true, ignoreInvalid: false, createMigratedEvent: false, dryRun: false);
                 //return 0;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
@@ -67,6 +67,7 @@ public class SyncAllPersonsFromCrmJob
 
             await _trsDataSyncHelper.SyncPersonsAsync(
                 result.Entities.Select(e => e.ToEntity<Contact>()).ToArray(),
+                syncAudit: false,
                 ignoreInvalid: _syncOptionsAccessor.Value.IgnoreInvalidData,
                 dryRun: false,
                 cancellationToken);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -59,7 +59,7 @@ public class CheckPersonExistsFilter(
 
             if (dqtContact is not null)
             {
-                var synced = await syncHelper.SyncPersonAsync(personId, /*ignoreInvalid: */ false, /*dryRun:*/ false, CancellationToken.None);
+                var synced = await syncHelper.SyncPersonAsync(personId, /* syncAudit: */ true, /*ignoreInvalid: */ false, /*dryRun:*/ false, CancellationToken.None);
                 if (!synced)
                 {
                     throw new Exception($"Could not sync Person with contact ID: '{personId}'.");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Person.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Person.cs
@@ -15,7 +15,7 @@ public partial class TrsDataSyncHelperTests
         var contact = await CreatePersonEntity(contactId);
 
         // Act
-        await Helper.SyncPersonAsync(contact, ignoreInvalid: false);
+        await Helper.SyncPersonAsync(contact, syncAudit: false, ignoreInvalid: false);
 
         // Assert
         await AssertDatabasePersonMatchesEntity(contact);
@@ -28,14 +28,14 @@ public partial class TrsDataSyncHelperTests
         var contactId = Guid.NewGuid();
         var existingEntity = await CreatePersonEntity(contactId);
 
-        await Helper.SyncPersonAsync(existingEntity, ignoreInvalid: false);
+        await Helper.SyncPersonAsync(existingEntity, syncAudit: false, ignoreInvalid: false);
         var expectedFirstSync = Clock.UtcNow;
 
         Clock.Advance();
         var updatedEntity = await CreatePersonEntity(contactId, existingEntity);
 
         // Act
-        await Helper.SyncPersonAsync(updatedEntity, ignoreInvalid: false);
+        await Helper.SyncPersonAsync(updatedEntity, syncAudit: false, ignoreInvalid: false);
 
         // Assert
         await AssertDatabasePersonMatchesEntity(updatedEntity, expectedFirstSync);
@@ -48,7 +48,7 @@ public partial class TrsDataSyncHelperTests
         var contactId = Guid.NewGuid();
         var existingEntity = await CreatePersonEntity(contactId);
 
-        await Helper.SyncPersonAsync(existingEntity, ignoreInvalid: false);
+        await Helper.SyncPersonAsync(existingEntity, syncAudit: false, ignoreInvalid: false);
 
         // Act
         await Helper.DeleteRecordsAsync(TrsDataSyncHelper.ModelTypes.Person, new[] { contactId });
@@ -71,12 +71,12 @@ public partial class TrsDataSyncHelperTests
         Clock.Advance();
         var updatedEntity = await CreatePersonEntity(contactId, initialEntity);
 
-        await Helper.SyncPersonAsync(updatedEntity, ignoreInvalid: false);
+        await Helper.SyncPersonAsync(updatedEntity, syncAudit: false, ignoreInvalid: false);
         var expectedFirstSync = Clock.UtcNow;
         var expectedLastSync = Clock.UtcNow;
 
         // Act
-        await Helper.SyncPersonAsync(initialEntity, ignoreInvalid: false);
+        await Helper.SyncPersonAsync(initialEntity, syncAudit: false, ignoreInvalid: false);
 
         // Assert
         await AssertDatabasePersonMatchesEntity(updatedEntity, expectedFirstSync, expectedLastSync);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Person.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Person.cs
@@ -41,7 +41,7 @@ public partial class TrsDataSyncServiceTests
         contact.CreatedOn = Clock.UtcNow;
         contact.ModifiedOn = Clock.UtcNow;
 
-        await fixture.Helper.SyncPersonAsync(contact, ignoreInvalid: false);
+        await fixture.Helper.SyncPersonAsync(contact, syncAudit: false, ignoreInvalid: false);
         var expectedFirstSync = Clock.UtcNow;
 
         var modifiedOn = Clock.Advance();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -572,7 +572,7 @@ public partial class TestData
             contact = retrieveContactHandle.GetResponse().Entity.ToEntity<Contact>();
 
             var syncedPerson = await testData.SyncConfiguration.SyncIfEnabledAsync(
-                helper => helper.SyncPersonAsync(contact, ignoreInvalid: false),
+                helper => helper.SyncPersonAsync(contact, syncAudit: true, ignoreInvalid: false),
                 _syncEnabledOverride);
 
             var (mqs, alerts, person) = await testData.WithDbContextAsync(async dbContext =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.UpdatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.UpdatePerson.cs
@@ -59,7 +59,7 @@ public partial class TestData
                     }
                 });
 
-                await testData.SyncConfiguration.SyncIfEnabledAsync(helper => helper.SyncPersonAsync(_personId.Value, ignoreInvalid: false));
+                await testData.SyncConfiguration.SyncIfEnabledAsync(helper => helper.SyncPersonAsync(_personId.Value, syncAudit: true, ignoreInvalid: false));
             }
         }
     }


### PR DESCRIPTION
We need to make sure that we also get any updated audit history when live syncing person details (from DQT contact).
This change makes it optional to also sync the audit history when syncing a person/contact.
