### PR TITLE
Add job to mop up bad InductionStatusWithoutExemption values

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -19,7 +19,7 @@ public class Person
     public string? EmailAddress { get; set; }
     public string? NationalInsuranceNumber { get; set; }
     public InductionStatus InductionStatus { get; private set; }
-    public InductionStatus InductionStatusWithoutExemption { get; private set; }
+    public InductionStatus InductionStatusWithoutExemption { get; internal set; }  // internally set-able for a data fix job
     public Guid[] InductionExemptionReasonIds { get; private set; } = [];
     public bool InductionExemptWithoutReason { get; internal set; }  // internally set-able for testing
     public DateOnly? InductionStartDate { get; private set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/FixInductionWithoutExemptionJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/FixInductionWithoutExemptionJob.cs
@@ -1,0 +1,54 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class FixInductionWithoutExemptionJob(IDbContextFactory<TrsDbContext> dbContextFactory, IClock clock)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        await using var readDbContext = await dbContextFactory.CreateDbContextAsync();
+        readDbContext.Database.SetCommandTimeout(Timeout.InfiniteTimeSpan);
+
+        var query = readDbContext.Persons
+            .Where(p => p.InductionStatusWithoutExemption == InductionStatus.Failed && p.InductionStatus != InductionStatus.Failed);
+
+        await foreach (var personChunk in query.ToAsyncEnumerable().ChunkAsync(20).WithCancellation(cancellationToken))
+        {
+            await using var writeDbContext = await dbContextFactory.CreateDbContextAsync();
+            
+            foreach (var person in personChunk)
+            {
+                writeDbContext.Attach(person);
+                var oldInduction = EventModels.Induction.FromModel(person);
+
+                person.InductionStatusWithoutExemption = InductionStatus.RequiredToComplete;
+
+                if (person.Trn == "0881545")
+                {
+                    person.InductionStatusWithoutExemption = InductionStatus.InProgress;
+                }
+
+                var newInduction = EventModels.Induction.FromModel(person);
+
+                var @event = new PersonInductionUpdatedEvent
+                {
+                    PersonId = person.PersonId,
+                    Induction = newInduction,
+                    OldInduction = oldInduction,
+                    ChangeReason = null,
+                    ChangeReasonDetail = null,
+                    EvidenceFile = null,
+                    Changes = PersonInductionUpdatedEventChanges.InductionStatusWithoutExemption,
+                    EventId = Guid.NewGuid(),
+                    CreatedUtc = clock.UtcNow,
+                    RaisedBy = DataStore.Postgres.Models.SystemUser.SystemUserId
+                };
+
+                writeDbContext.Events.Add(Event.FromEventBase(@event, inserted: null));
+            }
+
+            await writeDbContext.SaveChangesAsync();
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -226,6 +226,11 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
+                recurringJobManager.AddOrUpdate<FixInductionWithoutExemptionJob>(
+                    nameof(FixInductionWithoutExemptionJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
+                    Cron.Never);
+
                 return Task.CompletedTask;
             });
         }


### PR DESCRIPTION
We incorrectly set `InductionStatusWithoutExemption` to `Failed` for `Exempt` persons at induction migration (it should have been `RequiredToComplete`).

This adds a job to fix up the data, with one special case for a record that should be `InProgress`.