### PR TITLE
Amended workforce data import to trim whitespace from email addresses

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractFileImporter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractFileImporter.cs
@@ -141,12 +141,16 @@ public class TpsCsvExtractFileImporter(
                 loadErrors = loadErrors | TpsCsvExtractItemLoadErrors.GenderIncorrectFormat;
             }
 
-            if (row.MemberEmailAddress is not null && !EmailAddress.TryParse(row.MemberEmailAddress, out _))
+            var memberEmailAddress = row.MemberEmailAddress?.Trim();
+            memberEmailAddress = memberEmailAddress?.Length > 0 ? memberEmailAddress : null;
+            if (memberEmailAddress is not null && !EmailAddress.TryParse(memberEmailAddress, out _))
             {
                 loadErrors = loadErrors | TpsCsvExtractItemLoadErrors.MemberEmailAddressIncorrectFormat;
             }
 
-            if (row.EstablishmentEmailAddress is not null && !EmailAddress.TryParse(row.EstablishmentEmailAddress, out _))
+            var establishmentEmailAddress = row.EstablishmentEmailAddress?.Trim();
+            establishmentEmailAddress = establishmentEmailAddress?.Length > 0 ? establishmentEmailAddress : null;
+            if (establishmentEmailAddress is not null && !EmailAddress.TryParse(establishmentEmailAddress, out _))
             {
                 loadErrors = loadErrors | TpsCsvExtractItemLoadErrors.EstablishmentEmailAddressIncorrectFormat;
             }
@@ -159,11 +163,11 @@ public class TpsCsvExtractFileImporter(
             writer.Write(row.DateOfBirth, NpgsqlDbType.Varchar);
             writer.Write(row.DateOfDeath, NpgsqlDbType.Varchar);
             writer.Write(row.MemberPostcode, NpgsqlDbType.Varchar);
-            writer.Write(row.MemberEmailAddress, NpgsqlDbType.Varchar);
+            writer.Write(memberEmailAddress, NpgsqlDbType.Varchar);
             writer.Write(row.LocalAuthorityCode, NpgsqlDbType.Varchar);
             writer.Write(row.EstablishmentCode, NpgsqlDbType.Varchar);
             writer.Write(row.EstablishmentPostcode, NpgsqlDbType.Varchar);
-            writer.Write(row.EstablishmentEmailAddress, NpgsqlDbType.Varchar);
+            writer.Write(establishmentEmailAddress, NpgsqlDbType.Varchar);
             writer.Write(row.EmploymentStartDate, NpgsqlDbType.Varchar);
             writer.Write(row.EmploymentEndDate, NpgsqlDbType.Varchar);
             writer.Write(row.FullOrPartTimeIndicator, NpgsqlDbType.Varchar);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractFileImporterTests.cs
@@ -35,6 +35,7 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
         var invalidFormatGender = "None";
         var invalidFormatEmailAddress = "test.com";
         var validFormatEmailAddress = "test@myemail.com";
+        var whitespace = " ";
 
         return new()
         {
@@ -638,6 +639,30 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
                 },
                 ExpectedResult = TpsCsvExtractItemLoadErrors.MemberEmailAddressIncorrectFormat,
             },
+            // Whitespace in Member Email Address
+            new ()
+            {
+                Row = new()
+                {
+                    Trn = validFormatTrn,
+                    NationalInsuranceNumber = validFormatNationalInsuranceNumber,
+                    DateOfBirth = validFormatDateOfBirth,
+                    DateOfDeath = validFormatDateOfDeath,
+                    MemberPostcode = null,
+                    MemberEmailAddress = whitespace,
+                    LocalAuthorityCode = validFormatLocalAuthorityCode,
+                    EstablishmentCode = validFormatEstablishmentNumber,
+                    EstablishmentPostcode = null,
+                    EstablishmentEmailAddress = validFormatEmailAddress,
+                    EmploymentStartDate = validFormatEmploymentStartDate,
+                    EmploymentEndDate = validFormatEmploymentEndDate,
+                    FullOrPartTimeIndicator = validFullOrPartTimeIndicator,
+                    WithdrawlIndicator = validWithdrawlIndicator,
+                    ExtractDate = validFormatExtractDate,
+                    Gender = validFormatGender
+                },
+                ExpectedResult = TpsCsvExtractItemLoadErrors.None,
+            },
             // Invalid Establishment Email Address
             new ()
             {
@@ -661,6 +686,30 @@ public class TpsCsvExtractFileImporterTests(DbFixture dbFixture)
                     Gender = validFormatGender
                 },
                 ExpectedResult = TpsCsvExtractItemLoadErrors.EstablishmentEmailAddressIncorrectFormat,
+            },
+            // Whitespace in Establishment Email Address
+            new ()
+            {
+                Row = new()
+                {
+                    Trn = validFormatTrn,
+                    NationalInsuranceNumber = validFormatNationalInsuranceNumber,
+                    DateOfBirth = validFormatDateOfBirth,
+                    DateOfDeath = validFormatDateOfDeath,
+                    MemberPostcode = null,
+                    MemberEmailAddress = validFormatEmailAddress,
+                    LocalAuthorityCode = validFormatLocalAuthorityCode,
+                    EstablishmentCode = validFormatEstablishmentNumber,
+                    EstablishmentPostcode = null,
+                    EstablishmentEmailAddress = whitespace,
+                    EmploymentStartDate = validFormatEmploymentStartDate,
+                    EmploymentEndDate = validFormatEmploymentEndDate,
+                    FullOrPartTimeIndicator = validFullOrPartTimeIndicator,
+                    WithdrawlIndicator = validWithdrawlIndicator,
+                    ExtractDate = validFormatExtractDate,
+                    Gender = validFormatGender
+                },
+                ExpectedResult = TpsCsvExtractItemLoadErrors.None,
             }
         };
     }


### PR DESCRIPTION
### Context

The workforce data extract has been amended to include (and validate) the estblishment email address however when it was run in production it appears that some of the data has whitespace for the email address rather than just being empty - this is currently being rejected as invalid but really it could be trimmed and treated as null.

### Changes proposed in this pull request

Amend the workforce data import to trim any whitespace from the establishment_email_address before validating it (empty is allowed).
Applied the same logic for member_email_address too.