### PR TITLE
Add prevent-double-click to the GetATrn journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml
@@ -122,7 +122,7 @@
                 }
             </govuk-summary-list>
 
-            <govuk-button type="submit">Submit request</govuk-button>
+            <govuk-button prevent-double-click=true type="submit">Submit request</govuk-button>
         </form>
     </div>
 </div>


### PR DESCRIPTION
Get A Trn Journey has been experiencing users who are submitting multiple requests by double clicking the submit button from the CYA page. I've added prevent-double-click=true to the button to help mitigate the multiple requests. 