### PR TITLE
Add back end additions for TRN request support tasks

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
@@ -17,5 +17,6 @@ public class SupportTaskMapping : IEntityTypeConfiguration<SupportTask>
         builder.HasIndex(t => t.PersonId);
         builder.Property<JsonDocument>("_data").HasColumnName("data").IsRequired();
         builder.Ignore(t => t.Data);
+        builder.HasOne<TrnRequestMetadata>().WithMany().HasForeignKey(p => new { p.TrnRequestApplicationUserId, p.TrnRequestId });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424164400_SupportTaskTrnRequestMetadataLink.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424164400_SupportTaskTrnRequestMetadataLink.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250424164400_SupportTaskTrnRequestMetadataLink")]
+    partial class SupportTaskTrnRequestMetadataLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -16855,14 +16858,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Property<bool?>("PotentialDuplicate")
                         .HasColumnType("boolean")
                         .HasColumnName("potential_duplicate");
-
-                    b.Property<string>("PreviousFirstName")
-                        .HasColumnType("text")
-                        .HasColumnName("previous_first_name");
-
-                    b.Property<string>("PreviousLastName")
-                        .HasColumnType("text")
-                        .HasColumnName("previous_last_name");
 
                     b.Property<Guid?>("ResolvedPersonId")
                         .HasColumnType("uuid")

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424164400_SupportTaskTrnRequestMetadataLink.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424164400_SupportTaskTrnRequestMetadataLink.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SupportTaskTrnRequestMetadataLink : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "email",
+                table: "users",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "trn_request_application_user_id",
+                table: "support_tasks",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "trn_request_id",
+                table: "support_tasks",
+                type: "character varying(100)",
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_support_tasks_trn_request_metadata_trn_request_application_",
+                table: "support_tasks",
+                columns: new[] { "trn_request_application_user_id", "trn_request_id" },
+                principalTable: "trn_request_metadata",
+                principalColumns: new[] { "application_user_id", "request_id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_support_tasks_trn_request_metadata_trn_request_application_",
+                table: "support_tasks");
+
+            migrationBuilder.DropColumn(
+                name: "trn_request_application_user_id",
+                table: "support_tasks");
+
+            migrationBuilder.DropColumn(
+                name: "trn_request_id",
+                table: "support_tasks");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "email",
+                table: "users",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200,
+                oldNullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424170249_TrnRequestPreviousNames.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424170249_TrnRequestPreviousNames.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250424170249_TrnRequestPreviousNames")]
+    partial class TrnRequestPreviousNames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424170249_TrnRequestPreviousNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250424170249_TrnRequestPreviousNames.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnRequestPreviousNames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "previous_first_name",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "previous_last_name",
+                table: "trn_request_metadata",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "previous_first_name",
+                table: "trn_request_metadata");
+
+            migrationBuilder.DropColumn(
+                name: "previous_last_name",
+                table: "trn_request_metadata");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -19,6 +19,8 @@ public class SupportTask
     public required SupportTaskStatus Status { get; set; }
     public string? OneLoginUserSubject { get; init; }
     public Guid? PersonId { get; init; }
+    public Guid? TrnRequestApplicationUserId { get; init; }
+    public string? TrnRequestId { get; init; }
 
     public required object Data
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -11,6 +11,8 @@ public class TrnRequestMetadata
     public required string? FirstName { get; init; }
     public required string? MiddleName { get; init; }
     public required string? LastName { get; init; }
+    public string? PreviousFirstName { get; init; }
+    public string? PreviousLastName { get; init; }
     public required string[] Name { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public bool? PotentialDuplicate { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
@@ -21,6 +21,8 @@ public class TrnRequestMetadataMessageHandler(TrsDbContext dbContext) : IMessage
                 FirstName = message.FirstName,
                 MiddleName = message.MiddleName,
                 LastName = message.LastName,
+                PreviousFirstName = message.PreviousFirstName,
+                PreviousLastName = message.PreviousLastName,
                 DateOfBirth = message.DateOfBirth,
                 PotentialDuplicate = message.PotentialDuplicate,
                 NationalInsuranceNumber = message.NationalInsuranceNumber,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Messages/TrnRequestMetadataMessage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Messages/TrnRequestMetadataMessage.cs
@@ -12,6 +12,8 @@ public record TrnRequestMetadataMessage
     public string? FirstName { get; init; }
     public string? MiddleName { get; init; }
     public string? LastName { get; init; }
+    public string? PreviousFirstName { get; init; }
+    public string? PreviousLastName { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public bool? PotentialDuplicate { get; init; }
     public string? NationalInsuranceNumber { get; init; }


### PR DESCRIPTION
Adds a link between `SupportTask` and `TrnRequestMetadata` so we can associate a support task with a specific TRN request.

Also adds previous first & last name to `TrnRequestMetadata` as we'll need it for 'Get a TRN' requests going forward.

https://trello.com/c/8aPODZqj/1022-add-backend-support-for-support-tasks-related-to-trn-requests
