### PR TITLE
Add new user deactivate journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
@@ -5,4 +5,7 @@ namespace TeachingRecordSystem.Core.Events;
 public record UserDeactivatedEvent : EventBase
 {
     public required User User { get; init; }
+    public string? AdditionalReason { get; init; }
+    public string? MoreInformation { get; init; }
+    public Guid? EvidenceFileId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/UserDeactivatedEvent.cs
@@ -5,7 +5,7 @@ namespace TeachingRecordSystem.Core.Events;
 public record UserDeactivatedEvent : EventBase
 {
     public required User User { get; init; }
-    public string? AdditionalReason { get; init; }
-    public string? MoreInformation { get; init; }
+    public string? DeactivatedReason { get; init; }
+    public string? DeactivatedReasonDetail { get; init; }
     public Guid? EvidenceFileId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Confirm.cshtml
@@ -76,10 +76,11 @@
                     }
                 </govuk-radios-fieldset>
             </govuk-radios>
-            <govuk-button type="submit">Add user</govuk-button>
-            <p class="govuk-body">
-                <a class="govuk-link govuk-link--no-visited-state" href=@LinkGenerator.Users()>Cancel and return to users</a>
-            </p>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Add user</govuk-button>
+                <govuk-button-link class="govuk-button--secondary" href=@LinkGenerator.Users()>Cancel and return to users</govuk-button-link>
+            </div>
         </form>
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/AddUser/Index.cshtml
@@ -11,11 +11,10 @@
 
             <govuk-input asp-for="Email" label-class="govuk-label--m" type="email" autocomplete="off" />
 
-            <govuk-button type="submit">Add user</govuk-button>
-
-            <p class="govuk-body">
-                <a class="govuk-link govuk-link--no-visited-state" href=@LinkGenerator.Users()>Cancel and return to users</a>
-            </p>
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Add user</govuk-button>
+                <govuk-button-link class="govuk-button--secondary" href=@LinkGenerator.Users()>Cancel and return to users</govuk-button-link>
+            </div>
         </form>
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml
@@ -1,0 +1,105 @@
+﻿@page "/users/{userId}/deactivate/{handler?}"
+@using TeachingRecordSystem.Core
+@using TeachingRecordSystem.SupportUi.Pages.EditUser
+@model TeachingRecordSystem.SupportUi.Pages.Users.EditUser.DeactivateModel
+@{
+    ViewBag.Title = "Why are you deactivating this user?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.EditUser(Model.UserId)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+        <form method="post" enctype="multipart/form-data">
+            <govuk-radios asp-for="HasAdditionalReason">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-visually-hidden" />
+                    <govuk-radios-item value="@false">
+                        They no longer need access
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@true">
+                        Another reason
+
+                        <govuk-radios-item-conditional>
+                            <govuk-textarea textarea-class="govuk-!-width-one-half" 
+                                            label-class="govuk-label--s" 
+                                            asp-for="AdditionalReasonDetail" 
+                                            rows="DeactivateDefaults.DetailTextAreaMinimumRows" />
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+            
+            <h2 class="govuk-heading-m">Do you want to provide more details?</h2>
+            
+            <govuk-radios asp-for="HasMoreInformation">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-visually-hidden" />
+                    <govuk-radios-item value="@true">
+                        Yes
+
+                        <govuk-radios-item-conditional>
+                            <govuk-textarea textarea-class="govuk-!-width-one-half" 
+                                            label-class="govuk-label--s" 
+                                            asp-for="MoreInformationDetail" 
+                                            rows="DeactivateDefaults.DetailTextAreaMinimumRows" />
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+            
+            <h2 class="govuk-heading-m">Do you want to upload evidence?</h2>
+
+            <govuk-radios asp-for="UploadEvidence">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-visually-hidden" />
+                    <govuk-radios-item value="@true">
+                        Yes
+
+                        <govuk-radios-item-conditional>
+                            @if (Model.EvidenceFileId is not null)
+                            {
+                                <span class="govuk-caption-m">Currently uploaded file</span>
+                                <p class="govuk-body">
+                                    <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-file-link">@($"{Model.EvidenceFileName} ({Model.EvidenceFileSizeDescription})")</a>
+                                </p>
+                                <input type="hidden" asp-for="EvidenceFileId" />
+                                <input type="hidden" asp-for="EvidenceFileName" />
+                                <input type="hidden" asp-for="EvidenceFileSizeDescription" />
+                                <input type="hidden" asp-for="UploadedEvidenceFileUrl" />
+                            }
+                            <govuk-file-upload asp-for="EvidenceFile" 
+                                               label-class="govuk-label--m"
+                                               input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+                                <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+                                <govuk-file-upload-hint>Must be smaller than 100MB</govuk-file-upload-hint>
+                            </govuk-file-upload>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@false">
+                        No
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <button type="submit" class="govuk-button" data-module="govuk-button" data-govuk-button-init="">
+                Continue
+            </button>
+        </form>
+
+        <p class="govuk-body">
+          <a class="govuk-link govuk-link--no-visited-state" 
+             data-testid="cancel-link"
+             asp-page-handler="cancel"
+             asp-route-userid=@Model.UserId 
+             asp-route-evidencefileid=@Model.EvidenceFileId>Cancel and return to user</a>
+        </p>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml
@@ -89,17 +89,15 @@
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <button type="submit" class="govuk-button" data-module="govuk-button" data-govuk-button-init="">
-                Continue
-            </button>
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button type="submit"
+                              data-testid="cancel-button"
+                              formaction=@LinkGenerator.EditUserDeactivateCancel(Model.UserId)
+                              class="govuk-button--secondary">
+                    Cancel and return to user
+                </govuk-button>
+            </div>
         </form>
-
-        <p class="govuk-body">
-          <a class="govuk-link govuk-link--no-visited-state" 
-             data-testid="cancel-link"
-             asp-page-handler="cancel"
-             asp-route-userid=@Model.UserId 
-             asp-route-evidencefileid=@Model.EvidenceFileId>Cancel and return to user</a>
-        </p>
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml.cs
@@ -70,12 +70,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.Users.EditUser
 
         public async Task<IActionResult> OnPostAsync()
         {
-            if (_user is null)
-            {
-                return base.NotFound();
-            }
-
-            if (!_user.Active)
+            if (!_user!.Active)
             {
                 return BadRequest();
             }
@@ -138,8 +133,8 @@ namespace TeachingRecordSystem.SupportUi.Pages.Users.EditUser
                 User = EventModels.User.FromModel(_user),
                 RaisedBy = User.GetUserId(),
                 CreatedUtc = clock.UtcNow,
-                AdditionalReason = (HasAdditionalReason ?? false) ? AdditionalReasonDetail : null,
-                MoreInformation = (HasMoreInformation ?? false) ? MoreInformationDetail : null,
+                DeactivatedReason = (HasAdditionalReason ?? false) ? AdditionalReasonDetail : null,
+                DeactivatedReasonDetail = (HasMoreInformation ?? false) ? MoreInformationDetail : null,
                 EvidenceFileId = EvidenceFileId,
             });
 
@@ -162,16 +157,13 @@ namespace TeachingRecordSystem.SupportUi.Pages.Users.EditUser
             await next();
         }
 
