### PR TITLE
Prevent multiple nodes processing outbox messages at once

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DistributedLockKeys.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DistributedLockKeys.cs
@@ -8,4 +8,5 @@ public static class DistributedLockKeys
     public static string TrnRequestId(Guid applicationUserId, string requestId) => $"trn-request:{applicationUserId}/{requestId}";
     public static string DqtReportingReplicationSlot() => nameof(DqtReportingReplicationSlot);
     public static string DqtReportingMigrations() => nameof(DqtReportingMigrations);
+    public static string DqtOutboxMessageProcessorService() => nameof(DqtOutboxMessageProcessorService);
 }


### PR DESCRIPTION
We're getting errors due to multiple nodes attempting to update metadata at once.