### PR TITLE
Create new "Add a User" journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserPermissionTypes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserPermissionTypes.cs
@@ -21,7 +21,7 @@ public static class UserPermissionTypes
     public const string ManageUsers = "ManageUsers";
 
     [Display(Name = "Support tasks", Description = "Access to the Support tasks area of the console")]
-    public const string SuppportTasks = "SupportTasks";
+    public const string SupportTasks = "SupportTasks";
 
     public static IReadOnlyCollection<string> All { get; } = new[]
     {
@@ -30,18 +30,18 @@ public static class UserPermissionTypes
         NonDbsAlerts,
         DbsAlerts,
         ManageUsers,
-        SuppportTasks,
+        SupportTasks,
     };
 
     public static string GetDisplayNameForPermissionType(string permissionType)
     {
-        var member = typeof(UserPermissionTypes).GetField(permissionType) ?? throw new ArgumentException("Invalid permission type.", nameof(permissionType));
+        var member = typeof(UserPermissionTypes).GetField(permissionType) ?? throw new ArgumentException($@"Invalid permission type: ""{permissionType}"".", nameof(permissionType));
         return member.GetCustomAttribute<DisplayAttribute>()?.Name ?? member.Name;
     }
 
     public static string GetDisplayDescriptionForPermissionType(string permissionType)
     {
-        var member = typeof(UserPermissionTypes).GetField(permissionType) ?? throw new ArgumentException("Invalid permission type.", nameof(permissionType));
+        var member = typeof(UserPermissionTypes).GetField(permissionType) ?? throw new ArgumentException($@"Invalid permission type: ""{permissionType}"".", nameof(permissionType));
         return member.GetCustomAttribute<DisplayAttribute>()?.Description ?? string.Empty;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserRoles.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserRoles.cs
@@ -14,7 +14,7 @@ public static class UserRoles
         new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.None),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.View),
         new(UserPermissionTypes.ManageUsers, UserPermissionLevel.None),
-        new(UserPermissionTypes.SuppportTasks, UserPermissionLevel.None)
+        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.None)
     ];
 
     [Display(Name = "Support officer")]
@@ -26,7 +26,7 @@ public static class UserRoles
         new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.None),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.View),
         new(UserPermissionTypes.ManageUsers, UserPermissionLevel.None),
-        new(UserPermissionTypes.SuppportTasks, UserPermissionLevel.Edit)
+        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.Edit)
     ];
 
     [Display(Name = "Alerts manager (TRA decisions)")]
@@ -38,7 +38,7 @@ public static class UserRoles
         new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.View),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.Edit),
         new(UserPermissionTypes.ManageUsers, UserPermissionLevel.None),
-        new(UserPermissionTypes.SuppportTasks, UserPermissionLevel.None)
+        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.None)
     ];
 
     [Display(Name = "Alerts manager (TRA and DBS decisions)")]
@@ -50,7 +50,7 @@ public static class UserRoles
         new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.Edit),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.Edit),
         new(UserPermissionTypes.ManageUsers, UserPermissionLevel.None),
-        new(UserPermissionTypes.SuppportTasks, UserPermissionLevel.None)
+        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.None)
     ];
 
     [Display(Name = "Access manager")]
@@ -62,7 +62,7 @@ public static class UserRoles
         new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.None),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.View),
         new(UserPermissionTypes.ManageUsers, UserPermissionLevel.Edit),
-        new(UserPermissionTypes.SuppportTasks, UserPermissionLevel.Edit)
+        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.Edit)
     ];
 
     [Display(Name = "Administrator")]
@@ -80,7 +80,7 @@ public static class UserRoles
 
     public static string GetDisplayNameForRole(string role)
     {
-        var member = typeof(UserRoles).GetField(role) ?? throw new ArgumentException("Invalid role.", nameof(role));
+        var member = typeof(UserRoles).GetField(role) ?? throw new ArgumentException($@"Invalid role: ""{role}"".", nameof(role));
         return member.GetCustomAttribute<DisplayAttribute>()?.Name ?? member.Name;
     }
 
