### PR TITLE
Don't process messages multiple times

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OutboxProcessorMetadataMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OutboxProcessorMetadataMapping.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
+
+public class OutboxMessageProcessorMetadataMapping : IEntityTypeConfiguration<OutboxMessageProcessorMetadata>
+{
+    public void Configure(EntityTypeBuilder<OutboxMessageProcessorMetadata> builder)
+    {
+        builder.ToTable("outbox_message_processor_metadata");
+        builder.HasKey(o => o.Key);
+        builder.Property(o => o.Key).HasMaxLength(200);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250212140318_OutboxMessageProcessorMetadata.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250212140318_OutboxMessageProcessorMetadata.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250212140318_OutboxMessageProcessorMetadata")]
+    partial class OutboxMessageProcessorMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250212140318_OutboxMessageProcessorMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250212140318_OutboxMessageProcessorMetadata.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class OutboxMessageProcessorMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "outbox_message_processor_metadata",
+                columns: table => new
+                {
+                    key = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    value = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_outbox_message_processor_metadata", x => x.key);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "outbox_message_processor_metadata");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OutboxProcessorMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OutboxProcessorMetadata.cs
@@ -1,0 +1,12 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+public class OutboxMessageProcessorMetadata
+{
+    public required string Key { get; init; }
+    public required string Value { get; set; }
+
+    public static class Keys
+    {
+        public const string IgnoreUntil = "IgnoreUntil";
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -115,6 +115,8 @@ public class TrsDbContext : DbContext
 
     public DbSet<RouteToProfessionalStatus> RoutesToProfessionalStatus => Set<RouteToProfessionalStatus>();
 
+    public DbSet<OutboxMessageProcessorMetadata> OutboxMessageProcessorMetadata => Set<OutboxMessageProcessorMetadata>();
+
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string? connectionString = null, int? commandTimeout = null)
     {
         Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o.CommandTimeout(commandTimeout);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/DqtOutboxMessageProcessorService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/DqtOutboxMessageProcessorService.cs
@@ -1,8 +1,11 @@
+using System.Transactions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 using Polly;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.CrmEntityChanges;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 
@@ -10,17 +13,22 @@ namespace TeachingRecordSystem.Core.Services.DqtOutbox;
 
 public class DqtOutboxMessageProcessorService(
     [FromKeyedServices(DqtOutboxMessageProcessorService.CrmClientName)] ICrmEntityChangesService crmEntityChangesService,
-    OutboxMessageHandler outboxMessageHandler)
+    OutboxMessageHandler outboxMessageHandler,
+    IDbContextFactory<TrsDbContext> dbContextFactory)
     : BackgroundService
 {
     private const string CrmClientName = TrsDataSyncService.CrmClientName;
     private const string ChangesKey = "ProcessDqtOutboxMessagesService";
     private const string EntityName = dfeta_TrsOutboxMessage.EntityLogicalName;
     private const int PageSize = 50;
+    private const string DateTimeMetadataFormat = "o";
 
     private static readonly ColumnSet _columns = new(
+        "createdon",
         dfeta_TrsOutboxMessage.Fields.dfeta_MessageName,
         dfeta_TrsOutboxMessage.Fields.dfeta_Payload);
+
+    private static readonly TimeSpan _pollInterval = TimeSpan.FromSeconds(60);
 
     private static readonly ResiliencePipeline _resiliencePipeline = new ResiliencePipelineBuilder()
         .AddRetry(new Polly.Retry.RetryStrategyOptions()
@@ -31,28 +39,83 @@ public class DqtOutboxMessageProcessorService(
         })
         .Build();
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken) =>
-        await _resiliencePipeline.ExecuteAsync(async ct =>
-        {
-            await foreach (var changedItems in crmEntityChangesService.GetEntityChangesAsync(
-                ChangesKey,
-                EntityName,
-                _columns,
-                modifiedSince: null,
-                PageSize,
-                cancellationToken: ct))
-            {
-                foreach (var changedItem in changedItems)
-                {
-                    if (changedItem is not NewOrUpdatedItem newOrUpdatedItem)
-                    {
-                        throw new NotSupportedException($"Unsupported {nameof(IChangedItem)}: '{changedItem.GetType().Name}'.");
-                    }
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        DateTime? ignoreUntil = null;
 
-                    var message = newOrUpdatedItem.NewOrUpdatedEntity.ToEntity<dfeta_TrsOutboxMessage>();
-                    await outboxMessageHandler.HandleOutboxMessageAsync(message);
-                }
+        await using (var dbContext = await dbContextFactory.CreateDbContextAsync())
+        {
+            var ignoreUntilMetadata =
+                await dbContext.OutboxMessageProcessorMetadata.SingleOrDefaultAsync(o =>
+                    o.Key == OutboxMessageProcessorMetadata.Keys.IgnoreUntil);
+
+            if (ignoreUntilMetadata is not null)
+            {
+                ignoreUntil = DateTime.ParseExact(ignoreUntilMetadata.Value, DateTimeMetadataFormat, provider: null);
             }
-        },
-        stoppingToken);
+        }
+
+        using var timer = new PeriodicTimer(_pollInterval);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await _resiliencePipeline.ExecuteAsync(async ct =>
+            {
+                await foreach (var changedItems in crmEntityChangesService.GetEntityChangesAsync(
+                    ChangesKey,
+                    EntityName,
+                    _columns,
+                    modifiedSince: null,
+                    PageSize).WithCancellation(ct))
+                {
+                    foreach (var changedItem in changedItems)
+                    {
+                        if (changedItem is not NewOrUpdatedItem newOrUpdatedItem)
+                        {
+                            throw new NotSupportedException(
+                                $"Unsupported {nameof(IChangedItem)}: '{changedItem.GetType().Name}'.");
+                        }
+
+                        var message = newOrUpdatedItem.NewOrUpdatedEntity.ToEntity<dfeta_TrsOutboxMessage>();
+                        var createdOn = message.GetAttributeValue<DateTime>("createdon");
+
+                        if (createdOn <= ignoreUntil)
+                        {
+                            continue;
+                        }
+
+                        using var txn = new TransactionScope(TransactionScopeOption.RequiresNew,
+                            TransactionScopeAsyncFlowOption.Enabled);
+
+                        await outboxMessageHandler.HandleOutboxMessageAsync(message);
+
+                        await using (var dbContext = await dbContextFactory.CreateDbContextAsync())
+                        {
+                            var ignoreUntilMetadata =
+                                await dbContext.OutboxMessageProcessorMetadata.SingleOrDefaultAsync(o =>
+                                    o.Key == OutboxMessageProcessorMetadata.Keys.IgnoreUntil);
+
+                            if (ignoreUntilMetadata is null)
+                            {
+                                dbContext.OutboxMessageProcessorMetadata.Add(new OutboxMessageProcessorMetadata()
+                                {
+                                    Key = OutboxMessageProcessorMetadata.Keys.IgnoreUntil,
+                                    Value = createdOn.ToString(DateTimeMetadataFormat)
+                                });
+                            }
+                            else
+                            {
+                                ignoreUntilMetadata.Value = createdOn.ToString(DateTimeMetadataFormat);
+                            }
+
+                            await dbContext.SaveChangesAsync();
+                        }
+
+                        txn.Complete();
+                    }
+                }
+            },
+            stoppingToken);
+        }
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/OutboxMessageHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/OutboxMessageHandler.cs
@@ -4,7 +4,7 @@ using TeachingRecordSystem.Core.Services.DqtOutbox.Messages;
 
 namespace TeachingRecordSystem.Core.Services.DqtOutbox;
 
-public partial class OutboxMessageHandler(MessageSerializer messageSerializer, IServiceProvider serviceProvider)
+public class OutboxMessageHandler(MessageSerializer messageSerializer, IServiceProvider serviceProvider)
 {
     public async Task HandleOutboxMessageAsync(dfeta_TrsOutboxMessage outboxMessage)
     {


### PR DESCRIPTION
It's possible we can see an outbox message multiple times (if, say, the entity changes service has to reset and replay messages due to a CRM change).

We also need to be able to skip some messages in dev that are invalid.

This change adds a metadata table to the DB that contains a timestamp. Any messages before or equal to this timestamp will be ignored. Every time we process a message we update this metadata with that message's timestamp. With this we avoid processing a message multiple times *and* we have a mechanism to skip bad messages in dev.

This also fixes `DqtOutboxMessageProcessorService` to run forever instead of running once then completing.