### PR TITLE
Remodel induction to handle removing exemptions

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionExemptionReasonMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionExemptionReasonMapping.cs
@@ -27,6 +27,6 @@ public class InductionExemptionReasonMapping : IEntityTypeConfiguration<Inductio
             new InductionExemptionReason { InductionExemptionReasonId = new("4c97e211-10d2-4c63-8da9-b0fcebe7f2f9"), Name = "Overseas Trained Teacher", IsActive = true },
             new InductionExemptionReason { InductionExemptionReasonId = new("e7118bab-c2b1-4fe8-ad3f-4095d73f5b85"), Name = "Qualified through EEA mutual recognition route", IsActive = true },
             new InductionExemptionReason { InductionExemptionReasonId = new("42bb7bbc-a92c-4886-b319-3c1a5eac319a"), Name = "Registered teacher with at least 2 years full-time teaching experience", IsActive = true },
-            new InductionExemptionReason { InductionExemptionReasonId = new("35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db"), Name = "Exempt through QTLS status provided they maintain membership of The Society of Education and Training", IsActive = true });
+            new InductionExemptionReason { InductionExemptionReasonId = InductionExemptionReason.QtlsId, Name = "Exempt through QTLS status provided they maintain membership of The Society of Education and Training", IsActive = true });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonMapping.cs
@@ -22,5 +22,6 @@ public class PersonMapping : IEntityTypeConfiguration<Person>
         builder.Property(p => p.DqtLastName).HasMaxLength(100).UseCollation("case_insensitive");
         builder.Property(p => p.InductionStatus).IsRequired().HasDefaultValue(InductionStatus.None);
         builder.Property(p => p.InductionExemptionReasonIds).IsRequired();
+        builder.Property(p => p.InductionStatusWithoutExemption).IsRequired();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250206162245_InductionStatusWithoutExemption.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250206162245_InductionStatusWithoutExemption.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250206162245_InductionStatusWithoutExemption")]
+    partial class InductionStatusWithoutExemption
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250206162245_InductionStatusWithoutExemption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250206162245_InductionStatusWithoutExemption.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class InductionStatusWithoutExemption : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_completed_date",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_start_date",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "cpd_induction_status",
+                table: "persons");
+
+            migrationBuilder.AddColumn<int>(
+                name: "induction_status_without_exemption",
+                table: "persons",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.Sql(
+                "update persons set induction_status_without_exemption = case when induction_status = 2 then 5 else induction_status end");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "induction_status_without_exemption",
+                table: "persons");
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "cpd_induction_completed_date",
+                table: "persons",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "cpd_induction_start_date",
+                table: "persons",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "cpd_induction_status",
+                table: "persons",
+                type: "integer",
+                nullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InductionExemptionReason.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/InductionExemptionReason.cs
@@ -3,6 +3,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 public class InductionExemptionReason
 {
     public static Guid PassedInWalesId { get; } = new("39550fa9-3147-489d-b808-4feea7f7f979");
+    public static Guid QtlsId { get; } = new("35caa6a3-49f2-4a63-bd5a-2ba5fa9dc5db");
 
     public required Guid InductionExemptionReasonId { get; init; }
     public required string Name { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Induction.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Induction.cs
@@ -6,23 +6,19 @@ namespace TeachingRecordSystem.Core.Events.Models;
 public record Induction
 {
     public required InductionStatus Status { get; init; }
+    public required InductionStatus StatusWithoutExemption { get; init; }
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? CompletedDate { get; init; }
     public required Guid[] ExemptionReasonIds { get; init; }
-    public required Option<InductionStatus> CpdStatus { get; init; }
-    public required Option<DateOnly?> CpdStartDate { get; init; }
-    public required Option<DateOnly?> CpdCompletedDate { get; init; }
     public required Option<DateTime> CpdCpdModifiedOn { get; init; }
 
     public static Induction FromModel(Person person) => new()
     {
         Status = person.InductionStatus,
+        StatusWithoutExemption = person.InductionStatusWithoutExemption,
         StartDate = person.InductionStartDate,
         CompletedDate = person.InductionCompletedDate,
         ExemptionReasonIds = person.InductionExemptionReasonIds,
-        CpdStatus = person.CpdInductionStatus.ToOption(),
-        CpdStartDate = person.CpdInductionStatus is not null ? Option.Some(person.CpdInductionStartDate) : default,
-        CpdCompletedDate = person.CpdInductionStatus is not null ? Option.Some(person.CpdInductionCompletedDate) : default,
         CpdCpdModifiedOn = person.CpdInductionCpdModifiedOn.ToOption()
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonInductionUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonInductionUpdatedEvent.cs
@@ -19,7 +19,5 @@ public enum PersonInductionUpdatedEventChanges
     InductionStartDate = 1 << 1,
     InductionCompletedDate = 1 << 2,
     InductionExemptionReasons = 1 << 3,
-    CpdInductionStatus = 1 << 4,
-    CpdInductionStartDate = 1 << 5,
-    CpdInductionCompletedDate = 1 << 6
+    InductionStatusWithoutExemption = 1 << 7,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonInductionUpdatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonInductionUpdatedEvent.cshtml
@@ -30,18 +30,6 @@
         {
             heading = "Induction exemption reason changed";
         }
-        else if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus))
-        {
-            heading = "CPD induction status changed";
-        }
-        else if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate))
-        {
-            heading = "CPD induction start date changed";
-        }
-        else if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate))
-        {
-            heading = "CPD induction completed date changed";
-        }
     }
 }
 