-        public async Task<IActionResult> OnGetCancelAsync(Guid? evidenceFileId)
+        public async Task<IActionResult> OnPostCancelAsync()
         {
             // If the user cancels after having uploaded a file but before submitting,
             // we want to delete the file to clean up after ourselves.
-            // I've made it a GET rather than a POST as yes it does delete a file, but
-            // the file isn't used by anything any more, and it's not the specific resource
-            // logically corresponding to the URL that's being deleted (i.e. the user) - SS
-            if (evidenceFileId.HasValue)
+            if (EvidenceFileId.HasValue)
             {
-                await fileService.DeleteFileAsync(evidenceFileId.Value);
+                await fileService.DeleteFileAsync(EvidenceFileId.Value);
             }
 
             return Redirect(linkGenerator.EditUser(UserId));

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml.cs
@@ -1,0 +1,180 @@
+using System.ComponentModel.DataAnnotations;
+using Humanizer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.DataAnnotations;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+using TeachingRecordSystem.SupportUi.Pages.EditUser;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Users.EditUser
+{
+    [Authorize(Policy = AuthorizationPolicies.UserManagement)]
+    public class DeactivateModel(
+        TrsLinkGenerator linkGenerator,
+        IFileService fileService,
+        TrsDbContext dbContext,
+        IClock clock) : PageModel
+    {
+        private Core.DataStore.Postgres.Models.User? _user;
+
+        [FromRoute]
+        public Guid UserId { get; set; }
+
+        [BindProperty]
+        [Display(Name = "Reason for deactivating user")]
+        [Required(ErrorMessage = "Select a reason for deactivating this user")]
+        public bool? HasAdditionalReason { get; set; }
+
+        [BindProperty]
+        [Display(Name = "Enter a reason for deactivating this user")]
+        public string? AdditionalReasonDetail { get; set; }
+
+        [BindProperty]
+        [Display(Name = "Do you have more information?")]
+        [Required(ErrorMessage = "Select yes if you want to provide more details")]
+        public bool? HasMoreInformation { get; set; }
+
+        [BindProperty]
+        [Display(Name = "Enter details")]
+        public string? MoreInformationDetail { get; set; }
+
+        [BindProperty]
+        [Display(Name = "Do you have evidence to upload?")]
+        [Required(ErrorMessage = "Select yes if you want to upload evidence")]
+        public bool? UploadEvidence { get; set; }
+
+        [BindProperty]
+        [EvidenceFile]
+        [FileSize(DeactivateDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 100MB")]
+        public IFormFile? EvidenceFile { get; set; }
+
+        [BindProperty]
+        public Guid? EvidenceFileId { get; set; }
+
+        [BindProperty]
+        public string? EvidenceFileName { get; set; }
+
+        [BindProperty]
+        public string? EvidenceFileSizeDescription { get; set; }
+
+        [BindProperty]
+        public string? UploadedEvidenceFileUrl { get; set; }
+
+        public void OnGet()
+        {
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (_user is null)
+            {
+                return base.NotFound();
+            }
+
+            if (!_user.Active)
+            {
+                return BadRequest();
+            }
+
+            // Only admins can deactivate admins
+            if (!User.IsInRole(UserRoles.Administrator) && _user.Role == UserRoles.Administrator)
+            {
+                return BadRequest();
+            }
+
+            if (HasAdditionalReason == true && AdditionalReasonDetail is null)
+            {
+                ModelState.AddModelError(nameof(AdditionalReasonDetail), "Enter a reason");
+            }
+
+            if (HasMoreInformation == true && MoreInformationDetail is null)
+            {
+                ModelState.AddModelError(nameof(MoreInformationDetail), "Enter more details");
+            }
+
+            if (UploadEvidence == true && EvidenceFileId is null && EvidenceFile is null)
+            {
+                ModelState.AddModelError(nameof(EvidenceFile), "Select a file");
+            }
+
+            // Delete any previously uploaded file if they're uploading a new one,
+            // or choosing not to upload evidence (check for UploadEvidence != true because if
+            // UploadEvidence somehow got set to null we still want to delete the file)
+            if (EvidenceFileId.HasValue && (EvidenceFile is not null || UploadEvidence != true))
+            {
+                await fileService.DeleteFileAsync(EvidenceFileId.Value);
+            }
+
+            // Upload the file even if the rest of the form is invalid
+            // otherwise the user will have to re-upload every time they re-submit
+            if (UploadEvidence == true)
+            {
+                // Upload the file and set the display fields
+                if (EvidenceFile is not null)
+                {
+                    using var stream = EvidenceFile.OpenReadStream();
+                    var fileId = await fileService.UploadFileAsync(stream, EvidenceFile.ContentType);
+                    EvidenceFileName = EvidenceFile?.FileName;
+                    EvidenceFileSizeDescription = EvidenceFile?.Length.Bytes().Humanize();
+                    UploadedEvidenceFileUrl = await fileService.GetFileUrlAsync(fileId, DeactivateDefaults.FileUrlExpiry);
+                    EvidenceFileId = fileId;
+                }
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return this.PageWithErrors();
+            }
+
+            _user.Active = false;
+
+            await dbContext.AddEventAndBroadcastAsync(new UserDeactivatedEvent
+            {
+                EventId = Guid.NewGuid(),
+                User = EventModels.User.FromModel(_user),
+                RaisedBy = User.GetUserId(),
+                CreatedUtc = clock.UtcNow,
+                AdditionalReason = (HasAdditionalReason ?? false) ? AdditionalReasonDetail : null,
+                MoreInformation = (HasMoreInformation ?? false) ? MoreInformationDetail : null,
+                EvidenceFileId = EvidenceFileId,
+            });
+
+            await dbContext.SaveChangesAsync();
+            TempData.SetFlashSuccess(message: $"{_user.Name}\u2019s account has been deactivated.");
+
+            return Redirect(linkGenerator.Users());
+        }
+
+        public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            _user = await dbContext.Users.SingleOrDefaultAsync(u => u.UserId == UserId);
+
+            if (_user is null)
+            {
+                context.Result = NotFound();
+                return;
+            }
+
+            await next();
+        }
+
+        public async Task<IActionResult> OnGetCancelAsync(Guid? evidenceFileId)
+        {
+            // If the user cancels after having uploaded a file but before submitting,
+            // we want to delete the file to clean up after ourselves.
+            // I've made it a GET rather than a POST as yes it does delete a file, but
+            // the file isn't used by anything any more, and it's not the specific resource
+            // logically corresponding to the URL that's being deleted (i.e. the user) - SS
+            if (evidenceFileId.HasValue)
+            {
+                await fileService.DeleteFileAsync(evidenceFileId.Value);
+            }
+
+            return Redirect(linkGenerator.EditUser(UserId));
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/DeactivateDefaults.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/DeactivateDefaults.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.SupportUi.Pages.EditUser;
+
+public static class DeactivateDefaults
+{
+    public const int MaxFileUploadSizeMb = 100;
+    public const int DetailTextAreaMinimumRows = 5;
+    public static TimeSpan FileUrlExpiry { get; } = TimeSpan.FromMinutes(15);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Index.cshtml
@@ -81,16 +81,16 @@
                 <div class="govuk-button-group">
                     <govuk-button type="submit">Save changes</govuk-button>
                     <govuk-button-link class="govuk-button--secondary" href=@LinkGenerator.EditUserDeactivate(Model.UserId)>Deactivate user</govuk-button-link>
+                    <govuk-button-link class="govuk-button--secondary" href=@LinkGenerator.Users()>Cancel and return to users</govuk-button-link>
                 </div>
             }
             else
             {
-                <govuk-button type="submit" asp-page-handler="activate">Reactivate user</govuk-button>
+                <div class="govuk-button-group">
+                    <govuk-button type="submit" asp-page-handler="activate">Reactivate user</govuk-button>
+                    <govuk-button-link class="govuk-button--secondary" href=@LinkGenerator.Users()>Cancel and return to users</govuk-button-link>
+                </div>
             }
-
-            <p class="govuk-body">
-                <a class="govuk-link govuk-link--no-visited-state" href=@LinkGenerator.Users()>Cancel and return to users</a>
-            </p>
 
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Index.cshtml
@@ -1,7 +1,6 @@
 @page "/users/{userId}/{handler?}"
 @using TeachingRecordSystem.Core
-@using TeachingRecordSystem.Core.Legacy
-@model TeachingRecordSystem.SupportUi.Pages.Users.EditUser
+@model TeachingRecordSystem.SupportUi.Pages.Users.EditUser.IndexModel
 @{
     ViewBag.Title = $"Change {Model.Name}\u2019s role";
 }
@@ -79,7 +78,10 @@
 
             @if (Model.IsActiveUser)
             {
-                <govuk-button type="submit">Save changes</govuk-button>
+                <div class="govuk-button-group">
+                    <govuk-button type="submit">Save changes</govuk-button>
+                    <govuk-button-link class="govuk-button--secondary" href=@LinkGenerator.EditUserDeactivate(Model.UserId)>Deactivate user</govuk-button-link>
+                </div>
             }
             else
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Index.cshtml.cs
@@ -48,11 +48,6 @@ public class IndexModel(
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (_user is null)
-        {
-            return NotFound();
-        }
-
         // Ensure submitted roles is valid
         if (!string.IsNullOrWhiteSpace(Role) && !UserRoles.All.Contains(Role))
         {
@@ -71,7 +66,7 @@ public class IndexModel(
         }
 
         var changes = UserUpdatedEventChanges.None |
-            (_user.Name != Name ? UserUpdatedEventChanges.Name : UserUpdatedEventChanges.None) |
+            (_user!.Name != Name ? UserUpdatedEventChanges.Name : UserUpdatedEventChanges.None) |
             (_user.Role != Role ? UserUpdatedEventChanges.Roles : UserUpdatedEventChanges.None);
 
         if (changes != UserUpdatedEventChanges.None)
@@ -109,12 +104,7 @@ public class IndexModel(
 
     public async Task<IActionResult> OnPostActivateAsync()
     {
-        if (_user is null)
-        {
-            return NotFound();
-        }
-
-        if (_user.Active)
+        if (_user!.Active)
         {
             return BadRequest();
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/UserPermissionViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/UserPermissionViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
+﻿namespace TeachingRecordSystem.SupportUi.Pages.Users;
 
 public class UserPermissionViewModel
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/UserRoleViewModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/UserRoleViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace TeachingRecordSystem.SupportUi.Pages.Users.AddUser;
+﻿namespace TeachingRecordSystem.SupportUi.Pages.Users;
 
 public class UserRoleViewModel
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -366,6 +366,8 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
 
     public string EditUserDeactivate(Guid userId) => GetRequiredPathByPage("/Users/EditUser/Deactivate", routeValues: new { userId });
 
+    public string EditUserDeactivateCancel(Guid userId) => GetRequiredPathByPage("/Users/EditUser/Deactivate", "cancel", routeValues: new { userId });
+
     public string ApplicationUsers() => GetRequiredPathByPage("/ApplicationUsers/Index");
 
     public string AddApplicationUser() => GetRequiredPathByPage("/ApplicationUsers/AddApplicationUser");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -362,7 +362,9 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
 
     public string AddUserConfirm(string userId) => GetRequiredPathByPage("/Users/AddUser/Confirm", routeValues: new { userId });
 
-    public string EditUser(Guid userId) => GetRequiredPathByPage("/Users/EditUser", routeValues: new { userId });
+    public string EditUser(Guid userId) => GetRequiredPathByPage("/Users/EditUser/Index", routeValues: new { userId });
+
+    public string EditUserDeactivate(Guid userId) => GetRequiredPathByPage("/Users/EditUser/Deactivate", routeValues: new { userId });
 
     public string ApplicationUsers() => GetRequiredPathByPage("/ApplicationUsers/Index");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
@@ -65,6 +65,38 @@ public class UserTests : TestBase
     }
 
     [Fact]
+    public async Task DeactivateUser()
+    {
+        var azAdUserId = Guid.NewGuid();
+        var user = await TestData.CreateUserAsync(azureAdUserId: azAdUserId, role: UserRoles.AccessManager);
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToUsersPageAsync();
+
+        await page.AssertOnUsersPageAsync();
+
+        await page.ClickLinkForElementWithTestIdAsync($"edit-user-{user.UserId}");
+
+        await page.AssertOnEditUserPageAsync(user.UserId);
+
+        await page.ClickButtonAsync("Deactivate user");
+
+        await page.AssertOnEditUserDeactivatePageAsync(user.UserId);
+
+        await page.SetCheckedAsync("legend:has-text('Reason for deactivating user') + .govuk-radios label:has-text('They no longer need access')", true);
+        await page.SetCheckedAsync("legend:has-text('Do you have more information?') + .govuk-radios label:has-text('No')", true);
+        await page.SetCheckedAsync("legend:has-text('Do you have evidence to upload?') + .govuk-radios label:has-text('No')", true);
+
+        await page.ClickButtonAsync("Continue");
+
+        await page.AssertOnUsersPageAsync();
+
+        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name}’s account has been deactivated.");
+    }
+
+    [Fact]
     public async Task ReactivateUser()
     {
         var azAdUserId = Guid.NewGuid();
@@ -85,6 +117,6 @@ public class UserTests : TestBase
 
         await page.AssertOnUsersPageAsync();
 
-        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name} has been reactivated.");
+        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name}’s account has been reactivated.");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/UserTests.cs
@@ -93,7 +93,7 @@ public class UserTests : TestBase
 
         await page.AssertOnUsersPageAsync();
 
-        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name}’s account has been deactivated.");
+        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name}\u2019s account has been deactivated.");
     }
 
     [Fact]
@@ -117,6 +117,6 @@ public class UserTests : TestBase
 
         await page.AssertOnUsersPageAsync();
 
-        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name}’s account has been reactivated.");
+        await page.AssertFlashMessageAsync(expectedMessage: $"{user.Name}\u2019s account has been reactivated.");
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -448,6 +448,11 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/users/{userId}");
     }
 
+    public static async Task AssertOnEditUserDeactivatePageAsync(this IPage page, Guid userId)
+    {
+        await page.WaitForUrlPathAsync($"/users/{userId}/deactivate");
+    }
+
     public static async Task AssertOnApplicationUsersPageAsync(this IPage page)
     {
         await page.WaitForUrlPathAsync($"/application-users");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -63,19 +63,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<FakeTrnGenerator>();
             services.AddSingleton<TrsDataSyncHelper>();
             services.AddSingleton<IAuditRepository, TestableAuditRepository>();
-            services.AddSingleton(GetMockFileService());
-
-            IFileService GetMockFileService()
-            {
-                var fileService = new Mock<IFileService>();
-                fileService
-                    .Setup(s => s.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string?>(), null))
-                    .ReturnsAsync(Guid.NewGuid());
-                fileService
-                    .Setup(s => s.GetFileUrlAsync(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
-                    .ReturnsAsync("https://fake.blob.core.windows.net/fake");
-                return fileService.Object;
-            }
+            services.AddTestScoped<IFileService>(tss => tss.BlobStorageFileServiceMock.Object);
         });
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
@@ -24,7 +24,8 @@ public class ConfirmTests : TestBase, IAsyncLifetime
     public async Task Get_UserWithoutAccessManagerRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role: null));
