### PR TITLE
edit start date

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartDate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartDate.cshtml
@@ -1,0 +1,29 @@
+@page "/route/{qualificationId}/edit/start-date/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute.StartDateModel
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.TrainingStartDate);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@(Model.FromCheckAnswers == false ? LinkGenerator.RouteDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RouteEditStartDate(Model.QualificationId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
+            <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
+
+            <govuk-date-input asp-for="TrainingStartDate">
+                <govuk-date-input-fieldset>
+                    <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l" />
+                    <govuk-date-input-hint>For example, 27 3 2023</govuk-date-input-hint>
+                </govuk-date-input-fieldset>
+            </govuk-date-input>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteEditStartDateCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartDate.cshtml.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
+
+[Journey(JourneyNames.EditRouteToProfessionalStatus), RequireJourneyInstance]
+public class StartDateModel(
+    TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    [FromRoute]
+    public Guid QualificationId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    public Guid PersonId { get; set; }
+
+    [BindProperty]
+    [DateInput(ErrorMessagePrefix = "Start date")]
+    [Required(ErrorMessage = "Enter a start date")]
+    [Display(Name = "Enter the route start date")]
+    public DateOnly? TrainingStartDate { get; set; }
+
+    public void OnGet()
+    {
+        TrainingStartDate = JourneyInstance!.State.TrainingStartDate;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+        await JourneyInstance!.UpdateStateAsync(state => state.TrainingStartDate = TrainingStartDate);
+        if (TrainingStartDate.HasValue && JourneyInstance!.State.TrainingEndDate is DateOnly endDate && TrainingStartDate >= endDate)
+        {
+            return Redirect(linkGenerator.RouteEditEndDate(QualificationId, JourneyInstance.InstanceId));
+        }
+        return Redirect(FromCheckAnswers ?
+            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+            linkGenerator.RouteDetail(QualificationId, JourneyInstance.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancelAsync()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(linkGenerator.PersonQualifications(PersonId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+        PersonName = personInfo.Name;
+        PersonId = personInfo.PersonId;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
@@ -18,6 +18,10 @@ public partial class TrsLinkGenerator
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
     public string RouteAdd(Guid personId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Index", routeValues: new { personId });
+    public string RouteEditStartDate(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/StartDate", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string RouteEditStartDateCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/StartDate", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
     public string RouteEditEndDate(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/EndDate", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteEditEndDateCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/RouteDetailViewModel.cs
@@ -29,7 +29,9 @@ public class RouteDetailViewModel()
     public string[]? TrainingSubjects { get; set; }
     public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
 
+    public FieldRequirement StartDateRequired => QuestionDriverHelper.FieldRequired(RouteToProfessionalStatus.TrainingStartDateRequired, Status.GetStartDateRequirement());
     public FieldRequirement EndDateRequired => QuestionDriverHelper.FieldRequired(RouteToProfessionalStatus.TrainingEndDateRequired, Status.GetEndDateRequirement());
+    public FieldRequirement AwardDateRequired => QuestionDriverHelper.FieldRequired(RouteToProfessionalStatus.AwardDateRequired, Status.GetAwardDateRequirement());
     public FieldRequirement DegreeTypeRequired => QuestionDriverHelper.FieldRequired(RouteToProfessionalStatus.DegreeTypeRequired, Status.GetDegreeTypeRequirement());
 
     public bool FromCheckAnswers { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_RouteDetail.cshtml
@@ -9,10 +9,16 @@
         <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.Status.GetTitle()</govuk-summary-list-row-value>
     </govuk-summary-list-row>
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+    @if (Model.StartDateRequired != FieldRequirement.NotRequired)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-    </govuk-summary-list-row>
+        <govuk-summary-list-row-actions>
+            <govuk-summary-list-row-action data-testid="edit-start-date-link" href="@LinkGenerator.RouteEditStartDate(Model.QualificationId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" visually-hidden-text="start date">Change</govuk-summary-list-row-action>
+        </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
     @if (Model.EndDateRequired != FieldRequirement.NotRequired)
     {
         <govuk-summary-list-row>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/RouteToProfessionalStatusPageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/RouteToProfessionalStatusPageExtensions.cs
@@ -4,6 +4,11 @@ namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
 public static class RouteToProfessionalStatusPageExtensions
 {
+    public static Task AssertOnRouteEditStartDatePageAsync(this IPage page, Guid qualificationId)
+    {
+        return page.WaitForUrlPathAsync($"/route/{qualificationId}/edit/start-date");
+    }
+
     public static Task AssertOnRouteEditEndDatePageAsync(this IPage page, Guid qualificationId)
     {
         return page.WaitForUrlPathAsync($"/route/{qualificationId}/edit/end-date");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRoutePostRequestBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRoutePostRequestBuilder.cs
@@ -5,8 +5,8 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalSta
 
 public class EditRoutePostRequestBuilder
 {
-    private DateOnly? StartDate { get; set; }
-    private DateOnly? EndDate { get; set; }
+    private DateOnly? TrainingStartDate { get; set; }
+    private DateOnly? TrainingEndDate { get; set; }
     private ProfessionalStatusStatus? RouteStatus { get; set; }
     private Guid[]? ExemptionReasonIds { get; set; }
     private ChangeReasonOption? ChangeReason { get; set; }
@@ -19,13 +19,13 @@ public class EditRoutePostRequestBuilder
 
     public EditRoutePostRequestBuilder WithStartDate(DateOnly date)
     {
-        StartDate = date;
+        TrainingStartDate = date;
         return this;
     }
 
     public EditRoutePostRequestBuilder WithCompletedDate(DateOnly date)
     {
-        EndDate = date;
+        TrainingEndDate = date;
         return this;
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRouteStateBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRouteStateBuilder.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.EditRoute;
 
-public class EditRouteStateBuilder
+public class EditRouteStateBuilder()
 {
     private QualificationType? _qualificationType;
     private Guid? _routeToProfessionalStatusId;
@@ -22,15 +22,23 @@ public class EditRouteStateBuilder
     private ChangeReasonOption? _changeReasonOption;
     private ChangeReasonDetailsState _changeReasonDetail = new();
 
-
-    public async Task<EditRouteStateBuilder> WithPopulatedReferenceFieldsAsync(ReferenceDataCache referenceDataCache)
+    public EditRouteStateBuilder WithStatusWhereAllFieldsApply()
     {
-        _trainingCountryId = (await referenceDataCache.GetTrainingCountriesAsync()).RandomOne().CountryId;
-        _trainingProviderId = (await referenceDataCache.GetTrainingProvidersAsync()).RandomOne().TrainingProviderId;
-        _trainingSubjectIds = (await referenceDataCache.GetTrainingSubjectsAsync()).RandomSelection(1).Select(x => x.TrainingSubjectId).ToArray();
-        _trainingAgeSpecialismType = TrainingAgeSpecialismType.KeyStage1;
+        _status = ProfessionalStatusStatusRegistry.All
+            .Where(s => s.AgeRange != FieldRequirement.NotRequired
+                && s.AwardDate != FieldRequirement.NotRequired
+                && s.Country != FieldRequirement.NotRequired
+                && s.DegreeType != FieldRequirement.NotRequired
+                && s.EndDate != FieldRequirement.NotRequired
+                && s.InductionExemption != FieldRequirement.NotRequired
+                && s.TrainingProvider != FieldRequirement.NotRequired
+                && s.StartDate != FieldRequirement.NotRequired
+                && s.Subjects != FieldRequirement.NotRequired)
+            .RandomOne()
+            .Value;
         return this;
     }
+
     public EditRouteStateBuilder WithAwardedStatusFields(IClock clock)
     {
         _trainingStartDate = clock.Today.AddYears(-1);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/StartDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/StartDateTests.cs
@@ -1,0 +1,227 @@
+using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.EditRoute;
+
+public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Post_WhenStartDateIsAfterEndDate_NoError()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = startDate.AddDays(-1);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "TrainingStartDate.Day", $"{startDate:%d}" },
+                { "TrainingStartDate.Month", $"{startDate:%M}" },
+                { "TrainingStartDate.Year", $"{startDate:yyyy}" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenTrainingStartDateIsEntered_RedirectsToDetail()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = new DateOnly(2025, 01, 01);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/Start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "TrainingStartDate.Day", $"{startDate:%d}" },
+                { "TrainingStartDate.Month", $"{startDate:%M}" },
+                { "TrainingStartDate.Year", $"{startDate:yyyy}" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/route/{qualificationid}/edit/detail?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenNoStartDateIsEntered_ReturnsError()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = new DateOnly(2025, 01, 01);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusAsync())
+            .Where(r => r.TrainingStartDateRequired == FieldRequirement.Mandatory)
+            .RandomOne();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.InTraining)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationid}/edit/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>())
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "TrainingStartDate", "Enter a start date");
+    }
+
+    [Fact]
+    public async Task Post_StartDateAfterEndDate_RedirectToEndDatePage()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = startDate.AddDays(1);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusAsync())
+            .Where(r => r.TrainingStartDateRequired == FieldRequirement.Mandatory && r.TrainingEndDateRequired == FieldRequirement.Mandatory)
+            .RandomOne();
+        var status = ProfessionalStatusStatusRegistry.All
+            .Where(s => s.StartDate == FieldRequirement.Mandatory && s.EndDate == FieldRequirement.Mandatory)
+            .RandomOne()
+            .Value;
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationId = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(status)
+            .WithTrainingStartDate(startDate)
+            .WithTrainingEndDate(endDate)
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationId,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/route/{qualificationId}/edit/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContent(
+                new EditRoutePostRequestBuilder()
+                    .WithStartDate(endDate.AddDays(1))
+                    .Build())
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/route/{qualificationId}/edit/end-date?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Cancel_RedirectsToExpectedPage()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 01, 01);
+        var endDate = new DateOnly(2025, 01, 01);
+        var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusAsync()).Where(r => r.Name == "NI R").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithProfessionalStatus(r => r
+                .WithRoute(route.RouteToProfessionalStatusId)
+                .WithStatus(ProfessionalStatusStatus.Deferred)));
+        var qualificationid = person.ProfessionalStatuses.First().QualificationId;
+        var editRouteState = new EditRouteStateBuilder()
+            .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusId)
+            .WithStatus(ProfessionalStatusStatus.Deferred)
+            .WithTrainingStartDate(startDate)
+            .WithValidChangeReasonOption()
+            .WithDefaultChangeReasonNoUploadFileDetail()
+            .Build();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            qualificationid,
+            editRouteState
+            );
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/route/{qualificationid}/edit/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var cancelButton = doc.GetElementByTestId("cancel-button") as IHtmlButtonElement;
+        var redirectRequest = new HttpRequestMessage(HttpMethod.Post, cancelButton!.FormAction);
+        var redirectResponse = await HttpClient.SendAsync(redirectRequest);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)redirectResponse.StatusCode);
+        var location = redirectResponse.Headers.Location?.OriginalString;
+        Assert.Equal($"/persons/{person.PersonId}/qualifications", location);
+    }
+
+    private Task<JourneyInstance<EditRouteState>> CreateJourneyInstanceAsync(Guid qualificationId, EditRouteState? state = null) =>
+        CreateJourneyInstance(
+           JourneyNames.EditRouteToProfessionalStatus,
+           state ?? new EditRouteState(),
+           new KeyValuePair<string, object>("qualificationId", qualificationId));
+
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/TestDataHelper.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/TestDataHelper.cs
@@ -1,0 +1,50 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus;
+
+public static class TestDataHelper
+{
+    public static async Task<RouteToProfessionalStatus> GetRouteWhereAllFieldsApplyASync(ReferenceDataCache referenceDataCache)
+    {
+        return (await referenceDataCache.GetRoutesToProfessionalStatusAsync())
+            .Where(r => r.TrainingAgeSpecialismTypeRequired != FieldRequirement.NotRequired
+                && r.TrainingCountryRequired != FieldRequirement.NotRequired
+                && r.TrainingProviderRequired != FieldRequirement.NotRequired
+                && r.DegreeTypeRequired != FieldRequirement.NotRequired
+                && r.TrainingSubjectsRequired != FieldRequirement.NotRequired
+                && r.InductionExemptionRequired != FieldRequirement.NotRequired
+                && r.TrainingStartDateRequired != FieldRequirement.NotRequired
+                && r.TrainingEndDateRequired != FieldRequirement.NotRequired)
+            .RandomOne();
+    }
+
+    public static ProfessionalStatusStatus GetStatusWhereAllFieldsApply()
+    {
+        return ProfessionalStatusStatusRegistry.All
+            .Where(s => s.AgeRange != FieldRequirement.NotRequired
+                && s.AwardDate != FieldRequirement.NotRequired
+                && s.Country != FieldRequirement.NotRequired
+                && s.DegreeType != FieldRequirement.NotRequired
+                && s.EndDate != FieldRequirement.NotRequired
+                && s.InductionExemption != FieldRequirement.NotRequired
+                && s.TrainingProvider != FieldRequirement.NotRequired
+                && s.StartDate != FieldRequirement.NotRequired
+                && s.Subjects != FieldRequirement.NotRequired)
+            .RandomOne()
+            .Value;
+    }
+
+    public static Func<RouteToProfessionalStatus, bool> PropertyHasFieldRequirement<T>(string propertyName, FieldRequirement expectedValue)
+    {
+        return item =>
+        {
+            var property = typeof(T).GetProperty(propertyName);
+            if (property is null)
+            {
+                throw new InvalidOperationException($"Property {propertyName} not found on type RouteToProfessionalStatus");
+            }
+            var actualValue = property.GetValue(item);
+            return actualValue?.Equals(expectedValue) ?? false;
+        };
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AssertEx.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AssertEx.cs
@@ -68,4 +68,12 @@ public static partial class AssertEx
         Assert.NotEmpty(value);
         Assert.Equal(expected, value);
     }
+
+    public static void AssertChangeLinkExists(this IHtmlDocument doc, string keyContent)
+    {
+        var label = doc.QuerySelectorAll(".govuk-summary-list__key").Single(e => e.TextContent == keyContent);
+        Assert.NotNull(label);
+        var value = label.NextElementSibling;
+        Assert.NotNull(value!.NextElementSibling!.GetElementsByTagName("a").First());
+    }
 }


### PR DESCRIPTION
### Context

Edit start date

### Changes proposed in this pull request

https://trello.com/c/xLpCCppQ/871-routes-and-professional-status-front-end-edit-journey-start-date

Like edit end date but with different validation. If editing start date invalidates end date, user is taken to the end date page
