### PR TITLE
Create InductionMigratedEvents when there's no dfeta_induction record

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InductionMigratedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/InductionMigratedEvent.cs
@@ -10,5 +10,6 @@ public record InductionMigratedEvent : EventBase, IEventWithPersonId, IEventWith
     public required DateOnly? InductionCompletedDate { get; init; }
     public required InductionStatus InductionStatus { get; init; }
     public required Guid? InductionExemptionReasonId { get; init; }
-    public required DqtInduction DqtInduction { get; init; }
+    public required DqtInduction? DqtInduction { get; init; }
+    public required string DqtInductionStatus { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -593,7 +593,7 @@ public class TrsDataSyncHelper(
                 }
             }
 
-            if (induction is null)
+            if (induction is null && contact.dfeta_InductionStatus is null)
             {
                 continue;
             }
@@ -604,7 +604,7 @@ public class TrsDataSyncHelper(
                 continue;
             }
 
-            var migratedEvent = MapMigratedEvent(contact.ContactId!.Value, induction, mapped);
+            var migratedEvent = MapMigratedEvent(contact, induction, mapped);
             events.Add(migratedEvent);
         }
 
@@ -624,15 +624,17 @@ public class TrsDataSyncHelper(
 
         return events.Count;
 
-        EventBase MapMigratedEvent(Guid contactId, dfeta_induction dqtInduction, InductionInfo mappedInduction)
+        EventBase MapMigratedEvent(Contact contact, dfeta_induction? dqtInduction, InductionInfo mappedInduction)
         {
+            var dqtInductionStatus = contact.dfeta_InductionStatus!.Value.GetMetadata().Name;
+
             return new InductionMigratedEvent()
             {
                 EventId = Guid.NewGuid(),
-                Key = $"{dqtInduction.Id}-Migrated",
+                Key = $"{dqtInduction?.Id ?? contact.Id}-Migrated",
                 CreatedUtc = new DateTime(2025, 02, 18, 10, 17, 05, DateTimeKind.Utc),
                 RaisedBy = EventModels.RaisedByUserInfo.FromUserId(Core.DataStore.Postgres.Models.SystemUser.SystemUserId),
-                PersonId = contactId,
+                PersonId = contact.Id,
                 InductionStartDate = mappedInduction.InductionStartDate,
                 InductionCompletedDate = mappedInduction.InductionCompletedDate,
                 InductionStatus = mappedInduction.InductionStatus,
@@ -641,7 +643,8 @@ public class TrsDataSyncHelper(
                     [var id] => id,
                     _ => null
                 },
-                DqtInduction = GetEventDqtInduction(dqtInduction)
+                DqtInduction = dqtInduction is not null ? GetEventDqtInduction(dqtInduction) : null,
+                DqtInductionStatus = dqtInductionStatus
             };
         }
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/InductionMigratedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/InductionMigratedEvent.cshtml
@@ -49,14 +49,11 @@
             <govuk-details-summary>Previous data</govuk-details-summary>
             <govuk-details-text>
                 <govuk-summary-list>
-                    @if (@dqtInduction.InductionStatus.HasValue)
-                    {
-                        <govuk-summary-list-row>
-                            <govuk-summary-list-row-key>DQT induction status</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value data-testid="dqt-induction-status">@dqtInduction.InductionStatus.ValueOrDefault()</govuk-summary-list-row-value>
-                        </govuk-summary-list-row>
-                    }
-                    @if (@dqtInduction.InductionExemptionReason.HasValue)
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>DQT induction status</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="dqt-induction-status">@migratedEvent.DqtInductionStatus</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    @if (@dqtInduction?.InductionExemptionReason.HasValue == true)
                     {
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>DQT induction exemption reason</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
@@ -410,6 +410,7 @@ public class ChangeLogInductionEventTests : TestBase
         DateOnly? startDate = Clock.Today.AddYears(-1);
         DateOnly? completionDate = Clock.Today.AddDays(-10);
         dfeta_InductionStatus? inductionStatus = populatedFields.HasFlag(DqtInductionFields.ExemptionReason) ? Core.Dqt.Models.dfeta_InductionStatus.Exempt : Core.Dqt.Models.dfeta_InductionStatus.InProgress;
+        string dqtInductionStatus = populatedFields.HasFlag(DqtInductionFields.ExemptionReason) ? "Exempt" : "In progress";
         dfeta_InductionExemptionReason? inductionExemptionReason = Core.Dqt.Models.dfeta_InductionExemptionReason.QualifiedthroughEEAmutualrecognitionroute;
         InductionStatus migratedInductionStatus = inductionStatus == dfeta_InductionStatus.Exempt ? InductionStatus.Exempt : InductionStatus.InProgress;
         var exemptionReason = await ReferenceDataCache.GetInductionExemptionReasonByIdAsync(InductionExemptionReason.PassedInWalesId);
@@ -435,7 +436,8 @@ public class ChangeLogInductionEventTests : TestBase
             InductionExemptionReasonId = populatedFields.HasFlag(DqtInductionFields.ExemptionReason) ? migratedInductionExemptionReasonId : null,
             InductionStartDate = populatedFields.HasFlag(DqtInductionFields.StartDate) ? startDate : null,
             InductionCompletedDate = populatedFields.HasFlag(DqtInductionFields.CompletionDate) ? completionDate : null,
-            DqtInduction = induction
+            DqtInduction = induction,
+            DqtInductionStatus = dqtInductionStatus
         };
 
         await WithDbContext(async dbContext =>


### PR DESCRIPTION
Some people had statuses of `Exempt` without a `dfeta_induction` record; these people should have an `InductionMigratedEvent` created too.