@@ -74,7 +62,7 @@
                                 @foreach (var id in induction.ExemptionReasonIds)
                                 {
                                     <li>@exemptionReasons[id].Name</li>
-                                }                            
+                                }
                             </ul>
                         }
                         else
@@ -98,30 +86,6 @@
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Completed date</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="completed-date" use-empty-fallback>@induction.CompletedDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-            }
-
-            @if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus))
-            {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>CPD induction status</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="cpd-induction-status" use-empty-fallback>@(induction.CpdStatus.HasValue ? @induction.CpdStatus.ValueOrDefault().GetTitle() : null)</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-            }
-
-            @if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate))
-            {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>CPD start date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="cpd-start-date" use-empty-fallback>@induction.CpdStartDate.ValueOrDefault()?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-            }
-
-            @if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate))
-            {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>CPD completed date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value data-testid="cpd-completed-date" use-empty-fallback>@induction.CpdCompletedDate.ValueOrDefault()?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
             }
 
@@ -219,30 +183,6 @@
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Completed date</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value data-testid="old-completed-date" use-empty-fallback>@oldInduction.CompletedDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-                        </govuk-summary-list-row>
-                    }
-
-                    @if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus))
-                    {
-                        <govuk-summary-list-row>
-                            <govuk-summary-list-row-key>CPD induction status</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value data-testid="old-cpd-induction-status" use-empty-fallback>@(oldInduction.CpdStatus.HasValue ? @oldInduction.CpdStatus.ValueOrDefault().GetTitle() : null)</govuk-summary-list-row-value>
-                        </govuk-summary-list-row>
-                    }
-
-                    @if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate))
-                    {
-                        <govuk-summary-list-row>
-                            <govuk-summary-list-row-key>CPD start date</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value data-testid="old-cpd-start-date" use-empty-fallback>@oldInduction.CpdStartDate.ValueOrDefault()?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-                        </govuk-summary-list-row>
-                    }
-
-                    @if (updatedEvent.Changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate))
-                    {
-                        <govuk-summary-list-row>
-                            <govuk-summary-list-row-key>CPD completed date</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value data-testid="old-cpd-completed-date" use-empty-fallback>@oldInduction.CpdCompletedDate.ValueOrDefault()?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
@@ -7,6 +7,167 @@ public class PersonTests
 {
     public TestableClock Clock { get; } = new();
 
+    [Fact]
+    public void SetInductionStatus_None_UpdatesStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        // Act
+        person.SetInductionStatus(
+            InductionStatus.None,
+            startDate: null,
+            completedDate: null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.None, person.InductionStatus);
+    }
+
+    [Fact]
+    public void SetInductionStatus_RequiredToComplete_UpdatesStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        // Act
+        person.SetInductionStatus(
+            InductionStatus.RequiredToComplete,
+            startDate: null,
+            completedDate: null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.RequiredToComplete, person.InductionStatus);
+    }
+
+    [Fact]
+    public void SetInductionStatus_InProgress_UpdatesStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        // Act
+        person.SetInductionStatus(
+            InductionStatus.InProgress,
+            startDate: new(2024, 1, 1),
+            completedDate: null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.InProgress, person.InductionStatus);
+    }
+
+    [Fact]
+    public void SetInductionStatus_Passed_UpdatesStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        // Act
+        person.SetInductionStatus(
+            InductionStatus.Passed,
+            startDate: new(2024, 1, 1),
+            completedDate: new(2025, 1, 1),
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.Passed, person.InductionStatus);
+    }
+
+    [Fact]
+    public void SetInductionStatus_Failed_UpdatesStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        // Act
+        person.SetInductionStatus(
+            InductionStatus.Failed,
+            startDate: new(2024, 1, 1),
+            completedDate: new(2025, 1, 1),
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.Failed, person.InductionStatus);
+    }
+
+    [Fact]
+    public void SetInductionStatus_Exempt_UpdatesStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        // Act
+        person.SetInductionStatus(
+            InductionStatus.Exempt,
+            startDate: null,
+            completedDate: null,
+            exemptionReasonIds: [InductionExemptionReason.QtlsId],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.Exempt, person.InductionStatus);
+    }
+
+    [Fact]
+    public void SetInductionStatus_FailedInWales_UpdatesStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        // Act
+        person.SetInductionStatus(
+            InductionStatus.FailedInWales,
+            startDate: new(2024, 1, 1),
+            completedDate: new(2025, 1, 1),
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.FailedInWales, person.InductionStatus);
+    }
+
     [Theory]
     [InlineData(InductionStatus.Passed)]
     [InlineData(InductionStatus.InProgress)]
