### PR TITLE
Add missing AllowRegisterPiiUpdates tag to query handler

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateContactPiiHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/UpdateContactPiiHandler.cs
@@ -4,12 +4,11 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-
 public class UpdateContactPiiHandler : ICrmQueryHandler<UpdateContactPiiQuery, bool>
 {
     public async Task<bool> ExecuteAsync(UpdateContactPiiQuery query, IOrganizationServiceAsync organizationService)
     {
-        await organizationService.ExecuteAsync(new UpdateRequest()
+        var updateRequest = new UpdateRequest()
         {
             Target = new Contact()
             {
@@ -22,7 +21,10 @@ public class UpdateContactPiiHandler : ICrmQueryHandler<UpdateContactPiiQuery, b
                 GenderCode = query.Gender,
                 EMailAddress1 = query.EmailAddress
             }
-        });
+        };
+        updateRequest.Parameters.Add("tag", "AllowRegisterPiiUpdates");
+
+        await organizationService.ExecuteAsync(updateRequest);
 
         return true;
     }


### PR DESCRIPTION
Without this all calls to the V3 update endpoint end up clearing the 'allow PII updates' flag.