### PR TITLE
Handle 'definite duplicate' TRN requests in GET endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
@@ -1,16 +1,12 @@
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Implementation.Dtos;
-using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Dqt;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
 public record GetTrnRequestCommand(string RequestId);
 
-public class GetTrnRequestHandler(
-    TrsDbContext dbContext,
-    TrnRequestHelper trnRequestHelper,
-    ICurrentUserProvider currentUserProvider)
+public class GetTrnRequestHandler(TrnRequestHelper trnRequestHelper, ICurrentUserProvider currentUserProvider)
 {
     public async Task<ApiResult<TrnRequestInfo>> HandleAsync(GetTrnRequestCommand command)
     {
@@ -20,15 +16,6 @@ public class GetTrnRequestHandler(
         if (trnRequest is null)
         {
             return ApiError.TrnRequestDoesNotExist(command.RequestId);
-        }
-
-        // The request may have been completed since we last checked; ensure we have a TRN token if that's the case
-        if (trnRequest.IsCompleted && trnRequest.TrnToken is null && trnRequest.Metadata.EmailAddress is string emailAddress)
-        {
-            var trnToken = await trnRequestHelper.CreateTrnTokenAsync(trnRequest.Trn, emailAddress);
-
-            trnRequest.Metadata.TrnToken = trnToken;
-            await dbContext.SaveChangesAsync();
         }
 
         var contact = trnRequest.Contact;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250422155112_TrnRequestMetadataResolvedPersonId.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250422155112_TrnRequestMetadataResolvedPersonId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250422155112_TrnRequestMetadataResolvedPersonId")]
+    partial class TrnRequestMetadataResolvedPersonId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250422155112_TrnRequestMetadataResolvedPersonId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250422155112_TrnRequestMetadataResolvedPersonId.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnRequestMetadataResolvedPersonId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "resolved_person_id",
+                table: "trn_request_metadata",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "resolved_person_id",
+                table: "trn_request_metadata");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -23,4 +23,5 @@ public class TrnRequestMetadata
     public string? Postcode { get; init; }
     public string? Country { get; init; }
     public string? TrnToken { get; set; }
+    public Guid? ResolvedPersonId { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTeacherQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateTeacherQuery.cs
@@ -4,6 +4,7 @@ namespace TeachingRecordSystem.Core.Dqt.Queries;
 
 public record CreateContactQuery : ICrmQuery<Guid>
 {
+    public required Guid ContactId { get; init; }
     public required string FirstName { get; init; }
     public required string MiddleName { get; init; }
     public required string LastName { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
@@ -9,7 +9,7 @@ public class CreateContactHandler : ICrmQueryHandler<CreateContactQuery, Guid>
 {
     public async Task<Guid> ExecuteAsync(CreateContactQuery query, IOrganizationServiceAsync organizationService)
     {
-        var contactId = Guid.NewGuid();
+        var contactId = query.ContactId;
 
         var requestBuilder = RequestBuilder.CreateTransaction(organizationService);
         var serializer = new MessageSerializer();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
@@ -31,7 +31,8 @@ public class TrnRequestMetadataMessageHandler(TrsDbContext dbContext) : IMessage
                 City = message.City,
                 Postcode = message.Postcode,
                 Country = message.Country,
-                TrnToken = message.TrnToken
+                TrnToken = message.TrnToken,
+                ResolvedPersonId = message.ResolvedPersonId
             });
             await dbContext.SaveChangesAsync();
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Messages/TrnRequestMetadataMessage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Messages/TrnRequestMetadataMessage.cs
@@ -23,4 +23,5 @@ public record TrnRequestMetadataMessage
     public string? Postcode { get; init; }
     public string? Country { get; init; }
     public string? TrnToken { get; init; }
+    public Guid? ResolvedPersonId { get; set; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
@@ -34,6 +34,7 @@ public class CreateContactTests : IAsyncLifetime
 
         var query = new CreateContactQuery()
         {
+            ContactId = Guid.NewGuid(),
             TrnRequestId = null,
             FirstName = firstName,
             MiddleName = middleName,


### PR DESCRIPTION
During TRN allocation, when we've found a 'definite duplicate' (i.e. exactly one record matches with NINO and DOB), we return its TRN immediately with status `Completed`. However, if the `GET` endpoint were subsequently polled, we'd return a `404` since we have no record of the request in the `trn_requests` table (legacy) and we have no CRM `contact` with matching `dfeta_trnrequestid`.

This change adds `ResolvedPersonId` to `TrnRequestMetadata` and populates it during TRN allocation if the resolved record is known. Every time a `Pending` request is queried we check if it's been completed since the last time and populate `ResolvedPersonId` if it has been.

At some point we'll need a back-fill job to populate this field for all existing requests, since we won't have `dfeta_trnrequestid` available after the contact record has been migrated to TRS.