### PR TITLE
Fix main workflow needs dependency for domain jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
   deploy_domains_infra:
     name: Deploy Domains Infrastructure
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: always() && needs.deploy_prod.result == 'success'
     concurrency: deploy_domains_infra
     needs: [deploy_prod]
     environment:
@@ -129,7 +129,7 @@ jobs:
   deploy_domains_env:
     name: Deploy Domains to ${{ matrix.domain_environment }} environment
     runs-on: ubuntu-22.04
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: always() && needs.deploy_domains_infra.result == 'success'
     concurrency: deploy_domains_env_${{ matrix.domain_environment }}
     needs: [deploy_domains_infra]
     strategy:


### PR DESCRIPTION
### Context

For the main Github workflow, deploy_domains_infra and deploy_domains_env do not run if deploy_preprod is skipped.
This is because once a job in the workflow is failed or skipped, you need to overwrite the conditional for all subsequent jobs

### Changes proposed in this pull request

Update the if statement to check the required job result is success.

### Guidance to review

Check code looks correct

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
