### PR TITLE
Add a test that there are no DbContext changes not covered by a migration

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/DbContextTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/DbContextTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TeachingRecordSystem.Core.Tests.DataStore.Postgres;
+
+public class DbContextTests(DbFixture dbFixture)
+{
+    [Fact]
+    public Task NoOutstandingMigrations() => dbFixture.WithDbContextAsync(dbContext =>
+    {
+        var migrationsAssembly = dbContext.GetService<IMigrationsAssembly>();
+
+        if (migrationsAssembly.ModelSnapshot is not null)
+        {
+            var snapshotModel = migrationsAssembly.ModelSnapshot.Model;
+
+            if (snapshotModel is IMutableModel mutableModel)
+            {
+                snapshotModel = mutableModel.FinalizeModel();
+            }
+
+            snapshotModel = dbContext.GetService<IModelRuntimeInitializer>().Initialize(snapshotModel);
+            var hasDifferences = dbContext.GetService<IMigrationsModelDiffer>().HasDifferences(
+                snapshotModel.GetRelationalModel(),
+                dbContext.GetService<IDesignTimeModel>().Model.GetRelationalModel());
+
+            Assert.False(hasDifferences, "DbContext has pending changes not covered by a migration.");
+        }
+
+        return Task.CompletedTask;
+    });
+}


### PR DESCRIPTION
We've had a few cases where we've changed models in some way and not generated a migration. This adds a test that to prevent that from happening.