### PR TITLE
Remove DQT sync columns for migrated entities

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250108144947_RemoveDqtSyncAttributes.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250108144947_RemoveDqtSyncAttributes.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250108144947_RemoveDqtSyncAttributes")]
+    partial class RemoveDqtSyncAttributes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250108144947_RemoveDqtSyncAttributes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250108144947_RemoveDqtSyncAttributes.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveDqtSyncAttributes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "dqt_created_on",
+                table: "alerts");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_first_sync",
+                table: "alerts");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_last_sync",
+                table: "alerts");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_modified_on",
+                table: "alerts");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_sanction_id",
+                table: "alerts");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_state",
+                table: "alerts");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "dqt_created_on",
+                table: "alerts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "dqt_first_sync",
+                table: "alerts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "dqt_last_sync",
+                table: "alerts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "dqt_modified_on",
+                table: "alerts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "dqt_sanction_id",
+                table: "alerts",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "dqt_state",
+                table: "alerts",
+                type: "integer",
+                nullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
@@ -23,13 +23,6 @@ public class Alert
     public DateTime? DeletedOn { get; set; }
     [Projectable] public bool IsOpen => EndDate == null;
 
-    public Guid? DqtSanctionId { get; set; }
-    public DateTime? DqtFirstSync { get; set; }
-    public DateTime? DqtLastSync { get; set; }
-    public int? DqtState { get; set; }
-    public DateTime? DqtCreatedOn { get; set; }
-    public DateTime? DqtModifiedOn { get; set; }
-
     public static Alert Create(
         Guid alertTypeId,
         Guid personId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -2,6 +2,11 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class MandatoryQualification : Qualification
 {
+    public MandatoryQualification()
+    {
+        QualificationType = QualificationType.MandatoryQualification;
+    }
+
     public MandatoryQualificationProvider? Provider { get; }
     public required Guid? ProviderId { get; set; }
     public required MandatoryQualificationSpecialism? Specialism { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
@@ -8,7 +8,7 @@ public abstract class Qualification
     public required DateTime CreatedOn { get; init; }
     public required DateTime UpdatedOn { get; set; }
     public DateTime? DeletedOn { get; set; }
-    public QualificationType QualificationType { get; }
+    public QualificationType QualificationType { get; protected init; }
     public required Guid PersonId { get; init; }
     public Person Person { get; } = null!;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -79,48 +79,6 @@ public class TrsDataSyncHelper(
         await Task.WhenAll(audits.Select(async kvp => await auditRepository.SetAuditDetailAsync(entityLogicalName, kvp.Key, kvp.Value)));
     }
 
-    public static Alert? MapAlertFromDqtSanction(
-        dfeta_sanction sanction,
-        IEnumerable<dfeta_sanctioncode> sanctionCodes,
-        IEnumerable<AlertType> alertTypes,
-        bool ignoreInvalid)
-    {
-        if (sanction.dfeta_SanctionCodeId is null)
-        {
-            if (ignoreInvalid)
-            {
-                return null;
-            }
-
-            throw new InvalidOperationException($"Sanction {sanction.Id} does not have a {nameof(dfeta_sanction.Fields.dfeta_SanctionCodeId)}.");
-        }
-
-        var sanctionCode = sanctionCodes.Single(c => c.Id == sanction.dfeta_SanctionCodeId.Id).dfeta_Value;
-        var alertType = alertTypes.SingleOrDefault(t => t.DqtSanctionCode == sanctionCode);
-
-        if (alertType is null)
-        {
-            return null;
-        }
-
-        return new Alert()
-        {
-            AlertId = sanction.Id,
-            AlertTypeId = alertType.AlertTypeId,
-            PersonId = sanction.dfeta_PersonId.Id,
-            Details = sanction.dfeta_SanctionDetails,
-            ExternalLink = sanction.dfeta_DetailsLink,
-            StartDate = sanction.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
-            EndDate = sanction.dfeta_EndDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
-            CreatedOn = sanction.CreatedOn!.Value,
-            UpdatedOn = sanction.ModifiedOn!.Value,
-            DqtSanctionId = sanction.Id,
-            DqtState = (int)sanction.StateCode!,
-            DqtCreatedOn = sanction.CreatedOn!.Value,
-            DqtModifiedOn = sanction.ModifiedOn!.Value,
-        };
-    }
-
     private InductionInfo? MapInductionInfoFromDqtInduction(
         dfeta_induction? induction,
         Contact contact,


### PR DESCRIPTION
These attributes were added just in case we needed them around migration. We didn't, so now they're going.

We still have a few around `Person` but these can be tidied up later when induction migration changes are less frequent.