### PR TITLE
Add SourceApplication references to ProfessionalStatus

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProfessionalStatusMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProfessionalStatusMapping.cs
@@ -11,5 +11,12 @@ public class ProfessionalStatusMapping : IEntityTypeConfiguration<ProfessionalSt
         builder.HasOne(q => q.Country).WithMany().HasForeignKey(q => q.CountryId);
         builder.HasOne(q => q.TrainingProvider).WithMany().HasForeignKey(q => q.TrainingProviderId);
         builder.HasOne(q => q.InductionExemptionReason).WithMany().HasForeignKey(q => q.InductionExemptionReasonId);
+        builder.HasOne<ApplicationUser>().WithMany().HasForeignKey(q => q.SourceApplicationUserId);
+        builder
+            .Property(q => q.SourceApplicationReference)
+            .HasMaxLength(ProfessionalStatus.SourceApplicationReferenceMaxLength);
+        builder.HasIndex(q => new { q.SourceApplicationUserId, q.SourceApplicationReference })
+            .IsUnique()
+            .HasFilter("source_application_user_id is not null and source_application_reference is not null");
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250121102214_ProfessionalStatusSourceApplication.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250121102214_ProfessionalStatusSourceApplication.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250121102214_ProfessionalStatusSourceApplication")]
+    partial class ProfessionalStatusSourceApplication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250121102214_ProfessionalStatusSourceApplication.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250121102214_ProfessionalStatusSourceApplication.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProfessionalStatusSourceApplication : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "source_application_reference",
+                table: "qualifications",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "source_application_user_id",
+                table: "qualifications",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_qualifications_source_application_user_id_source_applicatio",
+                table: "qualifications",
+                columns: new[] { "source_application_user_id", "source_application_reference" },
+                unique: true,
+                filter: "source_application_user_id is not null and source_application_reference is not null");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_qualifications_application_users_source_application_user_id",
+                table: "qualifications",
+                column: "source_application_user_id",
+                principalTable: "users",
+                principalColumn: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_qualifications_application_users_source_application_user_id",
+                table: "qualifications");
+
+            migrationBuilder.DropIndex(
+                name: "ix_qualifications_source_application_user_id_source_applicatio",
+                table: "qualifications");
+
+            migrationBuilder.DropColumn(
+                name: "source_application_reference",
+                table: "qualifications");
+
+            migrationBuilder.DropColumn(
+                name: "source_application_user_id",
+                table: "qualifications");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ProfessionalStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ProfessionalStatus.cs
@@ -2,8 +2,12 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class ProfessionalStatus : Qualification
 {
+    public const int SourceApplicationReferenceMaxLength = 200;
+
     public new required QualificationType QualificationType { get; set; }
     public required Guid RouteToProfessionalStatusId { get; init; }
+    public Guid? SourceApplicationUserId { get; init; }
+    public string? SourceApplicationReference { get; init; }
     public RouteToProfessionalStatus Route { get; } = null!;
     public required ProfessionalStatusStatus Status { get; set; }
     public DateOnly? AwardDate { get; set; }


### PR DESCRIPTION
The new API for professional statuses uses the source system's reference as an ID; this adds the two columns to do that, with an index.