@@ -14,17 +175,7 @@ public class PersonTests
     public void SetCpdInductionStatus_SetsOverallStatusAndOutsEvent(InductionStatus status)
     {
         // Arrange
-        var person = new Person
-        {
-            PersonId = Guid.NewGuid(),
-            CreatedOn = Clock.UtcNow,
-            UpdatedOn = Clock.UtcNow,
-            Trn = "1234567",
-            FirstName = "Joe",
-            MiddleName = "",
-            LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1),
-        };
+        var person = CreatePerson();
 
         // Act
         person.SetCpdInductionStatus(
@@ -38,6 +189,7 @@ public class PersonTests
 
         // Assert
         Assert.Equal(status, person.InductionStatus);
+        Assert.Equal(status, person.InductionStatusWithoutExemption);
         Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
         Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
     }
@@ -46,17 +198,7 @@ public class PersonTests
     public void SetCpdInductionStatus_PersonIsExemptAndNewStatusIsPassed_SetsOverallStatusToPassed()
     {
         // Arrange
-        var person = new Person
-        {
-            PersonId = Guid.NewGuid(),
-            CreatedOn = Clock.UtcNow,
-            UpdatedOn = Clock.UtcNow,
-            Trn = "1234567",
-            FirstName = "Joe",
-            MiddleName = "",
-            LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1),
-        };
+        var person = CreatePerson();
 
         person.SetInductionStatus(
             InductionStatus.Exempt,
@@ -85,6 +227,7 @@ public class PersonTests
 
         // Assert
         Assert.Equal(InductionStatus.Passed, person.InductionStatus);
+        Assert.Equal(InductionStatus.Passed, person.InductionStatusWithoutExemption);
         Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
         Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
     }
@@ -95,17 +238,7 @@ public class PersonTests
     public void SetCpdInductionStatus_PersonIsExemptAndNewStatusIsNotPassed_KeepsOverallStatusAsExempt(InductionStatus status)
     {
         // Arrange
-        var person = new Person
-        {
-            PersonId = Guid.NewGuid(),
-            CreatedOn = Clock.UtcNow,
-            UpdatedOn = Clock.UtcNow,
-            Trn = "1234567",
-            FirstName = "Joe",
-            MiddleName = "",
-            LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1),
-        };
+        var person = CreatePerson();
 
         person.SetInductionStatus(
             InductionStatus.Exempt,
@@ -134,39 +267,28 @@ public class PersonTests
 
         // Assert
         Assert.Equal(InductionStatus.Exempt, person.InductionStatus);
-        Assert.NotEqual(Clock.UtcNow, person.InductionModifiedOn);
+        Assert.Equal(status, person.InductionStatusWithoutExemption);
+        Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
         Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
     }
 
     [Theory]
     [InlineData(true, InductionStatus.Exempt)]
-    [InlineData(true, InductionStatus.InProgress)]
     [InlineData(true, InductionStatus.Passed)]
     [InlineData(true, InductionStatus.Failed)]
-    [InlineData(false, InductionStatus.Exempt)]
     [InlineData(false, InductionStatus.InProgress)]
     [InlineData(false, InductionStatus.Passed)]
     [InlineData(false, InductionStatus.Failed)]
