### PR TITLE
Sync contact audit changes mop up job

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -209,6 +209,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<SyncDqtContactAuditsMopUpJob>(
+                    nameof(SyncDqtContactAuditsMopUpJob),
+                    job => job.ExecuteAsync(/*modifiedSince: */new DateTime(2024, 11, 24), CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -211,7 +211,7 @@ public static class HostApplicationBuilderExtensions
 
                 recurringJobManager.AddOrUpdate<SyncDqtContactAuditsMopUpJob>(
                     nameof(SyncDqtContactAuditsMopUpJob),
-                    job => job.ExecuteAsync(/*modifiedSince: */new DateTime(2024, 11, 24), CancellationToken.None),
+                    job => job.ExecuteAsync(/*modifiedSince: */new DateTime(2024, 12, 24), CancellationToken.None),
                     Cron.Never);
 
                 return Task.CompletedTask;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncDqtContactAuditsMopUpJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncDqtContactAuditsMopUpJob.cs
@@ -1,0 +1,84 @@
+using System.ServiceModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class SyncDqtContactAuditsMopUpJob(
+    [FromKeyedServices(TrsDataSyncService.CrmClientName)] IOrganizationServiceAsync2 organizationService,
+    TrsDataSyncHelper trsDataSyncHelper,
+    ILogger<SyncDqtContactAuditsMopUpJob> logger)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var changedSince = new DateTime(2024, 12, 24);
+        const int pageSize = 1000;
+
+        var filter = new FilterExpression();
+        filter.AddCondition(Contact.Fields.ModifiedOn, ConditionOperator.GreaterEqual, changedSince);
+
+        var query = new QueryExpression(Contact.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(),
+            Orders =
+            {
+                new OrderExpression(Contact.Fields.CreatedOn, OrderType.Ascending),
+                new OrderExpression(Contact.PrimaryIdAttribute, OrderType.Ascending)
+            },
+            PageInfo = new PagingInfo()
+            {
+                Count = pageSize,
+                PageNumber = 1
+            },
+            Criteria = filter
+        };
+
+        var fetched = 0;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            EntityCollection result;
+            try
+            {
+                result = await organizationService.RetrieveMultipleAsync(query);
+            }
+            catch (FaultException<OrganizationServiceFault> fex) when (fex.IsCrmRateLimitException(out var retryAfter))
+            {
+                await Task.Delay(retryAfter, cancellationToken);
+                continue;
+            }
+
+            fetched += result.Entities.Count;
+
+            await trsDataSyncHelper.SyncAuditAsync(
+                Contact.EntityLogicalName,
+                result.Entities.Select(e => e.Id),
+                skipIfExists: true,
+                cancellationToken);
+
+            if (fetched > 0 && fetched % 50000 == 0)
+            {
+                logger.LogWarning("Synced {Count} contact audit records.", fetched);
+            }
+
+            if (result.MoreRecords)
+            {
+                query.PageInfo.PageNumber++;
+                query.PageInfo.PagingCookie = result.PagingCookie;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        logger.LogWarning("Synced {Count} contact audit records.", fetched);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncDqtContactAuditsMopUpJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncDqtContactAuditsMopUpJob.cs
@@ -14,13 +14,12 @@ public class SyncDqtContactAuditsMopUpJob(
     TrsDataSyncHelper trsDataSyncHelper,
     ILogger<SyncDqtContactAuditsMopUpJob> logger)
 {
-    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    public async Task ExecuteAsync(DateTime modifiedSince, CancellationToken cancellationToken)
     {
-        var changedSince = new DateTime(2024, 12, 24);
         const int pageSize = 1000;
 
         var filter = new FilterExpression();
-        filter.AddCondition(Contact.Fields.ModifiedOn, ConditionOperator.GreaterEqual, changedSince);
+        filter.AddCondition(Contact.Fields.ModifiedOn, ConditionOperator.GreaterEqual, modifiedSince);
 
         var query = new QueryExpression(Contact.EntityLogicalName)
         {
@@ -60,7 +59,7 @@ public class SyncDqtContactAuditsMopUpJob(
             await trsDataSyncHelper.SyncAuditAsync(
                 Contact.EntityLogicalName,
                 result.Entities.Select(e => e.Id),
-                skipIfExists: true,
+                skipIfExists: false,
                 cancellationToken);
 
             if (fetched > 0 && fetched % 50000 == 0)


### PR DESCRIPTION
The job to sync all contact audit records from DQT to TRS took several days to run to completion.. during which time there may have been more changes in DQT.
This mop up job syncs all contact audit history records with any changes since Christmas Eve
