### PR TITLE
Show differences between matched record and TRN request

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
@@ -250,10 +250,10 @@ public class SignInJourneyHelper(
             {
                 return new(getAnIdentityPerson.PersonId, getAnIdentityPerson.Trn!, MatchRoute: null, MatchedAttributes: null);
             }
-            var matchedAttributes = new Dictionary<OneLoginUserMatchedAttribute, string>()
+            var matchedAttributes = new Dictionary<PersonMatchedAttribute, string>()
             {
-                { OneLoginUserMatchedAttribute.LastName, matchedLastName },
-                { OneLoginUserMatchedAttribute.DateOfBirth, matchedDateOfBirth.ToString("yyyy-MM-dd") }
+                { PersonMatchedAttribute.LastName, matchedLastName },
+                { PersonMatchedAttribute.DateOfBirth, matchedDateOfBirth.ToString("yyyy-MM-dd") }
             };
 
             if (trnTokenModel is not null)
@@ -437,7 +437,7 @@ public class SignInJourneyHelper(
         Guid PersonId,
         string Trn,
         OneLoginUserMatchRoute? MatchRoute,
-        IReadOnlyCollection<KeyValuePair<OneLoginUserMatchedAttribute, string>>? MatchedAttributes);
+        IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>>? MatchedAttributes);
 
     private record TryMatchToTrnRequestResult(string Trn);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
