### PR TITLE
Different behaviour for statuses exempt and FailedInWales when ManagedByCpd

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
@@ -27,7 +27,7 @@ public static class InductionStatusRegistry
 
     public static IReadOnlyCollection<InductionStatusInfo> All => _info.Values.ToArray();
 
-    public static IReadOnlyCollection<InductionStatusInfo> ValidStatusChangesWhenManagedByCpd =>
+    public static ICollection<InductionStatusInfo> ValidStatusChangesWhenManagedByCpd =>
         _info
             .Where(s => s.Key is InductionStatus.Exempt or InductionStatus.FailedInWales)
             .Select(s => s.Value)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
@@ -29,7 +29,7 @@ public static class InductionStatusRegistry
 
     public static IReadOnlyCollection<InductionStatusInfo> ValidStatusChangesWhenManagedByCpd =>
         _info
-            .Where(s => s.Key is InductionStatus.RequiredToComplete or InductionStatus.Exempt or InductionStatus.FailedInWales)
+            .Where(s => s.Key is InductionStatus.Exempt or InductionStatus.FailedInWales)
             .Select(s => s.Value)
             .ToArray();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/InductionStatus.cs
@@ -27,7 +27,7 @@ public static class InductionStatusRegistry
 
     public static IReadOnlyCollection<InductionStatusInfo> All => _info.Values.ToArray();
 
-    public static ICollection<InductionStatusInfo> ValidStatusChangesWhenManagedByCpd =>
+    public static IReadOnlyCollection<InductionStatusInfo> ValidStatusChangesWhenManagedByCpd =>
         _info
             .Where(s => s.Key is InductionStatus.Exempt or InductionStatus.FailedInWales)
             .Select(s => s.Value)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/EditInductionState.cs
@@ -13,6 +13,7 @@ public class EditInductionState : IRegisterJourney
 
     public InductionJourneyPage? JourneyStartPage { get; set; }
     public InductionStatus InductionStatus { get; set; }
+    public InductionStatus CurrentInductionStatus { get; set; }
     public DateOnly? StartDate { get; set; }
     public DateOnly? CompletedDate { get; set; }
     public Guid[]? ExemptionReasonIds { get; set; } = [];
@@ -46,11 +47,16 @@ public class EditInductionState : IRegisterJourney
 
         var person = await dbContext.Persons.SingleAsync(q => q.PersonId == personId);
 
-        InductionStatus = person.InductionStatus;
+        CurrentInductionStatus = person.InductionStatus;
         JourneyStartPage = startPage;
         StartDate = person.InductionStartDate;
         CompletedDate = person.InductionCompletedDate;
         ExemptionReasonIds = person.InductionExemptionReasonIds;
+        if (InductionStatus == InductionStatus.None)
+        {
+            InductionStatus = CurrentInductionStatus;
+        }
+
         Initialized = true;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml
@@ -21,7 +21,7 @@
                     <govuk-radios-fieldset-legend data-testid="status-choices-legend" class="govuk-fieldset__legend--l" is-page-heading="true" />
                     @foreach (var inductionStatus in Model.StatusChoices)
                     {
-                        <govuk-radios-item value="@inductionStatus.Value" checked="@(Model.InductionStatus == inductionStatus.Value && Model.FromCheckAnswers == JourneyFromCheckYourAnswersPage.CheckYourAnswers)">@inductionStatus.Title</govuk-radios-item>
+                        <govuk-radios-item value="@inductionStatus.Value" checked="@(Model.InductionStatus == inductionStatus.Value)">@inductionStatus.Title</govuk-radios-item>
                     }
                 </govuk-radios-fieldset>
             </govuk-radios>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
