### PR TITLE
Add Enddate Page for routes

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/FieldRequirement.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/FieldRequirement.cs
@@ -1,4 +1,4 @@
-namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
+namespace TeachingRecordSystem.Core.Models;
 
 public enum FieldRequirement
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ProfessionalStatusStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ProfessionalStatusStatus.cs
@@ -28,7 +28,7 @@ public enum ProfessionalStatusStatus
         subjects: FieldRequirement.Optional)]
     Awarded = 1,
     [ProfessionalStatusStatusInfo("Deferred",
-        startDate: FieldRequirement .NotRequired,
+        startDate: FieldRequirement.NotRequired,
         endDate: FieldRequirement.NotRequired,
         awardDate: FieldRequirement.NotRequired,
         inductionExemption: FieldRequirement.NotRequired,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ProfessionalStatusStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ProfessionalStatusStatus.cs
@@ -2,102 +2,96 @@ using System.Reflection;
 
 namespace TeachingRecordSystem.Core;
 
-public enum FieldRequirementLevel
-{
-    NotAppplicable,
-    Required,
-    Optional
-}
 
 public enum ProfessionalStatusStatus
 {
     [ProfessionalStatusStatusInfo("In training",
-        startDate: FieldRequirementLevel.Required,
-        endDate: FieldRequirementLevel.Required,
-        awardDate: FieldRequirementLevel.NotAppplicable,
-        inductionExemption: FieldRequirementLevel.NotAppplicable,
-        trainingProvider: FieldRequirementLevel.Optional,
-        degreeType: FieldRequirementLevel.Optional,
-        country: FieldRequirementLevel.Optional,
-        ageRange: FieldRequirementLevel.Optional,
-        subjects: FieldRequirementLevel.Optional)]
+        startDate: FieldRequirement.Mandatory,
+        endDate: FieldRequirement.Mandatory,
+        awardDate: FieldRequirement.NotRequired,
+        inductionExemption: FieldRequirement.NotRequired,
+        trainingProvider: FieldRequirement.Optional,
+        degreeType: FieldRequirement.Optional,
+        country: FieldRequirement.Optional,
+        ageRange: FieldRequirement.Optional,
+        subjects: FieldRequirement.Optional)]
     InTraining = 0,
     [ProfessionalStatusStatusInfo("Awarded",
-        startDate: FieldRequirementLevel.Required,
-        endDate: FieldRequirementLevel.Required,
-        awardDate: FieldRequirementLevel.Required,
-        inductionExemption: FieldRequirementLevel.Required,
-        trainingProvider: FieldRequirementLevel.Optional,
-        degreeType: FieldRequirementLevel.Optional,
-        country: FieldRequirementLevel.Optional,
-        ageRange: FieldRequirementLevel.Optional,
-        subjects: FieldRequirementLevel.Optional)]
+        startDate: FieldRequirement.Mandatory,
+        endDate: FieldRequirement.Mandatory,
+        awardDate: FieldRequirement.Mandatory,
+        inductionExemption: FieldRequirement.Mandatory,
+        trainingProvider: FieldRequirement.Optional,
+        degreeType: FieldRequirement.Optional,
+        country: FieldRequirement.Optional,
+        ageRange: FieldRequirement.Optional,
+        subjects: FieldRequirement.Optional)]
     Awarded = 1,
     [ProfessionalStatusStatusInfo("Deferred",
-        startDate: FieldRequirementLevel.NotAppplicable,
-        endDate: FieldRequirementLevel.NotAppplicable,
-        awardDate: FieldRequirementLevel.NotAppplicable,
-        inductionExemption: FieldRequirementLevel.NotAppplicable,
-        trainingProvider: FieldRequirementLevel.NotAppplicable,
-        degreeType: FieldRequirementLevel.NotAppplicable,
-        country: FieldRequirementLevel.NotAppplicable,
-        ageRange: FieldRequirementLevel.NotAppplicable,
-        subjects: FieldRequirementLevel.NotAppplicable)]
+        startDate: FieldRequirement .NotRequired,
+        endDate: FieldRequirement.NotRequired,
+        awardDate: FieldRequirement.NotRequired,
+        inductionExemption: FieldRequirement.NotRequired,
+        trainingProvider: FieldRequirement.NotRequired,
+        degreeType: FieldRequirement.NotRequired,
+        country: FieldRequirement.NotRequired,
+        ageRange: FieldRequirement.NotRequired,
+        subjects: FieldRequirement.NotRequired)]
     Deferred = 2,
     [ProfessionalStatusStatusInfo("Deferred for skills tests",
-        startDate: FieldRequirementLevel.NotAppplicable,
-        endDate: FieldRequirementLevel.NotAppplicable,
-        awardDate: FieldRequirementLevel.NotAppplicable,
-        inductionExemption: FieldRequirementLevel.NotAppplicable,
-        trainingProvider: FieldRequirementLevel.NotAppplicable,
-        degreeType: FieldRequirementLevel.NotAppplicable,
-        country: FieldRequirementLevel.NotAppplicable,
-        ageRange: FieldRequirementLevel.NotAppplicable,
-        subjects: FieldRequirementLevel.NotAppplicable)]
+        startDate: FieldRequirement.NotRequired,
+        endDate: FieldRequirement.NotRequired,
+        awardDate: FieldRequirement.NotRequired,
+        inductionExemption: FieldRequirement.NotRequired,
+        trainingProvider: FieldRequirement.NotRequired,
+        degreeType: FieldRequirement.NotRequired,
+        country: FieldRequirement.NotRequired,
+        ageRange: FieldRequirement.NotRequired,
+        subjects: FieldRequirement.NotRequired)]
     DeferredForSkillsTest = 3,
     [ProfessionalStatusStatusInfo("Failed",
-        startDate: FieldRequirementLevel.NotAppplicable,
-        endDate: FieldRequirementLevel.NotAppplicable,
-        awardDate: FieldRequirementLevel.NotAppplicable,
-        inductionExemption: FieldRequirementLevel.NotAppplicable,
-        trainingProvider: FieldRequirementLevel.NotAppplicable,
-        degreeType: FieldRequirementLevel.NotAppplicable,
-        country: FieldRequirementLevel.NotAppplicable,
-        ageRange: FieldRequirementLevel.NotAppplicable,
-        subjects: FieldRequirementLevel.NotAppplicable)]
+        startDate: FieldRequirement.NotRequired,
+        endDate: FieldRequirement.NotRequired,
+        awardDate: FieldRequirement.NotRequired,
+        inductionExemption: FieldRequirement.NotRequired,
+        trainingProvider: FieldRequirement.NotRequired,
+        degreeType: FieldRequirement.NotRequired,
+        country: FieldRequirement.NotRequired,
+        ageRange: FieldRequirement.NotRequired,
+        subjects: FieldRequirement.NotRequired)]
     Failed = 4,
     [ProfessionalStatusStatusInfo("Withdrawn",
-        startDate: FieldRequirementLevel.NotAppplicable,
-        endDate: FieldRequirementLevel.NotAppplicable,
-        awardDate: FieldRequirementLevel.NotAppplicable,
-        inductionExemption: FieldRequirementLevel.NotAppplicable,
-        trainingProvider: FieldRequirementLevel.NotAppplicable,
-        degreeType: FieldRequirementLevel.NotAppplicable,
-        country: FieldRequirementLevel.NotAppplicable,
-        ageRange: FieldRequirementLevel.NotAppplicable,
-        subjects: FieldRequirementLevel.NotAppplicable)]
+        startDate: FieldRequirement.NotRequired,
+        endDate: FieldRequirement.NotRequired,
+        awardDate: FieldRequirement.NotRequired,
+        inductionExemption: FieldRequirement.NotRequired,
+        trainingProvider: FieldRequirement.NotRequired,
+        degreeType: FieldRequirement.NotRequired,
+        country: FieldRequirement.NotRequired,
+        ageRange: FieldRequirement.NotRequired,
+        subjects: FieldRequirement.NotRequired)]
     Withdrawn = 5,
     [ProfessionalStatusStatusInfo("Under assessment",
-        startDate: FieldRequirementLevel.Required,
-        endDate: FieldRequirementLevel.Required,
-        awardDate: FieldRequirementLevel.NotAppplicable,
-        inductionExemption: FieldRequirementLevel.NotAppplicable,
-        trainingProvider: FieldRequirementLevel.Optional,
-        degreeType: FieldRequirementLevel.Optional,
-        country: FieldRequirementLevel.Optional,
-        ageRange: FieldRequirementLevel.Optional,
-        subjects: FieldRequirementLevel.Optional)]
+        startDate: FieldRequirement.Mandatory,
+        endDate: FieldRequirement.Mandatory,
+        awardDate: FieldRequirement.NotRequired,
+        inductionExemption: FieldRequirement.NotRequired,
+        trainingProvider: FieldRequirement.Optional,
+        degreeType: FieldRequirement.Optional,
+        country: FieldRequirement.Optional,
+        ageRange: FieldRequirement.Optional,
+        subjects: FieldRequirement.Optional)]
     UnderAssessment = 6,
     [ProfessionalStatusStatusInfo("Approved",
-        startDate: FieldRequirementLevel.Required,
-        endDate: FieldRequirementLevel.Required,
-        awardDate: FieldRequirementLevel.Required,
-        inductionExemption: FieldRequirementLevel.Required,
-        trainingProvider: FieldRequirementLevel.Optional,
-        degreeType: FieldRequirementLevel.Optional,
-        country: FieldRequirementLevel.Optional,
-        ageRange: FieldRequirementLevel.Optional,
-        subjects: FieldRequirementLevel.Optional)]
+        startDate: FieldRequirement.Mandatory,
+        endDate: FieldRequirement.Mandatory,
+        awardDate: FieldRequirement.Mandatory,
+        inductionExemption: FieldRequirement.Mandatory,
+        trainingProvider: FieldRequirement.Optional,
+        degreeType: FieldRequirement.Optional,
+        country: FieldRequirement.Optional,
+        ageRange: FieldRequirement.Optional,
+        subjects: FieldRequirement.Optional)]
     Approved = 7
 }
 
