### PR TITLE
Fix end-to-end user tests

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -100,10 +100,16 @@ public sealed class HostFixture : IAsyncDisposable, IStartupTask
                     {
                         var userService = new Mock<IAadUserService>();
                         userService
-                            .Setup(s => s.GetUserByEmailAsync(It.IsAny<string>()))
+                            .Setup(s => s.GetUserByEmailAsync(TestUsers.TestLegacyAzureActiveDirectoryUser.Email))
+                            .ReturnsAsync(TestUsers.TestLegacyAzureActiveDirectoryUser);
+                        userService
+                            .Setup(s => s.GetUserByEmailAsync(TestUsers.TestAzureActiveDirectoryUser.Email))
                             .ReturnsAsync(TestUsers.TestAzureActiveDirectoryUser);
                         userService
-                            .Setup(s => s.GetUserByIdAsync(It.IsAny<string>()))
+                            .Setup(s => s.GetUserByIdAsync(TestUsers.TestLegacyAzureActiveDirectoryUser.UserId))
+                            .ReturnsAsync(TestUsers.TestLegacyAzureActiveDirectoryUser);
+                        userService
+                            .Setup(s => s.GetUserByIdAsync(TestUsers.TestAzureActiveDirectoryUser.UserId))
                             .ReturnsAsync(TestUsers.TestAzureActiveDirectoryUser);
                         return userService.Object;
                     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/LegacyUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/LegacyUserTests.cs
@@ -7,10 +7,10 @@ public class LegacyUserTests : TestBase
     {
     }
 
-    [Fact(Skip = "Timing out at page.AssertOnLegacyAddUserConfirmPageAsync() - needs looking into")]
+    [Fact]
     public async Task AddUser()
     {
-        var testAzAdUser = TestUsers.TestAzureActiveDirectoryUser;
+        var testAzAdUser = TestUsers.TestLegacyAzureActiveDirectoryUser;
         await TestData.CreateCrmUserAsync(azureAdUserId: Guid.Parse(testAzAdUser.UserId), dqtRoles: ["CRM Helpdesk"]);
 
         await using var context = await HostFixture.CreateBrowserContext();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
@@ -7,7 +7,7 @@ public class UserTests : TestBase
     {
     }
 
-    [Fact(Skip = "Timing out at page.AssertOnLegacyAddUserConfirmPageAsync() - needs looking into")]
+    [Fact]
     public async Task AddUser()
     {
         var testAzAdUser = TestUsers.TestAzureActiveDirectoryUser;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestUsers.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestUsers.cs
@@ -22,6 +22,13 @@ public static class TestUsers
         Name = "Test AZ AD User"
     };
 
+    public static AzAdUser TestLegacyAzureActiveDirectoryUser { get; } = new()
+    {
+        UserId = Guid.NewGuid().ToString(),
+        Email = Faker.Internet.Email(),
+        Name = "Test Legacy AZ AD User"
+    };
+
     public class CreateUsersStartupTask(TrsDbContext trsDbContext) : IStartupTask
     {
         public Task ExecuteAsync()


### PR DESCRIPTION
Fixes failing end-to-end tests caused by more than one add user test (legacy and new add user journeys) - meaning whichever add user test ran last failed as it was seeing the edit user page.