### PR TITLE
Induction fix 'check your answers'

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -309,8 +309,7 @@ public class Person
     public bool InductionStatusManagedByCpd(DateOnly now)
     {
         var sevenYearsAgo = now.AddYears(-7);
-        return InductionCompletedDate is not null
-            && InductionCompletedDate < sevenYearsAgo;
+        return (CpdInductionStatus is not null && (CpdInductionCompletedDate is null || CpdInductionCompletedDate > sevenYearsAgo));
     }
 
     private static void AssertInductionChangeIsValid(

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml
@@ -19,7 +19,7 @@
                 {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Induction status</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@Model.InductionStatus</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value>@Model.InductionStatus.GetDisplayName()</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action
                                 href="@LinkGenerator.InductionEditStatus(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: JourneyFromCheckYourAnswersPage.CheckYourAnswers)"

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml
@@ -9,7 +9,7 @@
 }
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-grid-column-full-from-desktop">
         <form action="@LinkGenerator.InductionCheckYourAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post">
             <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
@@ -53,13 +53,15 @@
                 }
                 @if(Model.ShowExemptionReasons)
                 {
-                    <govuk-summary-list-row>
+                    <govuk-summary-list-row class="govuk-list--spaced">
                         <govuk-summary-list-row-key>Exemption reason</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>
-                            @foreach (var exemptionReason in Model.SelectedExemptionReasonsValues!)
-                            {
-                                <div>@exemptionReason</div>
-                            }
+                            <ul class="govuk-list">
+                                @foreach (var exemptionReason in Model.SelectedExemptionReasonsValues!)
+                                {
+                                    <li>@exemptionReason</li>
+                                }
+                            </ul>
                         </govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml
@@ -23,7 +23,7 @@
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action
                                 href="@LinkGenerator.InductionEditStatus(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: JourneyFromCheckYourAnswersPage.CheckYourAnswers)"
-                                visually-hidden-text="new induction status">Change</govuk-summary-list-row-action>
+                                visually-hidden-text="induction status">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
                 }
@@ -35,7 +35,7 @@
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action
                                 href="@LinkGenerator.InductionEditStartDate(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: JourneyFromCheckYourAnswersPage.CheckYourAnswers)"
-                                visually-hidden-text="new start date">Change</govuk-summary-list-row-action>
+                                visually-hidden-text="start date">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
                 }
@@ -47,7 +47,7 @@
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action
                                 href="@LinkGenerator.InductionEditCompletedDate(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: JourneyFromCheckYourAnswersPage.CheckYourAnswers)"
-                                visually-hidden-text="new completed date">Change</govuk-summary-list-row-action>
+                                visually-hidden-text="completed date">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
                 }
@@ -64,7 +64,7 @@
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action
                                 href="@LinkGenerator.InductionEditExemptionReason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: JourneyFromCheckYourAnswersPage.CheckYourAnswers)"
-                                visually-hidden-text="new exemption reason">Change</govuk-summary-list-row-action>
+                                visually-hidden-text="exemption reason">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
                 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CheckYourAnswers.cshtml.cs
@@ -78,6 +78,11 @@ public class CheckYourAnswersModel : CommonJourneyPage
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (JourneyInstance!.State.StartDate > JourneyInstance!.State.CompletedDate)
+        {
+            return Redirect(LinkGenerator.InductionEditCompletedDate(PersonId, JourneyInstance!.InstanceId, fromCheckAnswers: JourneyFromCheckYourAnswersPage.CheckYourAnswers));
+        }
+
         var person = await _dbContext.Persons
             .SingleAsync(q => q.PersonId == PersonId);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CommonJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CommonJourneyPage.cs
@@ -22,15 +22,15 @@ public abstract class CommonJourneyPage : PageModel
         return Redirect(LinkGenerator.PersonInduction(PersonId));
     }
 
