### PR TITLE
Added new job to backfill trn_request_metadata table

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/GeneratedOptionSets.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Models/GeneratedOptionSets.cs
@@ -3790,6 +3790,19 @@ namespace TeachingRecordSystem.Core.Dqt.Models
 	}
 	
 	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum SystemUser_SystemManagedUserType
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("C2 User", 1)]
+		C2User = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Entra User", 0)]
+		EntraUser = 0,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
 	public enum Task_PriorityCode
 	{
 		
@@ -3833,6 +3846,19 @@ namespace TeachingRecordSystem.Core.Dqt.Models
 		[System.Runtime.Serialization.EnumMemberAttribute()]
 		[OptionSetMetadataAttribute("Waiting on someone else", 2)]
 		Waitingonsomeoneelse = 4,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum aiinsightcard_Surface
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Table", 0, "#0000ff")]
+		Table = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Record", 1, "#0000ff")]
+		Record = 1,
 	}
 	
 	[System.Runtime.Serialization.DataContractAttribute()]
@@ -3880,6 +3906,10 @@ namespace TeachingRecordSystem.Core.Dqt.Models
 		[System.Runtime.Serialization.EnumMemberAttribute()]
 		[OptionSetMetadataAttribute("DesktopScript", 1, null, "authorize this credential in power automate for desktop script", "DesktopScript")]
 		DesktopScript = 280920001,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Network", 2, null, "authorize this credential in power automate for network", "Network")]
+		Network = 280920002,
 	}
 	
 	[System.Runtime.Serialization.DataContractAttribute()]
@@ -3931,6 +3961,19 @@ namespace TeachingRecordSystem.Core.Dqt.Models
 		[System.Runtime.Serialization.EnumMemberAttribute()]
 		[OptionSetMetadataAttribute("Link article and send article content", 3, "#0000ff")]
 		Linkarticleandsendarticlecontent = 3,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	public enum msdyn_msdyn_liveworkstream_msdyn_BlockCapacityforConsult
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Chat consult", 0, "#0000ff", "Chat consult")]
+		Chatconsult = 192350001,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		[OptionSetMetadataAttribute("Voice consult", 1, "#0000ff", "Voice consult")]
+		Voiceconsult = 192350002,
 	}
 	
 	[System.Runtime.Serialization.DataContractAttribute()]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -175,6 +175,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<TrnRequestMetadataBackfillJob>(
+                    nameof(TrnRequestMetadataBackfillJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 recurringJobManager.AddOrUpdate<ClearAlertsJob>(
                     nameof(ClearAlertsJob),
                     job => job.ExecuteAsync(),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -1,4 +1,3 @@
-
 using System.ServiceModel;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Configuration;
@@ -142,10 +141,10 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                             // Assuming the audit detail holds the new values under the "NewValue" key.
                             if (detail.NewValue is not null)
                             {
-                                string? firstName = null;
-                                string? middleName = null;
-                                string? lastName = null;
-                                DateTime? dob = null;
+                                string firstName = string.Empty;
+                                string middleName = string.Empty;
+                                string lastName = string.Empty;
+                                DateTime dob = default(DateTime);
                                 int? gender = null;
                                 string? email = null;
                                 var addressline1 = default(string?);
@@ -164,7 +163,7 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                                     middleName = middleNameOut;
                                 if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.LastName, out string lastNameOut))
                                     lastName = lastNameOut;
-                                if (detail.NewValue.TryGetAttributeValue<DateTime?>(Contact.Fields.BirthDate, out DateTime? dobOut))
+                                if (detail.NewValue.TryGetAttributeValue<DateTime>(Contact.Fields.BirthDate, out DateTime dobOut))
                                     dob = dobOut;
                                 if (detail.NewValue.TryGetAttributeValue<OptionSetValue?>(Contact.Fields.GenderCode, out OptionSetValue? genderOut))
                                     gender = genderOut?.Value;
@@ -209,7 +208,6 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                                 if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.dfeta_NINumber, out string ninoOut))
                                     nino = ninoOut;
 
-
                                 //applicationUser & contact.dfeta_TrnRequestID
                                 var requestId = contact.Value;
 
@@ -218,7 +216,7 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                                     ApplicationUserId = userId,
                                     RequestId = requestId,
                                     CreatedOn = createdOn,
-                                    DateOfBirth = dob.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false),
+                                    DateOfBirth = dob.ToDateOnlyWithDqtBstFix(isLocalTime: false),
                                     EmailAddress = email ?? string.Empty,
                                     IdentityVerified = false,
                                     Name = new string[] { firstName, middleName, lastName }.Where(s => !string.IsNullOrEmpty(s)).ToArray(),
@@ -287,8 +285,6 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
             await command.ExecuteNonQueryAsync();
         }
     }
