### PR TITLE
Always show Induction card if person has QTS

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
@@ -10,12 +10,12 @@
 @section BeforeContent {
     <govuk-back-link href="@LinkGenerator.PersonDetail(person.PersonId)" data-testid="induction-backlink">Back to record</govuk-back-link>
 }
-@if (!String.IsNullOrEmpty(Model.StatusWarningMessage))
+@if (!string.IsNullOrEmpty(Model.StatusWarningMessage))
 {
     <govuk-warning-text icon-fallback-text="Warning" data-testid="induction-status-warning">@Model.StatusWarningMessage</govuk-warning-text>
 }
 
-@if (Model.Status != InductionStatus.None)
+@if (Model.HasQts)
 {
     <govuk-summary-card data-testid="induction-card">
         <govuk-summary-card-title data-testid="induction-title">Induction details</govuk-summary-card-title>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -34,7 +34,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_WithPersonIdForPersonWithNoQTS_DisplaysExpectedContent()
+    public async Task Get_WithPersonIdForPersonWithNoQts_DisplaysExpectedContent()
     {
         // Arrange
         var person = await TestData.CreatePersonAsync();
@@ -48,27 +48,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
         Assert.Contains(expectedWarning, doc.GetElementByTestId("induction-status-warning")!.TextContent);
-    }
-
-    [Fact]
-    public async Task Get_WithPersonIdForPersonWithInductionStatusNone_DisplaysExpectedContent()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(builder =>
-            builder
-                .WithInductionStatus(InductionStatus.None)
-                .WithQtlsDate(Clock.Today));
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.ContactId}/induction");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        var doc = await AssertEx.HtmlResponseAsync(response);
-        Assert.Null(doc.GetElementByTestId("induction-status-warning"));
         Assert.Null(doc.GetElementByTestId("induction-card"));
-        Assert.NotNull(doc.GetAllElementsByTestId("induction-backlink"));
     }
 
     [Theory]


### PR DESCRIPTION
We have some people with an `InductionStatus` of `None` even though they have QTS. Currently we don't show the induction card or allow the status to be changed for `None`. This amends the logic to always show the card if the person has QTS.