### PR TITLE
Don't produce dbml for every push

### DIFF
--- a/.github/workflows/dbml.yml
+++ b/.github/workflows/dbml.yml
@@ -1,9 +1,6 @@
 name: Create dbml from database
 
 on:
-  push:
-    branches:
-    - '*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We don't need a DBML file producing for every push; being able to run it on demand is sufficient.