### PR TITLE
Added Job to import ITT providers

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrainingProviderMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrainingProviderMapping.cs
@@ -9,15 +9,9 @@ public class TrainingProviderMapping : IEntityTypeConfiguration<TrainingProvider
     {
         builder.ToTable("training_providers");
         builder.HasKey(x => x.TrainingProviderId);
+        builder.HasIndex(x => x.Ukprn).HasDatabaseName(TrainingProvider.UkprnIndexName).IsUnique();
         builder.Property(x => x.Name).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Ukprn).IsRequired().HasMaxLength(8).IsFixedLength();
         builder.Property(x => x.IsActive).IsRequired();
-
-        builder.HasData(
-            new TrainingProvider
-            {
-                TrainingProviderId = new("98BCF32F-9F84-4142-89A5-ACCB616153A2"),
-                Name = "Test provider",
-                IsActive = true
-            });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207130532_TrainingProviderUkprn.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207130532_TrainingProviderUkprn.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250207130532_TrainingProviderUkprn")]
+    partial class TrainingProviderUkprn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1962,10 +1965,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Property<DateOnly?>("InductionCompletedDate")
                         .HasColumnType("date")
                         .HasColumnName("induction_completed_date");
-
-                    b.Property<bool>("InductionExemptWithoutReason")
-                        .HasColumnType("boolean")
-                        .HasColumnName("induction_exempt_without_reason");
 
                     b.Property<Guid[]>("InductionExemptionReasonIds")
                         .IsRequired()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207130532_TrainingProviderUkprn.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207130532_TrainingProviderUkprn.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrainingProviderUkprn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "training_providers",
+                keyColumn: "training_provider_id",
+                keyValue: new Guid("98bcf32f-9f84-4142-89a5-accb616153a2"));
+
+            migrationBuilder.AddColumn<string>(
+                name: "ukprn",
+                table: "training_providers",
+                type: "character(8)",
+                fixedLength: true,
+                maxLength: 8,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_training_provider_ukprn",
+                table: "training_providers",
+                column: "ukprn",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_training_provider_ukprn",
+                table: "training_providers");
+
+            migrationBuilder.DropColumn(
+                name: "ukprn",
+                table: "training_providers");
+
+            migrationBuilder.InsertData(
+                table: "training_providers",
+                columns: new[] { "training_provider_id", "is_active", "name" },
+                values: new object[] { new Guid("98bcf32f-9f84-4142-89a5-accb616153a2"), true, "Test provider" });
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207145156_DqtReportingSyncTrainingProviders.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207145156_DqtReportingSyncTrainingProviders.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250207145156_DqtReportingSyncTrainingProviders")]
+    partial class DqtReportingSyncTrainingProviders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1962,10 +1965,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Property<DateOnly?>("InductionCompletedDate")
                         .HasColumnType("date")
                         .HasColumnName("induction_completed_date");