-    protected string PageLink(InductionJourneyPage? pageName, JourneyFromCheckYourAnswersPage? fromCyaPage = null)
+    protected string PageLink(InductionJourneyPage? pageName, JourneyFromCheckYourAnswersPage? fromCheckYourAnswersPage = null)
     {
         return pageName switch
         {
-            InductionJourneyPage.Status => LinkGenerator.InductionEditStatus(PersonId, JourneyInstance!.InstanceId),
-            InductionJourneyPage.CompletedDate => LinkGenerator.InductionEditCompletedDate(PersonId, JourneyInstance!.InstanceId),
-            InductionJourneyPage.ExemptionReason => LinkGenerator.InductionEditExemptionReason(PersonId, JourneyInstance!.InstanceId),
-            InductionJourneyPage.StartDate => LinkGenerator.InductionEditStartDate(PersonId, JourneyInstance!.InstanceId, fromCyaPage),
-            InductionJourneyPage.ChangeReasons => LinkGenerator.InductionChangeReason(PersonId, JourneyInstance!.InstanceId),
+            InductionJourneyPage.Status => LinkGenerator.InductionEditStatus(PersonId, JourneyInstance!.InstanceId, fromCheckYourAnswersPage),
+            InductionJourneyPage.CompletedDate => LinkGenerator.InductionEditCompletedDate(PersonId, JourneyInstance!.InstanceId, fromCheckYourAnswersPage),
+            InductionJourneyPage.ExemptionReason => LinkGenerator.InductionEditExemptionReason(PersonId, JourneyInstance!.InstanceId, fromCheckYourAnswersPage),
+            InductionJourneyPage.StartDate => LinkGenerator.InductionEditStartDate(PersonId, JourneyInstance!.InstanceId, fromCheckYourAnswersPage),
+            InductionJourneyPage.ChangeReasons => LinkGenerator.InductionChangeReason(PersonId, JourneyInstance!.InstanceId, fromCheckYourAnswersPage),
             InductionJourneyPage.CheckAnswers => LinkGenerator.InductionCheckYourAnswers(PersonId, JourneyInstance!.InstanceId),
             _ => LinkGenerator.PersonInduction(PersonId)
         };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
@@ -46,16 +46,12 @@ public class EditInductionState : IRegisterJourney
         var person = await dbContext.Persons
             .SingleAsync(q => q.PersonId == personId);
 
-        CurrentInductionStatus = person.InductionStatus;
-        StartDate = person.InductionStartDate;
-        CompletedDate = person.InductionCompletedDate;
+        InductionStatus = person.InductionStatus;
+        //StartDate = person.InductionStartDate;
+        //CompletedDate = person.InductionCompletedDate;
         if (JourneyStartPage == null)
         {
             JourneyStartPage = startPage;
-        }
-        if (InductionStatus == InductionStatus.None)
-        {
-            InductionStatus = CurrentInductionStatus;
         }
 
         Initialized = true;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
@@ -46,22 +46,20 @@ public class EditInductionState : IRegisterJourney
             .SingleAsync(q => q.PersonId == personId);
 
         InductionStatus = person.InductionStatus;
-        if (JourneyStartPage == null)
+        JourneyStartPage ??= startPage;
+
+        switch (startPage)
         {
-            JourneyStartPage = startPage;
-        }
-        if (startPage == InductionJourneyPage.StartDate)
-        {
-            StartDate = person.InductionStartDate;
-        }
-        if (startPage == InductionJourneyPage.CompletedDate)
-        {
-            StartDate = person.InductionStartDate;
-            CompletedDate = person.InductionCompletedDate;
-        }
-        if (startPage == InductionJourneyPage.ExemptionReason)
-        {
-            ExemptionReasonIds = person.InductionExemptionReasonIds;
+            case InductionJourneyPage.StartDate:
+                StartDate = person.InductionStartDate;
+                break;
+            case InductionJourneyPage.CompletedDate:
+                StartDate = person.InductionStartDate;
+                CompletedDate = person.InductionCompletedDate;
+                break;
+            case InductionJourneyPage.ExemptionReason:
+                ExemptionReasonIds = person.InductionExemptionReasonIds;
+                break;
         }
 
         Initialized = true;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
@@ -13,7 +13,6 @@ public class EditInductionState : IRegisterJourney
 
     public InductionJourneyPage? JourneyStartPage { get; set; }
     public InductionStatus InductionStatus { get; set; }
-    public InductionStatus CurrentInductionStatus { get; set; }
     public DateOnly? StartDate { get; set; }
     public DateOnly? CompletedDate { get; set; }
     public Guid[]? ExemptionReasonIds { get; set; } = Array.Empty<Guid>();
@@ -47,11 +46,22 @@ public class EditInductionState : IRegisterJourney
             .SingleAsync(q => q.PersonId == personId);
 
         InductionStatus = person.InductionStatus;
-        //StartDate = person.InductionStartDate;
-        //CompletedDate = person.InductionCompletedDate;
         if (JourneyStartPage == null)
         {
             JourneyStartPage = startPage;
+        }
+        if (startPage == InductionJourneyPage.StartDate)
+        {
+            StartDate = person.InductionStartDate;
+        }
+        if (startPage == InductionJourneyPage.CompletedDate)
+        {
+            StartDate = person.InductionStartDate;
+            CompletedDate = person.InductionCompletedDate;
+        }
+        if (startPage == InductionJourneyPage.ExemptionReason)
+        {
+            ExemptionReasonIds = person.InductionExemptionReasonIds;
         }
 
         Initialized = true;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
@@ -22,15 +22,14 @@ public class StatusModel : CommonJourneyPage
     [Display(Name = "What is their induction status?")]
     [NotEqual(InductionStatus.None, ErrorMessage = "Select a status")]
     public InductionStatus InductionStatus { get; set; }
-    public InductionStatus CurrentInductionStatus { get; set; }
     public string? PersonName { get; set; }
     public IEnumerable<InductionStatusInfo> StatusChoices
     {
         get
         {
             return InductionStatusManagedByCpd ?
-                 InductionStatusRegistry.ValidStatusChangesWhenManagedByCpd.Where(i => i.Value != CurrentInductionStatus)
-                : InductionStatusRegistry.All.ToArray()[1..].Where(i => i.Value != CurrentInductionStatus);
+                 InductionStatusRegistry.ValidStatusChangesWhenManagedByCpd
+                : InductionStatusRegistry.All.ToArray()[1..];
         }
     }
     public string? StatusWarningMessage
@@ -97,17 +96,6 @@ public class StatusModel : CommonJourneyPage
             {
                 state.JourneyStartPage = InductionJourneyPage.Status;
             }
-            // Editing status is considered a 'start again' action - clear all other fields currently set
-            state.StartDate = null;
-            state.CompletedDate = null;
-            state.ExemptionReasonIds = null;
-            state.HasAdditionalReasonDetail = null;
-            state.ChangeReason = null;
-            state.ChangeReasonDetail = null;
-            state.EvidenceFileId = null;
-            state.EvidenceFileName = null;
-            state.EvidenceFileSizeDescription = null;
-            state.UploadEvidence = null;
         });
 
         return Redirect(PageLink(NextPage));