@@ -29,8 +29,8 @@ public class OneLoginUserMapping : IEntityTypeConfiguration<OneLoginUser>
         builder.Property(o => o.LastCoreIdentityVc).HasColumnType("jsonb");
         builder.Property(o => o.MatchedAttributes).HasColumnType("jsonb").HasConversion<string>(
             v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-            v => JsonSerializer.Deserialize<KeyValuePair<OneLoginUserMatchedAttribute, string>[]>(v, (JsonSerializerOptions?)null),
-            new ValueComparer<KeyValuePair<OneLoginUserMatchedAttribute, string>[]>(
+            v => JsonSerializer.Deserialize<KeyValuePair<PersonMatchedAttribute, string>[]>(v, (JsonSerializerOptions?)null),
+            new ValueComparer<KeyValuePair<PersonMatchedAttribute, string>[]>(
                 (a, b) => a == b,  // Reference equality is fine here; we'll always replace the entire collection
                 v => v.GetHashCode()));
         builder.HasOne<ApplicationUser>().WithMany().HasForeignKey(o => o.VerifiedByApplicationUserId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
@@ -18,7 +18,7 @@ public class OneLoginUser
     public DateOnly[]? VerifiedDatesOfBirth { get; private set; }
     public string? LastCoreIdentityVc { get; set; }
     public OneLoginUserMatchRoute? MatchRoute { get; private set; }
-    public KeyValuePair<OneLoginUserMatchedAttribute, string>[]? MatchedAttributes { get; private set; }
+    public KeyValuePair<PersonMatchedAttribute, string>[]? MatchedAttributes { get; private set; }
     public Guid? VerifiedByApplicationUserId { get; private set; }
 
     public void SetVerified(
@@ -52,7 +52,7 @@ public class OneLoginUser
     public void SetMatched(
         Guid personId,
         OneLoginUserMatchRoute route,
-        KeyValuePair<OneLoginUserMatchedAttribute, string>[]? matchedAttributes)
+        KeyValuePair<PersonMatchedAttribute, string>[]? matchedAttributes)
     {
         Debug.Assert(VerifiedOn is not null);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/PersonMatchedAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/PersonMatchedAttribute.cs
@@ -1,6 +1,6 @@
 namespace TeachingRecordSystem.Core.Models;
 
-public enum OneLoginUserMatchedAttribute
+public enum PersonMatchedAttribute
 {
     FullName = 1,
     LastName = 2,
@@ -8,4 +8,6 @@ public enum OneLoginUserMatchedAttribute
     NationalInsuranceNumber = 4,
     Trn = 5,
     FirstName = 6,
+    MiddleName = 7,
+    EmailAddress = 8
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/IPersonMatchingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/IPersonMatchingService.cs
@@ -4,5 +4,5 @@ public interface IPersonMatchingService
 {
     Task<MatchResult?> MatchAsync(MatchRequest request);
     Task<IReadOnlyCollection<SuggestedMatch>> GetSuggestedMatchesAsync(GetSuggestedMatchesRequest request);
-    Task<IReadOnlyCollection<KeyValuePair<OneLoginUserMatchedAttribute, string>>> GetMatchedAttributesAsync(GetSuggestedMatchesRequest request, Guid personId);
+    Task<IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>>> GetMatchedAttributesAsync(GetSuggestedMatchesRequest request, Guid personId);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/MatchResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/MatchResult.cs
@@ -1,3 +1,3 @@
 namespace TeachingRecordSystem.Core.Services.PersonMatching;
 
-public record MatchResult(Guid PersonId, string Trn, IReadOnlyCollection<KeyValuePair<OneLoginUserMatchedAttribute, string>> MatchedAttributes);
+public record MatchResult(Guid PersonId, string Trn, IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>> MatchedAttributes);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/PersonMatchingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/PersonMatching/PersonMatchingService.cs
@@ -59,10 +59,10 @@ public class PersonMatchingService(TrsDbContext dbContext) : IPersonMatchingServ
             _ => null
         };
 
-        static IReadOnlyCollection<KeyValuePair<OneLoginUserMatchedAttribute, string>> MapMatchedAttrs(JsonDocument doc) =>
+        static IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>> MapMatchedAttrs(JsonDocument doc) =>
             doc.Deserialize<MatchedAttribute[]>()!
-                .Select(a => new KeyValuePair<OneLoginUserMatchedAttribute, string>(
-                    Enum.Parse<OneLoginUserMatchedAttribute>(a.attribute_type),
+                .Select(a => new KeyValuePair<PersonMatchedAttribute, string>(
+                    Enum.Parse<PersonMatchedAttribute>(a.attribute_type),
                     a.attribute_value))
                 .AsReadOnly();
     }
@@ -148,7 +148,7 @@ public class PersonMatchingService(TrsDbContext dbContext) : IPersonMatchingServ
             .AsReadOnly();
     }
 
-    public async Task<IReadOnlyCollection<KeyValuePair<OneLoginUserMatchedAttribute, string>>> GetMatchedAttributesAsync(GetSuggestedMatchesRequest request, Guid personId)
+    public async Task<IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>>> GetMatchedAttributesAsync(GetSuggestedMatchesRequest request, Guid personId)
     {
         var fullNames = request.Names.Where(parts => parts.Length > 1).Select(parts => $"{parts.First()} {parts.Last()}").ToArray();
         var lastNames = request.Names.Select(parts => parts.Last()).ToArray();
@@ -186,7 +186,7 @@ public class PersonMatchingService(TrsDbContext dbContext) : IPersonMatchingServ
             ).ToArrayAsync();
 
         return results
-            .Select(r => KeyValuePair.Create(Enum.Parse<OneLoginUserMatchedAttribute>(r.attribute_type), r.attribute_value))
+            .Select(r => KeyValuePair.Create(Enum.Parse<PersonMatchedAttribute>(r.attribute_type), r.attribute_value))
             .OrderBy(r => (int)r.Key)
             .ThenBy(r => r.Value)
             .AsReadOnly();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Matches.cshtml
@@ -15,7 +15,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half-from-desktop">
             <govuk-inset-text class="govuk-!-margin-top-0">
-                Differences are highlighted in the existing record
+                Differences are <highlight>highlighted</highlight> in the existing record
             </govuk-inset-text>
             
             <govuk-summary-card data-testid="request">
@@ -34,10 +34,6 @@
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.LastName</govuk-summary-list-row-value>
-                    </govuk-summary-list-row>
-                    <govuk-summary-list-row>
-                        <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value use-empty-fallback>@Model.RequestData!.MiddleName</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
@@ -63,6 +59,27 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
             <h2 class="govuk-heading-m">Potential matches</h2>
+            
+            @functions {
+#pragma warning disable CS1998
+                private async Task RenderWithHighlightIfNotMatched(string? value, bool matched)
+                {
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        value = UiDefaults.EmptyDisplayContent;
+                    }
+
+                    if (!matched)
+                    {
+                        <highlight>@value</highlight>
+                    }
+                    else
+                    {
+                        @value
+                    }
+                }
+#pragma warning restore CS1998
+            }
 
             @foreach (var match in Model.PotentialDuplicates!)
             {
@@ -70,6 +87,9 @@
                     <govuk-summary-card-title>
                         Record @match.Identifier
                     </govuk-summary-card-title>
+                    <govuk-summary-card-actions>
+                        <govuk-summary-card-action href="@LinkGenerator.PersonDetail(match.PersonId)">View record</govuk-summary-card-action>    
+                    </govuk-summary-card-actions>
                     <govuk-summary-list>
                         @{
                             var tags = new List<string>();
@@ -104,31 +124,39 @@
 
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>First name</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value use-empty-fallback>@match.FirstName</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfNotMatched(match.FirstName, match.MatchedAttributes.Contains(PersonMatchedAttribute.FirstName)); }
+                            </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value use-empty-fallback>@match.MiddleName</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfNotMatched(match.MiddleName, match.MatchedAttributes.Contains(PersonMatchedAttribute.MiddleName)); }
+                            </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value use-empty-fallback>@match.LastName</govuk-summary-list-row-value>
-                        </govuk-summary-list-row>
-                        <govuk-summary-list-row>
-                            <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value use-empty-fallback>@match.MiddleName</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfNotMatched(match.LastName, match.MatchedAttributes.Contains(PersonMatchedAttribute.LastName)); }
+                            </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value use-empty-fallback>@match.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfNotMatched(match.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat), match.MatchedAttributes.Contains(PersonMatchedAttribute.DateOfBirth)); }
+                            </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value use-empty-fallback>@match.EmailAddress</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfNotMatched(match.EmailAddress, match.MatchedAttributes.Contains(PersonMatchedAttribute.EmailAddress)); }
+                            </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value use-empty-fallback>@match.NationalInsuranceNumber</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfNotMatched(match.NationalInsuranceNumber, match.MatchedAttributes.Contains(PersonMatchedAttribute.NationalInsuranceNumber)); }
+                            </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         @* <govuk-summary-list-row> *@
                         @*     <govuk-summary-list-row-key>Gender</govuk-summary-list-row-key> *@

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/HighlightTagHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/HighlightTagHelper.cs
@@ -1,0 +1,25 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TeachingRecordSystem.SupportUi.TagHelpers;
+
+[HtmlTargetElement("highlight")]
+public class HighlightTagHelper : TagHelper
+{
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var content = await output.GetChildContentAsync();
+
+        output.TagMode = TagMode.StartTagAndEndTag;
+        output.TagName = "mark";
+        output.AddClass("hods-highlight", HtmlEncoder.Default);
+
+        var wrapper = new TagBuilder("strong");
+        wrapper.InnerHtml.AppendHtml(content);
+
+        output.Content.SetHtmlContent(wrapper);
+    }
+}
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -230,3 +230,28 @@
     opacity: 0.5;
   }
 }