@@ -112,23 +106,23 @@ public static class ProfessionalStatusStatusRegistry
 
     public static string GetTitle(this ProfessionalStatusStatus status) => _info[status].Title;
 
-    public static FieldRequirementLevel GetStartDateRequirement(this ProfessionalStatusStatus status) => _info[status].StartDate;
+    public static FieldRequirement GetStartDateRequirement(this ProfessionalStatusStatus status) => _info[status].StartDate;
 
-    public static FieldRequirementLevel GetEndDateRequirement(this ProfessionalStatusStatus status) => _info[status].EndDate;
+    public static FieldRequirement GetEndDateRequirement(this ProfessionalStatusStatus status) => _info[status].EndDate;
 
-    public static FieldRequirementLevel GetAwardDateRequirement(this ProfessionalStatusStatus status) => _info[status].AwardDate;
+    public static FieldRequirement GetAwardDateRequirement(this ProfessionalStatusStatus status) => _info[status].AwardDate;
 
-    public static FieldRequirementLevel GetInductionExemptionRequirement(this ProfessionalStatusStatus status) => _info[status].InductionExemption;
+    public static FieldRequirement GetInductionExemptionRequirement(this ProfessionalStatusStatus status) => _info[status].InductionExemption;
 
-    public static FieldRequirementLevel GetTrainingProviderRequirement(this ProfessionalStatusStatus status) => _info[status].TrainingProvider;
+    public static FieldRequirement GetTrainingProviderRequirement(this ProfessionalStatusStatus status) => _info[status].TrainingProvider;
 
