### PR TITLE
Add an index on events for event_name and created

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -20,5 +20,6 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.HasIndex(e => new { e.PersonId, e.EventName }).HasFilter("person_id is not null");
         builder.HasIndex(e => new { e.QualificationId, e.EventName }).HasFilter("qualification_id is not null");
         builder.HasIndex(e => new { e.AlertId, e.EventName }).HasFilter("alert_id is not null");
+        builder.HasIndex(e => new { e.EventName, e.Created }).IsCreatedConcurrently();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250211110334_EventNameCreatedIndex.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250211110334_EventNameCreatedIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250211110334_EventNameCreatedIndex")]
+    partial class EventNameCreatedIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250211110334_EventNameCreatedIndex.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250211110334_EventNameCreatedIndex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EventNameCreatedIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_events_event_name_created",
+                table: "events",
+                columns: new[] { "event_name", "created" })
+                .Annotation("Npgsql:CreatedConcurrently", true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_events_event_name_created",
+                table: "events");
+        }
+    }
+}


### PR DESCRIPTION
We have a nightly job that's looking for particular event types within a time period - it's currently timing out. This adds an index to speed it up.