### PR TITLE
Tidy induction pages

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CommonJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CommonJourneyPage.cs
@@ -3,18 +3,14 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi;
 using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditInduction;
 
-public abstract class CommonJourneyPage : PageModel
+public abstract class CommonJourneyPage(TrsLinkGenerator linkGenerator) : PageModel
 {
-    protected TrsLinkGenerator LinkGenerator { get; set; }
     public JourneyInstance<EditInductionState>? JourneyInstance { get; set; }
+
+    protected TrsLinkGenerator LinkGenerator { get; } = linkGenerator;
 
     [FromRoute]
     public Guid PersonId { get; set; }
-
-    protected CommonJourneyPage(TrsLinkGenerator linkGenerator)
-    {
-        LinkGenerator = linkGenerator;
-    }
 
     public async Task<IActionResult> OnPostCancelAsync()
     {
@@ -22,7 +18,7 @@ public abstract class CommonJourneyPage : PageModel
         return Redirect(LinkGenerator.PersonInduction(PersonId));
     }
 
-    protected string PageLink(InductionJourneyPage? pageName, JourneyFromCheckYourAnswersPage? fromCheckYourAnswersPage = null)
+    protected string GetPageLink(InductionJourneyPage? pageName, JourneyFromCheckYourAnswersPage? fromCheckYourAnswersPage = null)
     {
         return pageName switch
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
@@ -15,7 +15,7 @@ public class EditInductionState : IRegisterJourney
     public InductionStatus InductionStatus { get; set; }
     public DateOnly? StartDate { get; set; }
     public DateOnly? CompletedDate { get; set; }
-    public Guid[]? ExemptionReasonIds { get; set; } = Array.Empty<Guid>();
+    public Guid[]? ExemptionReasonIds { get; set; } = [];
     public InductionChangeReasonOption? ChangeReason { get; set; }
     public bool? HasAdditionalReasonDetail { get; set; }
     public string? ChangeReasonDetail { get; set; }
@@ -25,6 +25,7 @@ public class EditInductionState : IRegisterJourney
     public string? EvidenceFileSizeDescription { get; set; }
 
     public bool Initialized { get; set; }
+
     [JsonIgnore]
     public bool IsComplete =>
         InductionStatus != InductionStatus.None &&
@@ -42,11 +43,11 @@ public class EditInductionState : IRegisterJourney
         {
             return;
         }
-        var person = await dbContext.Persons
-            .SingleAsync(q => q.PersonId == personId);
+
+        var person = await dbContext.Persons.SingleAsync(q => q.PersonId == personId);
 
         InductionStatus = person.InductionStatus;
-        JourneyStartPage ??= startPage;
+        JourneyStartPage = startPage;
         StartDate = person.InductionStartDate;
         CompletedDate = person.InductionCompletedDate;
         ExemptionReasonIds = person.InductionExemptionReasonIds;


### PR DESCRIPTION
- Use primary constructors.
- Amended `protected` properties to `private`, where appropriate.
- Removed redundant `JourneyStartPage` assignments.