### PR TITLE
Add beginnings of list of API TRN requests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
@@ -17,6 +17,6 @@ public class SupportTaskMapping : IEntityTypeConfiguration<SupportTask>
         builder.HasIndex(t => t.PersonId);
         builder.Property<JsonDocument>("_data").HasColumnName("data").IsRequired();
         builder.Ignore(t => t.Data);
-        builder.HasOne<TrnRequestMetadata>().WithMany().HasForeignKey(p => new { p.TrnRequestApplicationUserId, p.TrnRequestId });
+        builder.HasOne(t => t.TrnRequestMetadata).WithMany().HasForeignKey(p => new { p.TrnRequestApplicationUserId, p.TrnRequestId });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
@@ -12,5 +12,6 @@ public class TrnRequestMetadataMapping : IEntityTypeConfiguration<TrnRequestMeta
         builder.Property(r => r.OneLoginUserSubject).HasMaxLength(255);
         builder.HasIndex(r => r.OneLoginUserSubject);
         builder.HasIndex(r => r.EmailAddress);
+        builder.HasOne(r => r.ApplicationUser).WithMany().HasForeignKey(r => r.ApplicationUserId);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250429081808_TrnRequestMetadataUserForeignKey.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250429081808_TrnRequestMetadataUserForeignKey.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250429081808_TrnRequestMetadataUserForeignKey")]
+    partial class TrnRequestMetadataUserForeignKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250429081808_TrnRequestMetadataUserForeignKey.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250429081808_TrnRequestMetadataUserForeignKey.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnRequestMetadataUserForeignKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddForeignKey(
+                name: "fk_trn_request_metadata_application_users_application_user_id",
+                table: "trn_request_metadata",
+                column: "application_user_id",
+                principalTable: "users",
+                principalColumn: "user_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_trn_request_metadata_application_users_application_user_id",
+                table: "trn_request_metadata");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -21,6 +21,7 @@ public class SupportTask
     public Guid? PersonId { get; init; }
     public Guid? TrnRequestApplicationUserId { get; init; }
     public string? TrnRequestId { get; init; }