+        var user = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        SetCurrentUser(user);
 
         var email = Faker.Internet.Email();
         var name = Faker.Name.FullName();
@@ -132,7 +133,8 @@ public class ConfirmTests : TestBase, IAsyncLifetime
     public async Task Post_UserWithoutAccessManagerRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role: null));
+        var user = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        SetCurrentUser(user);
 
         var email = Faker.Internet.Email();
         var name = Faker.Name.FullName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
@@ -24,7 +24,8 @@ public class IndexTests : TestBase, IAsyncLifetime
     public async Task Get_UserWithoutAccessManagerRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role: null));
+        var user = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        SetCurrentUser(user);
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/users/add");
 
@@ -55,7 +56,8 @@ public class IndexTests : TestBase, IAsyncLifetime
     public async Task Post_UserWithoutAccessManagerRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role: null));
+        var user = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        SetCurrentUser(user);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/users/add");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
@@ -605,7 +605,7 @@ public class DeactivateTests : TestBase, IAsyncLifetime
 
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();
-        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}\u2019s account has been deactivated.");
     }
 
     [Fact]
@@ -654,7 +654,7 @@ public class DeactivateTests : TestBase, IAsyncLifetime
 
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();
-        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}\u2019s account has been deactivated.");
     }
 
     [Fact]