-
-
 
     private async Task<IReadOnlyDictionary<Guid, AuditDetailCollection>> GetAuditRecordsAsync(
         string entityLogicalName,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -252,7 +252,10 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                                     AddressLine3 = addressline3,
                                     City = city,
                                     Country = country,
-                                    TrnToken = contact.Value.Item3
+                                    TrnToken = contact.Value.Item3,
+                                    FirstName = firstName,
+                                    MiddleName = middleName,
+                                    LastName = lastName
                                 });
 
                             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -1,0 +1,419 @@
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Newtonsoft.Json.Linq;
+using Npgsql;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbContextFactory, ICrmServiceClientProvider crmServiceClientProvider, IConfiguration config)
+{
+    private const int BATCH_SIZE = 25;
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        using var writeDbContext = await dbContextFactory.CreateDbContextAsync();
+        var serviceClient = crmServiceClientProvider.GetClient(TrsDataSyncService.CrmClientName);
+
+        //teacherid & trnrequestid dictionary
+        var teacherIds = new Dictionary<Guid, string>();
+
+        //fetch trn requests from trs
+        var trnRequests = writeDbContext.TrnRequests.ToArray();
+        var teacherDictionary = trnRequests
+            .GroupBy(x => x.TeacherId)
+            .ToDictionary(
+                g => g.Key,
+                g => (g.First().TrnToken)
+            );
+
+        foreach (var kvp in teacherDictionary)
+        {
+            if (!teacherIds.ContainsKey(kvp.Key))
+            {
+                teacherIds.Add(kvp.Key, kvp.Value!);
+            }
+        }
+
+        var contactsQuery = new QueryExpression(Contact.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+            Contact.Fields.CreatedOn,
+            Contact.Fields.dfeta_TrnRequestID
+            ),
+            PageInfo = new()
+            {
+                PageNumber = 1,
+                Count = 500
+            }
+        };
+        contactsQuery.Criteria.AddCondition(Contact.Fields.dfeta_TrnRequestID, ConditionOperator.NotNull);
+        EntityCollection result;
+
+        //fetch contacts from crm that have a trnrequestid
+        do
+        {
+            result = await serviceClient.RetrieveMultipleAsync(contactsQuery);
+            foreach (var record in result.Entities)
+            {
+                teacherIds.Add(record.Id, record.GetAttributeValue<string>(Contact.Fields.dfeta_TrnRequestID));
+            }
+            contactsQuery.PageInfo.PageNumber++;
+            contactsQuery.PageInfo.PagingCookie = result.PagingCookie;
+        } while (result.MoreRecords);
+
+        var connstring = config.GetPostgresConnectionString();
+        using var conn = new NpgsqlConnection(connstring);
+        await conn.OpenAsync();
+        using var transaction = await conn.BeginTransactionAsync();
+        await CreateTempTableAsync(conn, transaction);
+        try
+        {
+            foreach (var chunk in teacherIds.Chunk(BATCH_SIZE))
+            {
+                var recordsToInsert = new List<TrnRequestMetadata>();
+
+                foreach (var contact in chunk)
+                {
+                    var potentialDuplicate = false;
+                    //fetch contact
+                    var contactColumnSet = new ColumnSet(
+                        Contact.Fields.Address1_Line1,
+                        Contact.Fields.Address1_Line2,
+                        Contact.Fields.Address1_Line3,
+                        Contact.Fields.Address1_City,
+                        Contact.Fields.Address1_Country,
+                        Contact.Fields.Address1_PostalCode
+                    );
+                    var crmContact = serviceClient.Retrieve(Contact.EntityLogicalName, contact.Key, contactColumnSet);
+
+                    //fetch audit records for contact
+                    var query = new QueryExpression(Audit.EntityLogicalName)
+                    {
+                        ColumnSet = new ColumnSet(true),
+                        Orders =
+                        {
+                            new OrderExpression(Audit.Fields.CreatedOn, OrderType.Ascending)
+                        },
+                        PageInfo = new()
+                        {
+                            PageNumber = 1,
+                            Count = 500
+                        }
+                    };
+                    query.Criteria.AddCondition(Audit.Fields.ObjectId, ConditionOperator.Equal, contact.Key);
+                    query.Criteria.AddCondition(Audit.Fields.ObjectTypeCode, ConditionOperator.Equal, "contact");
+                    query.Criteria.AddCondition(Audit.Fields.Operation, ConditionOperator.Equal, 1); //create
+                    var auditRecords = await serviceClient.RetrieveMultipleAsync(query);
+                    var audit = auditRecords.Entities.FirstOrDefault();
+
+                    //fetch any tasks for contact that were created if flagged as potential duplicate
+                    var contactDuplicateTaskQuery = new QueryExpression(CrmTask.EntityLogicalName)
+                    {
+                        ColumnSet = new ColumnSet(true),
+                        PageInfo = new()
+                        {
+                            PageNumber = 1,
+                            Count = 500
+                        }
+                    };
+                    contactDuplicateTaskQuery.Criteria.AddCondition(CrmTask.Fields.Subject, ConditionOperator.Equal, "Notification for QTS Unit Team");
+                    contactDuplicateTaskQuery.Criteria.AddCondition(CrmTask.Fields.RegardingObjectId, ConditionOperator.Equal, contact.Key);
+                    contactDuplicateTaskQuery.Criteria.AddCondition(CrmTask.Fields.dfeta_potentialduplicateid, ConditionOperator.NotNull);
+                    var duplicateTasks = await serviceClient.RetrieveMultipleAsync(contactDuplicateTaskQuery);
+                    if(duplicateTasks.Entities.Any())
+                    {
+                        potentialDuplicate = true;
+                    }
+
+                    //audit is stored in json
+                    if (audit != null)
+                    {
+                        var json = audit["changedata"].ToString();
+                        JObject outerData = JObject.Parse(json);
+
+                        if (outerData.ContainsKey("changedAttributes"))
+                        {
+                            JToken changedAttributesToken = outerData["changedAttributes"];
+
+                            if (changedAttributesToken is not null && changedAttributesToken.Type == JTokenType.Array)
+                            {
+                                JArray changedAttributesArray = (JArray)changedAttributesToken;
+
+                                var firstNameObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "firstname", StringComparison.OrdinalIgnoreCase));
+                                var lastNameObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "lastname", StringComparison.OrdinalIgnoreCase));
+                                var dobObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "birthdate", StringComparison.OrdinalIgnoreCase));
+
+                                var middleNameObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "middlename", StringComparison.OrdinalIgnoreCase));
+
+                                var genderObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "gendercode", StringComparison.OrdinalIgnoreCase));
+
+                                var emailAddressObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "emailaddress1", StringComparison.OrdinalIgnoreCase));
+
+                                var postalcodeObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "address1_postalcode", StringComparison.OrdinalIgnoreCase));
+
+                                var fullNameObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "fullname", StringComparison.OrdinalIgnoreCase));
+
+                                var ninoObj = changedAttributesArray
+                                    .Children<JObject>()
+                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "dfeta_ninumber", StringComparison.OrdinalIgnoreCase));
+
+                                var applicationUser = audit.GetAttributeValue<EntityReference>("userid").Id;
+                                var createdOn = audit.GetAttributeValue<DateTime>("createdon");
+                                var firstName = firstNameObj?.Value<string>("newValue");
+                                var middleName = middleNameObj?.Value<string>("newValue");
+                                var lastName = lastNameObj?.Value<string>("newValue");
+                                var dob = dobObj?.Value<DateTime?>("newValue");
+                                var gender = genderObj?.Value<int?>("newValue");
+                                var addressline1 = default(string?);
+                                var addressline2 = default(string?);
+                                var addressline3 = default(string?);
+                                var city = default(string?);
+                                var country = default(string?);
+
+                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Line1, out string crmaddressline1))
+                                    addressline1 = crmaddressline1;
+                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Line2, out string crmaddressline2))
+                                    addressline2 = crmaddressline2;
+                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Line3, out string crmaddressline3))
+                                    addressline3 = crmaddressline3;
+                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_City, out string crmCity))
+                                    city = crmCity;
+                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Country, out string crmCountry))
+                                    country = crmCountry;
+
+                                var email = emailAddressObj?.Value<string>("newValue");
+                                var postcode = postalcodeObj?.Value<string>("newValue");
+                                var fullname = fullNameObj?.Value<string>("newValue");
+                                var nino = ninoObj?.Value<string>("newValue");
+
+                                //applicationUser & contact.dfeta_TrnRequestID
+                                var requestId = TrnRequestHelper.GetCrmTrnRequestId(applicationUser, contact.Value);
+
+                                recordsToInsert.Add(new TrnRequestMetadata
+                                {
+                                    ApplicationUserId = audit.GetAttributeValue<EntityReference>("userid").Id,
+                                    RequestId = requestId,
+                                    CreatedOn = audit.GetAttributeValue<DateTime>("createdon"),
+                                    DateOfBirth = dob.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false),
+                                    EmailAddress = email ?? string.Empty,
+                                    IdentityVerified = false,
+                                    Name = new string[] { firstName, middleName, lastName }.Where(s => !string.IsNullOrEmpty(s)).ToArray(),
+                                    Gender = gender,
+                                    Postcode = postcode ?? string.Empty,
+                                    PotentialDuplicate = potentialDuplicate,
+                                    OneLoginUserSubject = null,
+                                    NationalInsuranceNumber = nino,
+                                    AddressLine1 = addressline1,
+                                    AddressLine2 = addressline2,
+                                    AddressLine3 = addressline3,
+                                    City = city,
+                                    Country = country,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                if (recordsToInsert.Any())
+                {
+                    //batch insert temp table
+                    await BulkInsertAsync(conn, transaction, recordsToInsert);
+
+                    //upsert into trn_request_metadata
+                    await UpsertAsync(conn, transaction);
+
+                    //clear temp table for next iteration
+                    await TruncateTempImportTrnRequestMetadataAsync(conn, transaction);
+                }
+            }
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+        await transaction.CommitAsync();
+
+    }
+
+    private async Task CreateTempTableAsync(NpgsqlConnection conn, NpgsqlTransaction transaction)
+    {
+        using (var command = new NpgsqlCommand(@"
+            CREATE TEMP TABLE temp_import_trn_request_metadata (
+                application_user_id uuid NOT NULL,
+                request_id character varying(255) NOT NULL,
+                created_on timestamp with time zone NOT NULL,
+                date_of_birth date NOT NULL,
+                email_address text,
+                identity_verified boolean,
+                name text[] NOT NULL DEFAULT ARRAY[]::text[],
+                gender integer,
+                postcode text,
+                potential_duplicate boolean,
+                address_line1 text,
+                address_line2 text,
+                address_line3 text,
+                city text,
+                country text,
+                national_insurance_number text
+            ) ON COMMIT DROP;
+        ", conn, transaction))
+        {
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    public async Task TruncateTempImportTrnRequestMetadataAsync(NpgsqlConnection conn, NpgsqlTransaction transaction)
+    {
+        var sql = "TRUNCATE TABLE temp_import_trn_request_metadata;";
+        using (var command = new NpgsqlCommand(sql, conn, transaction))
+        {
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task UpsertAsync(NpgsqlConnection conn, NpgsqlTransaction transaction)
+    {
+        using (var command = new NpgsqlCommand(@"
+                INSERT INTO trn_request_metadata (
+                    application_user_id,
+                    request_id,
+                    created_on,
+                    date_of_birth,
+                    email_address,
+                    identity_verified,
+                    name,
+                    gender,
+                    postcode,
+                    potential_duplicate,
+                    address_line1,
+                    address_line2,
+                    address_line3,
+                    city,
+                    country,
+                    national_insurance_number
+                )
+                SELECT 
+                    application_user_id,
+                    request_id,
+                    created_on,
+                    date_of_birth,
+                    email_address,
+                    identity_verified,
+                    name,
+                    gender,
+                    postcode,
+                    potential_duplicate,
+                    address_line1,
+                    address_line2,
+                    address_line3,
+                    city,
+                    country,
+                    national_insurance_number
+                FROM temp_import_trn_request_metadata
+                ON CONFLICT (application_user_id, request_id)
+                DO UPDATE SET 
+                    created_on = EXCLUDED.created_on,
+                    date_of_birth = EXCLUDED.date_of_birth,
+                    email_address = EXCLUDED.email_address,
+                    identity_verified = EXCLUDED.identity_verified,
+                    name = EXCLUDED.name,
+                    gender = EXCLUDED.gender,
+                    postcode = EXCLUDED.postcode,
+                    potential_duplicate = EXCLUDED.potential_duplicate,
+                    address_line1 = EXCLUDED.address_line1,
+                    address_line2 = EXCLUDED.address_line2,
+                    address_line3 = EXCLUDED.address_line3,
+                    city = EXCLUDED.city,
+                    country = EXCLUDED.country,
+                    national_insurance_number = EXCLUDED.national_insurance_number;
+            ", conn, transaction))
+        {
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    /// <summary>
+    /// inserts into temporary table (in batches)
+    /// </summary>
+    /// <param name="conn"></param>
+    /// <param name="transaction"></param>
+    /// <param name="records"></param>
+    /// <returns></returns>
+    private async Task BulkInsertAsync(NpgsqlConnection conn, NpgsqlTransaction transaction, List<TrnRequestMetadata> records)
+    {
+        using var writer = await conn.BeginBinaryImportAsync(@"
+            COPY temp_import_trn_request_metadata (
+                application_user_id,
+                request_id,
+                created_on,
+                date_of_birth, 
+                email_address,
+                identity_verified,
+                name,
+                gender,
+                postcode,
+                potential_duplicate,
+                address_line1,
+                address_line2,
+                address_line3,
+                city,
+                country,
+                national_insurance_number
+            ) FROM STDIN (FORMAT BINARY)");
+
+        foreach (var record in records)
+        {
+            await writer.StartRowAsync();
+            await writer.WriteAsync(record.ApplicationUserId, NpgsqlTypes.NpgsqlDbType.Uuid);
+            await writer.WriteAsync(record.RequestId, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.CreatedOn, NpgsqlTypes.NpgsqlDbType.TimestampTz);
+            await writer.WriteAsync(record.DateOfBirth.ToDateTime(TimeOnly.MinValue), NpgsqlTypes.NpgsqlDbType.Date);
+            await writer.WriteAsync(record.EmailAddress, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.IdentityVerified, NpgsqlTypes.NpgsqlDbType.Boolean);
+            await writer.WriteAsync(record.Name ?? Array.Empty<string>(), NpgsqlTypes.NpgsqlDbType.Array | NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.Gender ?? (object)DBNull.Value, NpgsqlTypes.NpgsqlDbType.Integer);
+            await writer.WriteAsync(record.Postcode, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.PotentialDuplicate, NpgsqlTypes.NpgsqlDbType.Boolean);
+            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // address_line1
+            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // address_line2
+            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // address_line3
+            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // city
+            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // country
+            await writer.WriteAsync(record.NationalInsuranceNumber, NpgsqlTypes.NpgsqlDbType.Text);  // national_insurance_number
+        }
+
+        await writer.CompleteAsync();
+    }
+
+    public class TrnRequestBackfillItem
+    {
+        public Guid ContactId { get; set; }
+        public string? addressLine1 { get; set; }
+        public string? AddressLine2 { get; set; }
+        public string? AddressLine3 { get; set; }
+        public string? city { get; set; }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -167,7 +167,7 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                                 var city = default(string?);
                                 var country = default(string?);
                                 var nino = default(string?);
-                                var postcode = default(string?);                  
+                                var postcode = default(string?);
                                 DateTime createdOn = detail.AuditRecord.GetAttributeValue<DateTime>(Audit.Fields.CreatedOn);
                                 if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.FirstName, out string firstNameOut))
                                     firstName = firstNameOut;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -492,9 +492,9 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                 city = COALESCE(EXCLUDED.city, trn_request_metadata.city),
                 country = COALESCE(EXCLUDED.country, trn_request_metadata.country),
                 national_insurance_number = COALESCE(EXCLUDED.national_insurance_number, trn_request_metadata.national_insurance_number),
-                trn_token = COALESCE(EXCLUDED.trn_token, trn_request_metadata.trn_token);
-                first_name = COALESCE(EXCLUDED.first_name, trn_request_metadata.first_name);
-                middle_name = COALESCE(EXCLUDED.middle_name, trn_request_metadata.middle_name);
+                trn_token = COALESCE(EXCLUDED.trn_token, trn_request_metadata.trn_token),
+                first_name = COALESCE(EXCLUDED.first_name, trn_request_metadata.first_name),
+                middle_name = COALESCE(EXCLUDED.middle_name, trn_request_metadata.middle_name),
                 last_name = COALESCE(EXCLUDED.last_name, trn_request_metadata.last_name);
         ", conn, transaction))
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -305,7 +305,10 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                 city text,
                 country text,
                 national_insurance_number text,
-                trn_token text
+                trn_token text,
+                first_name text,
+                middle_name text,
+                last_name text
             ) ON COMMIT DROP;
         ", conn, transaction))
         {
@@ -446,7 +449,10 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                 city,
                 country,
                 national_insurance_number,
-                trn_token
+                trn_token,
+                first_name,
+                middle_name,
+                last_name
             )
             SELECT 
                 application_user_id,
@@ -465,7 +471,10 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                 city,
                 country,
                 national_insurance_number,
-                trn_token
+                trn_token,
+                first_name,
+                middle_name,
+                last_name
             FROM temp_import_trn_request_metadata
             ON CONFLICT (application_user_id, request_id)
             DO UPDATE SET 
@@ -484,6 +493,9 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                 country = COALESCE(EXCLUDED.country, trn_request_metadata.country),
                 national_insurance_number = COALESCE(EXCLUDED.national_insurance_number, trn_request_metadata.national_insurance_number),
                 trn_token = COALESCE(EXCLUDED.trn_token, trn_request_metadata.trn_token);
+                first_name = COALESCE(EXCLUDED.first_name, trn_request_metadata.first_name);
+                middle_name = COALESCE(EXCLUDED.middle_name, trn_request_metadata.middle_name);
+                last_name = COALESCE(EXCLUDED.last_name, trn_request_metadata.last_name);
         ", conn, transaction))
         {
             await command.ExecuteNonQueryAsync();
@@ -518,7 +530,10 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                 city,
                 country,
                 national_insurance_number,
-                trn_token
+                trn_token,
+                first_name,
+                middle_name,
+                last_name
             ) FROM STDIN (FORMAT BINARY)");
 
         foreach (var record in records)
@@ -541,6 +556,9 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
             await writer.WriteAsync(record.Country, NpgsqlTypes.NpgsqlDbType.Text);
             await writer.WriteAsync(record.NationalInsuranceNumber, NpgsqlTypes.NpgsqlDbType.Text);  // national_insurance_number
             await writer.WriteAsync(record.TrnToken, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.FirstName, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.MiddleName, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.LastName, NpgsqlTypes.NpgsqlDbType.Text);
         }
 
         await writer.CompleteAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -1,8 +1,12 @@
 
+using System.ServiceModel;
+using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
-using Newtonsoft.Json.Linq;
 using Npgsql;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
@@ -11,7 +15,9 @@ using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.Core.Jobs;
 
-public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbContextFactory, ICrmServiceClientProvider crmServiceClientProvider, IConfiguration config)
+public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbContextFactory, ICrmServiceClientProvider crmServiceClientProvider, IConfiguration config,
+    ILogger<TrsDataSyncHelper> logger,
+    IOrganizationServiceAsync2 organizationService)
 {
     private const int BATCH_SIZE = 25;
 
@@ -44,6 +50,7 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
         {
             ColumnSet = new ColumnSet(
             Contact.Fields.CreatedOn,
+            Contact.Fields.CreatedBy,
             Contact.Fields.dfeta_TrnRequestID
             ),
             PageInfo = new()
@@ -61,7 +68,10 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
             result = await serviceClient.RetrieveMultipleAsync(contactsQuery);
             foreach (var record in result.Entities)
             {
-                teacherIds.Add(record.Id, record.GetAttributeValue<string>(Contact.Fields.dfeta_TrnRequestID));
+                var createdByUserId = record.GetAttributeValue<EntityReference>(Contact.Fields.CreatedBy).Id;
+                var trnRequestId = record.GetAttributeValue<string>(Contact.Fields.dfeta_TrnRequestID);
+                string request = TrnRequestHelper.GetCrmTrnRequestId(createdByUserId, trnRequestId);
+                teacherIds.Add(record.Id, trnRequestId);
             }
             contactsQuery.PageInfo.PageNumber++;
             contactsQuery.PageInfo.PagingCookie = result.PagingCookie;
@@ -81,6 +91,7 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                 foreach (var contact in chunk)
                 {
                     var potentialDuplicate = false;
+
                     //fetch contact
                     var contactColumnSet = new ColumnSet(
                         Contact.Fields.Address1_Line1,
@@ -92,25 +103,6 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                     );
                     var crmContact = serviceClient.Retrieve(Contact.EntityLogicalName, contact.Key, contactColumnSet);
 
-                    //fetch audit records for contact
-                    var query = new QueryExpression(Audit.EntityLogicalName)
-                    {
-                        ColumnSet = new ColumnSet(true),
-                        Orders =
-                        {
-                            new OrderExpression(Audit.Fields.CreatedOn, OrderType.Ascending)
-                        },
-                        PageInfo = new()
-                        {
-                            PageNumber = 1,
-                            Count = 500
-                        }
-                    };
-                    query.Criteria.AddCondition(Audit.Fields.ObjectId, ConditionOperator.Equal, contact.Key);
-                    query.Criteria.AddCondition(Audit.Fields.ObjectTypeCode, ConditionOperator.Equal, "contact");
-                    query.Criteria.AddCondition(Audit.Fields.Operation, ConditionOperator.Equal, 1); //create
-                    var auditRecords = await serviceClient.RetrieveMultipleAsync(query);
-                    var audit = auditRecords.Entities.FirstOrDefault();
 
                     //fetch any tasks for contact that were created if flagged as potential duplicate
                     var contactDuplicateTaskQuery = new QueryExpression(CrmTask.EntityLogicalName)
@@ -126,102 +118,112 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                     contactDuplicateTaskQuery.Criteria.AddCondition(CrmTask.Fields.RegardingObjectId, ConditionOperator.Equal, contact.Key);
                     contactDuplicateTaskQuery.Criteria.AddCondition(CrmTask.Fields.dfeta_potentialduplicateid, ConditionOperator.NotNull);
                     var duplicateTasks = await serviceClient.RetrieveMultipleAsync(contactDuplicateTaskQuery);
-                    if(duplicateTasks.Entities.Any())
+                    if (duplicateTasks.Entities.Any())
                     {
                         potentialDuplicate = true;
                     }
 
-                    //audit is stored in json
-                    if (audit != null)
+
+                    // fetch audits
+                    IEnumerable<Guid> ids = new[] { contact.Key };
+                    var audit = await GetAuditRecordsAsync(Contact.EntityLogicalName, ids, cancellationToken);
+
+                    var auditDetails = audit[contact.Key];
+
+                    var createAuditDetails = auditDetails.AuditDetails
+                        .OfType<AttributeAuditDetail>()
+                        .Where(a => a.AuditRecord.ToEntity<Audit>().Action == Audit_Action.Create);
+
+                    var attributeNames = new List<string>();
+                    if (createAuditDetails.Count() > 0)
                     {
-                        var json = audit["changedata"].ToString();
-                        JObject outerData = JObject.Parse(json);
-
-                        if (outerData.ContainsKey("changedAttributes"))
+                        foreach (var detail in createAuditDetails)
                         {
-                            JToken changedAttributesToken = outerData["changedAttributes"];
-
-                            if (changedAttributesToken is not null && changedAttributesToken.Type == JTokenType.Array)
+                            // Assuming the audit detail holds the new values under the "NewValue" key.
+                            if (detail.NewValue is not null)
                             {
-                                JArray changedAttributesArray = (JArray)changedAttributesToken;
-
-                                var firstNameObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "firstname", StringComparison.OrdinalIgnoreCase));
-                                var lastNameObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "lastname", StringComparison.OrdinalIgnoreCase));
-                                var dobObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "birthdate", StringComparison.OrdinalIgnoreCase));
-
-                                var middleNameObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "middlename", StringComparison.OrdinalIgnoreCase));
-
-                                var genderObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "gendercode", StringComparison.OrdinalIgnoreCase));
-
-                                var emailAddressObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "emailaddress1", StringComparison.OrdinalIgnoreCase));
-
-                                var postalcodeObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "address1_postalcode", StringComparison.OrdinalIgnoreCase));
-
-                                var fullNameObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "fullname", StringComparison.OrdinalIgnoreCase));
-
-                                var ninoObj = changedAttributesArray
-                                    .Children<JObject>()
-                                    .FirstOrDefault(jObj => string.Equals(jObj.Value<string>("logicalName"), "dfeta_ninumber", StringComparison.OrdinalIgnoreCase));
-
-                                var applicationUser = audit.GetAttributeValue<EntityReference>("userid").Id;
-                                var createdOn = audit.GetAttributeValue<DateTime>("createdon");
-                                var firstName = firstNameObj?.Value<string>("newValue");
-                                var middleName = middleNameObj?.Value<string>("newValue");
-                                var lastName = lastNameObj?.Value<string>("newValue");
-                                var dob = dobObj?.Value<DateTime?>("newValue");
-                                var gender = genderObj?.Value<int?>("newValue");
+                                string? firstName = null;
+                                string? middleName = null;
+                                string? lastName = null;
+                                DateTime? dob = null;
+                                int? gender = null;
+                                string? email = null;
                                 var addressline1 = default(string?);
                                 var addressline2 = default(string?);
                                 var addressline3 = default(string?);
                                 var city = default(string?);
                                 var country = default(string?);