-
-                    b.Property<bool>("InductionExemptWithoutReason")
-                        .HasColumnType("boolean")
-                        .HasColumnName("induction_exempt_without_reason");
 
                     b.Property<Guid[]>("InductionExemptionReasonIds")
                         .IsRequired()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207145156_DqtReportingSyncTrainingProviders.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250207145156_DqtReportingSyncTrainingProviders.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using TeachingRecordSystem.Core.Services.DqtReporting;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class DqtReportingSyncTrainingProviders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql($"ALTER PUBLICATION {DqtReportingService.TrsDbPublicationName} SET TABLE qualifications, tps_establishments, tps_employments, establishments, persons, alerts, alert_types, alert_categories, events, training_providers;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql($"ALTER PUBLICATION {DqtReportingService.TrsDbPublicationName} SET TABLE qualifications, tps_establishments, tps_employments, establishments, persons, alerts, alert_types, alert_categories, events;");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrainingProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrainingProvider.cs
@@ -2,7 +2,10 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class TrainingProvider
 {
+    public const string UkprnIndexName = "ix_training_provider_ukprn";
+
     public required Guid TrainingProviderId { get; init; }
+    public required string Ukprn { get; set; }
     public required string Name { get; set; }
     public required bool IsActive { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using TeachingRecordSystem.Core.Jobs.EwcWalesImport;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Services.Establishments.Gias;
+using TeachingRecordSystem.Core.Services.PublishApi;
 
 namespace TeachingRecordSystem.Core.Jobs;
 
@@ -235,10 +236,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(/*dryRun: */true, CancellationToken.None),
                     Cron.Never);
 
+                var publishApiOptions = sp.GetRequiredService<IOptions<PublishApiOptions>>().Value;
                 recurringJobManager.AddOrUpdate<RefreshTrainingProvidersJob>(
                     nameof(RefreshTrainingProvidersJob),
                     job => job.ExecuteAsync(CancellationToken.None),
-                    Cron.Never);
+                    publishApiOptions.RefreshTrainingProvidersJobSchedule);
 
                 return Task.CompletedTask;
             });

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -235,6 +235,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(/*dryRun: */true, CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<RefreshTrainingProvidersJob>(
+                    nameof(RefreshTrainingProvidersJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshTrainingProvidersJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshTrainingProvidersJob.cs
@@ -1,0 +1,46 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.PublishApi;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class RefreshTrainingProvidersJob(IPublishApiClient publishApiClient, IDbContextFactory<TrsDbContext> dbContextFactory)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var providers = await publishApiClient.GetAccreditedProvidersAsync();
+        using var dbContext = await dbContextFactory.CreateDbContextAsync();
+
+        foreach (var item in providers)
+        {
+            var existingProvider = await dbContext.TrainingProviders.SingleOrDefaultAsync(p => p.Ukprn == item.Attributes.Ukprn);
+            if (existingProvider == null)
+            {
+                dbContext.TrainingProviders.Add(new()
+                {
+                    TrainingProviderId = Guid.NewGuid(),
+                    Ukprn = item.Attributes.Ukprn,
+                    Name = item.Attributes.Name,
+                    IsActive = true
+                });
+            }
+            else
+            {
+                existingProvider.Name = item.Attributes.Name;
+                existingProvider.IsActive = true;
+            }
+        }
+
+        foreach (var existingProvider in await dbContext.TrainingProviders.ToListAsync())
+        {
+            if (!providers.Any(p => p.Attributes.Ukprn == existingProvider.Ukprn))
+            {
+                existingProvider.IsActive = false;
+            }
+        }
+
+        if (dbContext.ChangeTracker.HasChanges())
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0044_TrsTrainingProviders.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0044_TrsTrainingProviders.sql
@@ -1,0 +1,9 @@
+create table trs_training_providers (
+    training_provider_id uniqueidentifier primary key,
+    [name] varchar(200),
+    ukprn char(8),
+    is_active bit,
+    [__Inserted] datetime,
+    [__Updated] datetime
+)
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/HostApplicationBuilderExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace TeachingRecordSystem.Core.Services.PublishApi;
+
+public static class HostApplicationBuilderExtensions
+{
+    public static IHostApplicationBuilder AddPublishApi(this IHostApplicationBuilder builder)
+    {
+        if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests())
+        {
+            builder.Services.AddOptions<PublishApiOptions>()
+                .Bind(builder.Configuration.GetSection("PublishApi"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            builder.Services
+                .AddHttpClient<IPublishApiClient, PublishApiClient>((sp, httpClient) =>
+                {
+                    var options = sp.GetRequiredService<IOptions<PublishApiOptions>>();
+                    httpClient.BaseAddress = new Uri(options.Value.BaseAddress);
+                });
+        }
+
+        return builder;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/IPublishApiClient.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/IPublishApiClient.cs
@@ -1,0 +1,22 @@
+namespace TeachingRecordSystem.Core.Services.PublishApi;
+
+public interface IPublishApiClient
+{
+    Task<IReadOnlyCollection<ProviderResource>> GetAccreditedProvidersAsync();
+}
+
+public record ProviderListResponse
+{
+    public required List<ProviderResource> Data { get; set; }
+}
+
+public record ProviderResource
+{
+    public required ProviderAttributes Attributes { get; set; }
+}
+
+public record ProviderAttributes
+{
+    public required string Ukprn { get; set; }
+    public required string Name { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/PublishApiClient.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/PublishApiClient.cs
@@ -5,7 +5,7 @@ namespace TeachingRecordSystem.Core.Services.PublishApi;
 
 public class PublishApiClient : IPublishApiClient
 {
-    private readonly string[] noLongerAccreditedTrainingProviders = ["10034865", "10005413", "10002327", "10046628", "10055126", "10064183", "10007938"];
+    private readonly string[] _noLongerAccreditedTrainingProviders = ["10034865", "10005413", "10002327", "10046628", "10055126", "10064183", "10007938"];
     private readonly HttpClient _httpClient;
     private readonly ResiliencePipeline _resiliencePipeline;
 
@@ -34,6 +34,6 @@ public class PublishApiClient : IPublishApiClient
 
         var providerList = await response.Content.ReadFromJsonAsync<ProviderListResponse>();
         // Unfortunately the Publish API still includes some training providers that are no longer accredited, so we need to filter these out
-        return providerList!.Data.Where(p => p.Attributes.Ukprn is not null && !noLongerAccreditedTrainingProviders.Contains(p.Attributes.Ukprn)).AsReadOnly();
+        return providerList!.Data.Where(p => p.Attributes.Ukprn is not null && !_noLongerAccreditedTrainingProviders.Contains(p.Attributes.Ukprn)).AsReadOnly();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/PublishApiClient.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/PublishApiClient.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+using Polly;
+
+namespace TeachingRecordSystem.Core.Services.PublishApi;
+
+public class PublishApiClient : IPublishApiClient
+{
+    private readonly string[] noLongerAccreditedTrainingProviders = ["10034865", "10005413", "10002327", "10046628", "10055126", "10064183", "10007938"];
+    private readonly HttpClient _httpClient;
+    private readonly ResiliencePipeline _resiliencePipeline;
+
+    public PublishApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _resiliencePipeline = new ResiliencePipelineBuilder()
+            .AddRetry(new Polly.Retry.RetryStrategyOptions()
+            {
+                BackoffType = DelayBackoffType.Constant,
+                Delay = TimeSpan.FromSeconds(0),
+                MaxRetryAttempts = 2
+            })
+            .Build();
+    }
+
+    public async Task<IReadOnlyCollection<ProviderResource>> GetAccreditedProvidersAsync()
+    {
+        var response = await _resiliencePipeline.ExecuteAsync(async _ => await _httpClient.GetAsync("recruitment_cycles/current/providers?filter[is_accredited_body]=true&page[per_page]=500"));
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorMessage = $"Error calling Publish API to get a list of accredited training providers, Status Code {response.StatusCode}, Reason {response.ReasonPhrase}.";
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        var providerList = await response.Content.ReadFromJsonAsync<ProviderListResponse>();
+        // Unfortunately the Publish API still includes some training providers that are no longer accredited, so we need to filter these out
+        return providerList!.Data.Where(p => p.Attributes.Ukprn is not null && !noLongerAccreditedTrainingProviders.Contains(p.Attributes.Ukprn)).AsReadOnly();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/PublishApiOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PublishApi/PublishApiOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeachingRecordSystem.Core.Services.PublishApi;
+
+public class PublishApiOptions
+{
+    [Required]
+    public required string BaseAddress { get; init; }
+
+    [Required]
+    public required string RefreshTrainingProvidersJobSchedule { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -71,6 +71,7 @@
     <None Remove="Services\DqtReporting\Migrations\0036_TrsPersonsInduction.sql" />
     <None Remove="Services\DqtReporting\Migrations\0037_RenameSanctionTable.sql" />
     <None Remove="Services\DqtReporting\Migrations\0038_TrsPersonsInductionSync.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0044_TrsTrainingProviders.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -131,6 +132,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0027_TrsWorkforceData.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0028_TrsEstablishments.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0029_TrsPersons.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0044_TrsTrainingProviders.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0030_TrsAlerts.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0031_TrsAlertsSyncMetadata.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0032_AddMissingProgrammeTypes.sql" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/Program.cs
@@ -13,6 +13,7 @@ using TeachingRecordSystem.Core.Services.Establishments;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.NameSynonyms;
 using TeachingRecordSystem.Core.Services.Notify;
+using TeachingRecordSystem.Core.Services.PublishApi;
 using TeachingRecordSystem.Core.Services.TrnGenerationApi;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.Core.Services.Webhooks;
@@ -45,7 +46,8 @@ builder
     .AddNameSynonyms()
     .AddDqtOutboxMessageProcessorService()
     .AddWebhookDeliveryService()
-    .AddWebhookMessageFactory();
+    .AddWebhookMessageFactory()
+    .AddPublishApi();
 
 var crmServiceClient = new ServiceClient(builder.Configuration.GetRequiredValue("ConnectionStrings:Crm"))
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
@@ -74,7 +74,7 @@
   },
   "PublishApi": {
     "BaseAddress": "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/",
-    "RefreshTrainingProvidersJobSchedule": "0 3 * * *"
+    "RefreshTrainingProvidersJobSchedule": "30 2 * * *"
   },
   "TrsSyncService": {
     "PollIntervalSeconds": 60,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
@@ -72,6 +72,10 @@
     "BaseDownloadAddress": "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/",
     "RefreshEstablishmentsJobSchedule": "0 2 * * *"
   },
+  "PublishApi": {
+    "BaseAddress": "https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/",
+    "RefreshTrainingProvidersJobSchedule": "0 3 * * *"
+  },
   "TrsSyncService": {
     "PollIntervalSeconds": 60,
     "ModelTypes": [

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/RefreshTrainingProvidersJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/RefreshTrainingProvidersJobTests.cs
@@ -1,0 +1,184 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Jobs;
+using TeachingRecordSystem.Core.Services.PublishApi;
+
+namespace TeachingRecordSystem.Core.Tests.Jobs;
+
+public class RefreshTrainingProvidersJobTests(DbFixture dbFixture)
+{
+    [Fact]
+    public async Task RefreshTrainingProvidersJob_WhenCalledForNewUkprn_AddsNewTrainingProvider()
+    {
+        // Arrange
+        var dbContextFactory = dbFixture.GetDbContextFactory();
+        var publishApiClient = new Mock<IPublishApiClient>();
+        var provider1Name = "Test Training Provider 1";
+        var provider1Ukprn = "12345678";
+        var provider2Name = "Test Training Provider 2";
+        var provider2Ukprn = "87654321";
+        var providersExpected = new List<ProviderResource>
+        {
+            new ProviderResource
+            {
+                Attributes = new ProviderAttributes
+                {
+                    Ukprn = provider1Ukprn,
+                    Name = provider1Name
+                }
+            },
+            new ProviderResource
+            {
+                Attributes = new ProviderAttributes
+                {
+                    Ukprn = provider2Ukprn,
+                    Name = provider2Name
+                }
+            }
+        };
+
+
+        publishApiClient
+            .Setup(x => x.GetAccreditedProvidersAsync())
+            .ReturnsAsync(providersExpected);
+
+        var job = new RefreshTrainingProvidersJob(publishApiClient.Object, dbContextFactory);
+
+        // Act        
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        await dbFixture.WithDbContextAsync(async dbContext =>
+        {
+            var trainingProvidersActual = await dbContext.TrainingProviders.Where(p => p.Ukprn == provider1Ukprn || p.Ukprn == provider2Ukprn).OrderBy(p => p.Ukprn).ToListAsync();
+            Assert.Collection(trainingProvidersActual,
+                p =>
+                {
+                    Assert.Equal(provider1Ukprn, p.Ukprn);
+                    Assert.Equal(provider1Name, p.Name);
+                    Assert.True(p.IsActive);
+                },
+                p =>
+                {
+                    Assert.Equal(provider2Ukprn, p.Ukprn);
+                    Assert.Equal(provider2Name, p.Name);
+                    Assert.True(p.IsActive);
+                });
+        });
+    }
+
+    [Fact]
+    public async Task RefreshTrainingProvidersJob_WhenCalledForExistingUkprn_UpdatesTrainingProvider()
+    {
+        // Arrange
+        var dbContextFactory = dbFixture.GetDbContextFactory();
+        var publishApiClient = new Mock<IPublishApiClient>();
+        var existingProvider = new TrainingProvider
+        {
+            TrainingProviderId = Guid.NewGuid(),
+            Ukprn = "12345679",
+            Name = "Test Training Provider 1",
+            IsActive = false
+        };
+
+        await dbFixture.WithDbContextAsync(async dbContext =>
+        {
+            dbContext.TrainingProviders.Add(existingProvider);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var newProviderName = "Updated Test Training Provider 1";
+        var providersExpected = new List<ProviderResource>
+        {
+            new ProviderResource
+            {
+                Attributes = new ProviderAttributes
+                {
+                    Ukprn = existingProvider.Ukprn,
+                    Name = newProviderName
+                }
+            }
+        };
+
+        publishApiClient
+            .Setup(x => x.GetAccreditedProvidersAsync())
+            .ReturnsAsync(providersExpected);
+
+        var job = new RefreshTrainingProvidersJob(publishApiClient.Object, dbContextFactory);
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        await dbFixture.WithDbContextAsync(async dbContext =>
+        {
+            var trainingProvidersActual = await dbContext.TrainingProviders.Where(p => p.Ukprn == existingProvider.Ukprn).ToListAsync();
+            Assert.Single(trainingProvidersActual);
+            Assert.Equal(newProviderName, trainingProvidersActual.Single().Name);
+            Assert.True(trainingProvidersActual.Single().IsActive);
+        });
+    }
+
+    [Fact]
+    public async Task RefreshTrainingProvidersJob_WhenCalledForWithExistingUkprnMissing_DeactivatesTrainingProvider()
+    {
+        // Arrange
+        var dbContextFactory = dbFixture.GetDbContextFactory();
+        var publishApiClient = new Mock<IPublishApiClient>();
+        var newProviderName = "New Training Provider";
+        var newProviderUkprn = "76543210";
+
+        var existingProvider = new TrainingProvider
+        {
+            TrainingProviderId = Guid.NewGuid(),
+            Ukprn = "12345670",
+            Name = "Test Training Provider 1",
+            IsActive = true
+        };
+
+        await dbFixture.WithDbContextAsync(async dbContext =>
+        {
+            dbContext.TrainingProviders.Add(existingProvider);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var providersExpected = new List<ProviderResource>()
+        {
+            new ProviderResource
+            {
+                Attributes = new ProviderAttributes
+                {
+                    Ukprn = newProviderUkprn,
+                    Name = newProviderName
+                }
+            }
+        };
+
+        publishApiClient
+            .Setup(x => x.GetAccreditedProvidersAsync())
+            .ReturnsAsync(providersExpected);
+
+        var job = new RefreshTrainingProvidersJob(publishApiClient.Object, dbContextFactory);
+
+        // Act
+        await job.ExecuteAsync(CancellationToken.None);
+
+        // Assert
+        await dbFixture.WithDbContextAsync(async dbContext =>
+        {
+            var trainingProvidersActual = await dbContext.TrainingProviders.Where(p => p.Ukprn == existingProvider.Ukprn || p.Ukprn == newProviderUkprn).OrderBy(p => p.Ukprn).ToListAsync();
+            Assert.Collection(trainingProvidersActual,
+                p =>
+                {
+                    Assert.Equal(existingProvider.Ukprn, p.Ukprn);
+                    Assert.Equal(existingProvider.Name, p.Name);
+                    Assert.False(p.IsActive);
+                },
+                p =>
+                {
+                    Assert.Equal(newProviderUkprn, p.Ukprn);
+                    Assert.Equal(newProviderName, p.Name);
+                    Assert.True(p.IsActive);
+                });
+        });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/RefreshTrainingProvidersJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/RefreshTrainingProvidersJobTests.cs
@@ -36,7 +36,6 @@ public class RefreshTrainingProvidersJobTests(DbFixture dbFixture)
             }
         };
 
-
         publishApiClient
             .Setup(x => x.GetAccreditedProvidersAsync())
             .ReturnsAsync(providersExpected);


### PR DESCRIPTION
### Context

We need a set of ITT providers that is shared with Register and we can associate with professional statuses in TRS.

### Changes proposed in this pull request

Add a UKPRN field to the `training_providers` table in TRS.
Add a nightly job that calls the publish API and upserts the records into the TRS table. 
Note that some providers should be explicitly excluded (see the linked ticket).
Added trs_training_providers table to the reporting db.