### PR TITLE
Sync QTS and EYTS into TRS persons table

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250425142820_PersonQtsDateAndEytsDate.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250425142820_PersonQtsDateAndEytsDate.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250425142820_PersonQtsDateAndEytsDate")]
+    partial class PersonQtsDateAndEytsDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250425142820_PersonQtsDateAndEytsDate.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250425142820_PersonQtsDateAndEytsDate.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersonQtsDateAndEytsDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "eyts_date",
+                table: "persons",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "qts_date",
+                table: "persons",
+                type: "date",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "eyts_date",
+                table: "persons");
+
+            migrationBuilder.DropColumn(
+                name: "qts_date",
+                table: "persons");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -32,6 +32,8 @@ public class Person
     /// This is different to <see cref="CpdInductionModifiedOn"/> (which is our timestamp).
     /// </summary>
     public DateTime? CpdInductionCpdModifiedOn { get; private set; }
+    public DateOnly? QtsDate { get; set; }
+    public DateOnly? EytsDate { get; set; }
     public ICollection<Qualification> Qualifications { get; } = new List<Qualification>();
     public ICollection<Alert> Alerts { get; } = new List<Alert>();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0054_QtsAndEytsDates.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0054_QtsAndEytsDates.sql
@@ -1,0 +1,2 @@
+alter table trs_persons add qts_date date
+alter table trs_persons add eyts_date date

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -1223,7 +1223,9 @@ public class TrsDataSyncHelper(
             "dqt_modified_on",
             "dqt_first_name",
             "dqt_middle_name",
-            "dqt_last_name"
+            "dqt_last_name",
+            "qts_date",
+            "eyts_date"
         };
 
         var columnsToUpdate = columnNames.Except(new[] { "person_id", "dqt_contact_id" }).ToArray();
@@ -1267,6 +1269,7 @@ public class TrsDataSyncHelper(
             Contact.Fields.dfeta_InductionStatus,
             Contact.Fields.dfeta_qtlsdate,
             Contact.Fields.dfeta_QTSDate,
+            Contact.Fields.dfeta_EYTSDate
         };
 
         Action<NpgsqlBinaryImporter, PersonInfo> writeRecord = (writer, person) =>
@@ -1288,6 +1291,8 @@ public class TrsDataSyncHelper(
             writer.WriteValueOrNull(person.DqtFirstName, NpgsqlDbType.Varchar);
             writer.WriteValueOrNull(person.DqtMiddleName, NpgsqlDbType.Varchar);
             writer.WriteValueOrNull(person.DqtLastName, NpgsqlDbType.Varchar);
+            writer.WriteValueOrNull(person.QtsDate, NpgsqlDbType.Date);
+            writer.WriteValueOrNull(person.EytsDate, NpgsqlDbType.Date);
         };
 
         return new ModelTypeSyncInfo<PersonInfo>()
@@ -1534,6 +1539,8 @@ public class TrsDataSyncHelper(
             DateOfBirth = c.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false),
             EmailAddress = c.EMailAddress1.NormalizeString(),
             NationalInsuranceNumber = c.dfeta_NINumber.NormalizeString(),
+            QtsDate = c.dfeta_QTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
+            EytsDate = c.dfeta_EYTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             DqtContactId = c.Id,
             DqtState = (int)c.StateCode!,
             DqtCreatedOn = c.CreatedOn!.Value,
@@ -1817,6 +1824,8 @@ public class TrsDataSyncHelper(
         public required DateOnly? DateOfBirth { get; init; }
         public required string? EmailAddress { get; init; }
         public required string? NationalInsuranceNumber { get; init; }
+        public required DateOnly? QtsDate { get; init; }
+        public required DateOnly? EytsDate { get; init; }
         public required Guid? DqtContactId { get; init; }
         public required int? DqtState { get; init; }
         public required DateTime? DqtCreatedOn { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -162,6 +162,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0051_TpsEmploymentsPersonEmailAndEmployerPostcode.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0052_TrsQualificationsExemptFromInduction.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0053_TpsEmploymentsEmployerEmail.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0054_QtsAndEytsDates.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Person.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.Person.cs
@@ -104,6 +104,8 @@ public partial class TrsDataSyncHelperTests
             Assert.Equal(entity.BirthDate?.ToDateOnlyWithDqtBstFix(isLocalTime: false), person.DateOfBirth);
             Assert.Equal(entity.EMailAddress1, person.EmailAddress);
             Assert.Equal(entity.dfeta_NINumber, person.NationalInsuranceNumber);
+            Assert.Equal(entity.dfeta_QTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true), person.QtsDate);
+            Assert.Equal(entity.dfeta_EYTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true), person.EytsDate);
             Assert.Equal((int)entity.StateCode!, person.DqtState);
             Assert.Equal(entity.CreatedOn, person.DqtCreatedOn);
             Assert.Equal(entity.ModifiedOn, person.DqtModifiedOn);
@@ -126,6 +128,8 @@ public partial class TrsDataSyncHelperTests
         var dateOfBirth = Faker.Identification.DateOfBirth();
         var email = Faker.Internet.Email();
         var nino = Faker.Identification.UkNationalInsuranceNumber();
+        var qtsDate = Clock.Today.AddDays(-40);
+        var eytsDate = Clock.Today.AddDays(-30);
 
         var newContact = existingContact?.Clone<Contact>() ?? new()
         {
@@ -143,6 +147,8 @@ public partial class TrsDataSyncHelperTests
         newContact.BirthDate = dateOfBirth;
         newContact.EMailAddress1 = email;
         newContact.dfeta_NINumber = nino;
+        newContact.dfeta_QTSDate = qtsDate.ToDateTimeWithDqtBstFix(isLocalTime: true);
+        newContact.dfeta_EYTSDate = eytsDate.ToDateTimeWithDqtBstFix(isLocalTime: true);
 
         return newContact;
     }


### PR DESCRIPTION
For person matching for TRN requests, we need to know who has QTS and EYTS. This adds `QtsDate` and `EytsDate` properties to `Person` and updates the person sync to populate them.

We'll need to do a full person sync to back-fill this.