+
+// From https://github.com/UKHomeOffice/design-system/blob/6ed7b2a6ae6c3c16fc770d5f0c6c2d0f4d8ab2f2/components/highlight/assets/Highlight.scss
+.hods-highlight {
+  background-color: #FFE5CC;
+  border-bottom: 2px solid #FFB266;
+
+  &::before,
+  &::after {
+    clip-path: inset(100%);
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  &::before {
+    content: " [highlight start] ";
+  }
+
+  &::after {
+    content: " [highlight end] ";
+  }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
@@ -1220,10 +1220,10 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
                 .ReturnsAsync(new MatchResult(
                     person.PersonId,
                     person.Trn!,
-                    new Dictionary<OneLoginUserMatchedAttribute, string>()
+                    new Dictionary<PersonMatchedAttribute, string>()
                     {
-                        { OneLoginUserMatchedAttribute.FullName, $"{person.FirstName} {person.LastName}" },
-                        { OneLoginUserMatchedAttribute.NationalInsuranceNumber, person.NationalInsuranceNumber! },
+                        { PersonMatchedAttribute.FullName, $"{person.FirstName} {person.LastName}" },
+                        { PersonMatchedAttribute.NationalInsuranceNumber, person.NationalInsuranceNumber! },
                     }));
 
             // Act
@@ -1279,10 +1279,10 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
                 .ReturnsAsync(new MatchResult(
                     person.PersonId,
                     person.Trn!,
-                    new Dictionary<OneLoginUserMatchedAttribute, string>()
+                    new Dictionary<PersonMatchedAttribute, string>()
                     {
-                        { OneLoginUserMatchedAttribute.FullName, $"{person.FirstName} {person.LastName}" },
-                        { OneLoginUserMatchedAttribute.NationalInsuranceNumber, person.NationalInsuranceNumber! },
+                        { PersonMatchedAttribute.FullName, $"{person.FirstName} {person.LastName}" },
+                        { PersonMatchedAttribute.NationalInsuranceNumber, person.NationalInsuranceNumber! },
                     }));
 
             // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -58,7 +58,7 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             NationalInsuranceNumberArgumentOption nationalInsuranceNumberOption,
             TrnArgumentOption trnOption,
             bool expectMatch,
-            IEnumerable<OneLoginUserMatchedAttribute>? expectedMatchedAttributes) =>
+            IEnumerable<PersonMatchedAttribute>? expectedMatchedAttributes) =>
         DbFixture.WithDbContextAsync(async dbContext =>
         {
             // Arrange
@@ -264,43 +264,43 @@ public class PersonMatchingServiceTests : IAsyncLifetime
             // Assert
             Assert.Collection(
                 result,
-                m => AssertAttributeMatch(OneLoginUserMatchedAttribute.FullName, $"{firstName} {lastName}", m),
-                m => AssertAttributeMatch(OneLoginUserMatchedAttribute.LastName, lastName, m),
-                m => AssertAttributeMatch(OneLoginUserMatchedAttribute.DateOfBirth, dateOfBirth.ToString("yyyy-MM-dd"), m),
-                m => AssertAttributeMatch(OneLoginUserMatchedAttribute.NationalInsuranceNumber, nationalInsuranceNumber, m),
-                m => AssertAttributeMatch(OneLoginUserMatchedAttribute.Trn, person.Trn!, m),
-                m => AssertAttributeMatch(OneLoginUserMatchedAttribute.FirstName, firstName, m));
+                m => AssertAttributeMatch(PersonMatchedAttribute.FullName, $"{firstName} {lastName}", m),
+                m => AssertAttributeMatch(PersonMatchedAttribute.LastName, lastName, m),
+                m => AssertAttributeMatch(PersonMatchedAttribute.DateOfBirth, dateOfBirth.ToString("yyyy-MM-dd"), m),
+                m => AssertAttributeMatch(PersonMatchedAttribute.NationalInsuranceNumber, nationalInsuranceNumber, m),
+                m => AssertAttributeMatch(PersonMatchedAttribute.Trn, person.Trn!, m),
+                m => AssertAttributeMatch(PersonMatchedAttribute.FirstName, firstName, m));
 
-            static void AssertAttributeMatch(OneLoginUserMatchedAttribute expectedAttribute, string expectedValue, KeyValuePair<OneLoginUserMatchedAttribute, string> actual)
+            static void AssertAttributeMatch(PersonMatchedAttribute expectedAttribute, string expectedValue, KeyValuePair<PersonMatchedAttribute, string> actual)
             {
                 Assert.Equal(expectedAttribute, actual.Key);
                 Assert.Equal(expectedValue, actual.Value);
             }
         });
 
