### PR TITLE
Populate dfeta_allowpiiupdatesfromregister based on AllowContactPiiUpdatesFromUserIds config setting

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Testing.json
@@ -10,5 +10,8 @@
     }
   },
   "ConcurrentNameChangeWindowSeconds": 1,
-  "GetAnIdentity:BaseAddress": "https://dummy/"
+  "GetAnIdentity:BaseAddress": "https://dummy/",
+  "AllowContactPiiUpdatesFromUserIds": [
+    "c0c8c511-e8e4-4b8e-96e3-55085dafc05d"
+  ]
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTeacherQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTeacherQuery.cs
@@ -17,4 +17,5 @@ public class CreateContactQuery : ICrmQuery<Guid>
     public required string? Trn { get; init; }
     public required string? TrnRequestId { get; init; }
     public required IEnumerable<dfeta_TrsOutboxMessage> OutboxMessages { get; init; }
+    public required bool AllowPiiUpdates { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
@@ -29,9 +29,9 @@ public class CreateContactHandler : ICrmQueryHandler<CreateContactQuery, Guid>
             GenderCode = query.Gender,
             dfeta_NINumber = query.NationalInsuranceNumber,
             EMailAddress1 = query.EmailAddress,
-            dfeta_AllowPiiUpdatesFromRegister = false,
+            dfeta_AllowPiiUpdatesFromRegister = query.AllowPiiUpdates,
             dfeta_TrnRequestID = query.TrnRequestId,
-            dfeta_TRN = query.Trn
+            dfeta_TRN = query.Trn,
         };
 
         if (query.Trn is null)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Startup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Startup.cs
@@ -2,13 +2,20 @@ namespace TeachingRecordSystem.Api.Tests;
 
 public class Startup
 {
-    public void ConfigureHost(IHostBuilder hostBuilder) =>
+    public void ConfigureHost(IHostBuilder hostBuilder)
+    {
         hostBuilder
             .ConfigureHostConfiguration(builder => builder
                 .AddUserSecrets<HostFixture>(optional: true)
-                .AddEnvironmentVariables())
+                .AddEnvironmentVariables()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string?>
+                    {
+                        ["AllowContactPiiUpdatesFromUserIds:0"] = HostFixture.DefaultApplicationUserId.ToString()
+                    }))
             .ConfigureServices(services =>
             {
                 services.AddSingleton<HostFixture>();
             });
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Startup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.Tests/Startup.cs
@@ -7,12 +7,7 @@ public class Startup
         hostBuilder
             .ConfigureHostConfiguration(builder => builder
                 .AddUserSecrets<HostFixture>(optional: true)
-                .AddEnvironmentVariables()
-                .AddInMemoryCollection(
-                    new Dictionary<string, string?>
-                    {
-                        ["AllowContactPiiUpdatesFromUserIds:0"] = HostFixture.DefaultApplicationUserId.ToString()
-                    }))
+                .AddEnvironmentVariables())
             .ConfigureServices(services =>
             {
                 services.AddSingleton<HostFixture>();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
@@ -46,7 +46,8 @@ public class CreateContactTests : IAsyncLifetime
             Trn = trn,
             PotentialDuplicates = [],
             ApplicationUserName = "Tests",
-            OutboxMessages = []
+            OutboxMessages = [],
+            AllowPiiUpdates = true
         };
 
         // Act
@@ -65,6 +66,7 @@ public class CreateContactTests : IAsyncLifetime
         Assert.Equal(nino, contact.dfeta_NINumber);
         Assert.Equal(dateOfBirth, contact.BirthDate.ToDateOnlyWithDqtBstFix(true));
         Assert.Equal(gender, contact.GenderCode);
+        Assert.True(contact.dfeta_AllowPiiUpdatesFromRegister);
     }
 
     [Fact]
@@ -128,7 +130,8 @@ public class CreateContactTests : IAsyncLifetime
                 HasActiveAlert: false)
             ],
             ApplicationUserName = "Tests",
-            OutboxMessages = []
+            OutboxMessages = [],
+            AllowPiiUpdates = false
         };
         var createdTeacherId2 = await _crmQueryDispatcher.ExecuteQueryAsync(query);
         using var ctx = new DqtCrmServiceContext(_dataScope.OrganizationService);


### PR DESCRIPTION
### Context

There are rules in place that control whether we accept PII updates from Register over the API. Those rules rely on the value of the dfeta_allowpiiupdatesfromregisterattribute on the contact. The new TRN allocation API needs to be extended to populate that attribute.

### Changes proposed in this pull request

Populate the dfeta_allowpiiupdatesfromregister attribute when creating a contact in the v3 TRN allocation endpoint. Its value should be true when the calling user ID is present in the AllowContactPiiUpdatesFromUserIds configuration array.
