### PR TITLE
Amended person sync to create events if there are any QTLS related induction changes

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -409,17 +409,10 @@ public class TrsDataSyncHelper(
     {
         if (syncAudit)
         {
-            await SyncAuditAsync(Contact.EntityLogicalName, contacts.Select(q => q.ContactId!.Value), skipIfExists: false, cancellationToken);
             await SyncAuditAsync(dfeta_induction.EntityLogicalName, entities.Select(q => q.Id), skipIfExists: false, cancellationToken);
         }
 
-        var contactAuditDetails = await GetAuditRecordsFromAuditRepositoryAsync(Contact.EntityLogicalName, Contact.PrimaryIdAttribute, contacts.Select(q => q.ContactId!.Value), cancellationToken);
-        var inductionAuditDetails = await GetAuditRecordsFromAuditRepositoryAsync(dfeta_induction.EntityLogicalName, dfeta_induction.PrimaryIdAttribute, entities.Select(q => q.Id), cancellationToken);
-
-        var auditDetails = contactAuditDetails
-            .Concat(inductionAuditDetails)
-            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
+        var auditDetails = await GetAuditRecordsFromAuditRepositoryAsync(dfeta_induction.EntityLogicalName, dfeta_induction.PrimaryIdAttribute, entities.Select(q => q.Id), cancellationToken);
         return await SyncInductionsAsync(contacts, entities, auditDetails, ignoreInvalid, createMigratedEvent, dryRun, cancellationToken);
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Induction.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Induction.cs
@@ -754,37 +754,71 @@ public partial class TrsDataSyncHelperTests
     private async Task<Contact> CreateUpdatedContactEntityVersion(
         Contact existingContact,
         AuditDetailCollection auditDetailCollection,
-        dfeta_InductionStatus updatedInductionStatus)
+        dfeta_InductionStatus? updatedInductionStatus = null,
+        DateOnly? updatedQtlsDate = null)
     {
         var currentDqtUser = await TestData.GetCurrentCrmUserAsync();
 
         var updatedContact = existingContact.Clone<Contact>();
         updatedContact.ModifiedOn = Clock.UtcNow;
-        updatedContact.dfeta_InductionStatus = updatedInductionStatus;
 
-        var oldValue = new Entity(Contact.EntityLogicalName, existingContact.Id);
-        oldValue.Attributes[Contact.Fields.ModifiedOn] = existingContact.Attributes[Contact.Fields.ModifiedOn];
-        oldValue.Attributes[Contact.Fields.dfeta_InductionStatus] = existingContact.GetAttributeValue<dfeta_InductionStatus?>(Contact.Fields.dfeta_InductionStatus);
-
-        var newValue = new Entity(Contact.EntityLogicalName, existingContact.Id);
-        newValue.Attributes[Contact.Fields.ModifiedOn] = updatedContact.Attributes[Contact.Fields.ModifiedOn];
-        newValue.Attributes[Contact.Fields.dfeta_InductionStatus] = updatedContact.Attributes[Contact.Fields.dfeta_InductionStatus];
-
-        var auditId = Guid.NewGuid();
-        auditDetailCollection.Add(new AttributeAuditDetail()
+        if (updatedQtlsDate is not null)
         {
-            AuditRecord = new Audit()
+            updatedContact.dfeta_qtlsdate = updatedQtlsDate.Value.ToDateTimeWithDqtBstFix(isLocalTime: true);
+
+            var oldValueQtlsDate = new Entity(Contact.EntityLogicalName, existingContact.Id);
+            oldValueQtlsDate.Attributes[Contact.Fields.ModifiedOn] = existingContact.Attributes[Contact.Fields.ModifiedOn];
+            oldValueQtlsDate.Attributes[Contact.Fields.dfeta_qtlsdate] = existingContact.GetAttributeValue<DateTime?>(Contact.Fields.dfeta_qtlsdate);
+
+            var newValueQtlsDate = new Entity(Contact.EntityLogicalName, existingContact.Id);
+            newValueQtlsDate.Attributes[Contact.Fields.ModifiedOn] = updatedContact.Attributes[Contact.Fields.ModifiedOn];
+            newValueQtlsDate.Attributes[Contact.Fields.dfeta_qtlsdate] = updatedContact.Attributes[Contact.Fields.dfeta_qtlsdate];
+
+            var auditId = Guid.NewGuid();
+            auditDetailCollection.Add(new AttributeAuditDetail()
             {
-                Action = Audit_Action.Update,
-                AuditId = auditId,
-                CreatedOn = Clock.UtcNow,
-                Id = auditId,
-                Operation = Audit_Operation.Update,
-                UserId = currentDqtUser
-            },
-            OldValue = oldValue,
-            NewValue = newValue
-        });
+                AuditRecord = new Audit()
+                {
+                    Action = Audit_Action.Update,
+                    AuditId = auditId,
+                    CreatedOn = Clock.UtcNow,
+                    Id = auditId,
+                    Operation = Audit_Operation.Update,
+                    UserId = currentDqtUser
+                },
+                OldValue = oldValueQtlsDate,
+                NewValue = newValueQtlsDate
+            });
+        }
+
+        if (updatedInductionStatus is not null)
+        {
+            updatedContact.dfeta_InductionStatus = updatedInductionStatus;
+
+            var oldValueStatus = new Entity(Contact.EntityLogicalName, existingContact.Id);
+            oldValueStatus.Attributes[Contact.Fields.ModifiedOn] = existingContact.Attributes[Contact.Fields.ModifiedOn];
+            oldValueStatus.Attributes[Contact.Fields.dfeta_InductionStatus] = existingContact.GetAttributeValue<dfeta_InductionStatus?>(Contact.Fields.dfeta_InductionStatus);
+
+            var newValueStatus = new Entity(Contact.EntityLogicalName, existingContact.Id);
+            newValueStatus.Attributes[Contact.Fields.ModifiedOn] = updatedContact.Attributes[Contact.Fields.ModifiedOn];
+            newValueStatus.Attributes[Contact.Fields.dfeta_InductionStatus] = updatedContact.Attributes[Contact.Fields.dfeta_InductionStatus];
+
+            var auditId = Guid.NewGuid();
+            auditDetailCollection.Add(new AttributeAuditDetail()
+            {
+                AuditRecord = new Audit()
+                {
+                    Action = Audit_Action.Update,
+                    AuditId = auditId,
+                    CreatedOn = Clock.UtcNow,
+                    Id = auditId,
+                    Operation = Audit_Operation.Update,
+                    UserId = currentDqtUser
+                },
+                OldValue = oldValueStatus,
+                NewValue = newValueStatus
+            });
+        }
 
         return updatedContact;
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestableAuditRepository.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestableAuditRepository.cs
@@ -9,7 +9,7 @@ public class TestableAuditRepository : IAuditRepository
     private readonly ConcurrentDictionary<(string EntityLogicalName, Guid Id), AuditDetailCollection> _audits = new();
 
     public Task<AuditDetailCollection?> GetAuditDetailAsync(string entityLogicalName, string primaryIdAttribute, Guid id) =>
-        Task.FromResult(_audits.TryGetValue((entityLogicalName, id), out var audit) ? audit : null);
+        Task.FromResult(_audits.TryGetValue((entityLogicalName, id), out var audit) ? audit : (AuditDetailCollection?)new());
 
     public Task<bool> HaveAuditDetailAsync(string entityLogicalName, Guid id) =>
         Task.FromResult(_audits.ContainsKey((entityLogicalName, id)));


### PR DESCRIPTION
### Context

Teachers with QTLS can potentially have an induction status without any dfeta_induction records associated with a Contact.

We are currently only live syncing any induction status changes for changes to the dfeta_induction table.

We need to also capture any changes to the induction status on the Contact table when the QTLS date changes alone as part of the Person live sync.

### Changes proposed in this pull request

Amend the SyncPersons code in `TrsDataSyncHelper` to also generate any `DqtContactInductionStatusChangedEvent` events if there are any changes to the `Contact.dfeta_InductionStatus` field but only where the `Contact.dfeta_qtlsdate` field has changed too (i.e. the induction status has changed as a result of the QTLS date having changed).

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