+    public TrnRequestMetadata? TrnRequestMetadata { get; set; }
 
     public required object Data
     {
@@ -80,6 +81,7 @@ public class SupportTask
     internal static Type GetDataType(SupportTaskType supportTaskType) => supportTaskType switch
     {
         SupportTaskType.ConnectOneLoginUser => typeof(ConnectOneLoginUserData),
+        SupportTaskType.ApiTrnRequest => typeof(ApiTrnRequestData),
         _ => throw new ArgumentException($"Unknown {nameof(SupportTaskType)}: {supportTaskType}'.")
     };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -3,6 +3,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 public class TrnRequestMetadata
 {
     public required Guid ApplicationUserId { get; init; }
+    public ApplicationUser ApplicationUser { get; } = null!;
     public required string RequestId { get; init; }
     public required DateTime CreatedOn { get; init; }
     public required bool? IdentityVerified { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskCategory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskCategory.cs
@@ -8,6 +8,8 @@ public enum SupportTaskCategory
     OneLogin = 1,
     [SupportTaskCategoryInfo("change requests")]
     ChangeRequests = 2,
+    [SupportTaskCategoryInfo("TRN requests")]
+    TrnRequests = 3,
 }
 
 public static class SupportTaskCategoryRegistry

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ApiTrnRequestData.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ApiTrnRequestData.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Models.SupportTaskData;
+
+public record ApiTrnRequestData
+{
+}
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
@@ -10,6 +10,8 @@ public enum SupportTaskType
     ChangeNameRequest = 2,
     [SupportTaskTypeInfo("change date of birth request", SupportTaskCategory.ChangeRequests)]
     ChangeDateOfBirthRequest = 3,
+    [SupportTaskTypeInfo("TRN request from API", SupportTaskCategory.TrnRequests)]
+    ApiTrnRequest = 4,
 }
 
 public static class SupportTaskTypeRegistry

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml
@@ -1,0 +1,50 @@
+@page "/support-tasks/api-trn-requests"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Index
+@{
+    ViewBag.Title = "Potential duplicate records from APIs";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <span class="govuk-caption-l">Support tasks</span>
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+        <form action="@LinkGenerator.ApiTrnRequests()" method="get" asp-antiforgery="false">
+            <govuk-input asp-for="Search" label-class="govuk-label--s" autocomplete="off" />
+            @* TODO move this inside input when GFA library is updated *@
+            <govuk-button type="submit">Search</govuk-button>
+        </form>
+    </div>
+    <div class="govuk-grid-column-full-from-desktop" data-testid="results">
+        <table class="govuk-table">
+            <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">Name</th>
+                    <th scope="col" class="govuk-table__header">Email</th>
+                    <th scope="col" class="govuk-table__header">Requested on</th>
+                    <th scope="col" class="govuk-table__header">Source</th>
+                </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+                @if (Model.Results!.Length == 0)
+                {
+                    <tr class="govuk-table__row" data-testid="no-tasks-message">
+                        <td class="govuk-table__cell" colspan="4">No open support tasks</td>
+                    </tr>
+                }
+                else
+                {
+                    foreach (var result in Model.Results)
+                    {
+                        <tr class="govuk-table__row" data-testid="task:@result.SupportTaskReference">
+                            <th scope="row" class="govuk-table__header" data-testid="name">@result.FirstName @result.LastName</th>
+                            <td class="govuk-table__cell" data-testid="email">@result.EmailAddress</td>
+                            <td class="govuk-table__cell" data-testid="requested-on">@result.CreatedOn.ToString(UiDefaults.DateOnlyDisplayFormat)</td>
+                            <td class="govuk-table__cell" data-testid="source"><colored-tag>@result.SourceApplicationName</colored-tag></td>
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests;
+
+public class Index(TrsDbContext dbContext) : PageModel
+{
+    [Display(Name = "Search", Description = "By name, email or request date, for example 4/3/1975")]
+    [BindProperty(SupportsGet = true)]
+    [FromQuery]
+    public string? Search { get; set; }
+
+    public Result[]? Results { get; set; }
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var tasks = dbContext.SupportTasks
+            .Where(t => t.SupportTaskType == SupportTaskType.ApiTrnRequest && t.Status == SupportTaskStatus.Open);
+
+        Search = Search?.Trim() ?? string.Empty;
+
+        if (SearchTextIsDate(out var date))
+        {
+            var minDate = date.ToDateTime(new TimeOnly(0, 0, 0), DateTimeKind.Utc);
+            var maxDate = minDate.AddDays(1);
+            tasks = tasks.Where(t => t.TrnRequestMetadata!.CreatedOn >= minDate && t.TrnRequestMetadata.CreatedOn < maxDate);
+        }
+        else if (SearchTextIsEmail())
+        {
+            tasks = tasks
+                .Where(t => t.TrnRequestMetadata!.EmailAddress != null && t.TrnRequestMetadata.EmailAddress.ToLower() == Search.ToLower());
+        }
+        else
+        {
+            var nameParts = Search
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(n => n.ToLower())
+                .ToArray();
+
+            if (nameParts.Length > 0)
+            {
+                tasks = tasks.Where(t => nameParts.All(n => t.TrnRequestMetadata!.Name.Select(m => m.ToLower()).Contains(n)));
+            }
+        }
+
+        Results = await tasks
+            .Include(t => t.TrnRequestMetadata)
+            .ThenInclude(m => m!.ApplicationUser)
+            .Select(t => new Result(
+                t.SupportTaskReference,
+                t.TrnRequestMetadata!.FirstName!,
+                t.TrnRequestMetadata!.LastName!,
+                t.TrnRequestMetadata!.EmailAddress,
+                t.CreatedOn,
+                t.TrnRequestMetadata.ApplicationUser.Name))
+            .ToArrayAsync();
+
+        return Page();
+
+        bool SearchTextIsDate(out DateOnly date) =>
+            DateOnly.TryParseExact(Search, UiDefaults.DateOnlyDisplayFormat, out date) ||
+            DateOnly.TryParseExact(Search, "d/M/yyyy", out date);
+
+        bool SearchTextIsEmail() => Search.Contains('@');
+    }
+
+    public record Result(
+        string SupportTaskReference,
+        string FirstName,
+        string LastName,
+        string? EmailAddress,
+        DateTime CreatedOn,
+        string SourceApplicationName);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -382,6 +382,9 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
             _ => throw new ArgumentException($"Unknown {nameof(SupportTaskType)}: '{supportTaskType}'.", nameof(supportTaskType))
         };
 
+    public string ApiTrnRequests(string? search = null) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Index", routeValues: new { search });
+
     public string ConnectOneLoginUserSupportTask(string supportTaskReference) =>
         GetRequiredPathByPage("/SupportTasks/ConnectOneLoginUser/Index", routeValues: new { supportTaskReference });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
@@ -592,7 +592,7 @@ public class CreateTrnRequestTests(OperationTestFixture operationTestFixture) : 
     public async Task InitializeAsync()
     {
         // Any existing Contacts will affect our duplicate matching; clear them all out before every test
-        await OperationTestFixture.DbFixture.DbHelper.ClearDataAsync();
+        await OperationTestFixture.DbFixture.WithDbContextAsync(dbContext => dbContext.Persons.ExecuteDeleteAsync());
         XrmFakedContext.DeleteAllEntities<Contact>();
 
         GetAnIdentityApiClientMock

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnRequestTests.cs
@@ -185,7 +185,7 @@ public class GetTrnRequestTests(OperationTestFixture operationTestFixture) : Ope
     public async Task InitializeAsync()
     {
         // Any existing Contacts will affect our duplicate matching; clear them all out before every test
-        await OperationTestFixture.DbFixture.DbHelper.ClearDataAsync();
+        await OperationTestFixture.DbFixture.WithDbContextAsync(dbContext => dbContext.Persons.ExecuteDeleteAsync());
         XrmFakedContext.DeleteAllEntities<Contact>();
 
         GetAnIdentityApiClientMock

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/IndexTests.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using AngleSharp.Html.Dom;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.ApiTrnRequests;
+
+[Collection(nameof(DisableParallelization))]
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyncLifetime
+{
+    [Fact]
+    public async Task Get_NoOpenTasks_ShowsNoTasksMessage()
+    {
+        // Arrange
+        // TODO Create a Closed task when we can set them up
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/api-trn-requests/");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        Assert.NotNull(doc.GetElementByTestId("no-tasks-message"));
+    }
+
+    [Fact]
+    public async Task Get_WithTask_ShowsExpectedDataInResultsTable()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/api-trn-requests/");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var resultRow = doc.GetElementByTestId("results")
+            ?.GetElementsByTagName("tbody")
+            .FirstOrDefault()
+            ?.GetElementsByTagName("tr")
+            .FirstOrDefault();
+
+        Assert.NotNull(resultRow);
+        AssertRowHasContent("name", $"{supportTask.TrnRequestMetadata!.FirstName} {supportTask.TrnRequestMetadata!.LastName}");
+        AssertRowHasContent("email", supportTask.TrnRequestMetadata!.EmailAddress ?? string.Empty);
+        AssertRowHasContent("requested-on", supportTask.CreatedOn.ToString(UiDefaults.DateOnlyDisplayFormat));
+        AssertRowHasContent("source", applicationUser.Name);
+
+        void AssertRowHasContent(string testId, string expectedText)
+        {
+            var column = resultRow.GetElementByTestId(testId);
+            Assert.NotNull(column);
+            Assert.Equal(expectedText, column.TextContent);
+        }
+    }
+
+    [Fact]
+    public async Task Get_SearchByFirstName_ShowsMatchingResult()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var firstName = TestData.GenerateFirstName();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            configure: t => t.WithFirstName(firstName));
+
+        var search = firstName;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/?Search={Uri.EscapeDataString(search)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        doc.AssertResultsContainsTask(supportTask.SupportTaskReference);
+    }
+
+    [Fact]
+    public async Task Get_SearchByMiddleName_ShowsMatchingResult()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var middleName = TestData.GenerateMiddleName();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            configure: t => t.WithMiddleName(middleName));
+
+        var search = middleName;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/?Search={Uri.EscapeDataString(search)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        doc.AssertResultsContainsTask(supportTask.SupportTaskReference);
+    }
+
+    [Fact]
+    public async Task Get_SearchByLastName_ShowsMatchingResult()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var lastName = TestData.GenerateLastName();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            configure: t => t.WithLastName(lastName));
+
+        var search = lastName;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/?Search={Uri.EscapeDataString(search)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        doc.AssertResultsContainsTask(supportTask.SupportTaskReference);
+    }
+
+    [Fact]
+    public async Task Get_SearchByMultipleNameParts_ShowsMatchingResult()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var firstName = TestData.GenerateFirstName();
+        var lastName = TestData.GenerateFirstName();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            configure: t => t.WithFirstName(firstName).WithLastName(lastName));
+
+        var search = $"{firstName} {lastName}";
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/?Search={Uri.EscapeDataString(search)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        doc.AssertResultsContainsTask(supportTask.SupportTaskReference);
+    }
+
+    [Fact]
+    public async Task Get_SearchByEmailAddress_ShowsMatchingResult()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var emailAddress = TestData.GenerateUniqueEmail();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            configure: t => t.WithEmailAddress(emailAddress));
+
+        var search = emailAddress;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/?Search={Uri.EscapeDataString(search)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        doc.AssertResultsContainsTask(supportTask.SupportTaskReference);
+    }
+
+    [Theory]
+    [InlineData("d/M/yyyy")]
+    [InlineData("dd/MM/yyyy")]
+    [InlineData(UiDefaults.DateOnlyDisplayFormat)]
+    public async Task Get_SearchByRequestDate_ShowsMatchingResult(string dateFormat)
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var search = supportTask.CreatedOn.ToString(dateFormat);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/?Search={Uri.EscapeDataString(search)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        doc.AssertResultsContainsTask(supportTask.SupportTaskReference);
+    }
+
+    public Task InitializeAsync() => WithDbContext(dbContext =>
+        dbContext.SupportTasks.Where(t => t.SupportTaskType == SupportTaskType.ApiTrnRequest).ExecuteDeleteAsync());
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+
+file static class Extensions
+{
+    public static void AssertResultsContainsTask(this IHtmlDocument document, string supportTaskReference) =>
+        Assert.NotNull(document.GetElementByTestId($"task:{supportTaskReference}"));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
@@ -1,0 +1,114 @@
+using Optional;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+
+namespace TeachingRecordSystem.TestCommon;
+
+public partial class TestData
+{
+    public Task<SupportTask> CreateApiTrnRequestSupportTaskAsync(
+        Guid applicationUserId,
+        bool potentialDuplicate = false,
+        Action<CreateApiTrnRequestSupportTaskBuilder>? configure = null)
+    {
+        var builder = new CreateApiTrnRequestSupportTaskBuilder(applicationUserId, potentialDuplicate);
+        configure?.Invoke(builder);
+        return builder.ExecuteAsync(this);
+    }
+
+    public class CreateApiTrnRequestSupportTaskBuilder(Guid applicationUserId, bool potentialDuplicate)
+    {
+        private Option<string> _requestId;
+        private Option<string?> _emailAddress;
+        private Option<string> _firstName;
+        private Option<string> _middleName;
+        private Option<string> _lastName;
+        private Option<DateOnly> _dateOfBirth;
+        private Option<string?> _nationalInsuranceNumber;
+
+        public CreateApiTrnRequestSupportTaskBuilder WithFirstName(string firstName)
+        {
+            _firstName = Option.Some(firstName);
+            return this;
+        }
+
+        public CreateApiTrnRequestSupportTaskBuilder WithMiddleName(string? middleName)
+        {
+            _middleName = Option.Some(middleName ?? string.Empty);
+            return this;
+        }
+
+        public CreateApiTrnRequestSupportTaskBuilder WithLastName(string lastName)
+        {
+            _lastName = Option.Some(lastName);
+            return this;
+        }
+
+        public CreateApiTrnRequestSupportTaskBuilder WithEmailAddress(string? emailAddress)
+        {
+            _emailAddress = Option.Some(emailAddress);
+            return this;
+        }
+
+        public async Task<SupportTask> ExecuteAsync(TestData testData)
+        {
+            var trnRequestId = _requestId.ValueOr(Guid.NewGuid().ToString);
+            var emailAddress = _emailAddress.ValueOr(testData.GenerateUniqueEmail);
+            var firstName = _firstName.ValueOr(testData.GenerateFirstName);
+            var middleName = _middleName.ValueOr(testData.GenerateMiddleName);
+            var lastName = _lastName.ValueOr(testData.GenerateLastName);
+            var dateOfBirth = _dateOfBirth.ValueOr(testData.GenerateDateOfBirth);
+            var nationalInsuranceNumber = _nationalInsuranceNumber.ValueOr(testData.GenerateNationalInsuranceNumber);
+
+            var metadata = new TrnRequestMetadata
+            {
+                ApplicationUserId = applicationUserId,
+                RequestId = trnRequestId,
+                CreatedOn = testData.Clock.UtcNow,
+                IdentityVerified = null,
+                EmailAddress = emailAddress,
+                OneLoginUserSubject = null,
+                FirstName = firstName,
+                MiddleName = middleName,
+                LastName = lastName,
+                PreviousFirstName = null,
+                PreviousLastName = null,
+                Name = [firstName, middleName, lastName],
+                DateOfBirth = dateOfBirth,
+                PotentialDuplicate = potentialDuplicate,
+                NationalInsuranceNumber = nationalInsuranceNumber,
+                Gender = null,
+                AddressLine1 = null,
+                AddressLine2 = null,
+                AddressLine3 = null,
+                City = null,
+                Postcode = null,
+                Country = null,
+                TrnToken = null,
+                ResolvedPersonId = null
+            };
+
+            var task = new SupportTask
+            {
+                SupportTaskReference = SupportTask.GenerateSupportTaskReference(),
+                CreatedOn = testData.Clock.UtcNow,
+                UpdatedOn = testData.Clock.UtcNow,
+                SupportTaskType = SupportTaskType.ApiTrnRequest,
+                Status = SupportTaskStatus.Open,
+                Data = new ApiTrnRequestData(),
+                TrnRequestApplicationUserId = applicationUserId,
+                TrnRequestId = trnRequestId,
+                TrnRequestMetadata = metadata
+            };
+
+            await testData.WithDbContextAsync(async dbContext =>
+            {
+                dbContext.TrnRequestMetadata.Add(metadata);
+                dbContext.SupportTasks.Add(task);
+                await dbContext.SaveChangesAsync();
+            });
+
+            return task;
+        }
+    }
+}


### PR DESCRIPTION
This adds an initial version of the list of open API TRN requests page. There are some things that are not yet aligned to the designs or missing:
- Search button alignment;
- pagination;
- sortable table.

These will follow separately.

Permission checks will also be a in separate PR.

https://trello.com/c/kvHCycNP/1055-add-ui-for-managing-api-trn-request-potential-duplicates