-    public void TrySetWelshInductionStatus_StatusIsAlreadySetToHigherPriorityStatus_ReturnsFalse(bool passed, InductionStatus currentStatus)
+    public void TrySetWelshInductionStatus_StatusIsAlreadySetToHigherPriorityStatus_DoesNotChangeStatus(bool passed, InductionStatus currentStatus)
     {
         // Arrange
-        var person = new Person
-        {
-            PersonId = Guid.NewGuid(),
-            CreatedOn = Clock.UtcNow,
-            UpdatedOn = Clock.UtcNow,
-            Trn = "1234567",
-            FirstName = "Joe",
-            MiddleName = "",
-            LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1),
-        };
+        var person = CreatePerson();
 
         person.SetInductionStatus(
             currentStatus,
             startDate: currentStatus.RequiresStartDate() ? new(2024, 1, 1) : null,
             completedDate: currentStatus.RequiresCompletedDate() ? new(2024, 10, 1) : null,
-            exemptionReasonIds: currentStatus is InductionStatus.Exempt ? new[] { InductionExemptionReason.PassedInWalesId } : Array.Empty<Guid>(),
+            exemptionReasonIds: currentStatus is InductionStatus.Exempt ? new[] { InductionExemptionReason.QtlsId } : Array.Empty<Guid>(),
             changeReason: null,
             changeReasonDetail: null,
             evidenceFile: null,
@@ -177,7 +299,7 @@ public class PersonTests
         Clock.Advance();
 
         // Act
-        var result = person.TrySetWelshInductionStatus(
+        person.TrySetWelshInductionStatus(
             passed,
             startDate: !passed ? new(2024, 1, 1) : null,
             completedDate: !passed ? new(2024, 10, 1) : null,
@@ -186,27 +308,16 @@ public class PersonTests
             out _);
 
         // Assert
-        Assert.False(result);
         Assert.Equal(currentStatus, person.InductionStatus);
     }
 
-    [Fact]
-    public void TrySetWelshInductionStatus_PassedAndStatusIsAtLowerPriorityStatus_UpdatesStatusAndReturnsTrue()
+    [Theory]
+    [InlineData(InductionStatus.RequiredToComplete)]
+    [InlineData(InductionStatus.InProgress)]
+    public void TrySetWelshInductionStatus_PassedAndStatusIsAtLowerPriorityStatus_UpdatesStatusAndReturnsTrue(InductionStatus currentStatus)
     {
         // Arrange
-        var person = new Person
-        {
-            PersonId = Guid.NewGuid(),
-            CreatedOn = Clock.UtcNow,
-            UpdatedOn = Clock.UtcNow,
-            Trn = "1234567",
-            FirstName = "Joe",
-            MiddleName = "",
-            LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1),
-        };
-
-        var currentStatus = InductionStatus.RequiredToComplete;
+        var person = CreatePerson();
 
         person.SetInductionStatus(
             currentStatus,
@@ -223,7 +334,7 @@ public class PersonTests
         Clock.Advance();
 
         // Act
-        var result = person.TrySetWelshInductionStatus(
+        person.TrySetWelshInductionStatus(
             passed: true,
             startDate: null,
             completedDate: null,
@@ -232,7 +343,6 @@ public class PersonTests
             out _);
 
         // Assert
-        Assert.True(result);
         Assert.Equal(InductionStatus.Exempt, person.InductionStatus);
         Assert.Collection(person.InductionExemptionReasonIds, id => Assert.Equal(InductionExemptionReason.PassedInWalesId, id));
     }
@@ -241,18 +351,7 @@ public class PersonTests
     public void TrySetWelshInductionStatus_FailedAndStatusIsAtLowerPriorityStatus_UpdatesStatusAndReturnsTrue()
     {
         // Arrange
-        var person = new Person
-        {
-            PersonId = Guid.NewGuid(),
-            CreatedOn = Clock.UtcNow,
-            UpdatedOn = Clock.UtcNow,
-            Trn = "1234567",
-            FirstName = "Joe",
-            MiddleName = "",
-            LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1),
-        };
-
+        var person = CreatePerson();
         var currentStatus = InductionStatus.RequiredToComplete;
 
         person.SetInductionStatus(
@@ -270,7 +369,7 @@ public class PersonTests
         Clock.Advance();
 
         // Act
-        var result = person.TrySetWelshInductionStatus(
+        person.TrySetWelshInductionStatus(
             passed: false,
             startDate: new(2024, 1, 1),
             completedDate: new(2024, 10, 1),
@@ -279,42 +378,254 @@ public class PersonTests
             out _);
 
         // Assert
-        Assert.True(result);
         Assert.Equal(InductionStatus.FailedInWales, person.InductionStatus);
         Assert.Empty(person.InductionExemptionReasonIds);
     }
 
-    [Theory]
-    [InlineData(-3, true)]
-    [InlineData(-7, false)]
-    public void InductionManagedByCpd_ReturnsExpected(int yearsSinceCompleted, bool expected)
+    [Fact]
+    public void InductionManagedByCpd_CpdStatusIsNotNullWithNoCompletedDate_ReturnsTrue()
     {
         // Arrange
-        var dateTimeCompleted = Clock.UtcNow.AddYears(yearsSinceCompleted).AddDays(-1);
-        var dateCompleted = Clock.Today.AddYears(yearsSinceCompleted).AddDays(-1);
-        var person = new Person
-        {
-            PersonId = Guid.NewGuid(),
-            CreatedOn = dateTimeCompleted,
-            UpdatedOn = dateTimeCompleted,
-            Trn = "1234567",
-            FirstName = "Joe",
-            MiddleName = "",
-            LastName = "Bloggs",
-            DateOfBirth = new(1990, 1, 1)
-        };
+        var person = CreatePerson();
+
         person.SetCpdInductionStatus(
-            status: InductionStatus.Passed,
-            startDate: dateCompleted,
-            completedDate: dateCompleted,
-            cpdModifiedOn: dateTimeCompleted,
+            status: InductionStatus.InProgress,
+            startDate: new(2024, 1, 1),
+            completedDate: null,
+            cpdModifiedOn: Clock.UtcNow,
             SystemUser.SystemUserId,
-            Clock.UtcNow, out _);
+            Clock.UtcNow,
+            out _);
 
         // Act
         var result = person.InductionStatusManagedByCpd(Clock.Today);
 
         // Assert
-        Assert.Equal(expected, result);
+        Assert.True(result);
     }
+
+    [Fact]
+    public void InductionManagedByCpd_CpdStatusIsNotNullCompletedDateWithin7Years_ReturnsTrue()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetCpdInductionStatus(
+            status: InductionStatus.Passed,
+            startDate: Clock.Today.AddYears(-1),
+            completedDate: Clock.Today,
+            cpdModifiedOn: Clock.UtcNow,
+            SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+
+        // Act
+        var result = person.InductionStatusManagedByCpd(Clock.Today);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void InductionManagedByCpd_CpdStatusIsNotNullCompletedDateMoreThan7YearsAgo_ReturnsFalse()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetCpdInductionStatus(
+            status: InductionStatus.Passed,
+            startDate: Clock.Today.AddYears(-9),
+            completedDate: Clock.Today.AddYears(-7),
+            cpdModifiedOn: Clock.UtcNow,
+            SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+
+        // Act
+        var result = person.InductionStatusManagedByCpd(Clock.Today);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void InductionManagedByCpd_CpdStatusIsNull_ReturnsFalse()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetInductionStatus(
+            status: InductionStatus.InProgress,
+            startDate: Clock.Today,
+            completedDate: null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            SystemUser.SystemUserId,
+            Clock.UtcNow,
+            out _);
+
+        // Act
+        var result = person.InductionStatusManagedByCpd(Clock.Today);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.None)]
+    [InlineData(InductionStatus.RequiredToComplete)]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.FailedInWales)]
+    public void AddInductionExemptionReason_CurrentStatusIsLowerPriorityThanExempt_UpdatesStatus(InductionStatus currentStatus)
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetInductionStatus(
+            currentStatus,
+            startDate: currentStatus.RequiresStartDate() ? new(2024, 1, 1) : null,
+            completedDate: currentStatus.RequiresCompletedDate() ? new(2025, 1, 1) : null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Act
+        person.AddInductionExemptionReason(
+            InductionExemptionReason.QtlsId,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.Exempt, person.InductionStatus);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.Failed)]
+    [InlineData(InductionStatus.Passed)]
+    public void AddInductionExemptionReason_CurrentStatusIsHigherPriorityThanExempt_DoesNotChangeStatus(InductionStatus currentStatus)
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetInductionStatus(
+            currentStatus,
+            startDate: currentStatus.RequiresStartDate() ? new(2024, 1, 1) : null,
+            completedDate: currentStatus.RequiresCompletedDate() ? new(2025, 1, 1) : null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Act
+        person.AddInductionExemptionReason(
+            InductionExemptionReason.QtlsId,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(currentStatus, person.InductionStatus);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.None)]
+    [InlineData(InductionStatus.RequiredToComplete)]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.FailedInWales)]
+    public void RemoveInductionExemptionReason_StatusIsExemptWithNoOtherReasons_RollsBackStatus(InductionStatus initialStatus)
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetInductionStatus(
+            initialStatus,
+            startDate: initialStatus.RequiresStartDate() ? new(2024, 1, 1) : null,
+            completedDate: initialStatus.RequiresCompletedDate() ? new(2025, 1, 1) : null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        person.AddInductionExemptionReason(
+            InductionExemptionReason.QtlsId,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        Debug.Assert(person.InductionStatus == InductionStatus.Exempt);
+
+        // Act
+        person.RemoveInductionExemptionReason(
+            InductionExemptionReason.QtlsId,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(initialStatus, person.InductionStatus);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.Failed)]
+    [InlineData(InductionStatus.Passed)]
+    public void RemoveInductionExemptionReason_StatusIsHigherPriorityToExempt_DoesNotChangeStatus(InductionStatus currentStatus)
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetInductionStatus(
+            currentStatus,
+            startDate: new(2024, 1, 1),
+            completedDate: null,
+            exemptionReasonIds: [],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        person.AddInductionExemptionReason(
+            InductionExemptionReason.QtlsId,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        Debug.Assert(person.InductionStatus == currentStatus);
+
+        // Act
+        person.RemoveInductionExemptionReason(
+            InductionExemptionReason.QtlsId,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(currentStatus, person.InductionStatus);
+    }
+
+    private Person CreatePerson() => new Person
+    {
+        PersonId = Guid.NewGuid(),
+        CreatedOn = Clock.UtcNow,
+        UpdatedOn = Clock.UtcNow,
+        Trn = "1234567",
+        FirstName = "Joe",
+        MiddleName = "",
+        LastName = "Bloggs",
+        DateOfBirth = new(1990, 1, 1),
+    };
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
@@ -555,21 +555,6 @@ public class ChangeLogInductionEventTests : TestBase
     [InlineData(PersonInductionUpdatedEventChanges.InductionStartDate | PersonInductionUpdatedEventChanges.InductionStatus, false, true)]
     [InlineData(PersonInductionUpdatedEventChanges.InductionStartDate | PersonInductionUpdatedEventChanges.InductionCompletedDate | PersonInductionUpdatedEventChanges.InductionStatus, false, true)]
     [InlineData(PersonInductionUpdatedEventChanges.InductionStartDate | PersonInductionUpdatedEventChanges.InductionCompletedDate | PersonInductionUpdatedEventChanges.InductionStatus | PersonInductionUpdatedEventChanges.InductionExemptionReasons, false, true)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStatus, false, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStatus, true, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStatus, false, true)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate, false, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate, true, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate, false, true)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate, false, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate, true, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate, false, true)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate | PersonInductionUpdatedEventChanges.CpdInductionStatus, false, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate | PersonInductionUpdatedEventChanges.CpdInductionCompletedDate | PersonInductionUpdatedEventChanges.CpdInductionStatus, false, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate | PersonInductionUpdatedEventChanges.CpdInductionStatus, true, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate | PersonInductionUpdatedEventChanges.CpdInductionCompletedDate | PersonInductionUpdatedEventChanges.CpdInductionStatus, true, false)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate | PersonInductionUpdatedEventChanges.CpdInductionStatus, false, true)]