-    private static readonly OneLoginUserMatchedAttribute[] _matchNameDobNinoAndTrnAttributes =
+    private static readonly PersonMatchedAttribute[] _matchNameDobNinoAndTrnAttributes =
     [
-        OneLoginUserMatchedAttribute.FullName,
-        OneLoginUserMatchedAttribute.DateOfBirth,
-        OneLoginUserMatchedAttribute.NationalInsuranceNumber,
-        OneLoginUserMatchedAttribute.Trn
+        PersonMatchedAttribute.FullName,
+        PersonMatchedAttribute.DateOfBirth,
+        PersonMatchedAttribute.NationalInsuranceNumber,
+        PersonMatchedAttribute.Trn
     ];
 
-    private static readonly OneLoginUserMatchedAttribute[] _matchNameDobAndNinoAttributes =
+    private static readonly PersonMatchedAttribute[] _matchNameDobAndNinoAttributes =
     [
-        OneLoginUserMatchedAttribute.FullName,
-        OneLoginUserMatchedAttribute.DateOfBirth,
-        OneLoginUserMatchedAttribute.NationalInsuranceNumber
+        PersonMatchedAttribute.FullName,
+        PersonMatchedAttribute.DateOfBirth,
+        PersonMatchedAttribute.NationalInsuranceNumber
     ];
 