@@ -96,7 +96,7 @@ public static class UserRoles
             return UserPermissionTypes.All.Select(p => new UserPermission(p, UserPermissionLevel.Edit));
         }
 
-        var member = typeof(UserRoles).GetField($"{role}Permissions") ?? throw new ArgumentException("Invalid role.", nameof(role));
+        var member = typeof(UserRoles).GetField($"{role}Permissions") ?? throw new ArgumentException($@"Invalid role: ""{role}"".", nameof(role));
 
         if (member.GetValue(null) is IEnumerable<UserPermission> rolePermissions)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/ChangeManagementAuthorizationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/ChangeManagementAuthorizationHandler.cs
@@ -7,7 +7,7 @@ public class ChangeManagementAuthorizationHandler : AuthorizationHandler<ChangeM
 {
     protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ChangeManagementRequirement requirement)
     {
-        if (context.User.HasMinimumPermission(new(UserPermissionTypes.SuppportTasks, UserPermissionLevel.Edit)))
+        if (context.User.HasMinimumPermission(new(UserPermissionTypes.SupportTasks, UserPermissionLevel.Edit)))
         {
             context.Succeed(requirement);
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
@@ -95,7 +95,7 @@
     <govuk-notification-banner type="Success">
         @if (flashSuccess.Value.Heading is not null)
         {
-            <p class="govuk-notification-banner__heading">@flashSuccess.Value.Heading</p>
+            <h3 class="govuk-notification-banner__heading">@flashSuccess.Value.Heading</h3>
         }
         @if (flashSuccess.Value.Message is not null)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_Layout.cshtml
@@ -90,10 +90,13 @@
     @RenderSection("BeforeContent", required: false)
 }
 
-@if (TempData.TryGetFlashSuccess(out (string Heading, string? Message)? flashSuccess))
+@if (TempData.TryGetFlashSuccess(out (string? Heading, string? Message)? flashSuccess))
 {
     <govuk-notification-banner type="Success">
-        <p class="govuk-notification-banner__heading">@flashSuccess.Value.Heading</p>
+        @if (flashSuccess.Value.Heading is not null)
+        {
+            <p class="govuk-notification-banner__heading">@flashSuccess.Value.Heading</p>
+        }
         @if (flashSuccess.Value.Message is not null)
         {
             @foreach (var line in flashSuccess.Value.Message.Split("\n", StringSplitOptions.RemoveEmptyEntries))

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml
@@ -1,0 +1,85 @@
+@page "/users/add/confirm"
+@using TeachingRecordSystem.Core;
+@using TeachingRecordSystem.Core.Legacy
+@model TeachingRecordSystem.SupportUi.Pages.Users.AddUser.ConfirmModel
+@{
+    ViewBag.Title = "Add a user";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.AddUser()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form action="@LinkGenerator.AddUserConfirm(Model.UserId!)" method="post">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="Email" input-class="govuk-!-width-two-thirds" type="email" disabled />
+
+            <govuk-input asp-for="Name" input-class="govuk-!-width-two-thirds" />
+
+            <govuk-radios asp-for="@Model.Role" radios-class="trs-user-roles">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+
+                    @foreach (var role in Model.RoleOptions)
+                    {
+                        <govuk-radios-item value="@role.Name">@role.DisplayName</govuk-radios-item>
+                        <govuk-radios-divider>
+                            <table class="govuk-table">
+                                <caption class="govuk-table__caption govuk-table__caption--s">Permissions</caption>
+                     
+                                <thead class="govuk-table__head">
+                                    <tr class="govuk-table__row">
+                                        @foreach (var permission in role.Permissions)
+                                        {
+                                            <th scope="col" class="govuk-table__header">@permission.Type</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody class="govuk-table__body">
+                                    <tr class="govuk-table__row">
+                                        @foreach (var permission in role.Permissions)
+                                        {
+                                            switch (permission.Level)
+                                            {
+                                                case UserPermissionLevel.Edit:
+                                                    <td class="govuk-table__cell">
+                                                        <govuk-tag class="govuk-tag--green">
+                                                        EDIT
+                                                        </govuk-tag>
+                                                    </td>
+                                                    break;
+
+                                                case UserPermissionLevel.View:
+                                                    <td class="govuk-table__cell">
+                                                        <govuk-tag class="govuk-tag--yellow">
+                                                        VIEW
+                                                        </govuk-tag>
+                                                    </td>
+                                                    break;
+
+                                                default:
+                                                    <td class="govuk-table__cell">
+                                                        <govuk-tag class="govuk-tag--red">
+                                                        NO
+                                                        </govuk-tag>
+                                                    </td>
+                                                    break;
+                                            }
+                                        }
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </govuk-radios-divider>
+                    }
+                </govuk-radios-fieldset>
+            </govuk-radios>
+            <govuk-button type="submit">Add user</govuk-button>
+            <p class="govuk-body">
+                <a class="govuk-link govuk-link--no-visited-state" href=@LinkGenerator.Users()>Cancel and return to users</a>
+            </p>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
@@ -56,6 +56,12 @@ public class ConfirmModel(
             return BadRequest();
         }
 
+        // Only admins can create new admins
+        if (!User.IsInRole(UserRoles.Administrator) && Role == UserRoles.Administrator)
+        {
+            return BadRequest();
+        }
+
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();
@@ -104,7 +110,10 @@ public class ConfirmModel(
         Email = _user.Email;
         AzureAdUserId = _user.UserId;
 
-        RoleOptions = UserRoles.All.Select(r => new UserRoleViewModel
+        var showAdminRole = User.IsInRole(UserRoles.Administrator);
+        var userRoles = UserRoles.All.Where(r => showAdminRole || r != UserRoles.Administrator);
+
+        RoleOptions = userRoles.Select(r => new UserRoleViewModel
         {
             Name = r,
             DisplayName = UserRoles.GetDisplayNameForRole(r),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
+
+[Authorize(Policy = AuthorizationPolicies.UserManagement)]
+[RequireFeatureEnabledFilterFactory(FeatureNames.NewUserRoles)]
+public class ConfirmModel(
+    TrsDbContext dbContext,
+    IAadUserService userService,
+    IClock clock,
+    TrsLinkGenerator linkGenerator) : PageModel
+{
+    private Services.AzureActiveDirectory.User? _user;
+
+    [BindProperty(SupportsGet = true)]
+    public string? UserId { get; set; }
+
+    [Display(Name = "Email address")]
+    public string? Email { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Name")]
+    [Required(ErrorMessage = "Enter a name")]
+    [MaxLength(Core.DataStore.Postgres.Models.User.NameMaxLength, ErrorMessage = "Name must be 200 characters or less")]
+    public string? Name { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Role")]
+    [Required(ErrorMessage = "Select a role")]
+    public string? Role { get; set; }
+
+    public string? AzureAdUserId { get; set; }
+
+    public IEnumerable<UserRoleViewModel> RoleOptions { get; set; } = [];
+
+    public IActionResult OnGet()
+    {
+        Name = _user!.Name;
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        // Ensure submitted roles are valid
+        if (!string.IsNullOrWhiteSpace(Role) && !UserRoles.All.Contains(Role))
+        {
+            return BadRequest();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var newUser = new Core.DataStore.Postgres.Models.User()
+        {
+            Active = true,
+            AzureAdUserId = AzureAdUserId,
+            Email = _user!.Email,
+            Name = Name!,
+            Role = Role,
+            UserId = Guid.NewGuid()
+        };
+
+        dbContext.Users.Add(newUser);
+
+        await dbContext.AddEventAndBroadcastAsync(new UserAddedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            User = Core.Events.Models.User.FromModel(newUser),
+            RaisedBy = User.GetUserId(),
+            CreatedUtc = clock.UtcNow
+        });
+
+        await dbContext.SaveChangesAsync();
+
+        var roleName = UserRoles.GetDisplayNameForRole(Role!);
+        roleName = roleName.Substring(0, 1).ToLowerInvariant() + roleName.Substring(1);
+        var article = new[] { 'a', 'e', 'i', 'o', 'u' }.Any(vowel => roleName.StartsWith(vowel)) ? "an" : "a";
+
+        TempData.SetFlashSuccess(message: $"{Name} has been added as {article} {roleName}.");
+        return Redirect(linkGenerator.Users());
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        _user = await userService.GetUserByIdAsync(UserId!);
+
+        if (_user is null)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        Email = _user.Email;
+        AzureAdUserId = _user.UserId;
+
+        RoleOptions = UserRoles.All.Select(r => new UserRoleViewModel
+        {
+            Name = r,
+            DisplayName = UserRoles.GetDisplayNameForRole(r),
+            Permissions = UserRoles.GetPermissionsForRole(r).Select(p => new UserPermissionViewModel
+            {
+                Type = UserPermissionTypes.GetDisplayNameForPermissionType(p.Type),
+                Level = p.Level
+            })
+
+        });
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml
@@ -1,0 +1,21 @@
+@page "/users/add"
+@model TeachingRecordSystem.SupportUi.Pages.Users.AddUser.IndexModel
+@{
+    ViewBag.Title = "Add a user";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form action="@LinkGenerator.AddUser()" method="post">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="Email" label-class="govuk-label--m" type="email" autocomplete="off" />
+
+            <govuk-button type="submit">Add user</govuk-button>
+
+            <p class="govuk-body">
+                <a class="govuk-link govuk-link--no-visited-state" href=@LinkGenerator.Users()>Cancel and return to users</a>
+            </p>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
+
+[Authorize(Policy = AuthorizationPolicies.UserManagement)]
+[RequireFeatureEnabledFilterFactory(FeatureNames.NewUserRoles)]
+public class IndexModel(
+    TrsDbContext dbContext,
+    IAadUserService userService,
+    TrsLinkGenerator trsLinkGenerator) : PageModel
+{
+    [Display(Name = "Email address")]
+    [Required(ErrorMessage = "Enter an email address")]
+    [BindProperty]
+    public string? Email { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var email = Email!;
+        if (!email.Contains('@'))
+        {
+            email += "@education.gov.uk";
+        }
+
+        var user = await userService.GetUserByEmailAsync(email);
+
+        if (user is null)
+        {
+            ModelState.AddModelError(nameof(Email), "User does not exist");
+            return this.PageWithErrors();
+        }
+
+        var existingUser = await dbContext.Users.SingleOrDefaultAsync(u => u.AzureAdUserId == user.UserId);
+        if (existingUser is not null)
+        {
+            return Redirect(trsLinkGenerator.LegacyEditUser(existingUser.UserId));
+        }
+
+        return Redirect(trsLinkGenerator.AddUserConfirm(user.UserId));
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/UserPermissionViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/UserPermissionViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
+
+public class UserPermissionViewModel
+{
+    public required string Type { get; init; }
+    public required UserPermissionLevel Level { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/UserRoleViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/UserRoleViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
+
+public class UserRoleViewModel
+{
+    public required string Name { get; init; }
+    public required string DisplayName { get; init; }
+    public required IEnumerable<UserPermissionViewModel> Permissions { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/Index.cshtml
@@ -5,7 +5,7 @@
 }
 <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
-<govuk-button-link href="@LinkGenerator.LegacyAddUser()" data-testid="add-user">Add a new user</govuk-button-link>
+<govuk-button-link href="@LinkGenerator.AddUser()" data-testid="add-user">Add a new user</govuk-button-link>
 
 <div class="moj-filter-layout trs-filter-layout">
     <div class="moj-filter-layout__filter">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TempData.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TempData.cs
@@ -11,12 +11,12 @@ public static class TempDataKeys
 
 public static class TempDataExtensions
 {
-    public static void SetFlashSuccess(this ITempDataDictionary tempData, string heading, string? message = null)
+    public static void SetFlashSuccess(this ITempDataDictionary tempData, string? heading = null, string? message = null)
     {
         tempData.Add(TempDataKeys.FlashSuccess, new FlashSuccessData() { Heading = heading, Message = message }.Serialize());
     }
 
-    public static bool TryGetFlashSuccess(this ITempDataDictionary tempData, [NotNullWhen(true)] out (string Heading, string? Message)? result)
+    public static bool TryGetFlashSuccess(this ITempDataDictionary tempData, [NotNullWhen(true)] out (string? Heading, string? Message)? result)
     {
         if (tempData.TryGetValue(TempDataKeys.FlashSuccess, out object? flashSuccessObject) && flashSuccessObject is string flashSuccessString)
         {
@@ -33,7 +33,7 @@ public static class TempDataExtensions
 
     private class FlashSuccessData
     {
-        public required string Heading { get; init; }
+        public required string? Heading { get; init; }
         public required string? Message { get; init; }
 
         public string Serialize() => JsonSerializer.Serialize(this);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -355,6 +355,10 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
 
     public string Users() => GetRequiredPathByPage("/Users/Index");
 
+    public string AddUser() => GetRequiredPathByPage("/Users/AddUser/Index");
+
+    public string AddUserConfirm(string userId) => GetRequiredPathByPage("/Users/AddUser/Confirm", routeValues: new { userId });
+
     public string ApplicationUsers() => GetRequiredPathByPage("/ApplicationUsers/Index");
 
     public string AddApplicationUser() => GetRequiredPathByPage("/ApplicationUsers/AddApplicationUser");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -209,3 +209,23 @@
     }
   }
 }
+
+.govuk-radios.trs-user-roles {
+  .govuk-radios__divider {
+    width: inherit;
+    padding-left: 60px;
+
+    @include govuk-media-query($until: tablet) {
+      overflow-x: scroll;
+    }
+  }
+
+  .govuk-table {
+    table-layout: fixed;
+    min-width: 400px;
+
+    @include govuk-media-query($from: tablet) {
+      min-width: 500px;
+    }
+  }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
@@ -1,0 +1,426 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Users.AddUser;
+
+[Collection(nameof(DisableParallelization))]
+public class ConfirmTests : TestBase, IAsyncLifetime
+{
+    public ConfirmTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.NewUserRoles);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        TestUsers.ClearCache();
+    }
+
+    public Task DisposeAsync()
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.NewUserRoles);
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_UserWithoutAccessManagerRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role: null));
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/users/add/confirm?userId={userId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserIdDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/users/add/confirm?userId={userId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserWithoutAdministratorRole_CannotViewAdministratorInRoleOptions()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/users/add/confirm?userId={userId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var html = await AssertEx.HtmlResponseAsync(response);
+        var roleNames = html.QuerySelectorAll(".trs-user-roles input[type=radio]").Select(e => e.Attributes["value"]!.Value);
+
+        Assert.DoesNotContain(UserRoles.Administrator, roleNames);
+    }
+
+    [Fact]
+    public async Task Get_UserWithAdministratorRole_CanViewAdministratorInRoleOptions()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.Administrator);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/users/add/confirm?userId={userId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var html = await AssertEx.HtmlResponseAsync(response);
+        var roleNames = html.QuerySelectorAll(".trs-user-roles input[type=radio]").Select(e => e.Attributes["value"]!.Value);
+
+        Assert.Contains(UserRoles.Administrator, roleNames);
+    }
+
+    [Fact]
+    public async Task Post_UserWithoutAccessManagerRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role: null));
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+        var newName = Faker.Name.FullName();
+        var role = UserRoles.SupportOfficer;
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Name", newName },
+                { "Role", role }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserIdDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var userId = Guid.NewGuid().ToString();
+        var newName = Faker.Name.FullName();
+        var role = UserRoles.SupportOfficer;
+
+        ConfigureUserServiceMock(userId, null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Name", newName },
+                { "Role", role }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoName_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+        var role = UserRoles.SupportOfficer;
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Role", role },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "Name", "Enter a name");
+    }
+
+    [Fact]
+    public async Task Post_NoRole_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Name", name },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "Role", "Select a role");
+    }
+
+    [Fact]
+    public async Task Post_UserWithoutAdministratorRole_AddingUserWithNonExistentRole_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Name", name },
+                { "Role", "XXXXXX" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserWithoutAdministratorRole_AddingUserWithAdministratorRole_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Name", name },
+                { "Role", UserRoles.Administrator }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserWithAdministratorRole_AddingUserWithAdministratorRole_ReturnsFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.Administrator);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Name", name },
+                { "Role", UserRoles.Administrator }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_CreatesUserEmitsEventAndRedirectsWithFlashMessage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+        var newName = Faker.Name.FullName();
+        var role = UserRoles.SupportOfficer;
+
+        ConfigureUserServiceMock(userId, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/users/add/confirm?userId={userId}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Name", newName },
+                { "Role", role }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var newUser = await WithDbContext(dbContext => dbContext.Users.SingleOrDefaultAsync(u => u.AzureAdUserId == userId));
+        Assert.NotNull(newUser);
+
+        Assert.Equal(UserType.Person, newUser.UserType);
+        Assert.Equal(newName, newUser.Name);
+        Assert.Equal(email, newUser.Email);
+        Assert.Equal(userId, newUser.AzureAdUserId);
+        Assert.Equal(role, newUser.Role);
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var userCreatedEvent = Assert.IsType<UserAddedEvent>(e);
+            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
+            Assert.Equal(newName, userCreatedEvent.User.Name);
+            Assert.Equal(email, userCreatedEvent.User.Email);
+            Assert.Equal(userId, userCreatedEvent.User.AzureAdUserId);
+            Assert.Equal(role, userCreatedEvent.User.Role);
+        });
+
+        var redirectResponse = await response.FollowRedirectAsync(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{newName} has been added as a support officer.");
+    }
+
+    private void ConfigureUserServiceMock(string userId, Services.AzureActiveDirectory.User? user) =>
+        AzureActiveDirectoryUserServiceMock
+            .Setup(mock => mock.GetUserByIdAsync(userId))
+            .ReturnsAsync(user);
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
@@ -1,0 +1,216 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Users.AddUser;
+
+[Collection(nameof(DisableParallelization))]
+public class IndexTests : TestBase, IAsyncLifetime
+{
+    public IndexTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.NewUserRoles);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        TestUsers.ClearCache();
+    }
+
+    public Task DisposeAsync()
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.NewUserRoles);
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_UserWithoutAccessManagerRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role: null));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/users/add");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithAccessManagerUser_ReturnsOk()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/users/add");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserWithoutAccessManagerRole_ReturnsForbidden()
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(role: null));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/users/add");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoEmailEntered_RendersErrorMessage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/users/add")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", "" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "Email", "Enter an email address");
+    }
+
+
+    [Fact]
+    public async Task Post_UserNotFound_RendersErrorMessage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+
+        ConfigureUserServiceMock(email, null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/users/add")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "Email", "User does not exist");
+    }
+
+    [Fact]
+    public async Task Post_EmailDoesNotHaveSuffix_AppendsEducationSuffixBeforeSearching()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = "an.email";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/users/add")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        AzureActiveDirectoryUserServiceMock.Verify(mock => mock.GetUserByEmailAsync(email + "@education.gov.uk"));
+    }
+
+    [Fact]
+    public async Task Post_UserFound_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid().ToString();
+
+        ConfigureUserServiceMock(email, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/users/add")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/users/add/confirm?userId={userId}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_UserFound_ButAlreadyExistsInTrs_RedirectsToEditPage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var email = Faker.Internet.Email();
+        var name = Faker.Name.FullName();
+        var userId = Guid.NewGuid();
+        var existingUser = await TestData.CreateUserAsync(name: name, email: email, azureAdUserId: userId);
+
+        ConfigureUserServiceMock(email, new Services.AzureActiveDirectory.User()
+        {
+            Email = email,
+            Name = name,
+            UserId = userId.ToString()
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/users/add")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/legacy-users/{existingUser.UserId}", response.Headers.Location?.OriginalString);
+    }
+
+
+    private void ConfigureUserServiceMock(string email, Services.AzureActiveDirectory.User? user) =>
+        AzureActiveDirectoryUserServiceMock
+            .Setup(mock => mock.GetUserByEmailAsync(email))
+            .ReturnsAsync(user);
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
@@ -57,7 +57,7 @@ public class UsersTests : TestBase, IAsyncLifetime
     public async Task Get_ValidRequestAndUsersFound_RendersUsers()
     {
         // Arrange
-        var user = await TestData.CreateUserAsync();
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
         SetCurrentUser(user);
 
         // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
@@ -1,5 +1,4 @@
 using AngleSharp.Dom;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Users;
 
@@ -19,7 +18,11 @@ public class UsersTests : TestBase, IAsyncLifetime
         TestUsers.ClearCache();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public Task DisposeAsync()
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.NewUserRoles);
+        return Task.CompletedTask;
+    }
 
     [Fact]
     public async Task Get_UserWithoutAccessManagerRole_ReturnsForbidden()
@@ -55,6 +58,7 @@ public class UsersTests : TestBase, IAsyncLifetime
     {
         // Arrange
         var user = await TestData.CreateUserAsync();
+        SetCurrentUser(user);
 
         // Act
         var request = new HttpRequestMessage(HttpMethod.Get, RequestPath);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AssertEx.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AssertEx.cs
@@ -28,7 +28,7 @@ public static partial class AssertEx
         Assert.Equal(expectedMessage, errorMessage);
     }
 
-    public static void HtmlDocumentHasFlashSuccess(IHtmlDocument doc, string expectedMessage)
+    public static void HtmlDocumentHasFlashSuccess(IHtmlDocument doc, string? expectedHeading = null, string? expectedMessage = null)
     {
         var banner = doc.GetElementsByClassName("govuk-notification-banner--success").SingleOrDefault();
 
@@ -37,9 +37,19 @@ public static partial class AssertEx
             throw new XunitException("No notification banner found.");
         }
 
-        var message = banner.GetElementsByClassName("govuk-notification-banner__heading").SingleOrDefault();
+        if (expectedHeading != null)
+        {
+            var heading = banner.GetElementsByClassName("govuk-notification-banner__heading").SingleOrDefault();
 
-        Assert.Equal(expectedMessage, message?.TextContent?.Trim());
+            Assert.Equal(expectedHeading, heading?.TextContent?.Trim());
+        }
+
+        if (expectedMessage != null)
+        {
+            var message = string.Join("\n", banner.QuerySelectorAll(".govuk-notification-banner p").Select(e => e.TextContent.Trim()));
+
+            Assert.Equal(expectedMessage, message);
+        }
     }
 
     public static async Task HtmlResponseHasErrorAsync(


### PR DESCRIPTION
### Context

Following the access permissions redesign we need to update the Manage Users pages and journeys to reflect the new designs and functionality.

### Changes proposed in this pull request

* Adds new add user pages under the `users` path using new user role designs
* Prevents non-Administrators from viewing the Administrator role/adding Administrator users

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
