### PR TITLE
Added known types for entities we want to store audit details in blob storage for

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/BlobStorageAuditRepository.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/BlobStorageAuditRepository.cs
@@ -15,7 +15,9 @@ public class BlobStorageAuditRepository(BlobServiceClient blobServiceClient) : I
             knownTypes: [
                 typeof(Audit),
                 typeof(Contact),
-                typeof(dfeta_induction)
+                typeof(dfeta_induction),
+                typeof(dfeta_initialteachertraining),
+                typeof(dfeta_qtsregistration)
             ]);
 
     public async Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, Guid id)


### PR DESCRIPTION
The jobs to store ITT and QTS audit history in TRS needed to have `dfeta_initialteachertraining` and `dfeta_qtsregistration` added as aknown types to the serializer.
