### PR TITLE
Fix migrations deployment

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   package:
     name: Build & package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Important - later versions of ubuntu have a different .NET SDK which breaks trscli. Review on .NET 9 upgrade
     env:
       CONTAINER_REGISTRY: ghcr.io
 


### PR DESCRIPTION
`ubuntu-latest` has changed and has a newer version of the .NET SDK. For some reason that breaks `trscli`. This puts the package workflow back down to the old ubuntu version; we can review when we upgrade to .NET 9.