### PR TITLE
fix routing from check your answers

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CompletedDate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CompletedDate.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form data-testid="submit-form" action="@LinkGenerator.InductionEditCompletedDate(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+        <form data-testid="submit-form" action="@LinkGenerator.InductionEditCompletedDate(Model.PersonId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <span class="govuk-caption-l">Induction - @Model.PersonName</span>
 
             <govuk-date-input asp-for="CompletedDate">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/ExemptionReason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/ExemptionReason.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.InductionEditExemptionReason(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+        <form action="@LinkGenerator.InductionEditExemptionReason(Model.PersonId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <span class="govuk-caption-l">Induction - @Model.PersonName</span>
             <govuk-checkboxes asp-for="ExemptionReasonIds">
                 <govuk-checkboxes-fieldset>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/StartDate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/StartDate.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form data-testid="submit-form" action="@LinkGenerator.InductionEditStartDate(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+        <form data-testid="submit-form" action="@LinkGenerator.InductionEditStartDate(Model.PersonId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <span class="govuk-caption-l">Induction - @Model.PersonName</span>
 
             <govuk-date-input asp-for="StartDate">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <span data-testid="induction-status-caption" class="govuk-caption-l">Induction - @Model.PersonName</span>
-        <form data-testid="submit-form" action="@LinkGenerator.InductionEditStatus(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
+        <form data-testid="submit-form" action="@LinkGenerator.InductionEditStatus(Model.PersonId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <govuk-radios asp-for="InductionStatus">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend data-testid="status-choices-legend" class="govuk-fieldset__legend--m" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/InductionTests.cs
@@ -300,6 +300,109 @@ public class InductionTests : TestBase
     }
 
     [Fact]
+    public async Task EditInductionCompletedDate_CYA_ChangeCompletedDate_CYA()
+    {
+        var startDate = new DateOnly(2021, 1, 1);
+        var completedDate = startDate.AddDays(1);
+        var setStartDate = startDate.AddDays(1).AddMonths(1).AddYears(1);
+        var setCompletedDate = setStartDate.AddDays(1);
+        var person = await TestData.CreatePersonAsync(
+                personBuilder => personBuilder
+                .WithQts()
+                .WithInductionStatus(inductionBuilder => inductionBuilder
+                    .WithStatus(InductionStatus.Passed)
+                    .WithStartDate(startDate)
+                    .WithCompletedDate(completedDate)
+                ));
+        var personId = person.ContactId;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonInductionPageAsync(personId);
+        await page.ClickEditInductionCompletedDatePageAsync();
+
+        await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
+        await page.FillDateInputAsync(setCompletedDate);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionChangeReasonPageAsync(person.PersonId);
+        await page.SelectChangeReasonAsync(InductionChangeReasonOption.AnotherReason);
+        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+        await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Induction completed on");
+
+        await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
+        await page.FillDateInputAsync(setCompletedDate);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+    }
+
+    [Fact]
+    public async Task EditInductionStatus_CYA_ChangeSomething_NavigatesBackToCYA()
+    {
+        var startDate = new DateOnly(2021, 1, 1);
+        var completedDate = startDate.AddDays(1);
+        var setStartDate = startDate.AddDays(1).AddMonths(1).AddYears(1);
+        var setCompletedDate = setStartDate.AddDays(1);
+        var person = await TestData.CreatePersonAsync(
+                personBuilder => personBuilder
+                .WithQts()
+                .WithInductionStatus(inductionBuilder => inductionBuilder
+                    .WithStatus(InductionStatus.RequiredToComplete)
+                    .WithStartDate(startDate)
+                    .WithCompletedDate(completedDate)));
+        var personId = person.ContactId;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonInductionPageAsync(personId);
+        await page.ClickEditInductionStatusPageAsync();
+
+        await page.AssertOnEditInductionStatusPageAsync(person.PersonId);
+
+        await page.SelectStatusAsync(InductionStatus.Passed);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionStartDatePageAsync(person.PersonId);
+        await page.FillDateInputAsync(setStartDate);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
+        await page.AssertDateInputEmptyAsync();
+        await page.FillDateInputAsync(setCompletedDate);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionChangeReasonPageAsync(person.PersonId);
+        await page.SelectChangeReasonAsync(InductionChangeReasonOption.AnotherReason);
+        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+        await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Induction status");
+        await page.AssertOnEditInductionStatusPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+        await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Induction started on");
+        await page.AssertOnEditInductionStartDatePageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+        await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Induction completed on");
+        await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+    }
+
+    [Fact]
     public async Task EditInductionExemptionReason_NavigateBack()
     {
         var exemptionReasonId = (await TestData.ReferenceDataCache.GetInductionExemptionReasonsAsync(activeOnly: true))


### PR DESCRIPTION
### Context

Include relevant motivation and context.
Fix journey through pages after check your answers
check your answers page -> change a field page (status, exemption reason, start date, completed date or change reason) -> check your answers

### Changes proposed in this pull request
https://trello.com/c/NEIhwL98/758-induction-fix-cya-status-back-link-bug
https://trello.com/c/uMNS90PU/761-induction-fix-cya-routing-rules