-    private static readonly OneLoginUserMatchedAttribute[] _matchNameDobAndTrnAttributes =
+    private static readonly PersonMatchedAttribute[] _matchNameDobAndTrnAttributes =
     [
-        OneLoginUserMatchedAttribute.FullName,
-        OneLoginUserMatchedAttribute.DateOfBirth,
-        OneLoginUserMatchedAttribute.Trn
+        PersonMatchedAttribute.FullName,
+        PersonMatchedAttribute.DateOfBirth,
+        PersonMatchedAttribute.Trn
     ];
 
-    public static TheoryData<NameArgumentOption, DateOfBirthArgumentOption, NationalInsuranceNumberArgumentOption, TrnArgumentOption, bool, IEnumerable<OneLoginUserMatchedAttribute>?> MatchData { get; } = new()
+    public static TheoryData<NameArgumentOption, DateOfBirthArgumentOption, NationalInsuranceNumberArgumentOption, TrnArgumentOption, bool, IEnumerable<PersonMatchedAttribute>?> MatchData { get; } = new()
     {
         // *** Match cases ***
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
@@ -46,9 +46,21 @@ public partial class TestData
             return this;
         }
 
+        public CreateApiTrnRequestSupportTaskBuilder WithDateOfBirth(DateOnly dateOfBirth)
+        {
+            _dateOfBirth = Option.Some(dateOfBirth);
+            return this;
+        }
+
         public CreateApiTrnRequestSupportTaskBuilder WithEmailAddress(string? emailAddress)
         {
             _emailAddress = Option.Some(emailAddress);
+            return this;
+        }
+
+        public CreateApiTrnRequestSupportTaskBuilder WithNationalInsuranceNumber(string? nationalInsuranceNumber)
+        {
+            _nationalInsuranceNumber = Option.Some(nationalInsuranceNumber);
             return this;
         }
 
@@ -88,6 +100,7 @@ public partial class TestData
                         var person = await testData.CreatePersonAsync(p =>
                         {
                             p
+                                .WithTrn()
                                 .WithFirstName(firstName)
                                 .WithMiddleName(middleName)
                                 .WithLastName(lastName)


### PR DESCRIPTION
This adds highlights to matched records to show which attributes on the matched `Person` are different from the TRN request.

I've repurposed the `OneLoginUserMatchedAttribute` enum and renamed it to `PersonMatchedAttribute`.

The method that figures out the differences is currently on the `Matches` `PageModel`; that'll likely move with the next PR so it can be re-used on the 'merge' page. The logic here is different to what we use for the matching; here we want to show all differences (even in case) whereas the matching is more permissive. (e.g. we could have a match on first name but still have differences between the two first names.)

https://trello.com/c/kvHCycNP/1055-add-ui-for-managing-api-trn-request-potential-duplicates

<img width="523" alt="image" src="https://github.com/user-attachments/assets/f0014c03-485a-4a60-a5bb-5344981e9d8c" />