-    public static FieldRequirementLevel GetDegreeTypeRequirement(this ProfessionalStatusStatus status) => _info[status].DegreeType;
+    public static FieldRequirement GetDegreeTypeRequirement(this ProfessionalStatusStatus status) => _info[status].DegreeType;
 
-    public static FieldRequirementLevel GetCountryRequirement(this ProfessionalStatusStatus status) => _info[status].Country;
+    public static FieldRequirement GetCountryRequirement(this ProfessionalStatusStatus status) => _info[status].Country;
 
-    public static FieldRequirementLevel GetAgeRangeRequirement(this ProfessionalStatusStatus status) => _info[status].AgeRange;
+    public static FieldRequirement GetAgeRangeRequirement(this ProfessionalStatusStatus status) => _info[status].AgeRange;
 
-    public static FieldRequirementLevel GetSubjectsRequirement(this ProfessionalStatusStatus status) => _info[status].Subjects;
+    public static FieldRequirement GetSubjectsRequirement(this ProfessionalStatusStatus status) => _info[status].Subjects;
 
     private static ProfessionalStatusStatusInfo GetInfo(ProfessionalStatusStatus status)
     {
@@ -146,15 +140,15 @@ public static class ProfessionalStatusStatusRegistry
 public sealed record ProfessionalStatusStatusInfo(
     ProfessionalStatusStatus Value,
     string Name,
-    FieldRequirementLevel StartDate,
-    FieldRequirementLevel EndDate,
-    FieldRequirementLevel AwardDate,
-    FieldRequirementLevel InductionExemption,
-    FieldRequirementLevel TrainingProvider,
-    FieldRequirementLevel DegreeType,
-    FieldRequirementLevel Country,
-    FieldRequirementLevel AgeRange,
-    FieldRequirementLevel Subjects)
+    FieldRequirement StartDate,
+    FieldRequirement EndDate,
+    FieldRequirement AwardDate,
+    FieldRequirement InductionExemption,
+    FieldRequirement TrainingProvider,
+    FieldRequirement DegreeType,
+    FieldRequirement Country,
+    FieldRequirement AgeRange,
+    FieldRequirement Subjects)
 {
     public string Title => Name[..1].ToUpper() + Name[1..];
 }
