### PR TITLE
Add new reactivate user journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser.cshtml
@@ -81,6 +81,10 @@
             {
                 <govuk-button type="submit">Save changes</govuk-button>
             }
+            else
+            {
+                <govuk-button type="submit" asp-page-handler="activate">Reactivate user</govuk-button>
+            }
 
             <p class="govuk-body">
                 <a class="govuk-link govuk-link--no-visited-state" href=@LinkGenerator.Users()>Cancel and return to users</a>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
@@ -63,4 +63,28 @@ public class UserTests : TestBase
 
         await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name} has been changed to a support officer.");
     }
+
+    [Fact]
+    public async Task ReactivateUser()
+    {
+        var azAdUserId = Guid.NewGuid();
+        var user = await TestData.CreateUserAsync(active: false, azureAdUserId: azAdUserId, role: UserRoles.AccessManager);
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToUsersPageAsync();
+
+        await page.AssertOnUsersPageAsync();
+
+        await page.ClickLinkForElementWithTestIdAsync($"edit-user-{user.UserId}");
+
+        await page.AssertOnEditUserPageAsync(user.UserId);
+
+        await page.ClickButtonAsync("Reactivate user");
+
+        await page.AssertOnUsersPageAsync();
+
+        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name} has been reactivated.");
+    }
 }


### PR DESCRIPTION
### Context

Following the access permissions redesign we need to update the Reactivate users journey to reflect the new designs and functionality.

### Changes proposed in this pull request

* Adds reactivate action to edit user page
* Makes sure only Admins can reactivate other Admins

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
