### PR TITLE
Added employer email to workforce data

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEmploymentMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEmploymentMapping.cs
@@ -21,6 +21,7 @@ public class TpsEmploymentMapping : IEntityTypeConfiguration<TpsEmployment>
         builder.Property(e => e.PersonPostcode).HasMaxLength(10);
         builder.Property(e => e.PersonEmailAddress).HasMaxLength(100);
         builder.Property(e => e.EmployerPostcode).HasMaxLength(10);
+        builder.Property(e => e.EmployerEmailAddress).HasMaxLength(100);
         builder.HasIndex(e => e.Key).HasDatabaseName(TpsEmployment.KeyIndexName);
         builder.HasIndex(e => e.PersonId).HasDatabaseName(TpsEmployment.PersonIdIndexName);
         builder.HasIndex(e => e.EstablishmentId).HasDatabaseName(TpsEmployment.EstablishmentIdIndexName);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250401134352_TpsEmploymentEmployerEmailAddress.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250401134352_TpsEmploymentEmployerEmailAddress.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250401134352_TpsEmploymentEmployerEmailAddress")]
+    partial class TpsEmploymentEmployerEmailAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250401134352_TpsEmploymentEmployerEmailAddress.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250401134352_TpsEmploymentEmployerEmailAddress.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TpsEmploymentEmployerEmailAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "employer_email_address",
+                table: "tps_employments",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "employer_email_address",
+                table: "tps_employments");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsCsvExtractItemLoadErrors.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsCsvExtractItemLoadErrors.cs
@@ -20,5 +20,6 @@ public enum TpsCsvExtractItemLoadErrors
     FullOrPartTimeIndicatorIncorrectFormat = 1 << 12,
     WithdrawlIndicatorIncorrectFormat = 1 << 13,
     ExtractDateIncorrectFormat = 1 << 14,
-    GenderIncorrectFormat = 1 << 15
+    GenderIncorrectFormat = 1 << 15,
+    EstablishmentEmailAddressIncorrectFormat = 1 << 16,
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TpsEmployment.cs
@@ -22,4 +22,5 @@ public class TpsEmployment
     public required bool WithdrawalConfirmed { get; set; }
     public required string? PersonEmailAddress { get; set; }
     public required string? EmployerPostcode { get; set; }
+    public required string? EmployerEmailAddress { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/TpsEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/TpsEmployment.cs
@@ -15,6 +15,7 @@ public record TpsEmployment
     public required string? PersonPostcode { get; init; }
     public required string? PersonEmailAddress { get; init; }
     public required string? EmployerPostcode { get; init; }
+    public required string? EmployerEmailAddress { get; init; }
     public required string Key { get; init; }
 
     public static TpsEmployment FromModel(DataStore.Postgres.Models.TpsEmployment model) => new()
@@ -32,6 +33,7 @@ public record TpsEmployment
         PersonPostcode = model.PersonPostcode,
         PersonEmailAddress = model.PersonEmailAddress,
         EmployerPostcode = model.EmployerPostcode,
+        EmployerEmailAddress = model.EmployerEmailAddress,
         Key = model.Key
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/TpsEmploymentUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/TpsEmploymentUpdatedEvent.cs
@@ -24,5 +24,6 @@ public enum TpsEmploymentUpdatedEventChanges
     PersonPostcode = 1 << 7,
     WithdrawalConfirmed = 1 << 8,
     PersonEmailAddress = 1 << 9,
-    EmployerPostcode = 1 << 10
+    EmployerPostcode = 1 << 10,
+    EmployerEmailAddress = 1 << 11
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BackfillEmployerEmailAddressInEmploymentHistoryJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BackfillEmployerEmailAddressInEmploymentHistoryJob.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.Services.WorkforceData;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class BackfillEmployerEmailAddressInEmploymentHistoryJob(TpsCsvExtractProcessor tpsCsvExtractProcessor)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        await tpsCsvExtractProcessor.BackfillEmployerEmailAddressInEmploymentHistoryAsync(cancellationToken);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -221,6 +221,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     publishApiOptions.RefreshTrainingProvidersJobSchedule);
 