+                                var nino = default(string?);
+                                var postcode = default(string?);
+                                Guid userId = detail.AuditRecord.GetAttributeValue<EntityReference>(Audit.Fields.UserId).Id;
+                                DateTime createdOn = detail.AuditRecord.GetAttributeValue<DateTime>(Audit.Fields.CreatedOn);
 
-                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Line1, out string crmaddressline1))
-                                    addressline1 = crmaddressline1;
-                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Line2, out string crmaddressline2))
-                                    addressline2 = crmaddressline2;
-                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Line3, out string crmaddressline3))
-                                    addressline3 = crmaddressline3;
-                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_City, out string crmCity))
-                                    city = crmCity;
-                                if (crmContact.TryGetAttributeValue<string>(Contact.Fields.Address1_Country, out string crmCountry))
-                                    country = crmCountry;
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.FirstName, out string firstNameOut))
+                                    firstName = firstNameOut;
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.MiddleName, out string middleNameOut))
+                                    middleName = middleNameOut;
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.LastName, out string lastNameOut))
+                                    lastName = lastNameOut;
+                                if (detail.NewValue.TryGetAttributeValue<DateTime?>(Contact.Fields.BirthDate, out DateTime? dobOut))
+                                    dob = dobOut;
+                                if (detail.NewValue.TryGetAttributeValue<OptionSetValue?>(Contact.Fields.GenderCode, out OptionSetValue? genderOut))
+                                    gender = genderOut?.Value;
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.EMailAddress1, out string emailOut))
+                                    email = emailOut;
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.Address1_Line1, out string addressline1Out))
+                                    addressline1 = addressline1Out;
+                                else
+                                {
+                                    addressline1 = crmContact.GetAttributeValue<string>(Contact.Fields.Address1_Line1);
+                                }
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.Address1_Line2, out string addressline2Out))
+                                    addressline2 = addressline2Out;
+                                else
+                                {
+                                    addressline2 = crmContact.GetAttributeValue<string>(Contact.Fields.Address1_Line2);
+                                }
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.Address1_Line3, out string addressline3Out))
+                                    addressline3 = addressline3Out;
+                                else
+                                {
+                                    addressline3 = crmContact.GetAttributeValue<string>(Contact.Fields.Address1_Line3);
+                                }
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.Address1_City, out string cityOut))
+                                    city = cityOut;
+                                else
+                                {
+                                    city = crmContact.GetAttributeValue<string>(Contact.Fields.Address1_City);
+                                }
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.Address1_Country, out string countryOut))
+                                    country = countryOut;
+                                else
+                                {
+                                    country = crmContact.GetAttributeValue<string>(Contact.Fields.Address1_Country);
+                                }
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.Address1_PostalCode, out string postcodeOut))
+                                    postcode = postcodeOut;
+                                else
+                                {
+                                    addressline1 = crmContact.GetAttributeValue<string>(Contact.Fields.Address1_PostalCode);
+                                }
+                                if (detail.NewValue.TryGetAttributeValue<string>(Contact.Fields.dfeta_NINumber, out string ninoOut))
+                                    nino = ninoOut;
 