@@ -162,25 +156,25 @@ public sealed record ProfessionalStatusStatusInfo(
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
 file sealed class ProfessionalStatusStatusInfoAttribute(
         string name,
-        FieldRequirementLevel startDate,
-        FieldRequirementLevel endDate,
-        FieldRequirementLevel awardDate,
-        FieldRequirementLevel inductionExemption,
-        FieldRequirementLevel trainingProvider,
-        FieldRequirementLevel degreeType,
-        FieldRequirementLevel country,
-        FieldRequirementLevel ageRange,
-        FieldRequirementLevel subjects
+        FieldRequirement startDate,
+        FieldRequirement endDate,
+        FieldRequirement awardDate,
+        FieldRequirement inductionExemption,
+        FieldRequirement trainingProvider,
+        FieldRequirement degreeType,
+        FieldRequirement country,
+        FieldRequirement ageRange,
+        FieldRequirement subjects
     ) : Attribute
 {
     public string Name => name;
-    public FieldRequirementLevel StartDate => startDate;
-    public FieldRequirementLevel EndDate => endDate;
-    public FieldRequirementLevel AwardDate => awardDate;
-    public FieldRequirementLevel InductionExemption => inductionExemption;
-    public FieldRequirementLevel TrainingProvider => trainingProvider;
-    public FieldRequirementLevel DegreeType => degreeType;
-    public FieldRequirementLevel Country => country;
-    public FieldRequirementLevel AgeRange => ageRange;
-    public FieldRequirementLevel Subjects => subjects;
+    public FieldRequirement StartDate => startDate;
+    public FieldRequirement EndDate => endDate;
+    public FieldRequirement AwardDate => awardDate;
+    public FieldRequirement InductionExemption => inductionExemption;
+    public FieldRequirement TrainingProvider => trainingProvider;
+    public FieldRequirement DegreeType => degreeType;
+    public FieldRequirement Country => country;
+    public FieldRequirement AgeRange => ageRange;
+    public FieldRequirement Subjects => subjects;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
@@ -30,6 +30,8 @@ public class CheckYourAnswersModel(
 
     public async Task OnGetAsync()
     {
+        var routeToProfessionalStatus = await referenceDataCache.GetRouteToProfessionalStatusByIdAsync(RouteDetail.RouteToProfessionalStatusId);
+        RouteDetail.EndDateRequired = QuestionDriverHelper.FieldRequired(routeToProfessionalStatus.TrainingEndDateRequired, JourneyInstance!.State.Status.GetEndDateRequirement());
         RouteDetail.RouteToProfessionalStatusName = (await referenceDataCache.GetRouteToProfessionalStatusByIdAsync(RouteDetail.RouteToProfessionalStatusId))?.Name!;
         RouteDetail.ExemptionReason = RouteDetail.InductionExemptionReasonId is not null ? (await referenceDataCache.GetInductionExemptionReasonByIdAsync(RouteDetail.InductionExemptionReasonId!.Value))?.Name : null;
         RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is not null ? (await referenceDataCache.GetTrainingProviderByIdAsync(RouteDetail.TrainingProviderId!.Value))?.Name : null;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
@@ -88,7 +88,9 @@ public class CheckYourAnswersModel(
             TrainingAgeSpecialismRangeTo = JourneyInstance!.State.TrainingAgeSpecialismRangeTo,
             TrainingCountryId = JourneyInstance!.State.TrainingCountryId,
             TrainingProviderId = JourneyInstance!.State.TrainingProviderId,
-            InductionExemptionReasonId = JourneyInstance!.State.InductionExemptionReasonId
+            InductionExemptionReasonId = JourneyInstance!.State.InductionExemptionReasonId,
+            QualificationId = QualificationId,
+            JourneyInstance = JourneyInstance
         };
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
@@ -22,6 +22,9 @@ public class DetailModel(
     [FromRoute]
     public Guid QualificationId { get; set; }
 
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
     public async Task OnGetAsync()
     {
         RouteDetail.RouteToProfessionalStatusName = (await referenceDataCache.GetRouteToProfessionalStatusByIdAsync(RouteDetail.RouteToProfessionalStatusId))?.Name!;
@@ -63,7 +66,9 @@ public class DetailModel(
             TrainingAgeSpecialismRangeTo = JourneyInstance!.State.TrainingAgeSpecialismRangeTo,
             TrainingCountryId = JourneyInstance!.State.TrainingCountryId,
             TrainingProviderId = JourneyInstance!.State.TrainingProviderId,
-            InductionExemptionReasonId = JourneyInstance!.State.InductionExemptionReasonId
+            InductionExemptionReasonId = JourneyInstance!.State.InductionExemptionReasonId,
+            QualificationId = QualificationId,
+            JourneyInstance = JourneyInstance
         };
 
         return next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
@@ -27,7 +27,9 @@ public class DetailModel(
 
     public async Task OnGetAsync()
     {
-        RouteDetail.RouteToProfessionalStatusName = (await referenceDataCache.GetRouteToProfessionalStatusByIdAsync(RouteDetail.RouteToProfessionalStatusId))?.Name!;
+        var routeToProfessionalStatus = await referenceDataCache.GetRouteToProfessionalStatusByIdAsync(RouteDetail.RouteToProfessionalStatusId);
+        RouteDetail.EndDateRequired = QuestionDriverHelper.FieldRequired(routeToProfessionalStatus.TrainingEndDateRequired, JourneyInstance!.State.Status.GetEndDateRequirement());
+        RouteDetail.RouteToProfessionalStatusName = routeToProfessionalStatus?.Name;
         RouteDetail.ExemptionReason = RouteDetail.InductionExemptionReasonId is not null ? (await referenceDataCache.GetInductionExemptionReasonByIdAsync(RouteDetail.InductionExemptionReasonId!.Value))?.Name : null;
         RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is not null ? (await referenceDataCache.GetTrainingProviderByIdAsync(RouteDetail.TrainingProviderId!.Value))?.Name : null;
         RouteDetail.TrainingCountry = RouteDetail.TrainingCountryId is not null ? (await referenceDataCache.GetTrainingCountryByIdAsync(RouteDetail.TrainingCountryId))?.Name : null;
@@ -52,7 +54,7 @@ public class DetailModel(
         PersonName = personInfo.Name;
         PersonId = personInfo.PersonId;
 
-        RouteDetail = new RouteDetailViewModel
+        RouteDetail = new RouteDetailViewModel()
         {
             QualificationType = JourneyInstance!.State.QualificationType,
             RouteToProfessionalStatusId = JourneyInstance!.State.RouteToProfessionalStatusId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/EndDate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/EndDate.cshtml
@@ -1,0 +1,29 @@
+@page "/route/{qualificationId}/edit/enddate/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute.EndDateModel
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.TrainingEndDate);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@(Model.FromCheckDetails == true ? LinkGenerator.RouteDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RouteEditEndDate(Model.QualificationId, Model.JourneyInstance!.InstanceId, Model.FromCheckDetails)" method="post">
+            <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
+
+            <govuk-date-input asp-for="TrainingEndDate">
+                <govuk-date-input-fieldset>
+                    <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
+                    <govuk-date-input-hint>For example, 27 3 2023</govuk-date-input-hint>
+                </govuk-date-input-fieldset>
+            </govuk-date-input>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteEditEndDateCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/EndDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/EndDate.cshtml.cs
@@ -5,8 +5,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
-[Journey(JourneyNames.EditRouteToProfessionalStatus), ActivatesJourney, RequireJourneyInstance]
-public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.EditRouteToProfessionalStatus), RequireJourneyInstance]
+public class EndDateModel(
+    TrsLinkGenerator linkGenerator) : PageModel
 {
     public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
 
@@ -22,6 +23,7 @@ public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
 
     [BindProperty]
     [DateInput(ErrorMessagePrefix = "End date")]
+    [Required(ErrorMessage = "Enter an end date")]
     [Display(Name = "Enter the route end date")]
     public DateOnly? TrainingEndDate { get; set; }
 
@@ -32,11 +34,6 @@ public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
-        //TODO: This property will be conditionally required based on RouteToProfessionalStatus.EndDateRequired
-        if (TrainingEndDate is null)
-        {
-            ModelState.AddModelError(nameof(TrainingEndDate), "Enter a end date");
-        }
         if (TrainingEndDate.HasValue && JourneyInstance!.State.TrainingStartDate is DateOnly startDate && startDate >= TrainingEndDate)
         {
             ModelState.AddModelError(nameof(TrainingEndDate), "End date must be after start date");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/EndDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/EndDate.cshtml.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
+
+[Journey(JourneyNames.EditRouteToProfessionalStatus), ActivatesJourney, RequireJourneyInstance]
+public class EndDateModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
+
+    [FromQuery]
+    public bool FromCheckDetails { get; set; }
+
+    [FromRoute]
+    public Guid QualificationId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    [BindProperty]
+    [DateInput(ErrorMessagePrefix = "End date")]
+    [Display(Name = "Enter the route end date")]
+    public DateOnly? TrainingEndDate { get; set; }
+
+    public void OnGet()
+    {
+        TrainingEndDate = JourneyInstance!.State.TrainingEndDate;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        //TODO: This property will be conditionally required based on RouteToProfessionalStatus.EndDateRequired
+        if (TrainingEndDate is null)
+        {
+            ModelState.AddModelError(nameof(TrainingEndDate), "Enter a end date");
+        }
+        if (TrainingEndDate.HasValue && JourneyInstance!.State.TrainingStartDate is DateOnly startDate && startDate >= TrainingEndDate)
+        {
+            ModelState.AddModelError(nameof(TrainingEndDate), "End date must be after start date");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state => state.TrainingEndDate = TrainingEndDate);
+        return Redirect(FromCheckDetails ?
+            linkGenerator.RouteDetail(QualificationId, JourneyInstance.InstanceId) :
+            linkGenerator.RouteDetail(QualificationId, JourneyInstance.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancelAsync()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonQualifications(PersonId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+        PersonName = personInfo.Name;
+        PersonId = personInfo.PersonId;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/QuestionDriverHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/QuestionDriverHelper.cs
@@ -1,0 +1,20 @@
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus;
+
+public static class QuestionDriverHelper
+{
+    public static FieldRequirement FieldRequired(FieldRequirement routeFieldRequirement, FieldRequirement statusFieldRequirement)
+    {
+        if (routeFieldRequirement == FieldRequirement.NotRequired || statusFieldRequirement == FieldRequirement.NotRequired)
+        {
+            return FieldRequirement.NotRequired;
+        }
+        else if (routeFieldRequirement == FieldRequirement.Mandatory || statusFieldRequirement == FieldRequirement.Mandatory)
+        {
+            return FieldRequirement.Mandatory;
+        }
+        else
+        {
+            return FieldRequirement.Optional;
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
@@ -18,4 +18,8 @@ public partial class TrsLinkGenerator
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
     public string RouteAdd(Guid personId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Index", routeValues: new { personId });
+    public string RouteEditEndDate(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromDetails = null) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/EndDate", routeValues: new { qualificationId, fromDetails }, journeyInstanceId: journeyInstanceId);
+    public string RouteEditEndDateCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/EndDate", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
@@ -1,7 +1,10 @@
+using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
+
 namespace TeachingRecordSystem.SupportUi.Pages.Shared;
 
 public class RouteDetailViewModel
 {
+    public Guid QualificationId { get; set; }
     public QualificationType? QualificationType { get; set; }
     public Guid RouteToProfessionalStatusId { get; set; }
     public ProfessionalStatusStatus Status { get; set; }
@@ -21,4 +24,5 @@ public class RouteDetailViewModel
     public string? TrainingCountry { get; set; }
     public string[]? TrainingSubjects { get; set; }
     public string? RouteToProfessionalStatusName { get; set; }
+    public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Shared;
 
-public class RouteDetailViewModel
+public class RouteDetailViewModel()
 {
     public Guid QualificationId { get; set; }
     public QualificationType? QualificationType { get; set; }
@@ -25,4 +25,6 @@ public class RouteDetailViewModel
     public string[]? TrainingSubjects { get; set; }
     public string? RouteToProfessionalStatusName { get; set; }
     public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
+
+    public FieldRequirement EndDateRequired { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
@@ -13,13 +13,16 @@
         <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
     </govuk-summary-list-row>
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action href="@LinkGenerator.RouteEditEndDate(Model.QualificationId, Model.JourneyInstance!.InstanceId)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
+    @if (Model.EndDateRequired != FieldRequirement.NotRequired)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action href="@LinkGenerator.RouteEditEndDate(Model.QualificationId, Model.JourneyInstance!.InstanceId)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
     <govuk-summary-list-row>
         <govuk-summary-list-row-key>Award date</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.AwardedDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
@@ -16,6 +16,9 @@
     <govuk-summary-list-row>
         <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+        <govuk-summary-list-row-actions>
+            <govuk-summary-list-row-action href="@LinkGenerator.RouteEditEndDate(Model.QualificationId, Model.JourneyInstance!.InstanceId)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
+        </govuk-summary-list-row-actions>
     </govuk-summary-list-row>
     <govuk-summary-list-row>
         <govuk-summary-list-row-key>Award date</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
@@ -134,6 +135,94 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         doc.AssertRowContentMatches("Country of training", country.Name);
         doc.AssertRowContentMatches("Age range", ageRange.GetDisplayName()!);
         doc.AssertRowContentMatches("Subjects", subject.Name);
+    }
+
+    [Fact]
+    public async Task Get_EndDateApplies_EndDateAndChangeLinkShown()
+    {
+        // Arrange
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync())
+            .Where(r => r.TrainingEndDateRequired == FieldRequirement.Mandatory)
+            .RandomOne();
+        var status = ProfessionalStatusStatusRegistry.All
+            .Where(s => s.Value.GetEndDateRequirement() == FieldRequirement.Mandatory)
+            .RandomOne();
+
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = Clock.Today;
+
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.InTraining)));
+
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(status.Value)
+            .WithTrainingStartDate(startDate)
+            .WithTrainingEndDate(endDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertRowContentMatches("End date", endDate.ToString(UiDefaults.DateOnlyDisplayFormat));
+
+        var label = doc.QuerySelectorAll(".govuk-summary-list__key").Single(e => e.TextContent == "End date");
+        Assert.NotNull(label);
+        var value = label.NextElementSibling;
+        Assert.NotNull(value!.NextElementSibling!.GetElementsByTagName("a").First());
+    }
+
+    [Fact]
+    public async Task Get_EndDateNotApplicable_EndDateNotShown()
+    {
+        // Arrange
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync())
+            .Where(r => r.TrainingEndDateRequired == FieldRequirement.NotRequired)
+            .RandomOne();
+        var status = ProfessionalStatusStatusRegistry.All
+            .Where(s => s.Value.GetEndDateRequirement() == FieldRequirement.NotRequired)
+            .RandomOne();
+
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.InTraining)));
+
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(status.Value)
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        Assert.Empty(doc.QuerySelectorAll(".govuk-summary-list__key").Where(e => e.TextContent == "End date"));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EndDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EndDateTests.cs
@@ -1,0 +1,180 @@
+using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.EditRoute;
+
+public class EndDateTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Post_WhenEndDateIsEqualOrBeforeStartDate_RendersError(int daysAfter)
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = startDate.AddDays(daysAfter);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/enddate?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "TrainingEndDate.Day", $"{endDate:%d}" },
+                { "TrainingEndDate.Month", $"{endDate:%M}" },
+                { "TrainingEndDate.Year", $"{endDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "TrainingEndDate", "End date must be after start date");
+    }
+
+    [Fact]
+    public async Task Post_WhenTrainingEndDateIsEntered_RedirectsToDetail()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = new DateOnly(2025, 01, 01);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/enddate?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "TrainingEndDate.Day", $"{endDate:%d}" },
+                { "TrainingEndDate.Month", $"{endDate:%M}" },
+                { "TrainingEndDate.Year", $"{endDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoEndDateIsEntered_ReturnsError()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = new DateOnly(2025, 01, 01);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/enddate?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>())
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "TrainingEndDate", "Enter a end date");
+    }
+
+    [Fact]
+    public async Task Cancel_RedirectsToExpectedPage()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = new DateOnly(2025, 01, 01);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/enddate?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var cancelButton = doc.GetElementByTestId("cancel-button") as IHtmlButtonElement;
+        var redirectRequest = new HttpRequestMessage(HttpMethod.Post, cancelButton!.FormAction);
+        var redirectResponse = await HttpClient.SendAsync(redirectRequest);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)redirectResponse.StatusCode);
+        var location = redirectResponse.Headers.Location?.OriginalString;
+        Assert.Equal($"/persons/{person.PersonId}/qualifications", location);
+    }
+
+    private Task<JourneyInstance<EditRouteState>> CreateJourneyInstanceAsync(Guid qualificationId, EditRouteState? state = null) =>
+        CreateJourneyInstance(
+           JourneyNames.EditRouteToProfessionalStatus,
+           state ?? new EditRouteState(),
+           new KeyValuePair<string, object>("qualificationId", qualificationId));
+
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EndDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EndDateTests.cs
@@ -98,7 +98,9 @@ public class EndDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var startDate = new DateOnly(2024, 01, 01);
         var endDate = new DateOnly(2025, 01, 01);
-        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync()).Where(r => r.Name == "NI R").Single();
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusesAsync())
+            .Where(r => r.TrainingEndDateRequired == FieldRequirement.Mandatory)
+            .RandomOne();
         var person = await TestData.CreatePersonAsync(p => p
             .WithProfessionalStatus(r => r
                 .WithRoute(route.RouteToProfessionalStatusId)
@@ -106,7 +108,7 @@ public class EndDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualificationid = person.ProfessionalStatuses.First().QualificationId;
         var editRouteState = new EditRouteStateBuilder()
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
-            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithStatus(ProfessionalStatusStatus.InTraining)
             .WithTrainingStartDate(startDate)
             .WithValidChangeReasonOption()
             .WithDefaultChangeReasonNoUploadFileDetail()
@@ -126,7 +128,7 @@ public class EndDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "TrainingEndDate", "Enter a end date");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "TrainingEndDate", "Enter an end date");
     }
 
     [Fact]


### PR DESCRIPTION
Add End date Page for routes

This can be reviewed and merged as it's under a feature flag. 
This PR includes unifying the two 'FieldRequirement' enums into one.
EndDate only shows on the details page if it's applicable to the route and status combo, and the change link will always appear if EndDate is applicable
EndDate page validation is kept simple - if you've asked to edit the end date you have to add a value (removes the need for for mandatory/optional checks)

https://educationgovuk.sharepoint.com.mcas.ms/:x:/s/TRATransformationTeamDocs/ETLJKljZyxJCig3Pz_sPH2sBMV8QMbXNBs0EZfpKxA9ZCg?e=SmjX7Z). 

- Added page
- Added Tests

https://trello.com/c/bX0M9P80/837-routes-and-professional-status-front-end-edit-journey-end-date