### PR TITLE
Refactored sync induction job to generate DQT events from audit history partial entities

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using TeachingRecordSystem.Core.Events.Models;
+using TeachingRecordSystem.Core.Infrastructure.Json;
 
 namespace TeachingRecordSystem.Core.Events;
 
@@ -26,7 +27,8 @@ public abstract record EventBase
                     {
                         propertyInfo.IsRequired = false;
                     }
-                }
+                },
+                Modifiers.OptionProperties
             }
         }
     };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/DqtInduction.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/DqtInduction.cs
@@ -1,10 +1,12 @@
+using Optional;
+
 namespace TeachingRecordSystem.Core.Events.Models;
 
 public record DqtInduction
 {
     public required Guid InductionId { get; init; }
-    public required DateOnly? StartDate { get; init; }
-    public required DateOnly? CompletionDate { get; init; }
-    public required string? InductionStatus { get; init; }
-    public required string? InductionExemptionReason { get; init; }
+    public required Option<DateOnly?> StartDate { get; init; }
+    public required Option<DateOnly?> CompletionDate { get; init; }
+    public required Option<string?> InductionStatus { get; init; }
+    public required Option<string?> InductionExemptionReason { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllInductionsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllInductionsFromCrmJob.cs
@@ -18,7 +18,7 @@ public class SyncAllInductionsFromCrmJob(
 {
     public async Task ExecuteAsync(bool createMigratedEvent, bool dryRun, CancellationToken cancellationToken)
     {
-        const int pageSize = 500;
+        const int pageSize = 1000;
 
         var serviceClient = crmServiceClientProvider.GetClient(TrsDataSyncService.CrmClientName);
         var columns = new ColumnSet(TrsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Induction).AttributeNames);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Induction.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceTests.Induction.cs
@@ -88,24 +88,6 @@ public partial class TrsDataSyncServiceTests
         var induction = ctx.dfeta_inductionSet.SingleOrDefault(i => i.GetAttributeValue<Guid>(dfeta_induction.PrimaryIdAttribute) == inductionId);
         var inductionAuditDetails = new AuditDetailCollection();
 
-        ////var existingInduction = person.DqtInductions.Single();
-
-        ////var updatedInductionStatus = dfeta_InductionStatus.Pass;
-        ////var updatedInductionStartDate = Clock.Today.AddYears(-2);
-        ////var updatedInductionEndDate = Clock.Today.AddDays(-20);
-        ////var createdOn = Clock.UtcNow;
-        ////var modifiedOn = Clock.Advance();
-        ////var updatedInduction = new dfeta_induction()
-        ////{
-        ////    Id = existingInduction.InductionId,
-        ////    dfeta_PersonId = new EntityReference(Contact.EntityLogicalName, contactId),
-        ////    dfeta_InductionStatus = updatedInductionStatus,
-        ////    dfeta_StartDate = updatedInductionStartDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
-        ////    dfeta_CompletionDate = updatedInductionEndDate.ToDateTimeWithDqtBstFix(isLocalTime: true),
-        ////    CreatedOn = Clock.UtcNow,
-        ////    ModifiedOn = modifiedOn
-        ////};
-
         var updatedInduction = await CreateUpdatedInductionEntityVersion(
             induction!,
             inductionAuditDetails,
@@ -185,7 +167,7 @@ public partial class TrsDataSyncServiceTests
                     Operation = Audit_Operation.Create,
                     UserId = currentDqtUser
                 },
-                OldValue = new Entity(),
+                OldValue = new Entity(dfeta_induction.EntityLogicalName),
                 NewValue = newInduction.Clone()
             });
         }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -681,7 +681,7 @@ public partial class TestData
                     Operation = Audit_Operation.Create,
                     UserId = currentDqtUser
                 },
-                OldValue = new Entity(),
+                OldValue = new Entity(Contact.EntityLogicalName),
                 NewValue = contact.Clone()
             };
 


### PR DESCRIPTION
### Context

Induction data is moving from DQT to TRS and we want to ensure TRS' data is kept up to date with what’s in DQT.

During testing the sync inductions job against prod data, it has become apparent that there are gaps in audit history data which means we can’t use them to build full snapshots of entities over time.

### Include a summary of the change.

Amend the induction sync code in `TrsDataSyncHelper` to generate TRS events for `dfeta_induction` and `Contact` entities directly from audit history records.

The induction related eventshave been changed to just store any changed properties rather than a whole induction record snapshot.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