@@ -702,7 +702,7 @@ public class DeactivateTests : TestBase, IAsyncLifetime
 
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();
-        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}\u2019s account has been deactivated.");
     }
 
     [Fact]
@@ -752,7 +752,7 @@ public class DeactivateTests : TestBase, IAsyncLifetime
 
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();
-        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}\u2019s account has been deactivated.");
     }
 
     private async Task<Guid> AssertFileWasUploadedAsync()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
@@ -1,0 +1,807 @@
+using AngleSharp.Html.Dom;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Users.EditUser;
+
+[Collection(nameof(DisableParallelization))]
+public class DeactivateTests : TestBase, IAsyncLifetime
+{
+    public DeactivateTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.NewUserRoles);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        TestUsers.ClearCache();
+    }
+
+    public Task DisposeAsync()
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.NewUserRoles);
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_UserWithoutAccessManagerRole_ReturnsForbidden()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(existingUser.UserId));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserIdDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(Guid.NewGuid()));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserWithoutAccessManagerRole_ReturnsForbidden()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserIdDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(Guid.NewGuid()))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserExistsButIsAlreadyDeactivated_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync(active: false, role: UserRoles.SupportOfficer);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserWithoutAdministratorRole_DeactivatingUserWithAdministratorRole_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync(role: UserRoles.Administrator);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserWithAdministratorRole_DeactivatingUserWithAdministratorRole_ReturnsFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.Administrator);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync(role: UserRoles.Administrator);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_HasAdditionalReasonNotSelected_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.HtmlResponseHasErrorAsync(response, "HasAdditionalReason", "Select a reason for deactivating this user");
+    }
+
+    [Fact]
+    public async Task Post_HasAdditionalReasonSetToYes_ButAdditionalReasonDetailNotEntered_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", true },
+                { "AdditionalReasonDetail", "" },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.HtmlResponseHasErrorAsync(response, "AdditionalReasonDetail", "Enter a reason");
+    }
+
+    [Fact]
+    public async Task Post_HasMoreInformationNotSelected_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.HtmlResponseHasErrorAsync(response, "HasMoreInformation", "Select yes if you want to provide more details");
+    }
+
+    [Fact]
+    public async Task Post_HasMoreInformationSetToYes_ButMoreInformationDetailNotEntered_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", true },
+                { "MoreInformationDetail", "" },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.HtmlResponseHasErrorAsync(response, "MoreInformationDetail", "Enter more details");
+    }
+
+    [Fact]
+    public async Task Post_UploadEvidenceNotSelected_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.HtmlResponseHasErrorAsync(response, "UploadEvidence", "Select yes if you want to upload evidence");
+    }
+
+    [Fact]
+    public async Task Post_UploadEvidenceSetToYes_ButNoEvidenceFileSelected_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", true }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.HtmlResponseHasErrorAsync(response, "EvidenceFile", "Select a file");
+    }
+
+    [Fact]
+    public async Task Post_UploadEvidenceSetToYes_ButEvidenceFileIsInvalidType_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", true },
+                { "EvidenceFile", CreateEvidenceFileBinaryContent(), "invalidfile.cs" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await AssertEx.HtmlResponseHasErrorAsync(response, "EvidenceFile", "The selected file must be a BMP, CSV, DOC, DOCX, EML, JPEG, JPG, MBOX, MSG, ODS, ODT, PDF, PNG, TIF, TXT, XLS or XLSX");
+    }
+
+    [Fact]
+    public async Task Post_UploadEvidenceSetToYes_AndEvidenceFileIsSelected_ButOtherFieldsInvalid_ShowsUploadedFile()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasMoreInformation", false },
+                { "UploadEvidence", true },
+                { "EvidenceFile", CreateEvidenceFileBinaryContent(new byte[1230]), "validfile.png" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        var html = await AssertEx.HtmlResponseAsync(response, 400);
+
+        var evidenceFileId = AssertFileWasUploadedAsync();
+        var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
+
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        Assert.Equal("validfile.png (1.2 KB)", link.TextContent);
+        Assert.Equal(expectedFileUrl, link.Href);
+
+        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, "EvidenceFileId"));
+        Assert.Equal("validfile.png", GetHiddenInputValue(html, "EvidenceFileName"));
+        Assert.Equal("1.2 KB", GetHiddenInputValue(html, "EvidenceFileSizeDescription"));
+        Assert.Equal(expectedFileUrl, GetHiddenInputValue(html, "UploadedEvidenceFileUrl"));
+    }
+
+    [Fact]
+    public async Task Post_UploadEvidenceSetToYes_AndEvidenceFilePreviouslyUploaded_ButOtherFieldsInvalid_RemembersUploadedFile()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+        var evidenceFileId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasMoreInformation", false },
+                { "UploadEvidence", true },
+                { "EvidenceFileId", evidenceFileId },
+                { "EvidenceFileName", "testfile.jpg" },
+                { "EvidenceFileSizeDescription", "3 KB" },
+                { "UploadedEvidenceFileUrl", "http://test.com/file" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        var html = await AssertEx.HtmlResponseAsync(response, 400);
+
+        var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
+
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        Assert.Equal("testfile.jpg (3 KB)", link.TextContent);
+        Assert.Equal("http://test.com/file", link.Href);
+
+        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, "EvidenceFileId"));
+        Assert.Equal("testfile.jpg", GetHiddenInputValue(html, "EvidenceFileName"));
+        Assert.Equal("3 KB", GetHiddenInputValue(html, "EvidenceFileSizeDescription"));
+        Assert.Equal("http://test.com/file", GetHiddenInputValue(html, "UploadedEvidenceFileUrl"));
+    }
+
+    [Fact]
+    public async Task Post_UploadEvidenceSetToYes_AndEvidenceFilePreviouslyUploaded_AndNewFileUploaded_ButOtherFieldsInvalid_DeletesPreviouslyUploadedFile()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+        var evidenceFileId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasMoreInformation", false },
+                { "UploadEvidence", true },
+                { "EvidenceFile", CreateEvidenceFileBinaryContent(new byte[1230]), "validfile.png" },
+                { "EvidenceFileId", evidenceFileId },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+
+        AssertFileWasDeleted(evidenceFileId);
+    }
+
+    [Fact]
+    public async Task Post_UploadEvidenceSetToNo_ButEvidenceFilePreviouslyUploaded_AndOtherFieldsInvalid_DeletesPreviouslyUploadedFile()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+        var evidenceFileId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false },
+                { "EvidenceFileId", evidenceFileId },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+
+        AssertFileWasDeleted(evidenceFileId);
+    }
+
+    [Fact]
+    public async Task Post_EvidenceFilePreviouslyUploaded_AndOtherFieldsInvalid_CancelLinkContainsEvidenceFileId()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+        var evidenceFileId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false },
+                { "EvidenceFileId", evidenceFileId },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+        var html = await AssertEx.HtmlResponseAsync(response, 400);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("cancel-link"));
+        Assert.EndsWith($"/users/{existingUser.UserId}/deactivate/cancel?evidencefileid={evidenceFileId}", link.Href);
+    }
+
+    [Fact]
+    public async Task GetCancel_RedirectsToEditUserPage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+        var evidenceFileId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{GetRequestPath(existingUser.UserId)}/cancel");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/users/{existingUser.UserId}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task GetCancel_EvidenceFilePreviouslyUploaded_DeletesPreviouslyUploadedFileAndRedirectsToEditUserPage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync();
+        var evidenceFileId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"{GetRequestPath(existingUser.UserId)}/cancel?evidencefileid={evidenceFileId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/users/{existingUser.UserId}", response.Headers.Location?.OriginalString);
+
+        AssertFileWasDeleted(evidenceFileId);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_DeactivatesUserEmitsEventAndRedirectsWithFlashMessage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", false }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedUser = await WithDbContext(dbContext =>
+            dbContext.Users.SingleOrDefaultAsync(u => u.UserId == existingUser.UserId));
+        Assert.NotNull(updatedUser);
+
+        Assert.False(updatedUser.Active);
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
+            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
+            Assert.Null(userCreatedEvent.AdditionalReason);
+            Assert.Null(userCreatedEvent.MoreInformation);
+            Assert.Null(userCreatedEvent.EvidenceFileId);
+        });
+
+        var redirectResponse = await response.FollowRedirectAsync(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_WithAdditionalReasonMoreInformationAndEvidenceFile_DeactivatesUserUploadsEvidenceFileEmitsEventAndRedirectsWithFlashMessage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", true },
+                { "AdditionalReasonDetail", "Some additional reason" },
+                { "HasMoreInformation", true },
+                { "MoreInformationDetail", "Some more information" },
+                { "UploadEvidence", true },
+                { "EvidenceFile", CreateEvidenceFileBinaryContent(new byte[1230]), "validfile.png" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedUser = await WithDbContext(dbContext =>
+            dbContext.Users.SingleOrDefaultAsync(u => u.UserId == existingUser.UserId));
+        Assert.NotNull(updatedUser);
+        Assert.False(updatedUser.Active);
+
+        var evidenceFileId = await AssertFileWasUploadedAsync();
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
+            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
+            Assert.Equal("Some additional reason", userCreatedEvent.AdditionalReason);
+            Assert.Equal("Some more information", userCreatedEvent.MoreInformation);
+            Assert.Equal(evidenceFileId, userCreatedEvent.EvidenceFileId);
+        });
+
+        var redirectResponse = await response.FollowRedirectAsync(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_WithPreviouslyUploadedEvidenceFile_DeactivatesUserEmitsEventAndRedirectsWithFlashMessage()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        var evidenceFileId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "HasMoreInformation", false },
+                { "UploadEvidence", true },
+                { "EvidenceFileId", evidenceFileId },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedUser = await WithDbContext(dbContext =>
+            dbContext.Users.SingleOrDefaultAsync(u => u.UserId == existingUser.UserId));
+        Assert.NotNull(updatedUser);
+        Assert.False(updatedUser.Active);
+
+        AssertFileWasNotUploaded();
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
+            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
+            Assert.Null(userCreatedEvent.AdditionalReason);
+            Assert.Null(userCreatedEvent.MoreInformation);
+            Assert.Equal(evidenceFileId, userCreatedEvent.EvidenceFileId);
+        });
+
+        var redirectResponse = await response.FollowRedirectAsync(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_WithAdditionalInfo_ButAdditionalInfoRadioButtonsNotSetToYes_DeactivatesUserAndDiscardsAdditionalInfo()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        SetCurrentUser(user);
+
+        var existingUser = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        var evidenceFileId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(existingUser.UserId))
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "HasAdditionalReason", false },
+                { "AdditionalReasonDetail", "Some additional reason" },
+                { "HasMoreInformation", false },
+                { "MoreInformationDetail", "Some more information" },
+                { "UploadEvidence", false },
+                { "EvidenceFile", CreateEvidenceFileBinaryContent(new byte[1230]), "validfile.png" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedUser = await WithDbContext(dbContext =>
+            dbContext.Users.SingleOrDefaultAsync(u => u.UserId == existingUser.UserId));
+        Assert.NotNull(updatedUser);
+        Assert.False(updatedUser.Active);
+
+        AssertFileWasNotUploaded();
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
+            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
+            Assert.Null(userCreatedEvent.AdditionalReason);
+            Assert.Null(userCreatedEvent.MoreInformation);
+            Assert.Null(userCreatedEvent.EvidenceFileId);
+        });
+
+        var redirectResponse = await response.FollowRedirectAsync(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been deactivated.");
+    }
+
+    private async Task<Guid> AssertFileWasUploadedAsync()
+    {
+        FileServiceMock.Verify(mock => mock.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string?>(), null));
+        return await Assert.IsType<Task<Guid>>(FileServiceMock.Invocations.FirstOrDefault(i => i.Method.Name == "UploadFileAsync")?.ReturnValue);
+    }
+
+    private void AssertFileWasNotUploaded()
+    {
+        FileServiceMock.Verify(mock => mock.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string?>(), null), Times.Never);
+    }
+
+    private void AssertFileWasDeleted(Guid fileId)
+    {
+        FileServiceMock.Verify(mock => mock.DeleteFileAsync(fileId));
+    }
+
+    private string GetHiddenInputValue(IHtmlDocument html, string name)
+    {
+        var element = html.QuerySelector($@"input[type=""hidden""][name=""{name}""]");
+        var input = Assert.IsAssignableFrom<IHtmlInputElement>(element);
+
+        return input.Value;
+    }
+
+    private static string GetRequestPath(Guid userId) => $"/users/{userId}/deactivate";
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/IndexTests.cs
@@ -434,7 +434,7 @@ public class IndexTests : TestBase, IAsyncLifetime
     }
 
     [Fact]
