### PR TITLE
Routes details

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml
@@ -12,73 +12,8 @@
         <form action="@LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
             <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
-            <govuk-summary-list>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Route</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.RouteToProfessionalStatusName</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.Status.GetDisplayName()</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Award date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.AwardedDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Has exemption</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value use-empty-fallback>@Model.ExemptionReason</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.TrainingProvider</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Degree type</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value use-empty-fallback>@Model.QualificationType</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Country of training</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingCountry</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Age range</govuk-summary-list-row-key>
-                    @if (Model.TrainingAgeSpecialismRangeFrom is not null && Model.TrainingAgeSpecialismRangeTo is not null)
-                    {
-                        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismRange</govuk-summary-list-row-value>
-                    }
-                    else
-                    {
-                        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismType?.GetDisplayName()</govuk-summary-list-row-value>
-                    }
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>
-                        @if (Model.TrainingSubjects is not null)
-                        {
-                            <ul class="govuk-list">
-                            @foreach (var subject in Model.TrainingSubjects)
-                            {
-                                <li>@subject</li>
-                            }
-                            </ul>
-                        }
-                        else
-                        {
-                            <span use-empty-fallback></span>
-                        }
-                    </govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-            </govuk-summary-list>
+            <partial name="_RouteDetail" model="@Model.RouteDetail" />
+
             <h2 class="govuk-heading-l">Why are you editing this route?</h2>
             <govuk-summary-list>
                 <govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
