### PR TITLE
Update user page authorization to use policies instead of roles

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AlertAuthorization.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AlertAuthorization.cs
@@ -55,5 +55,10 @@ public static class AlertAuthorization
             AuthorizationPolicies.NonDbsAlertWrite,
             policy => policy
                 .RequireAuthenticatedUser()
-                .RequireRole(UserRoles.AlertsReadWrite, UserRoles.Administrator));
+                .RequireRole(UserRoles.AlertsReadWrite, UserRoles.Administrator))
+        .AddPolicy(
+            AuthorizationPolicies.AlertWrite,
+            policy => policy
+                .RequireAuthenticatedUser()
+                .RequireRole(UserRoles.AlertsReadWrite, UserRoles.DbsAlertsReadWrite, UserRoles.Administrator));
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationPolicies.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationPolicies.cs
@@ -11,5 +11,6 @@ public static class AuthorizationPolicies
     public const string NonDbsAlertFlag = "NonDbsAlertFlag";
     public const string NonDbsAlertRead = "NonDbsAlertRead";
     public const string NonDbsAlertWrite = "NonDbsAlertWrite";
+    public const string AlertWrite = "AlertWrite";
     public const string InductionReadWrite = "InductionReadWrite";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Conventions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.AddAlert;
 
@@ -12,11 +13,11 @@ public class Conventions : IConfigureFolderConventions
             this.GetFolderPathFromNamespace(),
             model =>
             {
-                // Check the user has either the AlertsReadWrite or DbsAlertsReadWrite role.
+                // Check the user has the ability to write alerts.
                 // The AlertType page will deal with ensuring that only permitted alert types can be selected.
                 model.EndpointMetadata.Add(new AuthorizeAttribute()
                 {
-                    Roles = $"{UserRoles.Administrator},{UserRoles.AlertsReadWrite},{UserRoles.DbsAlertsReadWrite}"
+                    Policy = AuthorizationPolicies.AlertWrite
                 });
 
                 model.Filters.Add(new CheckPersonExistsFilterFactory());

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
@@ -5,11 +5,12 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
 
-[Authorize(Roles = UserRoles.Administrator)]
+[Authorize(Policy = AuthorizationPolicies.UserManagement)]
 public class ConfirmModel(
     TrsDbContext dbContext,
     IAadUserService userService,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml.cs
@@ -3,11 +3,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
 
-[Authorize(Roles = UserRoles.Administrator)]
+[Authorize(Policy = AuthorizationPolicies.UserManagement)]
 public class IndexModel(
     TrsDbContext dbContext,
     IAadUserService userService,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml.cs
@@ -5,10 +5,11 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Users;
 
-[Authorize(Roles = UserRoles.Administrator)]
+[Authorize(Policy = AuthorizationPolicies.UserManagement)]
 public class EditUser(
     TrsDbContext dbContext,
     ICrmQueryDispatcher crmQueryDispatcher,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/Index.cshtml.cs
@@ -2,10 +2,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Users;
 
-[Authorize(Roles = UserRoles.Administrator)]
+[Authorize(Policy = AuthorizationPolicies.UserManagement)]
 public class IndexModel : PageModel
 {
     private readonly TrsDbContext _dbContext;


### PR DESCRIPTION
Updates user page authorization filter and conventions to use the `UserManagement` policy instead of the `Administrator` role

**To clarify:** these were the only instances within `TeachingRecordSystem.SupportUi` where roles were used instead of policies - there were other instances within `TeachingRecordSystem.Api` but those were out of scope of this PR