### PR TITLE
Make alert details optional on add journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/AddAlertState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/AddAlertState.cs
@@ -41,7 +41,6 @@ public class AddAlertState : IRegisterJourney
     [MemberNotNullWhen(true, nameof(AlertTypeId), nameof(Details), nameof(StartDate), nameof(UploadEvidence))]
     public bool IsComplete =>
         AlertTypeId.HasValue &&
-        !string.IsNullOrWhiteSpace(Details) &&
         AddLink.HasValue &&
         StartDate.HasValue &&
         AddReason.HasValue &&

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml.cs
@@ -21,7 +21,6 @@ public class DetailsModel(TrsLinkGenerator linkGenerator) : PageModel
     public string? AlertTypeName { get; set; }
 
     [BindProperty]
-    [Required(ErrorMessage = "Enter details")]
     [Display(Description = "For example, include any restrictions it places on a teacher.")]
     [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Details must be 4000 characters or less")]
     public string? Details { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Link.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Link.cshtml.cs
@@ -64,12 +64,6 @@ public class LinkModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (string.IsNullOrEmpty(JourneyInstance!.State.Details))
-        {
-            context.Result = Redirect(linkGenerator.AlertAddDetails(PersonId, JourneyInstance.InstanceId));
-            return;
-        }
-
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/DetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/DetailsTests.cs
@@ -148,7 +148,7 @@ public class DetailsTests : AddAlertTestBase
     }
 
     [Fact]
-    public async Task Post_WhenDetailsIsBlank_ReturnsError()
+    public async Task Post_WhenDetailsIsBlank_Redirects()
     {
         // Arrange
         var person = await TestData.CreatePersonAsync();
@@ -160,7 +160,8 @@ public class DetailsTests : AddAlertTestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "Details", "Enter details");
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/alerts/add/link?personId={person.PersonId}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]


### PR DESCRIPTION
Make alert details optional on the add alert journey.

https://trello.com/c/cda4Dtiy/658-make-entering-details-about-the-alert-type-an-optional-field-on-the-create-alert-journey

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Run DQT integration tests locally (if appropriate)