-    [InlineData(PersonInductionUpdatedEventChanges.CpdInductionStartDate | PersonInductionUpdatedEventChanges.CpdInductionCompletedDate | PersonInductionUpdatedEventChanges.CpdInductionStatus, false, true)]
     public async Task Person_WithPersonInductionUpdatedEvent_RendersExpectedContent(PersonInductionUpdatedEventChanges changes, bool previousValueIsDefault, bool newValueIsDefault)
     {
         // Arrange
@@ -603,11 +588,9 @@ public class ChangeLogInductionEventTests : TestBase
             StartDate = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionStartDate) && !newValueIsDefault ? startDate : null,
             CompletedDate = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionCompletedDate) && !newValueIsDefault ? completedDate : null,
             Status = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionStatus) && !newValueIsDefault ? inductionStatus : InductionStatus.None,
+            StatusWithoutExemption = InductionStatus.RequiredToComplete,
             ExemptionReasonIds = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionExemptionReasons) && !newValueIsDefault ? exemptionReasons : [],
-            CpdStatus = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus) && !newValueIsDefault ? Option.Some(inductionStatus) : Option.None<InductionStatus>(),
-            CpdStartDate = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate) && !newValueIsDefault ? Option.Some(startDate) : Option.None<DateOnly?>(),
-            CpdCompletedDate = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate) && !newValueIsDefault ? Option.Some(completedDate) : Option.None<DateOnly?>(),
-            CpdCpdModifiedOn = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus) || changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate) || changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate) && !newValueIsDefault ? Option.Some(cpdModifiedOn) : Option.None<DateTime>()
+            CpdCpdModifiedOn = Option.None<DateTime>()
         };
 
         var oldInduction = new EventModels.Induction
