### PR TITLE
Add ColoredTagHelper

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/ColoredTagHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/ColoredTagHelper.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TeachingRecordSystem.SupportUi.TagHelpers;
+
+[HtmlTargetElement("colored-tag")]
+[OutputElementHint("strong")]
+public class ColoredTagHelper : TagHelper
+{
+    private static readonly string[] _tagClasses =
+    [
+        "govuk-tag--green",
+        "govuk-tag--turquoise",
+        "govuk-tag--blue",
+        "govuk-tag--light-blue",
+        "govuk-tag--purple",
+        "govuk-tag--pink",
+        "govuk-tag--red",
+        "govuk-tag--orange",
+        "govuk-tag--yellow"
+    ];
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var content = await output.GetChildContentAsync();
+
+        var colorClass = _tagClasses[
+            Math.Abs(
+                BitConverter.ToInt64(MD5.HashData(Encoding.UTF8.GetBytes(content.ToHtmlString()))[..^8])
+                % _tagClasses.Length)];
+
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.TagName = "strong";
+        output.AddClass("govuk-tag", HtmlEncoder.Default);
+        output.AddClass(colorClass, HtmlEncoder.Default);
+    }
+}
+


### PR DESCRIPTION
We have designs that have coloured tags with an application user's name in, where the colour is random. This adds a tag helper that will produce GDS tag with a random, but deterministic, colour assigned based on the content.

```razor
<colored-tag>Register</colored-tag>
```

<img width="82" alt="image" src="https://github.com/user-attachments/assets/504f88c7-0198-4af6-a713-e138f37ada57" />
