### PR TITLE
Add support for mapping DQT induction exemption reason to TRS induction exemption reason

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
@@ -212,6 +212,12 @@ public class ReferenceDataCache(
         return inductionExemptionReasons;
     }
 
+    public async Task<InductionExemptionReason> GetInductionExemptionReasonByIdAsync(Guid inductionExemptionReasonId)
+    {
+        var inductionExemptionReasons = await EnsureInductionExemptionReasonsAsync();
+        return inductionExemptionReasons.Single(er => er.InductionExemptionReasonId == inductionExemptionReasonId, $"Could not find induction exemption reason with ID: '{inductionExemptionReasonId}'.");
+    }
+
     private Task<dfeta_sanctioncode[]> EnsureSanctionCodesAsync() =>
         LazyInitializer.EnsureInitialized(
             ref _getSanctionCodesTask,
@@ -312,5 +318,6 @@ public class ReferenceDataCache(
         // TRS
         await EnsureAlertCategoriesAsync();
         await EnsureAlertTypesAsync();
+        await EnsureInductionExemptionReasonsAsync();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
@@ -77,7 +77,7 @@
     "ModelTypes": [
       "Person",
       "Event",
-      "Alert"
+      "Induction"
     ],
     "IgnoreInvalidData": false,
     "RunService": false

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
@@ -106,7 +106,8 @@ public class DbHelper(IDbContextFactory<TrsDbContext> dbContextFactory)
                     "establishment_sources",
                     "tps_establishment_types",
                     "alert_types",
-                    "alert_categories"
+                    "alert_categories",
+                    "induction_exemption_reasons"
                 ]
             });
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
@@ -265,7 +265,7 @@ public partial class TestData
 
     public T GenerateEnumValue<T>() where T : Enum => Faker.Enum.Random<T>();
 
-    public T GenerateChangedEnumValue<T>(T? currentValue) where T : struct, Enum
+    public T GenerateChangedEnumValue<T>(T? currentValue, T[]? excluding = null) where T : struct, Enum
     {
         T newValue;
 
@@ -273,7 +273,7 @@ public partial class TestData
         {
             newValue = GenerateEnumValue<T>();
         }
-        while (newValue.Equals(currentValue));
+        while (newValue.Equals(currentValue) || (excluding is not null && excluding.Contains(newValue)));
 
         return newValue;
     }


### PR DESCRIPTION
### Context

Induction data is moving from DQT to TRS and we want to ensure TRS' data is kept up to date with what’s in DQT.
We only recently had a full picture with regard to how induction exemption reasons would be migrated to TRS.

### Changes proposed in this pull request

Enhance the induction sync code in TrsDataSyncHelper to also migrate induction exemptions reasons for persons who are exempt.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