-                                var email = emailAddressObj?.Value<string>("newValue");
-                                var postcode = postalcodeObj?.Value<string>("newValue");
-                                var fullname = fullNameObj?.Value<string>("newValue");
-                                var nino = ninoObj?.Value<string>("newValue");
 
                                 //applicationUser & contact.dfeta_TrnRequestID
-                                var requestId = TrnRequestHelper.GetCrmTrnRequestId(applicationUser, contact.Value);
+                                var requestId = contact.Value;
 
                                 recordsToInsert.Add(new TrnRequestMetadata
                                 {
-                                    ApplicationUserId = audit.GetAttributeValue<EntityReference>("userid").Id,
+                                    ApplicationUserId = userId,
                                     RequestId = requestId,
-                                    CreatedOn = audit.GetAttributeValue<DateTime>("createdon"),
+                                    CreatedOn = createdOn,
                                     DateOfBirth = dob.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false),
                                     EmailAddress = email ?? string.Empty,
                                     IdentityVerified = false,
                                     Name = new string[] { firstName, middleName, lastName }.Where(s => !string.IsNullOrEmpty(s)).ToArray(),
                                     Gender = gender,
-                                    Postcode = postcode ?? string.Empty,
+                                    Postcode = postcode,
                                     PotentialDuplicate = potentialDuplicate,
                                     OneLoginUserSubject = null,
                                     NationalInsuranceNumber = nino,
@@ -231,6 +233,7 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                                     City = city,
                                     Country = country,
                                 });