@@ -615,11 +598,9 @@ public class ChangeLogInductionEventTests : TestBase
             StartDate = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionStartDate) && !previousValueIsDefault ? oldStartDate : null,
             CompletedDate = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionCompletedDate) && !previousValueIsDefault ? oldCompletedDate : null,
             Status = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionStatus) && !previousValueIsDefault ? oldInductionStatus : InductionStatus.None,
+            StatusWithoutExemption = InductionStatus.RequiredToComplete,
             ExemptionReasonIds = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionExemptionReasons) && !previousValueIsDefault ? oldExemptionReasons : [],
-            CpdStatus = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus) && !previousValueIsDefault ? Option.Some(oldInductionStatus) : Option.None<InductionStatus>(),
-            CpdStartDate = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate) && !previousValueIsDefault ? Option.Some(oldStartDate) : Option.None<DateOnly?>(),
-            CpdCompletedDate = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate) && !previousValueIsDefault ? Option.Some(oldCompletedDate) : Option.None<DateOnly?>(),
-            CpdCpdModifiedOn = changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus) || changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate) || changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate) && !previousValueIsDefault ? Option.Some(oldCpdModifiedOn) : Option.None<DateTime>()
+            CpdCpdModifiedOn = Option.None<DateTime>()
         };
 
         var updatedEvent = new PersonInductionUpdatedEvent
