### PR TITLE
Use model types on InductionMigratedEvents

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InductionMigratedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InductionMigratedEvent.cs
@@ -8,7 +8,7 @@ public record InductionMigratedEvent : EventBase, IEventWithPersonId, IEventWith
     public required Guid PersonId { get; init; }
     public required DateOnly? InductionStartDate { get; init; }
     public required DateOnly? InductionCompletedDate { get; init; }
-    public required string? InductionStatus { get; init; }
-    public required string? InductionExemptionReason { get; init; }
+    public required InductionStatus InductionStatus { get; init; }
+    public required Guid? InductionExemptionReasonId { get; init; }
     public required DqtInduction DqtInduction { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -603,7 +603,7 @@ public class TrsDataSyncHelper(
                 continue;
             }
 
-            var migratedEvent = await MapMigratedEventAsync(contact.ContactId!.Value, induction!, mapped);
+            var migratedEvent = MapMigratedEvent(contact.ContactId!.Value, induction, mapped);
             events.Add(migratedEvent);
         }
 
@@ -623,15 +623,8 @@ public class TrsDataSyncHelper(
 
         return events.Count;
 
-        async Task<EventBase> MapMigratedEventAsync(Guid contactId, dfeta_induction dqtInduction, InductionInfo mappedInduction)
+        EventBase MapMigratedEvent(Guid contactId, dfeta_induction dqtInduction, InductionInfo mappedInduction)
         {
-            var inductionExemptionReason = "";
-            if (mappedInduction.InductionExemptionReasonIds.Length > 0)
-            {
-                var reason = await referenceDataCache.GetInductionExemptionReasonByIdAsync(mappedInduction.InductionExemptionReasonIds.Single());
-                inductionExemptionReason = reason.Name;
-            }
-
             return new InductionMigratedEvent()
             {
                 EventId = Guid.NewGuid(),
@@ -641,8 +634,8 @@ public class TrsDataSyncHelper(
                 PersonId = contactId,
                 InductionStartDate = mappedInduction.InductionStartDate,
                 InductionCompletedDate = mappedInduction.InductionCompletedDate,
-                InductionStatus = mappedInduction.InductionStatus.HasValue ? mappedInduction.InductionStatus!.Value.GetTitle() : null,
-                InductionExemptionReason = inductionExemptionReason,
+                InductionStatus = mappedInduction.InductionStatus,
+                InductionExemptionReasonId = mappedInduction.InductionExemptionReasonIds.SingleOrDefault(),
                 DqtInduction = GetEventDqtInduction(dqtInduction)
             };
         }
@@ -1604,7 +1597,7 @@ public class TrsDataSyncHelper(
         public required DateOnly? InductionCompletedDate { get; init; }
         public required Guid[] InductionExemptionReasonIds { get; init; }
         public required DateOnly? InductionStartDate { get; init; }
-        public required InductionStatus? InductionStatus { get; init; }
+        public required InductionStatus InductionStatus { get; init; }
         public required DateTime? DqtModifiedOn { get; init; }
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/InductionMigratedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/InductionMigratedEvent.cshtml
@@ -1,6 +1,7 @@
 @using Optional.Unsafe
 @using TeachingRecordSystem.Core.Events
 @using TeachingRecordSystem.Core.Services.Files
+@inject ReferenceDataCache ReferenceDataCache
 @model TimelineItem<TimelineEvent<InductionMigratedEvent>>
 @{
     var migratedEvent = Model.ItemModel.Event;
@@ -17,18 +18,16 @@
     </p>
     <div class="moj-timeline__description">
         <govuk-summary-list>
-            @if (!string.IsNullOrEmpty(migratedEvent.InductionStatus))
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Induction status</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="induction-status">@migratedEvent.InductionStatus.GetTitle()</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            @if (migratedEvent.InductionExemptionReasonId is Guid exemptionReasonId)
             {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Induction status</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="induction-status">@migratedEvent.InductionStatus</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-            }
-            @if (!string.IsNullOrEmpty(migratedEvent.InductionExemptionReason))
-            {
+                var exemptionReason = await ReferenceDataCache.GetInductionExemptionReasonByIdAsync(exemptionReasonId);
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Induction exemption reason</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="exemption-reason">@migratedEvent.InductionExemptionReason</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value data-testid="exemption-reason">@exemptionReason.Name</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
             }
             @if (migratedEvent.InductionStartDate.HasValue)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Induction.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Induction.cs
@@ -562,7 +562,7 @@ public partial class TrsDataSyncHelperTests
         Assert.Equal(inductionCompletionDate, migratedEvent.DqtInduction.CompletionDate.ValueOrFailure());
         Assert.Equal(inductionStartDate, migratedEvent.InductionStartDate);
         Assert.Equal(inductionCompletionDate, migratedEvent.InductionCompletedDate);
-        Assert.Equal(inductionStatus.ToInductionStatus().GetTitle(), migratedEvent.InductionStatus);
+        Assert.Equal(inductionStatus.ToInductionStatus(), migratedEvent.InductionStatus);
     }
 
     private async Task<dfeta_induction> CreateNewInductionEntityVersion(


### PR DESCRIPTION
Use our `InductionStatus` enum and `ExemptionReasonId` instead of strings.