@@ -27,7 +27,7 @@ public class StatusModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext,
         {
             return _inductionStatusManagedByCpd && (CurrentInductionStatus is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ?
                 InductionStatusRegistry.ValidStatusChangesWhenManagedByCpd
-                    .Concat(new[] { InductionStatusRegistry.All.Single(i => i.Value == CurrentInductionStatus) })
+                    .Append(InductionStatusRegistry.All.Single(i => i.Value == CurrentInductionStatus))
                     .OrderBy(i => i.Value)
                     .ToArray()
                 : InductionStatusRegistry.All.ToArray()[1..];

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
@@ -19,18 +19,22 @@ public class StatusModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext,
     [Display(Name = "What is their induction status?")]
     [NotEqual(InductionStatus.None, ErrorMessage = "Select a status")]
     public InductionStatus InductionStatus { get; set; }
+    public InductionStatus CurrentInductionStatus { get; set; }
     public string? PersonName { get; set; }
     public IEnumerable<InductionStatusInfo> StatusChoices
     {
         get
         {
-            return _inductionStatusManagedByCpd && (InductionStatus is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ?
-                 InductionStatusRegistry.ValidStatusChangesWhenManagedByCpd
+            return _inductionStatusManagedByCpd && (CurrentInductionStatus is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ?
+                InductionStatusRegistry.ValidStatusChangesWhenManagedByCpd
+                    .Concat(new[] { InductionStatusRegistry.All.Single(i => i.Value == CurrentInductionStatus) })
+                    .OrderBy(i => i.Value)
+                    .ToArray()
                 : InductionStatusRegistry.All.ToArray()[1..];
         }
     }
 
-    public string InductionIsManagedByCpdWarning => InductionStatus switch
+    public string InductionIsManagedByCpdWarning => CurrentInductionStatus switch
     {
         InductionStatus.RequiredToComplete => InductionWarnings.InductionIsManagedByCpdWarningRequiredToComplete,
         InductionStatus.InProgress => InductionWarnings.InductionIsManagedByCpdWarningInProgress,
@@ -39,7 +43,7 @@ public class StatusModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext,
         _ => InductionWarnings.InductionIsManagedByCpdWarningOther
     };
 
-    public string? StatusWarningMessage => _inductionStatusManagedByCpd && (InductionStatus is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ? InductionIsManagedByCpdWarning : null;
+    public string? StatusWarningMessage => _inductionStatusManagedByCpd && (CurrentInductionStatus is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ? InductionIsManagedByCpdWarning : null;
 
     public InductionJourneyPage NextPage =>
      InductionStatus switch
@@ -103,6 +107,7 @@ public class StatusModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext,
 
         var person = await dbContext.Persons.SingleAsync(q => q.PersonId == PersonId);
         _inductionStatusManagedByCpd = person.InductionStatusManagedByCpd(clock.Today);
+        CurrentInductionStatus = JourneyInstance!.State.CurrentInductionStatus;
 
         await next();
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
@@ -24,7 +24,7 @@ public class StatusModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext,
     {
         get
         {
-            return _inductionStatusManagedByCpd ?
+            return _inductionStatusManagedByCpd && (InductionStatus is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ?
                  InductionStatusRegistry.ValidStatusChangesWhenManagedByCpd
                 : InductionStatusRegistry.All.ToArray()[1..];
         }
@@ -39,20 +39,15 @@ public class StatusModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext,
         _ => InductionWarnings.InductionIsManagedByCpdWarningOther
     };
 
-    public string? StatusWarningMessage => _inductionStatusManagedByCpd ? InductionIsManagedByCpdWarning : null;
+    public string? StatusWarningMessage => _inductionStatusManagedByCpd && (InductionStatus is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ? InductionIsManagedByCpdWarning : null;
 
-    public InductionJourneyPage NextPage
-    {
-        get
-        {
-            return InductionStatus switch
+    public InductionJourneyPage NextPage =>
+     InductionStatus switch
             {
                 _ when InductionStatus.RequiresExemptionReasons() => InductionJourneyPage.ExemptionReason,
                 _ when InductionStatus.RequiresStartDate() => InductionJourneyPage.StartDate,
                 _ => InductionJourneyPage.ChangeReasons
             };
-        }
-    }
 
     public string BackLink
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/Status.cshtml.cs
@@ -43,11 +43,11 @@ public class StatusModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext,
 
     public InductionJourneyPage NextPage =>
      InductionStatus switch
-            {
-                _ when InductionStatus.RequiresExemptionReasons() => InductionJourneyPage.ExemptionReason,
-                _ when InductionStatus.RequiresStartDate() => InductionJourneyPage.StartDate,
-                _ => InductionJourneyPage.ChangeReasons
-            };
+     {
+         _ when InductionStatus.RequiresExemptionReasons() => InductionJourneyPage.ExemptionReason,
+         _ when InductionStatus.RequiresStartDate() => InductionJourneyPage.StartDate,
+         _ => InductionJourneyPage.ChangeReasons
+     };
 
     public string BackLink
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
@@ -47,8 +47,8 @@ public class InductionModel(
     };
 
     public string? StatusWarningMessage =>
-         _teacherHoldsQualifiedTeacherStatus ? NoQualifiedTeacherStatusWarning :
-         _statusIsManagedByCpd && CanWrite ? InductionIsManagedByCpdWarning :
+        _statusIsManagedByCpd && CanWrite && (Status is not InductionStatus.FailedInWales and not InductionStatus.Exempt) ? InductionIsManagedByCpdWarning :
+        _teacherHoldsQualifiedTeacherStatus ? NoQualifiedTeacherStatusWarning :
         null;
 
     public bool CanWrite { get; set; }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
@@ -5,6 +5,7 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.Ed
 public class EditInductionStateBuilder
 {
     private InductionStatus InductionStatus { get; set; }
+    private InductionStatus CurrentInductionStatus { get; set; }
     private DateOnly? StartDate { get; set; }
     private DateOnly? CompletedDate { get; set; }
     private Guid[]? ExemptionReasonIds { get; set; }
@@ -23,6 +24,7 @@ public class EditInductionStateBuilder
         this.Initialized = true;
         JourneyStartPage = startPage;
         InductionStatus = currentInductionStatus;
+        CurrentInductionStatus = currentInductionStatus;
         return this;
     }
 
@@ -84,6 +86,7 @@ public class EditInductionStateBuilder
         return new EditInductionState()
         {
             InductionStatus = InductionStatus,
+            CurrentInductionStatus = CurrentInductionStatus,
             StartDate = StartDate,
             CompletedDate = CompletedDate,
             ExemptionReasonIds = ExemptionReasonIds,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
@@ -102,7 +102,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
     public async Task Get_InductionManagedByCpd_ExpectedRadioButtonsExistOnPage(InductionStatus currentInductionStatus)
     {
         // Arrange
-        InductionStatus[] expectedStatuses = new List<InductionStatus>(){ InductionStatus.Exempt, InductionStatus.FailedInWales, currentInductionStatus }.OrderBy(i => i).ToArray();
+        InductionStatus[] expectedStatuses = new List<InductionStatus>() { InductionStatus.Exempt, InductionStatus.FailedInWales, currentInductionStatus }.OrderBy(i => i).ToArray();
         var expectedChoices = expectedStatuses.Select(s => s.ToString());
         var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
         var person = await TestData.CreatePersonAsync(p => p.WithQts());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
@@ -150,7 +150,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
 
         // test setup here is convoluted because I need to set up a person,
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
-        // then set the induction status to the one we want to test
+        // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
             p => p.WithTrn().WithQts());
         await WithDbContext(async dbContext =>
@@ -323,7 +323,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
 
         // test setup here is convoluted because I need to set up a person,
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
-        // then set the induction status to the one we want to test
+        // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
             p => p.WithTrn().WithQts());
         await WithDbContext(async dbContext =>
@@ -376,7 +376,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
 
         // test setup here is convoluted because I need to set up a person,
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
-        // then set the induction status to the one we want to test
+        // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
             p => p.WithTrn().WithQts());
         await WithDbContext(async dbContext =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
@@ -99,7 +99,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
     {
         // Arrange
         var currentInductionStatus = InductionStatus.Passed;
-        InductionStatus[] expectedStatuses = { InductionStatus.RequiredToComplete, InductionStatus.Exempt, InductionStatus.FailedInWales };
+        InductionStatus[] expectedStatuses = { InductionStatus.Exempt, InductionStatus.FailedInWales };
         var expectedChoices = expectedStatuses.Select(s => s.ToString());
         var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
         var person = await TestData.CreatePersonAsync(p => p.WithQts());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -264,6 +264,57 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
         }
     }
 
+    [Theory]
+    [InlineData(InductionStatus.Exempt)]
+    [InlineData(InductionStatus.FailedInWales)]
+    public async Task Get_WithPersonIdForPersonWithInductionStatusManagedByCpd_ShowsNoWarning(InductionStatus trsInductionStatus)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(UserRoles.InductionReadWrite));
+
+        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
+
+        // test setup here is convoluted because I need to set up a person,
+        // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
+        // then set the induction status to the one we want to test
+        var person = await TestData.CreatePersonAsync(
+            p => p.WithTrn().WithQts());
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.Attach(person.Person);
+            person.Person.SetCpdInductionStatus(
+                InductionStatus.RequiredToComplete, // CPD induction status can't be Exempt or FailedInWales
+                startDate: null,
+                completedDate: null,
+                cpdModifiedOn: Clock.UtcNow,
+                updatedBy: SystemUser.SystemUserId,
+                now: Clock.UtcNow,
+                out _);
+            person.Person.SetInductionStatus(
+                trsInductionStatus,
+                startDate: null,
+                completedDate: null,
+                exemptionReasonIds: [],
+                changeReason: null,
+                changeReasonDetail: null,
+                evidenceFile: null,
+                updatedBy: SystemUser.SystemUserId,
+                now: Clock.UtcNow,
+                out _);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.ContactId}/induction");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        Assert.Null(doc.GetElementByTestId("induction-status-warning"));
+    }
+
     [Fact]
     public async Task Get_WithPersonIdForPersonWithInductionStatusNotManagedByCpd_DoesNotShowWarning()
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -276,7 +276,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // test setup here is convoluted because I need to set up a person,
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
-        // then set the induction status to the one we want to test
+        // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
             p => p.WithTrn().WithQts());
         await WithDbContext(async dbContext =>


### PR DESCRIPTION
### Context

When the status is Exempt or FailedInWales, even if the logic says it's managed by CPD, don't show the warning message about it being managed by CPD and allow all the statuses

https://trello.com/c/rWMyoTUr