@@ -15,7 +15,7 @@ public class CheckYourAnswersModel(
 {
     public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
 
-    public RouteDetailViewModel RouteDetail { get; set; }
+    public RouteDetailViewModel RouteDetail { get; set; } = new(); 
 
     public string? PersonName { get; set; }
     public Guid PersonId { get; private set; }
@@ -61,7 +61,7 @@ public class CheckYourAnswersModel(
         JourneyInstance!.State.EnsureInitialized(context.HttpContext.GetCurrentProfessionalStatusFeature());
         if (!JourneyInstance!.State.IsComplete)
         {
-            //context.Result = Redirect(linkGenerator.RouteEditPage(QualificationId, JourneyInstance.InstanceId)); // CML TODo go back to the start when i have that page
+            context.Result = Redirect(linkGenerator.RouteDetail(QualificationId, JourneyInstance.InstanceId));
             return;
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
@@ -15,7 +15,7 @@ public class CheckYourAnswersModel(
 {
     public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
 
-    public RouteDetailViewModel RouteDetail { get; set; } = new(); 
+    public RouteDetailViewModel RouteDetail { get; set; } = new();
 
     public string? PersonName { get; set; }
     public Guid PersonId { get; private set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml
@@ -5,17 +5,16 @@
 }
 
 @section BeforeContent {
-    var test = "test";
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RouteDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+        <form method="post">
             <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
             <partial name="_RouteDetail" model="@Model.RouteDetail" />
             <div class="govuk-button-group">
-                <govuk-button type="submit" data-testid="confirm-button">Confirm</govuk-button>
+                <govuk-button-link data-testid="continue-button" href="@LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId)">Continue</govuk-button-link>
                 <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteDetailCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml
@@ -1,0 +1,24 @@
+@page "/route/{qualificationId}/edit/detail/{handler?}"
+@model DetailModel
+@{
+    ViewBag.Title = "Edit route details";
+}
+
+@section BeforeContent {
+    var test = "test";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RouteDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+            <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+            <partial name="_RouteDetail" model="@Model.RouteDetail" />
+            <div class="govuk-button-group">
+                <govuk-button type="submit" data-testid="confirm-button">Confirm</govuk-button>
+                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteDetailCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
@@ -13,7 +13,7 @@ public class DetailModel(
 {
     public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
 
-    public RouteDetailViewModel RouteDetail { get; set; }
+    public RouteDetailViewModel RouteDetail { get; set; } = new();
     public string? PersonName { get; set; }
     public Guid PersonId { get; private set; }
 
@@ -33,19 +33,13 @@ public class DetailModel(
                 .ToArray() : null;
     }
 
-    public async Task<IActionResult> OnPostAsync()
-    {
-        // CML TODO - go to the change reason page when it exists
-        return Redirect(linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId));
-    }
-
     public async Task<IActionResult> OnPostCancelAsync()
     {
         await JourneyInstance!.DeleteAsync();
         return Redirect(linkGenerator.PersonQualifications(PersonId));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         JourneyInstance!.State.EnsureInitialized(context.HttpContext.GetCurrentProfessionalStatusFeature());
 
@@ -70,6 +64,6 @@ public class DetailModel(
             InductionExemptionReasonId = JourneyInstance!.State.InductionExemptionReasonId
         };
 
-        next();
+        return next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
@@ -4,6 +4,10 @@ public partial class TrsLinkGenerator
 {
     public string PersonRoute(Guid personId) =>
         GetRequiredPathByPage("/Persons/PersonDetail/Route", routeValues: new { personId });
+    public string RouteDetail(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Detail", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string RouteDetailCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Detail", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
     public string RouteCheckYourAnswers(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
     public string RouteCheckYourAnswersCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
@@ -1,0 +1,24 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Shared;
+
+public class RouteDetailViewModel
+{
+    public QualificationType? QualificationType { get; set; }
+    public Guid RouteToProfessionalStatusId { get; set; }
+    public ProfessionalStatusStatus Status { get; set; }
+    public DateOnly? AwardedDate { get; set; }
+    public DateOnly? TrainingStartDate { get; set; }
+    public DateOnly? TrainingEndDate { get; set; }
+    public Guid[]? TrainingSubjectIds { get; set; }
+    public TrainingAgeSpecialismType? TrainingAgeSpecialismType { get; set; }
+    public int? TrainingAgeSpecialismRangeFrom { get; set; }
+    public int? TrainingAgeSpecialismRangeTo { get; set; }
+    public string? TrainingAgeSpecialismRange => TrainingAgeSpecialismRangeFrom is not null ? $"From {TrainingAgeSpecialismRangeFrom} to {TrainingAgeSpecialismRangeTo}" : null;
+    public string? TrainingCountryId { get; set; }
+    public Guid? TrainingProviderId { get; set; }
+    public Guid? InductionExemptionReasonId { get; set; }
+    public string? ExemptionReason { get; set; }
+    public string? TrainingProvider { get; set; }
+    public string? TrainingCountry { get; set; }
+    public string[]? TrainingSubjects { get; set; }
+    public string? RouteToProfessionalStatusName { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
@@ -1,0 +1,71 @@
+using TeachingRecordSystem.SupportUi.Pages.Share
+@model RouteDetailViewModel
+
+<govuk-summary-list>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Route</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>@Model.RouteToProfessionalStatusName</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>@Model.Status.GetDisplayName()</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Award date</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>@Model.AwardedDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Has exemption</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value use-empty-fallback>@Model.ExemptionReason</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>@Model.TrainingProvider</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Degree type</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value use-empty-fallback>@Model.QualificationType</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Country of training</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingCountry</govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Age range</govuk-summary-list-row-key>
+        @if (Model.TrainingAgeSpecialismRangeFrom is not null && Model.TrainingAgeSpecialismRangeTo is not null)
+        {
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismRange</govuk-summary-list-row-value>
+        }
+        else
+        {
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismType?.GetDisplayName()</govuk-summary-list-row-value>
+        }
+    </govuk-summary-list-row>
+    <govuk-summary-list-row>
+        <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
+        <govuk-summary-list-row-value>
+            @if (Model.TrainingSubjects is not null)
+            {
+                <ul class="govuk-list">
+                    @foreach (var subject in Model.TrainingSubjects)
+                    {
+                        <li>@subject</li>
+                    }
+                </ul>
+            }
+            else
+            {
+                <span use-empty-fallback></span>
+            }
+        </govuk-summary-list-row-value>
+    </govuk-summary-list-row>
+</govuk-summary-list>
+

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
@@ -47,7 +47,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_RedirectsToExpectedPage()
+    public async Task Continue_LinksToExpectedPage()
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
@@ -68,15 +68,15 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
             editRouteState
             );
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        var location = response.Headers.Location?.OriginalString;
-        Assert.Equal($"/route/{qualificationid}/edit/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", location); // will go to change reason page
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var continueButton = doc.GetElementByTestId("continue-button") as IHtmlAnchorElement;
+        Assert.Contains($"/route/{qualificationid}/edit/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", continueButton!.Href);
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
@@ -1,0 +1,194 @@
+using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.EditRoute;
+
+public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Cancel_RedirectsToExpectedPage()
+    {
+        // Arrange
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var cancelButton = doc.GetElementByTestId("cancel-button") as IHtmlButtonElement;
+
+        // Act
+        var redirectRequest = new HttpRequestMessage(HttpMethod.Post, cancelButton!.FormAction);
+        var redirectResponse = await HttpClient.SendAsync(redirectRequest);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)redirectResponse.StatusCode);
+        var location = redirectResponse.Headers.Location?.OriginalString;
+        Assert.Equal($"/persons/{person.PersonId}/qualifications", location);
+    }
+
+    [Fact]
+    public async Task Post_RedirectsToExpectedPage()
+    {
+        // Arrange
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        var location = response.Headers.Location?.OriginalString;
+        Assert.Equal($"/route/{qualificationid}/edit/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", location); // will go to change reason page
+    }
+
+    [Fact]
+    public async Task Get_ShowsDetail_AsExpected()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = Clock.Today;
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "Apprenticeship").Single();
+        var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).First();
+        var subjects = (await ReferenceDataCache.GetTrainingSubjectsAsync()).RandomSelection(1);
+        var country = (await ReferenceDataCache.GetTrainingCountriesAsync()).RandomOne();
+        var ageRange = TrainingAgeSpecialismType.KeyStage3;
+
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.InTraining)));
+
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.InTraining)
+            .WithTrainingStartDate(startDate)
+            .WithTrainingEndDate(endDate)
+            .WithTrainingProviderId(trainingProvider.TrainingProviderId)
+            .WithTrainingSubjectIds(subjects.Select(s => s.TrainingSubjectId).ToArray())
+            .WithTrainingCountryId(country.CountryId)
+            .WithTrainingAgeSpecialismType(ageRange)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertRowContentMatches("Route", route.Name);
+        doc.AssertRowContentMatches("Status", "In training");
+        doc.AssertRowContentMatches("Start date", startDate.ToString(UiDefaults.DateOnlyDisplayFormat));
+        doc.AssertRowContentMatches("End date", endDate.ToString(UiDefaults.DateOnlyDisplayFormat));
+        //Assert.Null(doc.GetSummaryListRowForKey("Has Exemption"));
+        doc.AssertRowContentMatches("Has exemption", "Not provided"); // CML TODO page will need to not show rows that don't apply to each RouteType and status combo
+        doc.AssertRowContentMatches("Training provider", trainingProvider.Name);
+        //doc.AssertRowContentMatches("Degree type", ); // CML TODO degree type not defined yet
+        doc.AssertRowContentMatches("Country of training", country.Name);
+        doc.AssertRowContentMatches("Age range", ageRange.GetDisplayName()!);
+        doc.AssertRowContentMatches("Subjects", subjects.Select(s => s.Name));
+    }
+
+    [Fact]
+    public async Task Get_ShowsOptionalAnswers_AsExpected()
+    {
+        // Arrange
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = Clock.Today;
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "Apprenticeship").Single();
+        var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).First();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.InTraining)));
+
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.InTraining)
+            .WithTrainingStartDate(startDate)
+            .WithTrainingEndDate(endDate)
+            .WithTrainingProviderId(trainingProvider.TrainingProviderId)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertRowContentMatches("Route", route.Name);
+        doc.AssertRowContentMatches("Status", "In training");
+        doc.AssertRowContentMatches("Start date", startDate.ToString(UiDefaults.DateOnlyDisplayFormat));
+        doc.AssertRowContentMatches("End date", endDate.ToString(UiDefaults.DateOnlyDisplayFormat));
+        //Assert.Null(doc.GetSummaryListRowForKey("Has Exemption"));
+        doc.AssertRowContentMatches("Has exemption", "Not provided"); // CML TODO page will need to not show rows that don't apply to each RouteType and status combo
+        doc.AssertRowContentMatches("Training provider", trainingProvider.Name);
+        //doc.AssertRowContentMatches("Degree type", ); // CML TODO degree type not defined yet
+        doc.AssertRowContentMatches("Country of training", "Not provided");
+        doc.AssertRowContentMatches("Age range", "Not provided");
+        doc.AssertRowContentMatches("Subjects", "Not provided");
+    }
+
+    private Task<JourneyInstance<EditRouteState>> CreateJourneyInstanceAsync(Guid qualificationId, EditRouteState? state = null) =>
+    CreateJourneyInstance(
+        JourneyNames.EditRouteToProfessionalStatus,
+        state ?? new EditRouteState(),
+        new KeyValuePair<string, object>("qualificationId", qualificationId));
+}


### PR DESCRIPTION
### Context

The details view for routes (comes after hitting 'edit route' on the qualification and routes tab) and also before committing changes.
I did this next because this page plus the 'routes and quals tab' ticket gives us some kind of user journey through.

### Changes proposed in this pull request
Some, but not all of this ticket
https://trello.com/c/kcfqcyPh/800-routes-and-professional-status-front-end-edit-details-edit-cya-and-reasons

I used a partial because I think I can use it for both pages-  if not I'll split the views off later.

