### PR TITLE
Don't send webhook messages to disabled endpoints

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookDeliveryService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookDeliveryService.cs
@@ -81,6 +81,7 @@ public class WebhookDeliveryService(
                 limit {BatchSize + 1}
                 for update skip locked
             """)
+            .Where(m => m.WebhookEndpoint.Enabled)
             .Include(m => m.WebhookEndpoint)
             .ToArrayAsync();
 


### PR DESCRIPTION
Once we've disabled an endpoint we shouldn't try to send messages to it until it's re-enabled.