### PR TITLE
Add missing professional_status_type column to trs_qualifications in reporting db

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0048_TrsQualificationsProfessionalStatusType.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0048_TrsQualificationsProfessionalStatusType.sql
@@ -1,0 +1,1 @@
+alter table trs_qualifications add professional_status_type int

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -73,6 +73,7 @@
     <None Remove="Services\DqtReporting\Migrations\0038_TrsPersonsInductionSync.sql" />
     <None Remove="Services\DqtReporting\Migrations\0044_TrsTrainingProviders.sql" />
     <None Remove="Services\DqtReporting\Migrations\0047_DegreeTypesTrainingSubjectsAndCountries.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0048_TrsQualificationsProfessionalStatusType.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -151,6 +152,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0045_InductionExemptWithoutReason.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0046_ProfessionalStatusUpdates.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0047_DegreeTypesTrainingSubjectsAndCountries.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0048_TrsQualificationsProfessionalStatusType.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`professional_status_type` was added to TRS qualifications tables recently and so needs to be added to the reporting DB too
