### PR TITLE
Add page to choose potential duplicate for TRN request

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Infrastructure.EntityFramework;
 
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
 
@@ -13,5 +14,6 @@ public class TrnRequestMetadataMapping : IEntityTypeConfiguration<TrnRequestMeta
         builder.HasIndex(r => r.OneLoginUserSubject);
         builder.HasIndex(r => r.EmailAddress);
         builder.HasOne(r => r.ApplicationUser).WithMany().HasForeignKey(r => r.ApplicationUserId);
+        builder.OwnsOne(r => r.Matches, m => m.ToJson().OwnsMany(m => m.MatchedRecords));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250430074942_TrnRequestMetadataMatches.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250430074942_TrnRequestMetadataMatches.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250430074942_TrnRequestMetadataMatches")]
+    partial class TrnRequestMetadataMatches
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250430074942_TrnRequestMetadataMatches.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250430074942_TrnRequestMetadataMatches.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnRequestMetadataMatches : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "matches",
+                table: "trn_request_metadata",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "matches",
+                table: "trn_request_metadata");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -27,4 +27,15 @@ public class TrnRequestMetadata
     public string? Country { get; init; }
     public string? TrnToken { get; set; }
     public Guid? ResolvedPersonId { get; set; }
+    public TrnRequestMatches? Matches { get; set; }
+}
+
+public record TrnRequestMatches
+{
+    public required IReadOnlyList<TrnRequestMatchedRecord> MatchedRecords { get; init; }
+}
+
+public record TrnRequestMatchedRecord
+{
+    public required Guid PersonId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -21,4 +21,5 @@ public static class JourneyNames
     public const string EditInduction = nameof(EditInduction);
     public const string EditRouteToProfessionalStatus = nameof(EditRouteToProfessionalStatus);
     public const string AddRouteToProfessionalStatus = nameof(AddRouteToProfessionalStatus);
+    public const string ResolveApiTrnRequest = nameof(ResolveApiTrnRequest);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Conventions.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests;
+
+public class Conventions : IConfigureFolderConventions
+{
+    public void Configure(RazorPagesOptions options)
+    {
+        options.Conventions.AddFolderApplicationModelConvention(
+            this.GetFolderPathFromNamespace(),
+            model =>
+            {
+                // The Index page shows a list rather than a single task
+                if (model.RelativePath.EndsWith("/Index.cshtml"))
+                {
+                    return;
+                }
+
+                model.Filters.Add(new CheckSupportTaskExistsFilterFactory(openOnly: true, supportTaskType: SupportTaskType.ApiTrnRequest));
+            });
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Matches.cshtml
@@ -1,0 +1,172 @@
+@page "/support-tasks/api-trn-requests/{supportTaskReference}/matches/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Matches
+@{
+    ViewBag.Title = "Compare potential duplicates records";
+}
+
+<form action="@LinkGenerator.ApiTrnRequestMatches(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" method="post">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <span class="govuk-caption-l">Support tasks</span>
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half-from-desktop">
+            <govuk-inset-text class="govuk-!-margin-top-0">
+                Differences are highlighted in the existing record
+            </govuk-inset-text>
+            
+            <govuk-summary-card data-testid="request">
+                <govuk-summary-card-title>
+                    @Model.SourceApplicationUserName request
+                </govuk-summary-card-title>
+                <govuk-summary-list>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>First name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.FirstName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.MiddleName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.LastName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.MiddleName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.DateOfBirth.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.EmailAddress</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.NationalInsuranceNumber</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.Gender</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                </govuk-summary-list>
+            </govuk-summary-card>
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <h2 class="govuk-heading-m">Potential matches</h2>
+
+            @foreach (var match in Model.PotentialDuplicates!)
+            {
+                <govuk-summary-card data-testid="match">
+                    <govuk-summary-card-title>
+                        Record @match.Identifier
+                    </govuk-summary-card-title>
+                    <govuk-summary-list>
+                        @{
+                            var tags = new List<string>();
+
+                            if (match.HasActiveAlerts)
+                            {
+                                tags.Add("Alerts");
+                            }
+
+                            if (match.HasQts)
+                            {
+                                tags.Add("QTS");
+                            }
+
+                            if (match.HasEyts)
+                            {
+                                tags.Add("EYTS");
+                            }
+                        }
+                        @if (tags.Count > 0)
+                        {
+                            <govuk-summary-list-row>
+                                <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
+                                <govuk-summary-list-row-value>
+                                    @foreach (var tag in tags)
+                                    {
+                                        <govuk-tag>@tag</govuk-tag>
+                                    }
+                                </govuk-summary-list-row-value>
+                            </govuk-summary-list-row>
+                        }
+
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>First name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value use-empty-fallback>@match.FirstName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value use-empty-fallback>@match.MiddleName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value use-empty-fallback>@match.LastName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value use-empty-fallback>@match.MiddleName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value use-empty-fallback>@match.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value use-empty-fallback>@match.EmailAddress</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value use-empty-fallback>@match.NationalInsuranceNumber</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        @* <govuk-summary-list-row> *@
+                        @*     <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key> *@
+                        @*     <govuk-summary-list-row-value use-empty-fallback>@match.Gender</govuk-summary-list-row-value> *@
+                        @* </govuk-summary-list-row> *@
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@match.Trn</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    </govuk-summary-list>
+                </govuk-summary-card>
+            }
+                
+            <govuk-radios asp-for="PersonId">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m">
+                        Select a record to merge the @Model.SourceApplicationUserName request into
+                    </govuk-radios-fieldset-legend>
+                        
+                    @foreach (var match in Model.PotentialDuplicates!)
+                    {
+                        <govuk-radios-item value="@match.PersonId">
+                            Record @match.Identifier
+                        </govuk-radios-item>
+                    }
+                        
+                    <govuk-radios-divider>or</govuk-radios-divider>
+                        
+                    <govuk-radios-item value="@ResolveApiTrnRequestState.CreateNewRecordPersonIdSentinel">
+                        I want to create a new record from the @Model.SourceApplicationUserName request
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+                
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button type="submit" formaction="@LinkGenerator.ApiTrnRequestMatchesCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary">Cancel</govuk-button>
+            </div>
+        </div>
+    </div>
+</form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Matches.cshtml.cs
@@ -1,0 +1,114 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt.Models;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests;
+
+[Journey(JourneyNames.ResolveApiTrnRequest), RequireJourneyInstance, ActivatesJourney]
+public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<ResolveApiTrnRequestState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public string? SupportTaskReference { get; set; }
+
+    public TrnRequestMetadata? RequestData { get; set; }
+
+    public string SourceApplicationUserName => RequestData!.ApplicationUser.Name;
+
+    public PotentialDuplicate[]? PotentialDuplicates { get; set; }
+
+    [BindProperty]
+    [Required(ErrorMessage = "Select a record")]
+    public Guid? PersonId { get; set; }
+
+    public void OnGet()
+    {
+        PersonId = JourneyInstance!.State.PersonId;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        // Verify the submitted ID is legit
+        if (PersonId is Guid personId &&
+            (!PotentialDuplicates!.Any(d => d.PersonId == personId) && personId != ResolveApiTrnRequestState.CreateNewRecordPersonIdSentinel))
+        {
+            return BadRequest();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state => state.PersonId = PersonId);
+
+        return Redirect(linkGenerator.ApiTrnRequestMerge(SupportTaskReference!, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancelAsync()
+    {
+        await JourneyInstance!.DeleteAsync();
+
+        return Redirect(linkGenerator.ApiTrnRequests());
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        RequestData = supportTask.TrnRequestMetadata!;
+
+        if (RequestData.PotentialDuplicate != true ||
+            RequestData.Matches is not { MatchedRecords.Count: >= 1 })
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        var matchedPersonIds = RequestData.Matches.MatchedRecords.Select(m => m.PersonId).ToArray();
+
+        PotentialDuplicates = (await dbContext.Persons
+                .Where(p => matchedPersonIds.Contains(p.PersonId) && p.DqtState == (int)ContactState.Active)
+                .Select(p => new PotentialDuplicate
+                {
+                    Identifier = 'X', // We'll fix this below, can't do it over an IQueryable
+                    PersonId = p.PersonId,
+                    FirstName = p.FirstName,
+                    MiddleName = p.MiddleName,
+                    LastName = p.LastName,
+                    DateOfBirth = p.DateOfBirth,
+                    EmailAddress = p.EmailAddress,
+                    NationalInsuranceNumber = p.NationalInsuranceNumber,
+                    Trn = p.Trn!,
+                    HasQts = p.QtsDate != null,
+                    HasEyts = p.EytsDate != null,
+                    HasActiveAlerts = p.Alerts.Any(a => a.IsOpen)
+                })
+                .ToArrayAsync())
+            .Select((r, i) => r with { Identifier = (char)('A' + i) })
+            .ToArray();
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+    }
+
+    public record PotentialDuplicate
+    {
+        public required char Identifier { get; init; }
+        public required Guid PersonId { get; init; }
+        public required string FirstName { get; init; }
+        public required string MiddleName { get; init; }
+        public required string LastName { get; init; }
+        public required DateOnly? DateOfBirth { get; init; }
+        public required string? EmailAddress { get; init; }
+        public required string? NationalInsuranceNumber { get; init; }
+        public required string Trn { get; init; }
+        // TODO Gender
+        public required bool HasQts { get; init; }
+        public required bool HasEyts { get; init; }
+        public required bool HasActiveAlerts { get; init; }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Merge.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Merge.cshtml
@@ -1,0 +1,5 @@
+@page "/support-tasks/api-trn-requests/{supportTaskReference}/merge/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Merge
+@{
+    ViewBag.Title = "Select the details to merge";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Merge.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Merge.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests;
+
+[Journey(JourneyNames.ResolveApiTrnRequest), RequireJourneyInstance]
+public class Merge : PageModel
+{
+    public void OnGet()
+    {
+
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/ResolveApiTrnRequestState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/ResolveApiTrnRequestState.cs
@@ -1,0 +1,14 @@
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests;
+
+public class ResolveApiTrnRequestState : IRegisterJourney
+{
+    public static Guid CreateNewRecordPersonIdSentinel => Guid.Empty;
+
+    public static JourneyDescriptor Journey { get; } = new(
+        JourneyNames.ResolveApiTrnRequest,
+        typeof(ResolveApiTrnRequestState),
+        ["supportTaskReference"],
+        appendUniqueKey: true);
+
+    public Guid? PersonId { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -384,11 +384,21 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
         supportTaskType switch
         {
             SupportTaskType.ConnectOneLoginUser => ConnectOneLoginUserSupportTask(supportTaskReference),
+            SupportTaskType.ApiTrnRequest => ApiTrnRequestMatches(supportTaskReference),
             _ => throw new ArgumentException($"Unknown {nameof(SupportTaskType)}: '{supportTaskType}'.", nameof(supportTaskType))
         };
 
     public string ApiTrnRequests(string? search = null) =>
         GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Index", routeValues: new { search });
+
+    public string ApiTrnRequestMatches(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Matches", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+
+    public string ApiTrnRequestMatchesCancel(string supportTaskReference, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Matches", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId, handler: "Cancel");
+
+    public string ApiTrnRequestMerge(string supportTaskReference, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Merge", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
 
     public string ConnectOneLoginUserSupportTask(string supportTaskReference) =>
         GetRequiredPathByPage("/SupportTasks/ConnectOneLoginUser/Index", routeValues: new { supportTaskReference });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/IndexTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using AngleSharp.Html.Dom;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.ApiTrnRequests;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/MatchesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/MatchesTests.cs
@@ -1,0 +1,385 @@
+using AngleSharp.Dom;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.ApiTrnRequests;
+
+public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_TaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var taskReference = SupportTask.GenerateSupportTaskReference();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/{taskReference}/matches");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_TaskIsClosed_ReturnsNotFound()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            t => t.WithStatus(SupportTaskStatus.Closed));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ShowsRequestDetails()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var requestDetails = doc.GetElementByTestId("request");
+        Assert.NotNull(requestDetails);
+        Assert.Equal(requestDetails.GetSummaryListValueForKey("First name"), supportTask.TrnRequestMetadata!.FirstName);
+        Assert.Equal(requestDetails.GetSummaryListValueForKey("Middle name"), supportTask.TrnRequestMetadata!.MiddleName);
+        Assert.Equal(requestDetails.GetSummaryListValueForKey("Last name"), supportTask.TrnRequestMetadata!.LastName);
+        Assert.Equal(requestDetails.GetSummaryListValueForKey("Date of birth"), supportTask.TrnRequestMetadata!.DateOfBirth.ToString(UiDefaults.DateOnlyDisplayFormat));
+        Assert.Equal(requestDetails.GetSummaryListValueForKey("Email"), supportTask.TrnRequestMetadata!.EmailAddress);
+        Assert.Equal(requestDetails.GetSummaryListValueForKey("National Insurance number"), supportTask.TrnRequestMetadata!.NationalInsuranceNumber);
+        // TODO Gender
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ShowsDetailsOfMatchedRecords()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var firstMatch = await WithDbContext(
+            dbContext => dbContext.Persons.SingleAsync(
+                p => p.PersonId == supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId));
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var firstMatchDetails = doc.GetAllElementsByTestId("match").First();
+        Assert.NotNull(firstMatchDetails);
+        Assert.Equal(firstMatchDetails.GetSummaryListValueForKey("First name"), firstMatch.FirstName);
+        Assert.Equal(firstMatchDetails.GetSummaryListValueForKey("Middle name"), firstMatch.MiddleName);
+        Assert.Equal(firstMatchDetails.GetSummaryListValueForKey("Last name"), firstMatch.LastName);
+        Assert.Equal(firstMatchDetails.GetSummaryListValueForKey("Date of birth"), firstMatch.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat));
+        Assert.Equal(firstMatchDetails.GetSummaryListValueForKey("Email"), firstMatch.EmailAddress);
+        Assert.Equal(firstMatchDetails.GetSummaryListValueForKey("National Insurance number"), firstMatch.NationalInsuranceNumber);
+        // TODO Gender
+    }
+
+    [Fact]
+    public async Task Get_MatchedRecordHasActiveAlerts_ShowsAlertsTag()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithAlert());
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            t => t.WithMatchedRecords(matchedPerson.PersonId));
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var firstMatchDetails = doc.GetAllElementsByTestId("match").First();
+        Assert.NotNull(firstMatchDetails);
+        var tags = firstMatchDetails.GetSummaryListValueElementForKey("Status")?.GetElementsByClassName("govuk-tag").Select(e => e.TextContent) ?? [];
+        Assert.Contains("Alerts", tags);
+    }
+
+    [Fact]
+    public async Task Get_MatchedRecordHasQts_ShowsQtsTag()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithQts());
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            t => t.WithMatchedRecords(matchedPerson.PersonId));
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var firstMatchDetails = doc.GetAllElementsByTestId("match").First();
+        Assert.NotNull(firstMatchDetails);
+        var tags = firstMatchDetails.GetSummaryListValueElementForKey("Status")?.GetElementsByClassName("govuk-tag").Select(e => e.TextContent) ?? [];
+        Assert.Contains("QTS", tags);
+    }
+
+    [Fact]
+    public async Task Get_MatchedRecordHasEyts_ShowsQtsTag()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithEyts(Clock.Today.AddDays(-1), "222"));
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            t => t.WithMatchedRecords(matchedPerson.PersonId));
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var firstMatchDetails = doc.GetAllElementsByTestId("match").First();
+        Assert.NotNull(firstMatchDetails);
+        var tags = firstMatchDetails.GetSummaryListValueElementForKey("Status")?.GetElementsByClassName("govuk-tag").Select(e => e.TextContent) ?? [];
+        Assert.Contains("EYTS", tags);
+    }
+
+    [Fact]
+    public async Task Get_PersonIdInState_SelectsChosenRecord()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var firstMatchId = supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId;
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState() { PersonId = firstMatchId });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        Assert.True(
+            doc.GetElementsByName("PersonId")
+                .Single(e => e.GetAttribute("value") == firstMatchId.ToString())
+                .IsChecked());
+    }
+
+    [Fact]
+    public async Task Get_CreateNewRecordInState_SelectsCreateNewRecordOption()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState() { PersonId = ResolveApiTrnRequestState.CreateNewRecordPersonIdSentinel });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        Assert.True(
+            doc.GetElementsByName("PersonId")
+                .Single(e => e.GetAttribute("value") == ResolveApiTrnRequestState.CreateNewRecordPersonIdSentinel.ToString())
+                .IsChecked());
+    }
+
+    [Fact]
+    public async Task Post_TaskIsClosed_ReturnsNotFound()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUser.UserId,
+            t => t.WithStatus(SupportTaskStatus.Closed));
+
+        var personId = supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId;
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder() { { "PersonId", personId } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_SubmittedPersonIdIsNotValid_ReturnsBadRequest()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var unmatchedPerson = await TestData.CreatePersonAsync();
+        var personId = unmatchedPerson.PersonId;
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder() { { "PersonId", personId } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoChosenPersonId_ReturnsError()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "PersonId", "Select a record");
+    }
+
+    [Fact]
+    public async Task Post_ValidPersonIdChosen_UpdatesStateAndRedirects()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var personId = supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId;
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder() { { "PersonId", personId } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(personId, journeyInstance.State.PersonId);
+    }
+
+    [Fact]
+    public async Task Post_CreateNewRecordChosen_UpdatesStateAndRedirects()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var personId = ResolveApiTrnRequestState.CreateNewRecordPersonIdSentinel;
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder() { { "PersonId", personId } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(personId, journeyInstance.State.PersonId);
+    }
+
+    private Task<JourneyInstance<ResolveApiTrnRequestState>> CreateJourneyInstance(
+            string supportTaskReference,
+            ResolveApiTrnRequestState? state = null) =>
+        CreateJourneyInstance(
+            JourneyNames.ResolveApiTrnRequest,
+            state ?? new(),
+            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
+}
+


### PR DESCRIPTION
This adds a page where a user can select a matched record for a TRN request, or choose to create a new one.

Highlighting attribute differences isn't included here but will follow separately. Gender isn't included yet either since we have some model changes to fix up.