+
                             }
                         }
                     }
@@ -285,6 +288,97 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
         }
     }
 
+
+
+    private async Task<IReadOnlyDictionary<Guid, AuditDetailCollection>> GetAuditRecordsAsync(
+        string entityLogicalName,
+        IEnumerable<Guid> ids,
+        CancellationToken cancellationToken)
+    {
+        // Throttle the amount of concurrent requests
+        using var requestThrottle = new SemaphoreSlim(20, 20);
+
+        // Keep track of the last seen 'retry-after' value
+        var retryDelayUpdateLock = new object();
+        var retryDelay = Task.Delay(0, cancellationToken);
+
+        void UpdateRetryDelay(TimeSpan ts)
+        {
+            lock (retryDelayUpdateLock)
+            {
+                retryDelay = Task.Delay(ts, cancellationToken);
+            }
+        }
+
+        return (await Task.WhenAll(ids
+            .Chunk(10)
+            .Select(async chunk =>
+            {
+                var request = new ExecuteMultipleRequest()
+                {
+                    Requests = new(),
+                    Settings = new()
+                    {
+                        ContinueOnError = false,
+                        ReturnResponses = true
+                    }
+                };
+
+                // The following is not supported by FakeXrmEasy hence the check above to allow more test coverage
+                request.Requests.AddRange(chunk.Select(e => new RetrieveRecordChangeHistoryRequest() { Target = e.ToEntityReference(entityLogicalName) }));
+
+                ExecuteMultipleResponse response;
+                while (true)
+                {
+                    await retryDelay;
+                    await requestThrottle.WaitAsync(cancellationToken);
+                    try
+                    {
+                        response = (ExecuteMultipleResponse)await organizationService.ExecuteAsync(request, cancellationToken);
+                    }
+                    catch (FaultException fex) when (fex.IsCrmRateLimitException(out var retryAfter))
+                    {
+                        logger.LogWarning("Hit CRM service limits getting {entityLogicalName} audit records; Fault exception. Retrying after {retryAfter} seconds.", entityLogicalName, retryAfter.TotalSeconds);
+                        UpdateRetryDelay(retryAfter);
+                        continue;
+                    }
+                    finally
+                    {
+                        requestThrottle.Release();
+                    }
+
+                    if (response.IsFaulted)
+                    {
+                        var firstFault = response.Responses.First(r => r.Fault is not null).Fault;
+
+                        if (firstFault.IsCrmRateLimitFault(out var retryAfter))
+                        {
+                            logger.LogWarning("Hit CRM service limits getting {entityLogicalName} audit records; CRM rate limit fault. Retrying after {retryAfter} seconds.", entityLogicalName, retryAfter.TotalSeconds);
+                            UpdateRetryDelay(retryAfter);
+                            continue;
+                        }
+                        else if (firstFault.Message.Contains("The HTTP status code of the response was not expected (429)"))
+                        {
+                            logger.LogWarning("Hit CRM service limits getting {entityLogicalName} audit records; 429 too many requests", entityLogicalName);
+                            UpdateRetryDelay(TimeSpan.FromMinutes(2));
+                            continue;
+                        }
+
+                        throw new FaultException<OrganizationServiceFault>(firstFault, new FaultReason(firstFault.Message));
+                    }
+
+                    break;
+                }
+
+                return response.Responses.Zip(
+                    chunk,
+                    (r, e) => (Id: e, ((RetrieveRecordChangeHistoryResponse)r.Response).AuditDetailCollection));
+            })))
+            .SelectMany(b => b)
+            .ToDictionary(t => t.Id, t => t.AuditDetailCollection);
+    }
+
+
     public async Task TruncateTempImportTrnRequestMetadataAsync(NpgsqlConnection conn, NpgsqlTransaction transaction)
     {
         var sql = "TRUNCATE TABLE temp_import_trn_request_metadata;";
@@ -294,66 +388,70 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
         }
     }
 
