### PR TITLE
Amended validation to mandate country code for iQTS

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/SetProfessionalStatusRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/SetProfessionalStatusRequestValidator.cs
@@ -71,6 +71,7 @@ public class SetProfessionalStatusRequestValidator : AbstractValidator<SetProfes
                 .WithMessage($"Training country reference must be 'GB-SCT' when route type is '{RouteToProfessionalStatus.ScotlandRId}'.")
                 .NotEqual("GB-SCT")
                 .When(r => r.RouteTypeId != RouteToProfessionalStatus.ScotlandRId, ApplyConditionTo.CurrentValidator)
+                .When(r => r.RouteTypeId != RouteToProfessionalStatus.ScotlandRId, ApplyConditionTo.CurrentValidator)
                 .WithMessage($"Training country reference cannot be 'GB-SCT' when route type is not '{RouteToProfessionalStatus.ScotlandRId}'.")
                 .Equal("GB-NIR")
                 .When(r => r.RouteTypeId == RouteToProfessionalStatus.NiRId, ApplyConditionTo.CurrentValidator)
@@ -82,7 +83,12 @@ public class SetProfessionalStatusRequestValidator : AbstractValidator<SetProfes
         .Otherwise(() =>
         {
             RuleFor(r => r.TrainingCountryReference)
+                .Cascade(CascadeMode.Stop)
+                .NotEmpty()
+                .WithMessage(r => $"Training country reference must be specified when route type is '{r.RouteTypeId}'.")
+                .When(r => r.RouteTypeId == RouteToProfessionalStatus.InternationalQualifiedTeacherStatusId, ApplyConditionTo.CurrentValidator)
                 .Empty()
+                .When(r => r.RouteTypeId != RouteToProfessionalStatus.InternationalQualifiedTeacherStatusId, ApplyConditionTo.CurrentValidator)
                 .WithMessage(r => $"Training country reference cannot be specified when route type is '{r.RouteTypeId}'.");
         });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/SeedCrmReferenceData.cs
@@ -423,6 +423,12 @@ public class SeedCrmReferenceData : IStartupTask
 
         _xrmFakedContext.CreateEntity(new dfeta_country()
         {
+            dfeta_name = "United Kingdom",
+            dfeta_Value = "GB"
+        });
+
+        _xrmFakedContext.CreateEntity(new dfeta_country()
+        {
             dfeta_name = "Wales",
             dfeta_Value = "WA"
         });


### PR DESCRIPTION
### Context

During testing of the new routes v3 API, discovered that some validation from the v2 API around mandating a training country code for iQTS route type had not been ported to this version.

### Changes proposed in this pull request

Amend `SetProfessionalStatusRequestValidator` to ensure that the TrainingCountryReference field is populated for International Qualified Teacher Status route type + amend tests.