@@ -716,36 +697,6 @@ public class ChangeLogInductionEventTests : TestBase
                 {
                     Assert.Null(item.GetElementByTestId("exemption-reason"));
                     Assert.Null(item.GetElementByTestId("old-exemption-reason"));
-                }
-                if (changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStatus))
-                {
-                    Assert.Equal(newValueIsDefault ? UiDefaults.EmptyDisplayContent : inductionStatus.GetTitle(), item.GetElementByTestId("cpd-induction-status")?.TextContent.Trim());
-                    Assert.Equal(previousValueIsDefault ? UiDefaults.EmptyDisplayContent : oldInductionStatus.GetTitle(), item.GetElementByTestId("old-cpd-induction-status")?.TextContent.Trim());
-                }
-                else
-                {
-                    Assert.Null(item.GetElementByTestId("cpd-induction-status"));
-                    Assert.Null(item.GetElementByTestId("old-cpd-induction-status"));
-                }
-                if (changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionStartDate))
-                {
-                    Assert.Equal(newValueIsDefault ? UiDefaults.EmptyDisplayContent : startDate?.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("cpd-start-date")?.TextContent.Trim());
-                    Assert.Equal(previousValueIsDefault ? UiDefaults.EmptyDisplayContent : oldStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("old-cpd-start-date")?.TextContent.Trim());
-                }
-                else
-                {
-                    Assert.Null(item.GetElementByTestId("cpd-start-date"));
-                    Assert.Null(item.GetElementByTestId("old-cpd-start-date"));
-                }
-                if (changes.HasFlag(PersonInductionUpdatedEventChanges.CpdInductionCompletedDate))
-                {
-                    Assert.Equal(newValueIsDefault ? UiDefaults.EmptyDisplayContent : completedDate?.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("cpd-completed-date")?.TextContent.Trim());
-                    Assert.Equal(previousValueIsDefault ? UiDefaults.EmptyDisplayContent : oldCompletedDate?.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("old-cpd-completed-date")?.TextContent.Trim());
-                }
-                else
-                {
-                    Assert.Null(item.GetElementByTestId("cpd-completed-date"));
-                    Assert.Null(item.GetElementByTestId("old-cpd-completed-date"));
                 }
                 if (induction.CpdCpdModifiedOn.HasValue)
                 {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/ChangeReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/ChangeReasonTests.cs
@@ -18,11 +18,11 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithReasonChoice(reasonChoice)
                 .WithReasonDetailsChoice(true, reasonDetail)
                 .WithFileUploadChoice(false)
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -62,8 +62,8 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.InProgress, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.InProgress, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -106,8 +106,8 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -137,8 +137,8 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -160,8 +160,8 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -189,8 +189,8 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -220,8 +220,8 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -258,8 +258,8 @@ public class ChangeReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/change-reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CommonPageTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CommonPageTests.cs
@@ -42,9 +42,9 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(Clock.Today.AddYears(-2))
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/{fromPage}?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -89,13 +89,13 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(Clock.Today.AddYears(-2))
                 .WithCompletedDate(Clock.Today)
                 .WithReasonChoice(InductionChangeReasonOption.AnotherReason)
                 .WithReasonDetailsChoice(true, "Details")
                 .WithFileUploadChoice(false)
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/{fromPage}?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -136,10 +136,10 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, pageName)
+                .WithInitializedState(inductionStatus, pageName)
                 .WithStartDate(Clock.Today.AddYears(-2))
                 .WithCompletedDate(Clock.Today)
-                .Create());
+                .Build());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/{page}?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContent(new EditInductionPostRequestBuilder()
@@ -181,10 +181,10 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, startPage)
+                .WithInitializedState(inductionStatus, startPage)
                 .WithStartDate(Clock.Today.AddYears(-2))
                 .WithCompletedDate(Clock.Today)
-                .Create());
+                .Build());
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/{fromPage}?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -217,12 +217,12 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, startPage)
+                .WithInitializedState(inductionStatus, startPage)
                 .WithExemptionReasonIds(exemptionReasonIds)
                 .WithStartDate(new DateOnly(2000, 2, 2))
                 .WithCompletedDate(new DateOnly(2002, 2, 2))
                 .WithReasonChoice(InductionChangeReasonOption.AnotherReason)
-                .Create());
+                .Build());
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/{fromPage}?FromCheckAnswers={JourneyFromCheckYourAnswersPage.CheckYourAnswers}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -246,11 +246,11 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.StartDate)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.StartDate)
                 .WithStartDate(new DateOnly(2000, 2, 2))
                 .WithCompletedDate(new DateOnly(2002, 2, 2))
                 .WithReasonChoice(InductionChangeReasonOption.AnotherReason)
-                .Create());
+                .Build());
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/{fromPage}?FromCheckAnswers={JourneyFromCheckYourAnswersPage.CheckYourAnswersToStartDate.ToString()}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -289,12 +289,12 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-               .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+               .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                .WithExemptionReasonIds(exemptionReasonIds)
                .WithStartDate(startDate)
                .WithCompletedDate(completedDate)
                .WithReasonChoice(InductionChangeReasonOption.AnotherReason)
-               .Create());
+               .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/{page}?FromCheckAnswers={JourneyFromCheckYourAnswersPage.CheckYourAnswers}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -338,11 +338,11 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(startDate)
                 .WithCompletedDate(completedDate)
                 .WithReasonChoice(InductionChangeReasonOption.AnotherReason)
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/{fromPage}?FromCheckAnswers={JourneyFromCheckYourAnswersPage.CheckYourAnswers}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -383,9 +383,9 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(Clock.Today.AddYears(-2))
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Post,
             $"/persons/{person.PersonId}/{page}?{journeyInstance.GetUniqueIdQueryParameter()}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditCompletedDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditCompletedDateTests.cs
