### PR TITLE
Fix global_config for domains

### DIFF
--- a/global_config/domains.sh
+++ b/global_config/domains.sh
@@ -1,4 +1,3 @@
-CONFIG=production
 CONFIG_SHORT=pd
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
 AZURE_RESOURCE_PREFIX=s189p01


### PR DESCRIPTION
### Context

'make env domains-apply' is only running against the production environment, regardless of the env called.
see https://github.com/DFE-Digital/teaching-record-system/actions/runs/13371135644/job/37340178820

### Changes proposed in this pull request

Remove CONFIG from domains.sh as this is overriding the env setting

### Guidance to review

make dev|test|pre-production|production domains-plan
make domains-infra-plan

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
