### PR TITLE
remove ProfessionalstatusType from the reporting DB qualifications table

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0055_TrsQualificationsRemoveProfessionalStatusType.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0055_TrsQualificationsRemoveProfessionalStatusType.sql
@@ -1,0 +1,1 @@
+alter table trs_qualifications drop column professional_status_type

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -163,6 +163,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0052_TrsQualificationsExemptFromInduction.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0053_TpsEmploymentsEmployerEmail.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0054_QtsAndEytsDates.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0055_TrsQualificationsRemoveProfessionalStatusType.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context

remove ProfessionalstatusType from the reporting DB qualifications table because it has been removed from the TRS qualifications table