+                recurringJobManager.AddOrUpdate<BackfillEmployerEmailAddressInEmploymentHistoryJob>(
+                    nameof(BackfillEmployerEmailAddressInEmploymentHistoryJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0053_TpsEmploymentsEmployerEmail.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0053_TpsEmploymentsEmployerEmail.sql
@@ -1,0 +1,1 @@
+alter table trs_tps_employments add employer_email_address varchar(100)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewTpsEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/NewTpsEmployment.cs
@@ -16,6 +16,7 @@ public record NewTpsEmployment
     public required string? PersonPostcode { get; init; }
     public required string? PersonEmailAddress { get; init; }
     public required string? EmployerPostcode { get; init; }
+    public required string? EmployerEmailAddress { get; init; }
     public required DateTime CreatedOn { get; init; }
     public required DateTime UpdatedOn { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractFileImporter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractFileImporter.cs
@@ -146,6 +146,11 @@ public class TpsCsvExtractFileImporter(
                 loadErrors = loadErrors | TpsCsvExtractItemLoadErrors.MemberEmailAddressIncorrectFormat;
             }
 
+            if (row.EstablishmentEmailAddress is not null && !EmailAddress.TryParse(row.EstablishmentEmailAddress, out _))
+            {
+                loadErrors = loadErrors | TpsCsvExtractItemLoadErrors.EstablishmentEmailAddressIncorrectFormat;
+            }
+
             writer.StartRow();
             writer.Write(Guid.NewGuid(), NpgsqlDbType.Uuid);
             writer.Write(tpsCsvExtractId, NpgsqlDbType.Uuid);
@@ -236,7 +241,12 @@ public class TpsCsvExtractFileImporter(
             writer.Write(item.LocalAuthorityCode, NpgsqlDbType.Char);
             writer.Write(item.EstablishmentNumber, NpgsqlDbType.Char);
             writer.Write(item.EstablishmentPostcode, NpgsqlDbType.Varchar);
-            writer.Write(item.EstablishmentEmailAddress, NpgsqlDbType.Varchar);
+            string? establishmentEmailAddress = null;
+            if (item.EstablishmentEmailAddress != null)
+            {
+                establishmentEmailAddress = EmailAddress.Parse(item.EstablishmentEmailAddress).ToString();
+            }
+            writer.Write(establishmentEmailAddress, NpgsqlDbType.Varchar);
             writer.Write(employmentStartDate, NpgsqlDbType.Date);
             writer.Write(!string.IsNullOrEmpty(item.EmploymentEndDate) ? DateOnly.ParseExact(item.EmploymentEndDate!, "dd/MM/yyyy") : (DateOnly?)null, NpgsqlDbType.Date);
             writer.Write((int)EmploymentTypeHelper.FromFullOrPartTimeIndicator(item.FullOrPartTimeIndicator!), NpgsqlDbType.Integer);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedTpsEmployment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedTpsEmployment.cs
@@ -15,6 +15,7 @@ public record UpdatedTpsEmployment
     public required string? CurrentPersonPostcode { get; init; }
     public required string? CurrentPersonEmailAddress { get; init; }
     public required string? CurrentEmployerPostcode { get; init; }
+    public required string? CurrentEmployerEmailAddress { get; init; }
     public required DateOnly? NewEndDate { get; init; }
     public required DateOnly NewLastKnownTpsEmployedDate { get; init; }
     public required EmploymentType NewEmploymentType { get; init; }
@@ -24,5 +25,6 @@ public record UpdatedTpsEmployment
     public required string? NewPersonPostcode { get; init; }
     public required string? NewPersonEmailAddress { get; init; }
     public required string? NewEmployerPostcode { get; init; }
+    public required string? NewEmployerEmailAddress { get; init; }
     public required string Key { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedTpsEmploymentEmployerEmailAddress.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedTpsEmploymentEmployerEmailAddress.cs
@@ -1,10 +1,10 @@
 namespace TeachingRecordSystem.Core.Services.WorkforceData;
 
-public record UpdatedTpsEmploymentEstablishment
+public record UpdatedTpsEmploymentEmployerEmailAddress
 {
     public required Guid TpsEmploymentId { get; init; }
     public required Guid PersonId { get; init; }
-    public required Guid CurrentEstablishmentId { get; init; }
+    public required Guid EstablishmentId { get; init; }
     public required DateOnly StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
     public required DateOnly LastKnownTpsEmployedDate { get; init; }
@@ -15,7 +15,7 @@ public record UpdatedTpsEmploymentEstablishment
     public required string? PersonPostcode { get; set; }
     public required string? PersonEmailAddress { get; set; }
     public required string? EmployerPostcode { get; set; }
-    public required string? EmployerEmailAddress { get; set; }
+    public required string? CurrentEmployerEmailAddress { get; set; }
     public required string Key { get; init; }
-    public required Guid NewEstablishmentId { get; init; }
+    public required string? NewEmployerEmailAddress { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedTpsEmploymentEndDate.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/UpdatedTpsEmploymentEndDate.cs
@@ -15,6 +15,7 @@ public record UpdatedTpsEmploymentEndDate
     public required string? PersonPostcode { get; init; }
     public required string? PersonEmailAddress { get; init; }
     public required string? EmployerPostcode { get; init; }
+    public required string? EmployerEmailAddress { get; init; }
     public required string Key { get; init; }
     public required DateOnly? NewEndDate { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -76,6 +76,7 @@
     <None Remove="Services\DqtReporting\Migrations\0048_TrsQualificationsProfessionalStatusType.sql" />
     <None Remove="Services\DqtReporting\Migrations\0050_TrsEstablishmentsPhaseSizeFsm.sql" />
     <None Remove="Services\DqtReporting\Migrations\0051_TpsEmploymentsPersonEmailAndEmployerPostcode.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0053_TpsEmploymentsEmployerEmail.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -159,6 +160,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0050_TrsEstablishmentsPhaseSizeFsm.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0051_TpsEmploymentsPersonEmailAndEmployerPostcode.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0052_TrsQualificationsExemptFromInduction.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0053_TpsEmploymentsEmployerEmail.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
@@ -604,7 +604,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
                     LocalAuthorityCode = validFormatLocalAuthorityCode,
                     EstablishmentCode = validFormatEstablishmentNumber,
                     EstablishmentPostcode = null,
-                    EstablishmentEmailAddress = null,
+                    EstablishmentEmailAddress = validFormatEmailAddress,
                     EmploymentStartDate = validFormatEmploymentStartDate,
                     EmploymentEndDate = validFormatEmploymentEndDate,
                     FullOrPartTimeIndicator = validFullOrPartTimeIndicator,
@@ -614,7 +614,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
                 },
                 ExpectedResult = TpsCsvExtractItemLoadErrors.GenderIncorrectFormat,
             },
-            // Invalid Email Address
+            // Invalid Member Email Address
             new ()
             {
                 Row = new()
@@ -638,6 +638,30 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
                 },
                 ExpectedResult = TpsCsvExtractItemLoadErrors.MemberEmailAddressIncorrectFormat,
             },
+            // Invalid Establishment Email Address
+            new ()
+            {
+                Row = new()
+                {
+                    Trn = validFormatTrn,
+                    NationalInsuranceNumber = validFormatNationalInsuranceNumber,
+                    DateOfBirth = validFormatDateOfBirth,
+                    DateOfDeath = validFormatDateOfDeath,
+                    MemberPostcode = null,
+                    MemberEmailAddress = validFormatEmailAddress,
+                    LocalAuthorityCode = validFormatLocalAuthorityCode,
+                    EstablishmentCode = validFormatEstablishmentNumber,
+                    EstablishmentPostcode = null,
+                    EstablishmentEmailAddress = invalidFormatEmailAddress,
+                    EmploymentStartDate = validFormatEmploymentStartDate,
+                    EmploymentEndDate = validFormatEmploymentEndDate,
+                    FullOrPartTimeIndicator = validFullOrPartTimeIndicator,
+                    WithdrawlIndicator = validWithdrawlIndicator,
+                    ExtractDate = validFormatExtractDate,
+                    Gender = validFormatGender
+                },
+                ExpectedResult = TpsCsvExtractItemLoadErrors.EstablishmentEmailAddressIncorrectFormat,
+            }
         };
     }
 
@@ -707,7 +731,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
             LocalAuthorityCode = "123",
             EstablishmentNumber = "1234",
             EstablishmentPostcode = null,
-            EstablishmentEmailAddress = null,
+            EstablishmentEmailAddress = Faker.Internet.Email(),
             MemberId = null,
             EmploymentStartDate = "03/02/2023",
             EmploymentEndDate = "03/05/2024",
@@ -738,7 +762,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
             FullOrPartTimeIndicator = "PTI",
             WithdrawalIndicator = null,
             ExtractDate = "07/03/2024",
-            Gender = "Male",
+            Gender = "Not a gender",
             Created = clock.UtcNow,
             Errors = TpsCsvExtractItemLoadErrors.GenderIncorrectFormat
         };

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonEmployment.cs
@@ -17,7 +17,8 @@ public partial class TestData
         DateOnly? endDate = null,
         bool? withdrawalConfirmed = false,
         string? personEmailAddress = null,
-        string? employerPostcode = null)
+        string? employerPostcode = null,
+        string? employerEmailAddress = null)
     {
         var key = $"{person.Trn}.{establishment.LaCode}.{establishment.EstablishmentNumber}.{startDate:yyyyMMdd}";
 
@@ -38,6 +39,7 @@ public partial class TestData
                 PersonPostcode = personPostcode,
                 PersonEmailAddress = personEmailAddress,
                 EmployerPostcode = employerPostcode,
+                EmployerEmailAddress = employerEmailAddress,
                 CreatedOn = Clock.UtcNow,
                 UpdatedOn = Clock.UtcNow,
                 Key = key

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateTpsCsvExtract.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateTpsCsvExtract.cs
@@ -54,13 +54,14 @@ public partial class TestData
             DateOnly? dateOfBirth = null,
             string? memberPostcode = null,
             string? withdrawalIndicator = null,
-            string? memberEmailAddress = null)
+            string? memberEmailAddress = null,
+            string? employerEmailAddress = null)
         {
             nationalInsuranceNumber ??= Faker.Identification.UkNationalInsuranceNumber();
             dateOfBirth ??= DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
             fullOrPartTimeIndicator ??= validFullOrPartTimeIndicatorValues[Faker.RandomNumber.Next(0, 2)];
 
-            _items.Add(new TpsCsvExtractItem(trn, nationalInsuranceNumber, dateOfBirth.Value, localAuthorityCode, establishmentPostcode, establishmentNumber, startDate, endDate, fullOrPartTimeIndicator, extractDate, memberPostcode, withdrawalIndicator, memberEmailAddress));
+            _items.Add(new TpsCsvExtractItem(trn, nationalInsuranceNumber, dateOfBirth.Value, localAuthorityCode, establishmentPostcode, establishmentNumber, startDate, endDate, fullOrPartTimeIndicator, extractDate, memberPostcode, withdrawalIndicator, memberEmailAddress, employerEmailAddress));
             return this;
         }
 