@@ -122,7 +110,6 @@ public class StatusModel : CommonJourneyPage
         PersonName = personInfo.Name;
         var person = await _dbContext.Persons.SingleAsync(q => q.PersonId == PersonId);
         InductionStatusManagedByCpd = person.InductionStatusManagedByCpd(_clock.Today);
-        CurrentInductionStatus = JourneyInstance!.State.CurrentInductionStatus;
         await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
@@ -48,7 +48,7 @@
             @if (Model.ShowStartDate)
             {
                 <govuk-summary-list-row data-testid="induction-start-date">
-                    <govuk-summary-list-row-key>Induction start date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-key>Induction started on</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.StartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
                     @if (Model.CanWrite)
                     {
@@ -62,7 +62,7 @@
             @if (Model.ShowCompletedDate)
             {
                 <govuk-summary-list-row data-testid="induction-completed-date">
-                    <govuk-summary-list-row-key>Induction completed date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-key>Induction completed on</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.CompletedDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
                     @if (Model.CanWrite)
                     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
@@ -17,7 +17,7 @@
 
 @if (Model.Status != InductionStatus.None)
 {
-    <govuk-summary-card data-testid="induction-card">
+    <govuk-summary-card class="govuk-grid-column-full-from-desktop" data-testid="induction-card">
         <govuk-summary-card-title data-testid="induction-title">Induction details</govuk-summary-card-title>
         <govuk-summary-list>
             <govuk-summary-list-row data-testid="induction-status">
@@ -33,9 +33,16 @@
 
             @if (Model.ExemptionReasonIds!.Length > 0)
             {
-                <govuk-summary-list-row data-testid="induction-exemption-reasons">
+                <govuk-summary-list-row class="govuk-list--spaced" data-testid="induction-exemption-reasons">
                     <govuk-summary-list-row-key>Exemption reason</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.ExemptionReasonsText</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>
+                            <ul class="govuk-list">
+                            @foreach (var exemptionReason in Model.ExemptionReasonValues!)
+                            {
+                                <li>@exemptionReason</li>
+                            }
+                            </ul>
+                    </govuk-summary-list-row-value>
                     @if (Model.CanWrite)
                     {
                         <govuk-summary-list-row-actions>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
@@ -36,7 +36,7 @@ public class InductionModel(
 
     public bool ShowCompletedDate => Status.RequiresCompletedDate();
 
-    public string? ExemptionReasonsText { get; set; }
+    public IEnumerable<string>? ExemptionReasonValues { get; set; }
 
     public string? StatusWarningMessage
     {
@@ -78,9 +78,7 @@ public class InductionModel(
         _teacherHoldsQualifiedTeacherStatus = TeacherHoldsQualifiedTeacherStatusRule(result?.Contact.dfeta_QTSDate);
 
         var allExemptionReasons = await referenceDataCache.GetInductionExemptionReasonsAsync();
-        var exemptionReasons = allExemptionReasons.Where(r => ExemptionReasonIds.Contains(r.InductionExemptionReasonId))
-            .ToArray();
-        ExemptionReasonsText = string.Join(", ", exemptionReasons.Select(r => r.Name));
+        ExemptionReasonValues = allExemptionReasons.Where(r => ExemptionReasonIds.Contains(r.InductionExemptionReasonId)).Select(r => r.Name);
 
         CanWrite = (await authorizationService.AuthorizeAsync(User, AuthorizationPolicies.InductionReadWrite))
             .Succeeded;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/UseEmptyFallbackTagHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/UseEmptyFallbackTagHelper.cs
@@ -1,5 +1,3 @@
-using System.Text.Encodings.Web;
-using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace TeachingRecordSystem.SupportUi.TagHelpers;
@@ -16,7 +14,6 @@ public class UseEmptyFallbackTagHelper : TagHelper
 
         if (content.IsEmptyOrWhiteSpace)
         {
-            output.AddClass("trs-subtle-emphasis", HtmlEncoder.Default);
             output.Content.SetContent(UiDefaults.EmptyDisplayContent);
         }
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -200,8 +200,8 @@ public class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string InductionChangeReasonCancel(Guid personId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/Persons/PersonDetail/EditInduction/InductionChangeReason", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
-    public string InductionCheckYourAnswers(Guid personId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        GetRequiredPathByPage("/Persons/PersonDetail/EditInduction/CheckYourAnswers", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string InductionCheckYourAnswers(Guid personId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/Persons/PersonDetail/EditInduction/CheckYourAnswers", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
     public string InductionCheckYourAnswersCancel(Guid personId, JourneyInstanceId? journeyInstanceId) =>
     GetRequiredPathByPage("/Persons/PersonDetail/EditInduction/CheckYourAnswers", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
@@ -285,9 +285,9 @@ public class PersonTests
     }
 
     [Theory]
-    [InlineData(-3, false)]
-    [InlineData(-7, true)]
-    public void InductionManagedByCpd_ReturnsTrue(int yearsSinceCompleted, bool expected)
+    [InlineData(-3, true)]
+    [InlineData(-7, false)]
+    public void InductionManagedByCpd_ReturnsExpected(int yearsSinceCompleted, bool expected)
     {
         // Arrange
         var dateTimeCompleted = Clock.UtcNow.AddYears(yearsSinceCompleted).AddDays(-1);
@@ -301,15 +301,13 @@ public class PersonTests
             FirstName = "Joe",
             MiddleName = "",
             LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1),
+            DateOfBirth = new(1990, 1, 1)
         };
-        person.SetInductionStatus(
-            InductionStatus.Passed,
-            dateCompleted, dateCompleted,
-            [],
-            changeReason: null,
-            changeReasonDetail: null,
-            evidenceFile: null,
+        person.SetCpdInductionStatus(
+            status: InductionStatus.Passed,
+            startDate: dateCompleted,
+            completedDate: dateCompleted,
+            cpdModifiedOn: dateTimeCompleted,
             SystemUser.SystemUserId,
             Clock.UtcNow, out _);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/InductionTests.cs
@@ -20,9 +20,7 @@ public class InductionTests : TestBase
                 personBuilder => personBuilder
                 .WithQts()
                 .WithInductionStatus(inductionBuilder => inductionBuilder
-                    .WithStatus(InductionStatus.RequiredToComplete)
-                    .WithStartDate(startDate)
-                    .WithCompletedDate(completedDate)));
+                    .WithStatus(InductionStatus.RequiredToComplete)));
         var personId = person.ContactId;
 
         await using var context = await HostFixture.CreateBrowserContext();
@@ -41,7 +39,6 @@ public class InductionTests : TestBase
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
-        await page.AssertDateInputEmptyAsync();
         await page.FillDateInputAsync(setCompletedDate);
         await page.ClickContinueButtonAsync();
 
@@ -258,8 +255,7 @@ public class InductionTests : TestBase
     {
         var startDate = new DateOnly(2021, 1, 1);
         var completedDate = startDate.AddDays(1);
-        var setStartDate = startDate.AddDays(1).AddMonths(1).AddYears(1);
-        var setCompletedDate = setStartDate.AddDays(1);
+        var setCompletedDate = startDate.AddDays(1);
         var person = await TestData.CreatePersonAsync(
                 personBuilder => personBuilder
                 .WithQts()
@@ -328,7 +324,7 @@ public class InductionTests : TestBase
     }
 
     [Fact]
-    public async Task EditInductionStatus_CYA_ChangeAnythingOtherThanStatus_ContinueToCYA()
+    public async Task EditInductionStatus_CYA_ChangeAnyFieldOtherThanStatus_ContinueToCYA()
     {
         var startDate = new DateOnly(2021, 1, 1);
         var completedDate = startDate.AddYears(1);
@@ -338,9 +334,7 @@ public class InductionTests : TestBase
                 personBuilder => personBuilder
                 .WithQts()
                 .WithInductionStatus(inductionBuilder => inductionBuilder
-                    .WithStatus(InductionStatus.RequiredToComplete)
-                    .WithStartDate(startDate)
-                    .WithCompletedDate(completedDate)));
+                    .WithStatus(InductionStatus.RequiredToComplete)));
         var personId = person.ContactId;
 
         await using var context = await HostFixture.CreateBrowserContext();
@@ -359,7 +353,6 @@ public class InductionTests : TestBase
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
-        await page.AssertDateInputEmptyAsync();
         await page.FillDateInputAsync(setCompletedDate);
         await page.ClickContinueButtonAsync();
 
@@ -372,13 +365,11 @@ public class InductionTests : TestBase
         await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
         await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Induction started on");
         await page.AssertOnEditInductionStartDatePageAsync(person.PersonId);
-        await page.FillDateInputAsync(setStartDate);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
         await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Induction completed on");
         await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
-        await page.FillDateInputAsync(setCompletedDate);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
@@ -387,6 +378,63 @@ public class InductionTests : TestBase
         await page.SelectChangeReasonAsync(InductionChangeReasonOption.AnotherReason);
         await page.SelectReasonMoreDetailsAsync(false);
         await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+    }
+
+    [Fact]
+    public async Task EditInductionStatus_CYA_ChangeStatus_ContinueThroughJourneyToCYA()
+    {
+        var startDate = new DateOnly(2021, 1, 1);
+        var completedDate = startDate.AddYears(1);
+        var setStartDate = startDate.AddDays(1);
+        var setCompletedDate = completedDate.AddDays(1);
+        var person = await TestData.CreatePersonAsync(
+                personBuilder => personBuilder
+                .WithQts()
+                .WithInductionStatus(inductionBuilder => inductionBuilder
+                    .WithStatus(InductionStatus.RequiredToComplete)));
+
+        var personId = person.ContactId;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonInductionPageAsync(personId);
+        await page.ClickEditInductionStatusPageAsync();
+
+        await page.AssertOnEditInductionStatusPageAsync(person.PersonId);
+        await page.SelectStatusAsync(InductionStatus.Passed);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionStartDatePageAsync(person.PersonId);
+        await page.FillDateInputAsync(setStartDate);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
+        await page.FillDateInputAsync(setCompletedDate);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionChangeReasonPageAsync(person.PersonId);
+        await page.SelectChangeReasonAsync(InductionChangeReasonOption.AnotherReason);
+        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
+        await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Induction status");
+
+        await page.AssertOnEditInductionStatusPageAsync(person.PersonId);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionStartDatePageAsync(person.PersonId);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnEditInductionChangeReasonPageAsync(person.PersonId);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
@@ -403,9 +451,7 @@ public class InductionTests : TestBase
                 personBuilder => personBuilder
                 .WithQts()
                 .WithInductionStatus(inductionBuilder => inductionBuilder
-                    .WithStatus(InductionStatus.RequiredToComplete)
-                    .WithStartDate(startDate)
-                    .WithCompletedDate(completedDate)));
+                    .WithStatus(InductionStatus.RequiredToComplete)));
         var personId = person.ContactId;
 
         await using var context = await HostFixture.CreateBrowserContext();
@@ -420,12 +466,11 @@ public class InductionTests : TestBase
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionStartDatePageAsync(person.PersonId);
-        await page.FillDateInputAsync(setStartDate);
+        await page.FillDateInputAsync(startDate);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionCompletedDatePageAsync(person.PersonId);
-        await page.AssertDateInputEmptyAsync();
-        await page.FillDateInputAsync(setCompletedDate);
+        await page.FillDateInputAsync(completedDate);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionChangeReasonPageAsync(person.PersonId);
@@ -452,9 +497,6 @@ public class InductionTests : TestBase
         await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
         await page.ClickChangeLinkForSummaryListRowWithKeyAsync("Reason details");
         await page.AssertOnEditInductionChangeReasonPageAsync(person.PersonId);
-        await page.SelectChangeReasonAsync(InductionChangeReasonOption.AnotherReason);
-        await page.SelectReasonMoreDetailsAsync(false);
-        await page.SelectReasonFileUploadAsync(false);
         await page.ClickBackLink();
 
         await page.AssertOnEditInductionCheckYourAnswersPageAsync(person.PersonId);
@@ -483,7 +525,6 @@ public class InductionTests : TestBase
         await page.ClickEditInductionExemptionReasonPageAsync();
 
         await page.AssertOnEditInductionExemptionReasonPageAsync(person.PersonId);
-        await page.SelectExemptionReasonAsync(exemptionReasonId);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditInductionChangeReasonPageAsync(person.PersonId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CheckYourAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CheckYourAnswersTests.cs
@@ -289,7 +289,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         {
             var label = doc.QuerySelectorAll(".govuk-summary-list__key").Single(e => e.TextContent == labelContent);
             Assert.NotNull(label);
-            var reasons = label.NextElementSibling!.QuerySelectorAll("div").Select(d => d.TextContent.Trim());
+            var reasons = label.NextElementSibling!.QuerySelectorAll("li").Select(d => d.TextContent.Trim());
             Assert.NotEmpty(reasons);
             Assert.Equal(expectedReasons, reasons);
         }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
@@ -5,7 +5,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.Ed
 public class EditInductionStateBuilder
 {
     private InductionStatus InductionStatus { get; set; }
-    private InductionStatus CurrentInductionStatus { get; set; }
     private DateOnly? StartDate { get; set; }
     private DateOnly? CompletedDate { get; set; }
     private Guid[]? ExemptionReasonIds { get; set; }
@@ -19,18 +18,17 @@ public class EditInductionStateBuilder
     private InductionJourneyPage? JourneyStartPage { get; set; }
     private bool Initialized { get; set; }
 
-    public EditInductionStateBuilder WithInitialisedState(InductionStatus? currentInductionStatus, InductionJourneyPage startPage)
+    public EditInductionStateBuilder WithInitialisedState(InductionStatus currentInductionStatus, InductionJourneyPage startPage)
     {
         this.Initialized = true;
         JourneyStartPage = startPage;
-        CurrentInductionStatus = currentInductionStatus ?? InductionStatus.None;
-        InductionStatus = CurrentInductionStatus;
+        InductionStatus = currentInductionStatus;
         return this;
     }
 
     public EditInductionStateBuilder WithUpdatedState(InductionStatus inductionStatus)
     {
-        if (CurrentInductionStatus == InductionStatus.None)
+        if (InductionStatus == InductionStatus.None)
         {
             throw new NotSupportedException("Initialised state must be set using WithInitialisedState");
         }
@@ -83,7 +81,6 @@ public class EditInductionStateBuilder
         return new EditInductionState()
         {
             InductionStatus = InductionStatus,
-            CurrentInductionStatus = CurrentInductionStatus,
             StartDate = StartDate,
             CompletedDate = CompletedDate,
             ExemptionReasonIds = ExemptionReasonIds,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
@@ -65,16 +65,12 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         Assert.Equal("Cancel and return to record", buttons.ElementAt(1)!.TextContent);
     }
 
-    [Theory]
-    [InlineData(InductionStatus.RequiredToComplete, new InductionStatus[] { InductionStatus.Exempt, InductionStatus.InProgress, InductionStatus.Passed, InductionStatus.Failed, InductionStatus.FailedInWales })]
-    [InlineData(InductionStatus.Exempt, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.InProgress, InductionStatus.Passed, InductionStatus.Failed, InductionStatus.FailedInWales })]
-    [InlineData(InductionStatus.InProgress, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.Passed, InductionStatus.Failed, InductionStatus.FailedInWales })]
-    [InlineData(InductionStatus.Passed, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.InProgress, InductionStatus.Failed, InductionStatus.FailedInWales })]
-    [InlineData(InductionStatus.Failed, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.InProgress, InductionStatus.Passed, InductionStatus.FailedInWales })]
-    [InlineData(InductionStatus.FailedInWales, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.InProgress, InductionStatus.Passed, InductionStatus.Failed })]
-    public async Task Get_InductionNotManagedByCpd_ExpectedRadioButtonsExistOnPage(InductionStatus currentInductionStatus, InductionStatus[] expectedStatuses)
+    [Fact]
+    public async Task Get_InductionNotManagedByCpd_ExpectedRadioButtonsExistOnPage()
     {
         // Arrange
+        InductionStatus currentInductionStatus = InductionStatus.InProgress;
+        var expectedStatuses = new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.InProgress, InductionStatus.Passed, InductionStatus.Failed, InductionStatus.FailedInWales };
         var expectedChoices = expectedStatuses.Select(s => s.ToString());
 
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
@@ -99,12 +95,14 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
     }
 
     [Theory]
-    [InlineData(InductionStatus.Passed, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.FailedInWales })]
-    [InlineData(InductionStatus.Failed, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.FailedInWales })]
-    [InlineData(InductionStatus.FailedInWales, new InductionStatus[] { InductionStatus.RequiredToComplete, InductionStatus.Exempt })]
-    public async Task Get_InductionManagedByCpd_ExpectedRadioButtonsExistOnPage(InductionStatus currentInductionStatus, InductionStatus[] expectedStatuses)
+    [InlineData(InductionStatus.Passed)]
+    [InlineData(InductionStatus.Failed)]
+    [InlineData(InductionStatus.FailedInWales)]
+    // CML - TODO just test 1 when page changes are complete
+    public async Task Get_InductionManagedByCpd_ExpectedRadioButtonsExistOnPage(InductionStatus currentInductionStatus)
     {
         // Arrange
+        InductionStatus[] expectedStatuses = { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.FailedInWales };
         var expectedChoices = expectedStatuses.Select(s => s.ToString());
         var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
@@ -142,13 +140,14 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
     }
 
     [Theory]
-    [InlineData(InductionStatus.RequiredToComplete, InductionStatus.Exempt)]
-    [InlineData(InductionStatus.Exempt, InductionStatus.RequiredToComplete)]
-    [InlineData(InductionStatus.InProgress, InductionStatus.Passed)]
-    [InlineData(InductionStatus.Passed, InductionStatus.InProgress)]
-    [InlineData(InductionStatus.Failed, InductionStatus.FailedInWales)]
-    [InlineData(InductionStatus.FailedInWales, InductionStatus.Failed)]
-    public async Task Get_InductionStatusHasBeenSet_ShowsSelectedRadioButton(InductionStatus currentInductionStatus, InductionStatus selectedInductionStatus)
+    [InlineData(InductionStatus.RequiredToComplete)]
+    [InlineData(InductionStatus.Exempt)]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.Passed)]
+    [InlineData(InductionStatus.Failed)]
+    [InlineData(InductionStatus.FailedInWales)]
+    //CML TODO just test 1 when page changes are complete
+    public async Task Get_InductionStatusHasBeenSet_ShowsSelectedRadioButton(InductionStatus currentInductionStatus)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
@@ -157,7 +156,6 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitialisedState(currentInductionStatus, InductionJourneyPage.Status)
-                .WithUpdatedState(selectedInductionStatus)
                 .Create());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -168,7 +166,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
         var selectedStatus = doc.QuerySelectorAll<IHtmlInputElement>("[type=radio]").Single(r => r.IsChecked == true);
