### PR TITLE
Run startup tasks earlier in startup process

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/StartupTasks.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/StartupTasks.cs
@@ -45,7 +45,7 @@ public static partial class ServiceCollectionExtensions
         public Task ExecuteAsync() => _action(_serviceProvider);
     }
 
-    private class RunStartupTasksHostedService : IHostedService
+    private class RunStartupTasksHostedService : IHostedLifecycleService
     {
         private readonly IEnumerable<IStartupTask> _startupTasks;
 
@@ -54,7 +54,11 @@ public static partial class ServiceCollectionExtensions
             _startupTasks = startupTasks;
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public async Task StartingAsync(CancellationToken cancellationToken)
         {
             foreach (var startupTask in _startupTasks)
             {
@@ -62,6 +66,10 @@ public static partial class ServiceCollectionExtensions
             }
         }
 
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task StartedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Future versions of .NET are moving to start background services in parallel;
we need startup tasks to run before everything else.
This changes to using the StartingAsync hook of IHostedLifecycleService.
