### PR TITLE
Add potential duplicate flag and AYTQ link to TRN allocation endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The following new endpoints have been added:
 - `PUT /v3/persons/<trn>/welsh-induction` - to set a person's induction for teachers in Wales.
 - `PUT /v3/persons/<trn>/professional-statuses/<id>` - to set a professional status.
 
+The `GET /v3/trn-requests` and `POST /v3/trn-requests` endpoints return the following additional properties:
+- `potentialDuplicate`;
+- `accessYourTeachingQualificationsLink`.
+`accessYourTeachingQualificationsLink` will only be populated for `Completed` requests.
+
 ## 20250327
 
 The `qts` object in responses to the following endpoints has a new `awardedOrApprovedCount` property:

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Dtos/TrnRequestInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Dtos/TrnRequestInfo.cs
@@ -8,12 +8,13 @@ public record TrnRequestInfo
 #pragma warning restore TRS0001
     public required TrnRequestStatus Status { get; init; }
     public required string? Trn { get; init; }
+    public required bool PotentialDuplicate { get; init; }
+    public required string? AccessYourTeachingQualificationsLink { get; init; }
 }
 
 // The CreateTrnRequest API populates this with the data from the original request
-// but we want to return the details of the resolved person instead.
-// As such, newer CreateTrnRequest versions don't return data like this at all
-// but the GetTrnRequest endpoint will return the data for the resolved record. 
+// but the GetTrnRequest endpoint uses the resolved record.
+// To remove the inconsistency newer API versions don't return this object at all.
 [Obsolete("Maintained for older API versions", DiagnosticId = "TRS0001")]
 public record TrnRequestInfoPerson
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
@@ -1,12 +1,16 @@
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Implementation.Dtos;
+using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
 public record GetTrnRequestCommand(string RequestId);
 
