### PR TITLE
Removed audit primary Id attributes from audit NewValue and OldValue properties

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllInductionsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllInductionsFromCrmJob.cs
@@ -18,7 +18,7 @@ public class SyncAllInductionsFromCrmJob(
 {
     public async Task ExecuteAsync(bool createMigratedEvent, bool dryRun, CancellationToken cancellationToken)
     {
-        const int pageSize = 1000;
+        const int pageSize = 500;
 
         var serviceClient = crmServiceClientProvider.GetClient(TrsDataSyncService.CrmClientName);
         var columns = new ColumnSet(TrsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Induction).AttributeNames);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/IAuditRepository.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/IAuditRepository.cs
@@ -4,7 +4,7 @@ namespace TeachingRecordSystem.Core.Services.TrsDataSync;
 
 public interface IAuditRepository
 {
-    Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, Guid id);
+    Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, string primaryIdAttribute, Guid id);
     Task<bool> HaveAuditDetailAsync(string entityLogicalName, Guid id);
     Task SetAuditDetailAsync(string entityLogicalName, Guid id, AuditDetailCollection auditDetailCollection);
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestableAuditRepository.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestableAuditRepository.cs
@@ -8,7 +8,7 @@ public class TestableAuditRepository : IAuditRepository
 {
     private readonly ConcurrentDictionary<(string EntityLogicalName, Guid Id), AuditDetailCollection> _audits = new();
 
-    public Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, Guid id) =>
+    public Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, string primaryIdAttribute, Guid id) =>
         Task.FromResult(_audits.TryGetValue((entityLogicalName, id), out var audit) ? audit : null);
 
     public Task<bool> HaveAuditDetailAsync(string entityLogicalName, Guid id) =>


### PR DESCRIPTION
Due to us needing to store audit history as serialized XML in blob storage, the deserialization was incorrectly setting the primary Id attributes for the NewValue and OldValue properties (making it seem like they had changed).
This change removes them after they have been deserialized.