-    public async Task PostActivate_ValidRequest_ActivatesUsersEmitsEventAndRedirectsWithFlashMessage()
+    public async Task PostActivate_ValidRequest_ActivatesUserEmitsEventAndRedirectsWithFlashMessage()
     {
         // Arrange
         var user = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
@@ -464,7 +464,7 @@ public class IndexTests : TestBase, IAsyncLifetime
 
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();
-        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}’s account has been reactivated.");
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, expectedMessage: $"{existingUser.Name}\u2019s account has been reactivated.");
     }
 
     private static string GetRequestPath(Guid userId) => $"/users/{userId}";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
@@ -28,7 +28,8 @@ public class UsersTests : TestBase, IAsyncLifetime
     public async Task Get_UserWithoutAccessManagerRole_ReturnsForbidden()
     {
         // Arrange
-        SetCurrentUser(TestUsers.GetUser(role: null));
+        var user = await TestData.CreateUserAsync(role: UserRoles.SupportOfficer);
+        SetCurrentUser(user);
 
         // Act
         var request = new HttpRequestMessage(HttpMethod.Get, RequestPath);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Primitives;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
+using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure.Security;
@@ -61,6 +62,8 @@ public abstract class TestBase : IDisposable
     public TestableFeatureProvider FeatureProvider => _testServices.FeatureProvider;
 
     public ReferenceDataCache ReferenceDataCache => HostFixture.Services.GetRequiredService<ReferenceDataCache>();
+
+    public Mock<IFileService> FileServiceMock => _testServices.BlobStorageFileServiceMock;
 
     public async Task<JourneyInstance<TState>> CreateJourneyInstance<TState>(
             string journeyName,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
@@ -7,6 +7,8 @@ namespace TeachingRecordSystem.SupportUi.Tests;
 
 public class TestScopedServices
 {
+    public const string FakeBlobStorageFileUrlBase = "https://fake.blob.core.windows.net/";
+
     private static readonly AsyncLocal<TestScopedServices> _current = new();
 
     public TestScopedServices(IServiceProvider serviceProvider)
@@ -17,6 +19,12 @@ public class TestScopedServices
         EventObserver = new();
         FeatureProvider = ActivatorUtilities.CreateInstance<TestableFeatureProvider>(serviceProvider);
         BlobStorageFileServiceMock = new();
+        BlobStorageFileServiceMock
+            .Setup(s => s.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string?>(), null))
+            .ReturnsAsync(Guid.NewGuid());
+        BlobStorageFileServiceMock
+            .Setup(s => s.GetFileUrlAsync(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
+            .ReturnsAsync((Guid id, TimeSpan time) => $"{FakeBlobStorageFileUrlBase}{id}");
     }
 
     public static TestScopedServices GetCurrent() =>


### PR DESCRIPTION
### Context

Following the access permissions redesign we need to create a new deactivate user journey to reflect the new designs and functionality.

### Changes proposed in this pull request

* Adds deactivate user page with the ability to add additional information and upload evidence


### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