-public class GetTrnRequestHandler(TrnRequestHelper trnRequestHelper, ICurrentUserProvider currentUserProvider)
+public class GetTrnRequestHandler(
+    TrsDbContext dbContext,
+    TrnRequestHelper trnRequestHelper,
+    ICurrentUserProvider currentUserProvider)
 {
     public async Task<ApiResult<TrnRequestInfo>> HandleAsync(GetTrnRequestCommand command)
     {
@@ -16,6 +20,15 @@ public class GetTrnRequestHandler(TrnRequestHelper trnRequestHelper, ICurrentUse
         if (trnRequest is null)
         {
             return ApiError.TrnRequestDoesNotExist(command.RequestId);
+        }
+
+        // The request may have been completed since we last checked; ensure we have a TRN token if that's the case
+        if (trnRequest.IsCompleted && trnRequest.TrnToken is null && trnRequest.Metadata.EmailAddress is string emailAddress)
+        {
+            var trnToken = await trnRequestHelper.CreateTrnTokenAsync(trnRequest.Trn, emailAddress);
+
+            trnRequest.Metadata.TrnToken = trnToken;
+            await dbContext.SaveChangesAsync();
         }
 
         var contact = trnRequest.Contact;
@@ -35,8 +48,12 @@ public class GetTrnRequestHandler(TrnRequestHelper trnRequestHelper, ICurrentUse
                 NationalInsuranceNumber = contact.dfeta_NINumber,
                 DateOfBirth = contact.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false)
             },
-            Trn = contact.dfeta_TRN,
-            Status = trnRequest.IsCompleted ? TrnRequestStatus.Completed : TrnRequestStatus.Pending
+            Trn = trnRequest.Trn,
+            Status = trnRequest.IsCompleted ? TrnRequestStatus.Completed : TrnRequestStatus.Pending,
+            PotentialDuplicate = trnRequest.PotentialDuplicate,
+            AccessYourTeachingQualificationsLink = trnRequest.TrnToken is not null ?
+                trnRequestHelper.GetAccessYourTeachingQualificationsLink(trnRequest.TrnToken) :
+                null
         };
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/TrnRequestsController.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Core.ApiSchema.V3.V20250203.Dtos;
+using TrnRequestInfo = TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos.TrnRequestInfo;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
+
+[Route("trn-requests")]
+[Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.CreateTrn)]
+public class TrnRequestsController(IMapper mapper) : ControllerBase
+{
+    [HttpPost("")]
+    [SwaggerOperation(
+        OperationId = "CreateTrnRequest",
+        Summary = "Creates a TRN request",
+        Description = """
+        Creates a new TRN request using the personally identifiable information in the request body.
+        If the request can be fulfilled immediately the response's status property will be 'Completed' and a TRN will also be returned.
+        Otherwise, the response's status property will be 'Pending' and the GET endpoint should be polled until a 'Completed' status is returned.
+        """)]
+    [ProducesResponseType(typeof(TrnRequestInfo), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [MapError(10029, statusCode: StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> CreateTrnRequestAsync(
+        [FromBody] CreateTrnRequestRequest request,
+        [FromServices] CreateTrnRequestHandler handler)
+    {
+        var command = new CreateTrnRequestCommand()
+        {
+            RequestId = request.RequestId,
+            FirstName = request.Person.FirstName,
+            MiddleName = request.Person.MiddleName,
+            LastName = request.Person.LastName,
+            DateOfBirth = request.Person.DateOfBirth,
+            EmailAddresses = request.Person.EmailAddresses ?? [],
+            NationalInsuranceNumber = request.Person.NationalInsuranceNumber,
+            IdentityVerified = request.IdentityVerified,
+            OneLoginUserSubject = request.OneLoginUserSubject,
+            Gender = request.Person.Gender is Gender gender ? mapper.Map<Implementation.Dtos.Gender>(gender) : null,
+        };
+
+        var result = await handler.HandleAsync(command);
+
+        return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.TrnRequestAlreadyCreated, StatusCodes.Status409Conflict);
+    }
+
+    [HttpGet("")]
+    [SwaggerOperation(
+        OperationId = "GetTrnRequest",
+        Summary = "Get the TRN request's details",
+        Description = """
+                      Gets the TRN request for the requestId specified in the query string.
+                      If the request's status is 'Completed' a TRN will also be returned.
+                      """)]
+    [ProducesResponseType(typeof(TrnRequestInfo), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetTrnRequestAsync(
+        [FromQuery] string requestId,
+        [FromServices] GetTrnRequestHandler handler)
+    {
+        var command = new GetTrnRequestCommand(requestId);
+        var result = await handler.HandleAsync(command);
+
+        return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.TrnRequestDoesNotExist, StatusCodes.Status404NotFound);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/MapperProfile.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/MapperProfile.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+namespace TeachingRecordSystem.Api.V3.VNext;
+
+public class MapperProfile : Profile
+{
+    public MapperProfile()
+    {
+        CreateMap<Implementation.Dtos.TrnRequestInfo, TrnRequestInfo>();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/CreateTrnRequestRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/CreateTrnRequestRequest.cs
@@ -1,0 +1,26 @@
+using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Core.ApiSchema.V3.V20250203.Dtos;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+
+public record CreateTrnRequestRequest
+{
+    [SwaggerSchema(description:
+        "A unique ID that represents this request. " +
+        "If a request has already been created with this ID then that existing record's result is returned.")]
+    public required string RequestId { get; init; }
+    public required CreateTrnRequestRequestPerson Person { get; init; }
+    public bool IdentityVerified { get; init; }
+    public string? OneLoginUserSubject { get; init; }
+}
+
+public record CreateTrnRequestRequestPerson
+{
+    public required string FirstName { get; init; }
+    public string? MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+    public IReadOnlyCollection<string>? EmailAddresses { get; init; }
+    public string? NationalInsuranceNumber { get; init; }
+    public Gender? Gender { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/CreateTrnRequestRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Validators/CreateTrnRequestRequestValidator.cs
@@ -1,0 +1,59 @@
+using FluentValidation;
+using TeachingRecordSystem.Api.Properties;
+using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Core.Dqt.Models;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Validators;
+
+public class CreateTrnRequestRequestValidator : AbstractValidator<CreateTrnRequestRequest>
+{
+    public CreateTrnRequestRequestValidator(IClock clock)
+    {
+        RuleFor(r => r.RequestId)
+            .Matches(PostgresModels.TrnRequest.ValidRequestIdPattern)
+            .WithMessage(StringResources.ErrorMessages_RequestIdCanOnlyContainCharactersDigitsUnderscoresAndDashes)
+            .MaximumLength(PostgresModels.TrnRequest.RequestIdMaxLength)
+            .WithMessage(StringResources.ErrorMessages_RequestIdMustBe100CharactersOrFewer);
+
+        RuleFor(r => r.Person.FirstName)
+            .NotEmpty()
+            .MaximumLength(AttributeConstraints.Contact.FirstNameMaxLength);
+
+        RuleFor(r => r.Person.MiddleName)
+            .MaximumLength(AttributeConstraints.Contact.MiddleNameMaxLength);
+
+        RuleFor(r => r.Person.LastName)
+            .NotEmpty()
+            .MaximumLength(AttributeConstraints.Contact.LastNameMaxLength);
+
+        RuleFor(r => r.Person.DateOfBirth)
+            .NotEmpty()
+            .Custom((value, ctx) =>
+            {
+                if (value >= DateOnly.FromDateTime(clock.UtcNow) || value < new DateOnly(1940, 1, 1))
+                {
+                    ctx.AddFailure(ctx.PropertyName, StringResources.ErrorMessages_BirthDateIsOutOfRange);
+                }
+            });
+
+        RuleForEach(r => r.Person.EmailAddresses)
+            .NotNull()
+            .WithMessage("Email address cannot be null.")
+            .EmailAddress()
+            .MaximumLength(AttributeConstraints.Contact.EMailAddress1MaxLength);
+
+        RuleFor(r => r.Person.NationalInsuranceNumber)
+            .Custom((value, ctx) =>
+            {
+                if (!string.IsNullOrEmpty(value) && !NationalInsuranceNumberHelper.IsValid(value))
+                {
+                    ctx.AddFailure(ctx.PropertyName, StringResources.ErrorMessages_EnterNinoNumberInCorrectFormat);
+                }
+            });
+
+        RuleFor(r => r.Person.Gender)
+            .IsInEnum();
+    }
+}
+
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -25,6 +25,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Infrastructure;
 using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.PersonMatching;
 using TeachingRecordSystem.SupportUi.Infrastructure.FormFlow;
 using TeachingRecordSystem.WebCommon;
@@ -170,7 +171,9 @@ if (!builder.Environment.IsUnitTests() && !builder.Environment.IsEndToEndTests()
     builder.Services.AddDbContext<IdDbContext>(options => options.UseNpgsql(builder.Configuration.GetRequiredConnectionString("Id")));
 }
 
-builder.AddBlobStorage();
+builder
+    .AddBlobStorage()
+    .AddIdentityApi();
 
 builder.Services
     .AddTrsBaseServices()
@@ -188,7 +191,8 @@ builder.Services
     .AddTransient<SignInJourneyHelper>()
     .AddSingleton<ITagHelperInitializer<FormTagHelper>, FormTagHelperInitializer>()
     .AddFileService()
-    .AddPersonMatching();
+    .AddPersonMatching()
+    .AddAccessYourTeachingQualificationsOptions(builder.Configuration, builder.Environment);
 
 builder.Services.AddOptions<AuthorizeAccessOptions>()
     .Bind(builder.Configuration)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrnRequestInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrnRequestInfo.cs
@@ -1,0 +1,12 @@
+using TeachingRecordSystem.Core.ApiSchema.V3.V20240606.Dtos;
+
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record TrnRequestInfo
+{
+    public required string RequestId { get; init; }
+    public required TrnRequestStatus Status { get; init; }
+    public required string? Trn { get; init; }
+    public required bool PotentialDuplicate { get; init; }
+    public required string? AccessYourTeachingQualificationsLink { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -22,5 +22,5 @@ public class TrnRequestMetadata
     public string? City { get; init; }
     public string? Postcode { get; init; }
     public string? Country { get; init; }
-    public string? TrnToken { get; init; }
+    public string? TrnToken { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V2/Operations/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V2/Operations/GetTrnRequestTests.cs
@@ -76,7 +76,8 @@ public class GetTrnRequestTests : TestBase
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithoutTrn()
-            .WithSlugId(slugId));
+            .WithSlugId(slugId)
+            .WithTrnRequest(ApplicationUserId, requestId));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -147,7 +148,8 @@ public class GetTrnRequestTests : TestBase
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
-            .WithSlugId(slugId));
+            .WithSlugId(slugId)
+            .WithTrnRequest(ApplicationUserId, requestId));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -220,6 +222,7 @@ public class GetTrnRequestTests : TestBase
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithSlugId(slugId)
+            .WithTrnRequest(ApplicationUserId, requestId)
             .WithTrnToken(trnToken));
 
         await WithDbContextAsync(async dbContext =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240307/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240307/CreateTrnRequestTests.cs
@@ -5,6 +5,7 @@ using TeachingRecordSystem.Core.ApiSchema.V3.V20240307.Dtos;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.Core.Services.GetAnIdentity.Api.Models;
 
 namespace TeachingRecordSystem.Api.IntegrationTests.V3.V20240307;
 
@@ -15,6 +16,16 @@ public class CreateTrnRequestTests : TestBase
         : base(hostFixture)
     {
         SetCurrentApiClient([ApiRoles.CreateTrn]);
+
+        GetAnIdentityApiClientMock
+            .Setup(mock => mock.CreateTrnTokenAsync(It.IsAny<CreateTrnTokenRequest>()))
+            .ReturnsAsync((CreateTrnTokenRequest req) => new CreateTrnTokenResponse()
+            {
+                Email = req.Email,
+                ExpiresUtc = Clock.UtcNow.AddDays(1),
+                Trn = req.Trn,
+                TrnToken = Guid.NewGuid().ToString()
+            });
     }
 
     [Theory, RoleNamesData(except: ApiRoles.CreateTrn)]
@@ -174,6 +185,7 @@ public class CreateTrnRequestTests : TestBase
 
         var existingContact = await TestData.CreatePersonAsync(p => p
             .WithTrn()
+            .WithTrnRequest(ApplicationUserId, requestId)
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/CreateTrnRequestTests.cs
@@ -5,6 +5,7 @@ using TeachingRecordSystem.Api.V3.V20250203.Requests;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.Core.Services.GetAnIdentity.Api.Models;
 
 namespace TeachingRecordSystem.Api.IntegrationTests.V3.V20250203;
 
@@ -15,6 +16,16 @@ public class CreateTrnRequestTests : TestBase
     {
         SetCurrentApiClient([ApiRoles.CreateTrn]);
         XrmFakedContext.DeleteAllEntities<Contact>();
+
+        GetAnIdentityApiClientMock
+            .Setup(mock => mock.CreateTrnTokenAsync(It.IsAny<CreateTrnTokenRequest>()))
+            .ReturnsAsync((CreateTrnTokenRequest req) => new CreateTrnTokenResponse()
+            {
+                Email = req.Email,
+                ExpiresUtc = Clock.UtcNow.AddDays(1),
+                Trn = req.Trn,
+                TrnToken = Guid.NewGuid().ToString()
+            });
     }
 
     [Theory, RoleNamesData(except: ApiRoles.CreateTrn)]
@@ -174,6 +185,7 @@ public class CreateTrnRequestTests : TestBase
 
         var existingContact = await TestData.CreatePersonAsync(p => p
             .WithTrn()
+            .WithTrnRequest(ApplicationUserId, requestId)
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/GetTrnRequestTests.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.GetAnIdentity.Api.Models;
+
+namespace TeachingRecordSystem.Api.IntegrationTests.V3.VNext;
+
+public class GetTrnRequestTests : TestBase
+{
+    public GetTrnRequestTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        SetCurrentApiClient([ApiRoles.CreateTrn]);
+
+        GetAnIdentityApiClientMock
+            .Setup(mock => mock.CreateTrnTokenAsync(It.IsAny<CreateTrnTokenRequest>()))
+            .ReturnsAsync((CreateTrnTokenRequest req) => new CreateTrnTokenResponse()
+            {
+                Email = req.Email,
+                ExpiresUtc = Clock.UtcNow.AddDays(1),
+                Trn = req.Trn,
+                TrnToken = Guid.NewGuid().ToString()
+            });
+    }
+
+    [Theory, RoleNamesData(except: ApiRoles.CreateTrn)]
+    public async Task Get_ClientDoesNotHavePermission_ReturnsForbidden(string[] roles)
+    {
+        // Arrange
+        SetCurrentApiClient(roles);
+
+        var requestId = Guid.NewGuid().ToString();
+        var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = new DateOnly(1990, 01, 01);
+        var email = Faker.Internet.Email();
+        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
+
+        var existingContact = await TestData.CreatePersonAsync(p => p
+            .WithTrn()
+            .WithFirstName(firstName)
+            .WithMiddleName(middleName)
+            .WithLastName(lastName)
+            .WithDateOfBirth(dateOfBirth)
+            .WithEmail(email)
+            .WithNationalInsuranceNumber(nationalInsuranceNumber: nationalInsuranceNumber));
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            dbContext.Add(new TrnRequest()
+            {
+                ClientId = ApplicationUserId.ToString(),
+                RequestId = requestId,
+                TeacherId = existingContact.ContactId
+            });
+
+            await dbContext.SaveChangesAsync();
+        });
+
+        // Act
+        var response = await GetHttpClientWithApiKey().GetAsync($"v3/trn-requests?requestId={requestId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_TrnRequestNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+
+        // Act
+        var response = await GetHttpClientWithApiKey().GetAsync($"v3/trn-requests?requestId={requestId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact(Skip = "Skipped until we have a way of processing outbox messages")]
+    public async Task Get_ValidCompletedTrnRequest_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+        var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = new DateOnly(1990, 01, 01);
+        var email = Faker.Internet.Email();
+        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
+
+        var existingContact = await TestData.CreatePersonAsync(p => p
+            .WithTrn()
+            .WithFirstName(firstName)
+            .WithMiddleName(middleName)
+            .WithLastName(lastName)
+            .WithDateOfBirth(dateOfBirth)
+            .WithEmail(email)
+            .WithNationalInsuranceNumber(nationalInsuranceNumber: nationalInsuranceNumber)
+            .WithTrnRequest(ApplicationUserId, requestId));
+
+        // Act
+        var response = await GetHttpClientWithApiKey().GetAsync($"v3/trn-requests?requestId={requestId}");
+
+        // Assert
+        await AssertEx.JsonResponseEqualsAsync(
+            response,
+            expected: new
+            {
+                requestId,
+                trn = existingContact.Trn,
+                status = "Completed",
+                potentialDuplicate = false,
+                accessYourTeachingQualificationsLink = (string?)null
+            },
+            expectedStatusCode: 200);
+    }
+
+    [Fact(Skip = "Skipped until we have a way of processing outbox messages")]
+    public async Task Get_ValidPendingTrnRequest_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var requestId = Guid.NewGuid().ToString();
+        var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = new DateOnly(1990, 01, 01);
+        var email = Faker.Internet.Email();
+        var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
+
+        var existingContact = await TestData.CreatePersonAsync(p => p
+            .WithoutTrn()
+            .WithFirstName(firstName)
+            .WithMiddleName(middleName)
+            .WithLastName(lastName)
+            .WithDateOfBirth(dateOfBirth)
+            .WithEmail(email)
+            .WithNationalInsuranceNumber(nationalInsuranceNumber: nationalInsuranceNumber)
+            .WithTrnRequest(ApplicationUserId, requestId));
+
+        // Act
+        var response = await GetHttpClientWithApiKey().GetAsync($"v3/trn-requests?requestId={requestId}");
+
+        // Assert
+        await AssertEx.JsonResponseEqualsAsync(
+            response,
+            expected: new
+            {
+                requestId,
+                trn = (string?)null,
+                status = "Pending",
+                potentialDuplicate = true,
+                accessYourTeachingQualificationsLink = (string?)null
+            },
+            expectedStatusCode: 200);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
@@ -2,6 +2,7 @@ using FakeXrmEasy;
 using FakeXrmEasy.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 
 namespace TeachingRecordSystem.Api.UnitTests;
 
@@ -29,6 +30,8 @@ public abstract class OperationTestBase
     public CrmQueryDispatcherSpy CrmQueryDispatcherSpy => _testServices.CrmQueryDispatcherSpy;
 
     public IXrmFakedContext XrmFakedContext => OperationTestFixture.Services.GetRequiredService<IXrmFakedContext>();
+
+    public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock => Mock.Get(OperationTestFixture.Services.GetRequiredService<IGetAnIdentityApiClient>());
 
     public T AssertSuccess<T>(ApiResult<T> result) where T : notnull
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Startup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Npgsql;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.NameSynonyms;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 
@@ -41,7 +42,8 @@ public class Startup
                             inner,
                             TestScopedServices.TryGetCurrent(out var tss) ? tss.CrmQueryDispatcherSpy : new()))
                     .AddSingleton<ICurrentUserProvider>(Mock.Of<ICurrentUserProvider>())
-                    .AddNameSynonyms();
+                    .AddNameSynonyms()
+                    .AddTestScoped<IGetAnIdentityApiClient>(tss => tss.GetAnIdentityApiClient.Object);
             });
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 
 namespace TeachingRecordSystem.Api.UnitTests;
 
@@ -10,6 +11,7 @@ public class TestScopedServices
     {
         CrmQueryDispatcherSpy = new();
         Clock = new();
+        GetAnIdentityApiClient = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -40,4 +42,6 @@ public class TestScopedServices
     public CrmQueryDispatcherSpy CrmQueryDispatcherSpy { get; }
 
     public TestableClock Clock { get; }
+
+    public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClient { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
@@ -9,6 +9,7 @@ using OpenIddict.Server.AspNetCore;
 using TeachingRecordSystem.AuthorizeAccess.EndToEndTests.Infrastructure.Security;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.UiTestCommon.Infrastructure.FormFlow;
 using TeachingRecordSystem.WebCommon.FormFlow.State;
@@ -94,6 +95,7 @@ public sealed class HostFixture(IConfiguration configuration) : IAsyncDisposable
                     services.AddSingleton<IAuditRepository, TestableAuditRepository>();
                     services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
                     services.AddSingleton(GetMockFileService());
+                    services.AddSingleton<IGetAnIdentityApiClient>(Mock.Of<IGetAnIdentityApiClient>());
 
                     IFileService GetMockFileService()
                     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using TeachingRecordSystem.AuthorizeAccess.Tests.Infrastructure.Security;
 using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.TestCommon.Infrastructure;
 using TeachingRecordSystem.UiTestCommon.Infrastructure.FormFlow;
@@ -64,6 +65,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<IAuditRepository, TestableAuditRepository>();
             services.AddSingleton<TrsDataSyncHelper>();
             services.AddSingleton(GetMockFileService());
+            services.AddTestScoped<IGetAnIdentityApiClient>(tss => tss.GetAnIdentityApiClient.Object);
 
             IFileService GetMockFileService()
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestScopedServices.cs
@@ -1,3 +1,6 @@
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using Xunit.Sdk;
+
 namespace TeachingRecordSystem.AuthorizeAccess.Tests;
 
 public class TestScopedServices
@@ -8,6 +11,7 @@ public class TestScopedServices
     {
         Clock = new();
         EventObserver = new();
+        GetAnIdentityApiClient = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -26,4 +30,6 @@ public class TestScopedServices
     public TestableClock Clock { get; }
 
     public CaptureEventObserver EventObserver { get; }
+
+    public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClient { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -356,6 +356,11 @@ public partial class TestData
                 contact.dfeta_qtlsdate = _qtlsDate.ToDateTimeWithDqtBstFix(isLocalTime: false);
             }
 
+            if (trn is not null && _trnToken is null && _email is not null)
+            {
+                _trnToken = Guid.NewGuid().ToString();
+            }
+
             var txnRequestBuilder = RequestBuilder.CreateTransaction(testData.OrganizationService);
             txnRequestBuilder.AddRequest(new CreateRequest() { Target = contact });
 
@@ -630,7 +635,8 @@ public partial class TestData
                         FirstName = firstName,
                         MiddleName = "",
                         LastName = lastName,
-                        DateOfBirth = dateOfBirth
+                        DateOfBirth = dateOfBirth,
+                        TrnToken = _trnToken
                     });
                 }
             });


### PR DESCRIPTION
There are a few tests skipped here as we need a way of processing CRM outbox messages - that'll follow in a separate PR.