+    // Insert if row with requestid & application user id does not exist
+    // Update row from audit history, but do not null out the fields if a field is null
+    // from the audit history.
     private async Task UpsertAsync(NpgsqlConnection conn, NpgsqlTransaction transaction)
     {
         using (var command = new NpgsqlCommand(@"
-                INSERT INTO trn_request_metadata (
-                    application_user_id,
-                    request_id,
-                    created_on,
-                    date_of_birth,
-                    email_address,
-                    identity_verified,
-                    name,
-                    gender,
-                    postcode,
-                    potential_duplicate,
-                    address_line1,
-                    address_line2,
-                    address_line3,
-                    city,
-                    country,
-                    national_insurance_number
-                )
-                SELECT 
-                    application_user_id,
-                    request_id,
-                    created_on,
-                    date_of_birth,
-                    email_address,
-                    identity_verified,
-                    name,
-                    gender,
-                    postcode,
-                    potential_duplicate,
-                    address_line1,
-                    address_line2,
-                    address_line3,
-                    city,
-                    country,
-                    national_insurance_number
-                FROM temp_import_trn_request_metadata
-                ON CONFLICT (application_user_id, request_id)
-                DO UPDATE SET 
-                    created_on = EXCLUDED.created_on,
-                    date_of_birth = EXCLUDED.date_of_birth,
-                    email_address = EXCLUDED.email_address,
-                    identity_verified = EXCLUDED.identity_verified,
-                    name = EXCLUDED.name,
-                    gender = EXCLUDED.gender,
-                    postcode = EXCLUDED.postcode,
-                    potential_duplicate = EXCLUDED.potential_duplicate,
-                    address_line1 = EXCLUDED.address_line1,
-                    address_line2 = EXCLUDED.address_line2,
-                    address_line3 = EXCLUDED.address_line3,
-                    city = EXCLUDED.city,
-                    country = EXCLUDED.country,
-                    national_insurance_number = EXCLUDED.national_insurance_number;
-            ", conn, transaction))
+            INSERT INTO trn_request_metadata (
+                application_user_id,
+                request_id,
+                created_on,
+                date_of_birth,
+                email_address,
+                identity_verified,
+                name,
+                gender,
+                postcode,
+                potential_duplicate,
+                address_line1,
+                address_line2,
+                address_line3,
+                city,
+                country,
+                national_insurance_number
+            )
+            SELECT 
+                application_user_id,
+                request_id,
+                created_on,
+                date_of_birth,
+                email_address,
+                identity_verified,
+                name,
+                gender,
+                postcode,
+                potential_duplicate,
+                address_line1,
+                address_line2,
+                address_line3,
+                city,
+                country,
+                national_insurance_number
+            FROM temp_import_trn_request_metadata
+            ON CONFLICT (application_user_id, request_id)
+            DO UPDATE SET 
+                created_on = COALESCE(EXCLUDED.created_on, trn_request_metadata.created_on),
+                date_of_birth = COALESCE(EXCLUDED.date_of_birth, trn_request_metadata.date_of_birth),
+                email_address = COALESCE(EXCLUDED.email_address, trn_request_metadata.email_address),
+                identity_verified = COALESCE(EXCLUDED.identity_verified, trn_request_metadata.identity_verified),
+                name = COALESCE(EXCLUDED.name, trn_request_metadata.name),
+                gender = COALESCE(EXCLUDED.gender, trn_request_metadata.gender),
+                postcode = COALESCE(EXCLUDED.postcode, trn_request_metadata.postcode),
+                potential_duplicate = COALESCE(EXCLUDED.potential_duplicate, trn_request_metadata.potential_duplicate),
+                address_line1 = COALESCE(EXCLUDED.address_line1, trn_request_metadata.address_line1),
+                address_line2 = COALESCE(EXCLUDED.address_line2, trn_request_metadata.address_line2),
+                address_line3 = COALESCE(EXCLUDED.address_line3, trn_request_metadata.address_line3),
+                city = COALESCE(EXCLUDED.city, trn_request_metadata.city),
+                country = COALESCE(EXCLUDED.country, trn_request_metadata.country),
+                national_insurance_number = COALESCE(EXCLUDED.national_insurance_number, trn_request_metadata.national_insurance_number);
+        ", conn, transaction))
         {
             await command.ExecuteNonQueryAsync();
         }
     }
+
 
     /// <summary>
     /// inserts into temporary table (in batches)
@@ -397,11 +495,11 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
             await writer.WriteAsync(record.Gender ?? (object)DBNull.Value, NpgsqlTypes.NpgsqlDbType.Integer);
             await writer.WriteAsync(record.Postcode, NpgsqlTypes.NpgsqlDbType.Text);
             await writer.WriteAsync(record.PotentialDuplicate, NpgsqlTypes.NpgsqlDbType.Boolean);
-            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // address_line1
-            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // address_line2
-            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // address_line3
-            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // city
-            await writer.WriteAsync(DBNull.Value, NpgsqlTypes.NpgsqlDbType.Text);  // country
+            await writer.WriteAsync(record.AddressLine1, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.AddressLine2, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.AddressLine3, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.City, NpgsqlTypes.NpgsqlDbType.Text);
+            await writer.WriteAsync(record.Country, NpgsqlTypes.NpgsqlDbType.Text);
             await writer.WriteAsync(record.NationalInsuranceNumber, NpgsqlTypes.NpgsqlDbType.Text);  // national_insurance_number
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/TrnRequestMetadataBackfillJob.cs
@@ -115,7 +115,15 @@ public class TrnRequestMetadataBackfillJob(IDbContextFactory<TrsDbContext> dbCon
                         Contact.Fields.Address1_Country,
                         Contact.Fields.Address1_PostalCode
                     );
-                    var crmContact = serviceClient.Retrieve(Contact.EntityLogicalName, contact.Key, contactColumnSet);
+                    Entity? crmContact = null;
+
+                    try
+                    {
+                        crmContact = serviceClient.Retrieve(Contact.EntityLogicalName, contact.Key, contactColumnSet);
+                    } catch(Exception)
+                    {
+                        continue;
+                    }
 
 
                     //fetch any tasks for contact that were created if flagged as potential duplicate


### PR DESCRIPTION
This PR is to backfill **trn_request_metadata** table - This branch isn't to be merged. Its raised as a PR to help review that it's correct before being run in production.

The sql statement will insert trn_requests_metadata that is missing, and update requests if the update changes are not null. It will never attempt to set existing field to null.