### PR TITLE
fix flaky E2E test

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
@@ -263,6 +263,12 @@ public class ReferenceDataCache(
         return trainingSubjects.Where(e => !activeOnly || e.IsActive).OrderBy(s => s.Name).ToArray();
     }
 
+    public async Task<TrainingSubject> GetTrainingSubjectsByIdAsync(Guid id)
+    {
+        var trainingSubjects = await EnsureTrainingSubjectsAsync();
+        return trainingSubjects.Single(e => e.TrainingSubjectId == id, $"Could not find subject with ID: '{id}'.");
+    }
+
     public async Task<Country[]> GetTrainingCountriesAsync()
     {
         return await EnsureTrainingCountriesAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditRouteToProfessionalStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditRouteToProfessionalStatusTests.cs
@@ -22,7 +22,8 @@ public class EditRouteToProfessionalStatusTests : TestBase
         var setEndDate = endDate.AddDays(1);
         var setStartDate = startDate.AddDays(1);
         var setAwardDate = setEndDate.AddDays(1);
-        var setDegreeType = "BSc (Hons) with Intercalated PGCE";
+        var setDegreeType = (await TestData.ReferenceDataCache.GetDegreeTypesAsync())
+            .RandomOne();
         var setAgeRange = TrainingAgeSpecialismType.KeyStage1;
         var setCountry = (await TestData.ReferenceDataCache.GetTrainingCountriesAsync())
             .RandomOne();
@@ -75,7 +76,7 @@ public class EditRouteToProfessionalStatusTests : TestBase
         await page.ClickLinkForElementWithTestIdAsync("edit-degree-type-link");
 
         await page.AssertOnRouteEditDegreeTypePageAsync(qualificationId);
-        await page.FillAsync("label:text-is('Enter the degree type awarded as part of this route')", setDegreeType);
+        await page.FillAsync("label:text-is('Enter the degree type awarded as part of this route')", setDegreeType.Name);
         await page.FocusAsync("button:text-is('Continue')");
         await page.ClickContinueButtonAsync();
 
@@ -123,11 +124,11 @@ public class EditRouteToProfessionalStatusTests : TestBase
         await page.AssertOnRouteCheckYourAnswersPageAsync(qualificationId);
         await page.AssertContentEquals(setStartDate.ToString(UiDefaults.DateOnlyDisplayFormat), "Start date");
         await page.AssertContentEquals(setEndDate.ToString(UiDefaults.DateOnlyDisplayFormat), "End date");
-        await page.AssertContentEquals(setDegreeType, "Degree type");
+        await page.AssertContentContains(setDegreeType.Name, "Degree type");
         await page.AssertContentEquals(setAgeRange.GetDisplayName()!, "Age range");
-        await page.AssertContentEquals(setCountry.Name, "Country of training");
+        await page.AssertContentContains(setCountry.Name, "Country of training");
         await page.AssertContentContains(setSubject.Name, "Subjects");
-        //await page.AssertContentEquals(setTrainingProvider.Name, "Training provider");
+        //await page.AssertContentContains(setTrainingProvider.Name, "Training provider");
         await page.ClickButtonAsync("Confirm and commit changes");
 
         await page.AssertOnPersonQualificationsPageAsync(personId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditRouteToProfessionalStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditRouteToProfessionalStatusTests.cs
@@ -22,13 +22,10 @@ public class EditRouteToProfessionalStatusTests : TestBase
         var setEndDate = endDate.AddDays(1);
         var setStartDate = startDate.AddDays(1);
         var setAwardDate = setEndDate.AddDays(1);
-        var setDegreeType = (await TestData.ReferenceDataCache.GetDegreeTypesAsync())
-            .RandomOne();
+        var setDegreeType = await TestData.ReferenceDataCache.GetDegreeTypeByIdAsync(new Guid("2f7a914f-f95f-421a-a55e-60ed88074cf2"));
         var setAgeRange = TrainingAgeSpecialismType.KeyStage1;
-        var setCountry = (await TestData.ReferenceDataCache.GetTrainingCountriesAsync())
-            .RandomOne();
-        var setSubject = (await TestData.ReferenceDataCache.GetTrainingSubjectsAsync())
-            .RandomOne();
+        var setCountry = await TestData.ReferenceDataCache.GetTrainingCountryByIdAsync("AG");
+        var setSubject = await TestData.ReferenceDataCache.GetTrainingSubjectsByIdAsync(new Guid("015d862e-2aed-49df-9e5f-d17b0d426972"));
         //var setTrainingProvider = (await TestData.ReferenceDataCache.GetTrainingProvidersAsync())
         //    .RandomOne();
         var person = await TestData.CreatePersonAsync(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/InductionExemptionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/InductionExemptionTests.cs
@@ -87,8 +87,8 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRoutesToProfessionalStatusAsync())
-            .Where(r => r.InductionExemptionRequired == FieldRequirement.Mandatory)
-            .RandomOne();
+            .Where(r => r.Name == "NI R")
+            .First();
         var status = ProfessionalStatusStatusRegistry.All
             .Where(s => s.InductionExemptionRequired == FieldRequirement.Mandatory)
             .RandomOne()


### PR DESCRIPTION
### Context
Fix the flaky E2E test whereby typing into the selection box can result in >1 match.

### Changes proposed in this pull request
Checks that the final content contains the string typed in, rather than equals it

