### PR TITLE
Handle exemptions without a reason

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207144159_InductionExemptWithoutReason.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207144159_InductionExemptWithoutReason.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250207144159_InductionExemptWithoutReason")]
+    partial class InductionExemptWithoutReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207144159_InductionExemptWithoutReason.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207144159_InductionExemptWithoutReason.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class InductionExemptWithoutReason : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "induction_exempt_without_reason",
+                table: "persons",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "induction_exempt_without_reason",
+                table: "persons");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Induction.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Induction.cs
@@ -11,6 +11,7 @@ public record Induction
     public required DateOnly? CompletedDate { get; init; }
     public required Guid[] ExemptionReasonIds { get; init; }
     public required Option<DateTime> CpdCpdModifiedOn { get; init; }
+    public required bool InductionExemptWithoutReason { get; init; }
 
     public static Induction FromModel(Person person) => new()
     {
@@ -19,6 +20,7 @@ public record Induction
         StartDate = person.InductionStartDate,
         CompletedDate = person.InductionCompletedDate,
         ExemptionReasonIds = person.InductionExemptionReasonIds,
-        CpdCpdModifiedOn = person.CpdInductionCpdModifiedOn.ToOption()
+        CpdCpdModifiedOn = person.CpdInductionCpdModifiedOn.ToOption(),
+        InductionExemptWithoutReason = person.InductionExemptWithoutReason
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonInductionUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonInductionUpdatedEvent.cs
@@ -20,4 +20,5 @@ public enum PersonInductionUpdatedEventChanges
     InductionCompletedDate = 1 << 2,
     InductionExemptionReasons = 1 << 3,
     InductionStatusWithoutExemption = 1 << 7,
+    InductionExemptWithoutReason = 1 << 8
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0043_InductionExemptWithoutReason.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0043_InductionExemptWithoutReason.sql
@@ -1,0 +1,1 @@
+alter table trs_persons add induction_exemption_without_reason bit default 0

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -171,7 +171,8 @@ public class TrsDataSyncHelper(
             InductionStartDate = induction?.dfeta_StartDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             InductionCompletedDate = induction?.dfeta_CompletionDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             InductionExemptionReasonIds = exemptionReasonIds,
-            DqtModifiedOn = induction?.ModifiedOn
+            DqtModifiedOn = induction?.ModifiedOn,
+            InductionExemptWithoutReason = contact.dfeta_InductionStatus.ToInductionStatus() is InductionStatus.Exempt && exemptionReasonIds.Length == 0
         };
     }
 
@@ -1109,7 +1110,8 @@ public class TrsDataSyncHelper(
             "induction_start_date",
             "induction_status",
             "induction_modified_on",
-            "dqt_induction_modified_on"
+            "dqt_induction_modified_on",
+            "induction_exempt_without_reason"
         };
 
         var columnsToUpdate = columnNames.Except(new[] { "person_id" }).ToArray();
@@ -1126,7 +1128,8 @@ public class TrsDataSyncHelper(
                 induction_start_date date,
                 induction_status integer,
                 induction_modified_on timestamp with time zone,
-                dqt_induction_modified_on timestamp with time zone
+                dqt_induction_modified_on timestamp with time zone,
+                induction_exempt_without_reason boolean
             )
             """;
 
@@ -1166,6 +1169,7 @@ public class TrsDataSyncHelper(
             writer.WriteValueOrNull((int?)induction.InductionStatus, NpgsqlDbType.Integer);
             writer.WriteValueOrNull(induction.DqtModifiedOn, NpgsqlDbType.TimestampTz);
             writer.WriteValueOrNull(induction.DqtModifiedOn, NpgsqlDbType.TimestampTz);
+            writer.WriteValueOrNull(induction.InductionExemptWithoutReason, NpgsqlDbType.Boolean);
         };
 
         return new ModelTypeSyncInfo<InductionInfo>()
@@ -1627,6 +1631,7 @@ public class TrsDataSyncHelper(
         public required DateOnly? InductionStartDate { get; init; }
         public required InductionStatus InductionStatus { get; init; }
         public required DateTime? DqtModifiedOn { get; init; }
+        public required bool InductionExemptWithoutReason { get; init; }
     }
 
     private record AuditInfo<TEntity>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -144,6 +144,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0040_PersonInductionExemptionReasons.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0041_ProfessionalStatus.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0042_InductionStatusWithoutExemption.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0043_InductionExemptWithoutReason.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
@@ -617,6 +617,37 @@ public class PersonTests
         Assert.Equal(currentStatus, person.InductionStatus);
     }
 
+    [Fact]
+    public void RemoveInductionExemptionReason_PersonIsAlsoExemptWithoutReason_DoesNotChangeStatus()
+    {
+        // Arrange
+        var person = CreatePerson();
+
+        person.SetInductionStatus(
+            InductionStatus.Exempt,
+            startDate: null,
+            completedDate: null,
+            exemptionReasonIds: [InductionExemptionReason.QtlsId],
+            changeReason: null,
+            changeReasonDetail: null,
+            evidenceFile: null,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        person.InductionExemptWithoutReason = true;
+
+        // Act
+        person.RemoveInductionExemptionReason(
+            InductionExemptionReason.QtlsId,
+            updatedBy: SystemUser.SystemUserId,
+            now: Clock.UtcNow,
+            out _);
+
+        // Assert
+        Assert.Equal(InductionStatus.Exempt, person.InductionStatus);
+    }
+
     private Person CreatePerson() => new Person
     {
         PersonId = Guid.NewGuid(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
@@ -590,7 +590,8 @@ public class ChangeLogInductionEventTests : TestBase
             Status = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionStatus) && !newValueIsDefault ? inductionStatus : InductionStatus.None,
             StatusWithoutExemption = InductionStatus.RequiredToComplete,
             ExemptionReasonIds = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionExemptionReasons) && !newValueIsDefault ? exemptionReasons : [],
-            CpdCpdModifiedOn = Option.None<DateTime>()
+            CpdCpdModifiedOn = Option.None<DateTime>(),
+            InductionExemptWithoutReason = false
         };
 
         var oldInduction = new EventModels.Induction
@@ -600,7 +601,8 @@ public class ChangeLogInductionEventTests : TestBase
             Status = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionStatus) && !previousValueIsDefault ? oldInductionStatus : InductionStatus.None,
             StatusWithoutExemption = InductionStatus.RequiredToComplete,
             ExemptionReasonIds = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionExemptionReasons) && !previousValueIsDefault ? oldExemptionReasons : [],
-            CpdCpdModifiedOn = Option.None<DateTime>()
+            CpdCpdModifiedOn = Option.None<DateTime>(),
+            InductionExemptWithoutReason = false
         };
 
         var updatedEvent = new PersonInductionUpdatedEvent


### PR DESCRIPTION
We have lots of production data that has people with `InductionStatus` of `Exempt` without any exemption reasons. Currently, if we were to add another exemption reason then remove it we would incorrectly change the status to `RequiredToComplete`.

This change adds a separate flag - `InductionExemptWithoutReason` - that we check before undoing an `Exempt` status when removing a reason. If the flag is set, we keep the status as `Exempt`. Whenever the status is explicitly set, we clear this flag.