### PR TITLE
Remove test environment from main deployment pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,28 +50,10 @@ jobs:
 
             core.setOutput("deploy_preprod", deployPreprod);
 
-  deploy_test:
-    name: Deploy test environment
-    runs-on: ubuntu-latest
-    needs: [package]
-    environment: test
-    concurrency: deploy_test
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/workflows/actions/deploy-aks-environment
-        id: deploy
-        with:
-          environment_name: test
-          docker_image: ${{ needs.package.outputs.docker_image }}
-          azure-client-id:  ${{ secrets.AZURE_CLIENT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-
   deploy_preprod:
     name: Deploy pre-production environment
     runs-on: ubuntu-latest
-    needs: [package, deploy_test, check_environments]
+    needs: [package, check_environments]
     if: needs.check_environments.outputs.deploy_preprod == 'true'
     environment: pre-production
     concurrency: deploy_pre-production
@@ -90,8 +72,8 @@ jobs:
   deploy_prod:
     name: Deploy production environment
     runs-on: ubuntu-latest
-    needs: [deploy_test, package, deploy_preprod]
-    if: always() && (needs.deploy_preprod.result == 'success' || needs.deploy_preprod.result == 'skipped') && (needs.package.result == 'success') && (needs.deploy_test.result == 'success')
+    needs: [package, deploy_preprod]
+    if: always() && (needs.deploy_preprod.result == 'success' || needs.deploy_preprod.result == 'skipped') && (needs.package.result == 'success')
     environment: production
     concurrency: deploy_production
     steps:


### PR DESCRIPTION
The test environment is currently broken (something to do with the replication slot and reporting service). Since we don't actually use this environment, I'm removing it from the pipeline completely for now.