@@ -101,7 +102,7 @@ public partial class TestData
                         LocalAuthorityCode = item.LocalAuthorityCode,
                         EstablishmentNumber = item.EstablishmentNumber,
                         EstablishmentPostcode = item.EstablishmentPostcode,
-                        EstablishmentEmailAddress = null,
+                        EstablishmentEmailAddress = item.EmployerEmailAddress,
                         MemberId = memberId++.ToString(),
                         EmploymentStartDate = item.StartDate.ToString("dd/MM/yyyy"),
                         EmploymentEndDate = item.EndDate.ToString("dd/MM/yyyy"),
@@ -150,5 +151,5 @@ public partial class TestData
         }
     }
 
-    public record TpsCsvExtractItem(string Trn, string NationalInsuranceNumber, DateOnly DateOfBirth, string LocalAuthorityCode, string EstablishmentPostcode, string? EstablishmentNumber, DateOnly StartDate, DateOnly EndDate, string FullOrPartTimeIndicator, DateOnly ExtractDate, string? MemberPostcode, string? WithdrawalIndicator, string? MemberEmailAddress);
+    public record TpsCsvExtractItem(string Trn, string NationalInsuranceNumber, DateOnly DateOfBirth, string LocalAuthorityCode, string EstablishmentPostcode, string? EstablishmentNumber, DateOnly StartDate, DateOnly EndDate, string FullOrPartTimeIndicator, DateOnly ExtractDate, string? MemberPostcode, string? WithdrawalIndicator, string? MemberEmailAddress, string? EmployerEmailAddress);
 }


### PR DESCRIPTION
### Context

Workforce data is being used by the Find Teachers For Research application and a number of additional fields have been identified which would improve this.

### Changes proposed in this pull request

Add a `employer_email_address` to the `tps_employments` table in TRS and amend the import job to include this field.

Add a backfill job to populate this field for the existing records in the `tps_employments` table.

Remember to include a migration for the reporting db.