-        Assert.Equal(selectedInductionStatus.ToString(), selectedStatus.Value);
+        Assert.Equal(currentInductionStatus.ToString(), selectedStatus.Value);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -250,21 +250,10 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
         var underSevenYearsAgo = Clock.Today.AddYears(-6);
 
         var person = await TestData.CreatePersonAsync(
-            builder => builder.WithQtlsDate(Clock.Today));
-
-        await WithDbContext(async dbContext =>
-        {
-            dbContext.Attach(person.Person);
-            person.Person.SetCpdInductionStatus(
-                InductionStatus.Passed,
-                startDate: underSevenYearsAgo.AddYears(-1),
-                completedDate: underSevenYearsAgo,
-                cpdModifiedOn: Clock.UtcNow,
-                updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
-                out _);
-            await dbContext.SaveChangesAsync();
-        });
+            builder => builder
+                .WithQts()
+                .WithInductionStatus(builder => builder
+                    .WithStatus(InductionStatus.InProgress)));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.ContactId}/induction");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -216,7 +216,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         //Arrange
         var expectedWarning = "To change this teacher’s induction status ";
-        var overSevenYearsAgo = Clock.Today.AddYears(-7).AddDays(-1);
+        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1).AddDays(-1);
 
         var person = await TestData.CreatePersonAsync();
         await WithDbContext(async dbContext =>
@@ -224,8 +224,8 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
             dbContext.Attach(person.Person);
             person.Person.SetCpdInductionStatus(
                 InductionStatus.Passed,
-                startDate: Clock.Today.AddYears(-7).AddMonths(-6),
-                completedDate: overSevenYearsAgo,
+                startDate: lessThanSevenYearsAgo.AddYears(-1),
+                completedDate: lessThanSevenYearsAgo,
                 cpdModifiedOn: Clock.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
                 now: Clock.UtcNow,


### PR DESCRIPTION
### Context

Issues arising from the review of the implemented inductions wizard

### Changes proposed in this pull request

Add validation to the CYA page to stop the Invalidation of the start and completed date by users using the browser back button-
https://trello.com/c/ARYIRGrR/764-induction-fix-additional-browser-back-button-fix

Improve the display of  the selected exemption reasons in the CYA page (and also in the Induction summary card as pointed out by AH)
https://trello.com/c/WpZQBftk/756-induction-fix-adjust-exemption-reasons-pattern-on-cya-page

The colour of the “Not provided” value should be black
https://trello.com/c/UVca4Pcx/757-induction-fix-adjust-contrast-on-not-provided-values-on-cya

A ticket that lists some current behaviour, but the new behaviour is that even if status is selected to be changed from cya, the relevant fields should be pre-populated with current values. 
Third bullet - "User should always see all the teacher's induction details [on the CYA page.] I.e. status should always be displayed no matter the entry point to the journey." - I'll do that as a separate ticket.
https://trello.com/c/o0cOv8Zv/763-induction-fix-align-cya-with-design-system-guidance

On the edit status page, remove logic to hide the original status from the radio buttons but don’t pre-select the status field. I.e. if the current status is exempt, the user should see the exempt.
All fields, besides induction status should be prepopulated with the previous information where applicable. 
https://trello.com/c/AwMa6p94/759-induction-fix-prepopulate-fields