@@ -18,8 +18,8 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -39,8 +39,8 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.Passed, InductionJourneyPage.StartDate)
-                .Create());
+                .WithInitializedState(InductionStatus.Passed, InductionJourneyPage.StartDate)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -62,10 +62,10 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(dateValid.AddYears(-2))
                 .WithCompletedDate(dateValid)
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -91,9 +91,9 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(Clock.Today.AddDays(-1))
-                .Create());
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -117,9 +117,9 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(Clock.Today.AddDays(-1))
-                .Create());
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -140,9 +140,9 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(Clock.Today.AddDays(-1))
-                .Create());
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -167,9 +167,9 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(startDate)
-                .Create());
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditExemptionReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditExemptionReasonTests.cs
@@ -14,8 +14,8 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.InProgress, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.InProgress, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/exemption-reasons?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -39,8 +39,8 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.Exempt, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.Exempt, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/exemption-reasons?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -70,9 +70,9 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.Exempt, InductionJourneyPage.Status)
+                .WithInitializedState(InductionStatus.Exempt, InductionJourneyPage.Status)
                 .WithExemptionReasonIds(selectedExemptionReasonIds)
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/exemption-reasons?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -96,8 +96,8 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.Exempt, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.Exempt, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/exemption-reasons?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -122,8 +122,8 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.Exempt, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.Exempt, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/exemption-reasons?{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
@@ -18,7 +18,7 @@ public class EditInductionStateBuilder
     private InductionJourneyPage? JourneyStartPage { get; set; }
     private bool Initialized { get; set; }
 
-    public EditInductionStateBuilder WithInitialisedState(InductionStatus currentInductionStatus, InductionJourneyPage startPage)
+    public EditInductionStateBuilder WithInitializedState(InductionStatus currentInductionStatus, InductionJourneyPage startPage)
     {
         this.Initialized = true;
         JourneyStartPage = startPage;
@@ -42,28 +42,31 @@ public class EditInductionStateBuilder
         return this;
     }
 
-    public EditInductionStateBuilder WithStartDate(DateOnly date)
+    public EditInductionStateBuilder WithStartDate(DateOnly? date)
     {
         StartDate = date;
         return this;
     }
 
-    public EditInductionStateBuilder WithCompletedDate(DateOnly date)
+    public EditInductionStateBuilder WithCompletedDate(DateOnly? date)
     {
         CompletedDate = date;
         return this;
     }
+
     public EditInductionStateBuilder WithReasonChoice(InductionChangeReasonOption option)
     {
         ChangeReason = option;
         return this;
     }
+
     public EditInductionStateBuilder WithReasonDetailsChoice(bool addDetails, string? detailText = null)
     {
         HasAdditionalReasonDetail = addDetails;
         AdditionalReasonDetail = detailText;
         return this;
     }
+
     public EditInductionStateBuilder WithFileUploadChoice(bool uploadFile)
     {
         FileUpload = uploadFile;
@@ -76,7 +79,7 @@ public class EditInductionStateBuilder
         return this;
     }
 
-    public EditInductionState Create()
+    public EditInductionState Build()
     {
         return new EditInductionState()
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
@@ -22,8 +22,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -46,8 +46,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -78,8 +78,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(currentInductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(currentInductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -120,8 +120,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(currentInductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(currentInductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -145,8 +145,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(currentInductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(currentInductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -168,8 +168,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(currentInductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(currentInductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/status?fromCheckAnswers={JourneyFromCheckYourAnswersPage.CheckYourAnswers}&{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -191,8 +191,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.Passed, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.Passed, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -219,8 +219,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.RequiredToComplete, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.RequiredToComplete, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -257,8 +257,8 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(InductionStatus.Passed, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(InductionStatus.Passed, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/status?{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditStartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditStartDateTests.cs
@@ -17,8 +17,8 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -40,9 +40,9 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
                 .WithStartDate(dateValid)
-                .Create());
+                .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/edit-induction/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -68,8 +68,8 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -93,8 +93,8 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -115,8 +115,8 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -140,8 +140,8 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
-                .WithInitialisedState(inductionStatus, InductionJourneyPage.Status)
-                .Create());
+                .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
+                .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {


### PR DESCRIPTION
When an induction exemption is removed (e.g. because QTLS has gone away) we need to know what `InductionStatus` to set the person to. Previously, this wasn't possible - we weren't storing enough information.

This change adds an `InductionStatusWithoutExemption` property to `Person`. It contains the status that the person would have if they weren't exempt. When the last induction exemption is removed, we revert to this status. To make this work, we also need to leave the `StartedDate` and `CompleteDate` values intact when we initially change the status to `Exempt`.

This also removes the need for the separate `CpdInduction*` fields.