### PR TITLE
Write all TRN request data to TRS DB

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
@@ -22,9 +22,10 @@ public class GetTrnRequestHandler(TrnRequestHelper trnRequestHelper, ICurrentUse
 
         return new TrnRequestInfo()
         {
-            RequestId = command.RequestId.ToString(),
+            RequestId = command.RequestId,
             Person = new TrnRequestInfoPerson()
             {
+                // FUTURE - these values should be what was submitted in the original request
                 FirstName = contact.FirstName,
                 LastName = contact.LastName,
                 MiddleName = contact.MiddleName,
@@ -33,7 +34,7 @@ public class GetTrnRequestHandler(TrnRequestHelper trnRequestHelper, ICurrentUse
                 DateOfBirth = contact.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false)
             },
             Trn = contact.dfeta_TRN,
-            Status = trnRequest.IsCompleted ? TrnRequestStatus.Completed : TrnRequestStatus.Pending,
+            Status = trnRequest.IsCompleted ? TrnRequestStatus.Completed : TrnRequestStatus.Pending
         };
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/MapperProfile.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/MapperProfile.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+namespace TeachingRecordSystem.Api.V3.VNext;
+
+public class MapperProfile : Profile
+{
+    public MapperProfile()
+    {
+        CreateMap<Implementation.Dtos.TrnRequestInfo, TrnRequestInfo>();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrnRequestInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrnRequestInfo.cs
@@ -1,0 +1,10 @@
+using TeachingRecordSystem.Core.ApiSchema.V3.V20240606.Dtos;
+
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record TrnRequestInfo
+{
+    public required string RequestId { get; init; }
+    public required TrnRequestStatus Status { get; init; }
+    public required string? Trn { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250116092809_TrnRequestMetadataAllPii.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250116092809_TrnRequestMetadataAllPii.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250116092809_TrnRequestMetadataAllPii")]
+    partial class TrnRequestMetadataAllPii
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250116092809_TrnRequestMetadataAllPii.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250116092809_TrnRequestMetadataAllPii.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnRequestMetadataAllPii : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "address_line1",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "address_line2",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "address_line3",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "city",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "country",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "gender",
+                table: "trn_request_metadata",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "national_insurance_number",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "postcode",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "potential_duplicate",
+                table: "trn_request_metadata",
+                type: "boolean",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "address_line1",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "address_line2",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "address_line3",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "city",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "country",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "gender",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "national_insurance_number",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "postcode",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "potential_duplicate",
+                table: "trn_request_metadata");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -10,4 +10,13 @@ public class TrnRequestMetadata
     public required string? OneLoginUserSubject { get; init; }
     public required string[] Name { get; init; }
     public required DateOnly DateOfBirth { get; init; }
+    public bool? PotentialDuplicate { get; init; }
+    public string? NationalInsuranceNumber { get; init; }
+    public int? Gender { get; init; }
+    public string? AddressLine1 { get; init; }
+    public string? AddressLine2 { get; init; }
+    public string? AddressLine3 { get; init; }
+    public string? City { get; init; }
+    public string? Postcode { get; init; }
+    public string? Country { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
@@ -20,6 +20,15 @@ public class TrnRequestMetadataMessageHandler(TrsDbContext dbContext) : IMessage
                 EmailAddress = message.EmailAddress,
                 Name = message.Name,
                 DateOfBirth = message.DateOfBirth,
+                PotentialDuplicate = message.PotentialDuplicate,
+                NationalInsuranceNumber = message.NationalInsuranceNumber,
+                Gender = message.Gender,
+                AddressLine1 = message.AddressLine1,
+                AddressLine2 = message.AddressLine2,
+                AddressLine3 = message.AddressLine3,
+                City = message.City,
+                Postcode = message.Postcode,
+                Country = message.Country
             });
             await dbContext.SaveChangesAsync();
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Messages/TrnRequestMetadataMessage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Messages/TrnRequestMetadataMessage.cs
@@ -10,4 +10,13 @@ public record TrnRequestMetadataMessage
     public required string? OneLoginUserSubject { get; init; }
     public required string[] Name { get; init; }
     public required DateOnly DateOfBirth { get; init; }
+    public bool? PotentialDuplicate { get; init; }
+    public string? NationalInsuranceNumber { get; init; }
+    public int? Gender { get; init; }
+    public string? AddressLine1 { get; init; }
+    public string? AddressLine2 { get; init; }
+    public string? AddressLine3 { get; init; }
+    public string? City { get; init; }
+    public string? Postcode { get; init; }
+    public string? Country { get; init; }
 }


### PR DESCRIPTION
We need to be able to return data submitted in the original TRN request from our API endpoints but currently that data isn't easily available. This is the first step to fixing that - stashing all data from all TRN requests in the TRS DB. A separate PR will follow to back-fill.