### PR TITLE
Choose attributes to merge from TRN request

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml
@@ -1,0 +1,5 @@
+@page "/support-tasks/api-trn-requests/{supportTaskReference}/check-answers/{handler?}"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.CheckAnswers
+@{
+    ViewBag.Title = "TODO";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
+
+public class CheckAnswers : PageModel
+{
+    public void OnGet()
+    {
+
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml
@@ -8,6 +8,27 @@
     <govuk-back-link href="@LinkGenerator.ApiTrnRequests()"/>
 }
 
+@functions {
+#pragma warning disable CS1998
+    private async Task RenderWithHighlightIfDifferent(string? value, bool different)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            value = UiDefaults.EmptyDisplayContent;
+        }
+
+        if (different)
+        {
+            <highlight>@value</highlight>
+        }
+        else
+        {
+            @value
+        }
+    }
+#pragma warning restore CS1998
+}
+
 <form action="@LinkGenerator.ApiTrnRequestMatches(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" method="post">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
@@ -64,27 +85,6 @@
         <div class="govuk-grid-column-two-thirds-from-desktop">
             <h2 class="govuk-heading-m">Potential matches</h2>
             
-            @functions {
-#pragma warning disable CS1998
-                private async Task RenderWithHighlightIfNotMatched(string? value, bool matched)
-                {
-                    if (string.IsNullOrEmpty(value))
-                    {
-                        value = UiDefaults.EmptyDisplayContent;
-                    }
-
-                    if (!matched)
-                    {
-                        <highlight>@value</highlight>
-                    }
-                    else
-                    {
-                        @value
-                    }
-                }
-#pragma warning restore CS1998
-            }
-
             @foreach (var match in Model.PotentialDuplicates!)
             {
                 <govuk-summary-card data-testid="match">
@@ -131,37 +131,37 @@
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>First name</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                @{ await RenderWithHighlightIfNotMatched(match.FirstName, match.MatchedAttributes.Contains(PersonMatchedAttribute.FirstName)); }
+                                @{ await RenderWithHighlightIfDifferent(match.FirstName, !match.MatchedAttributes.Contains(PersonMatchedAttribute.FirstName)); }
                             </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                @{ await RenderWithHighlightIfNotMatched(match.MiddleName, match.MatchedAttributes.Contains(PersonMatchedAttribute.MiddleName)); }
+                                @{ await RenderWithHighlightIfDifferent(match.MiddleName, !match.MatchedAttributes.Contains(PersonMatchedAttribute.MiddleName)); }
                             </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                @{ await RenderWithHighlightIfNotMatched(match.LastName, match.MatchedAttributes.Contains(PersonMatchedAttribute.LastName)); }
+                                @{ await RenderWithHighlightIfDifferent(match.LastName, !match.MatchedAttributes.Contains(PersonMatchedAttribute.LastName)); }
                             </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                @{ await RenderWithHighlightIfNotMatched(match.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat), match.MatchedAttributes.Contains(PersonMatchedAttribute.DateOfBirth)); }
+                                @{ await RenderWithHighlightIfDifferent(match.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat), !match.MatchedAttributes.Contains(PersonMatchedAttribute.DateOfBirth)); }
                             </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                @{ await RenderWithHighlightIfNotMatched(match.EmailAddress, match.MatchedAttributes.Contains(PersonMatchedAttribute.EmailAddress)); }
+                                @{ await RenderWithHighlightIfDifferent(match.EmailAddress, !match.MatchedAttributes.Contains(PersonMatchedAttribute.EmailAddress)); }
                             </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                @{ await RenderWithHighlightIfNotMatched(match.NationalInsuranceNumber, match.MatchedAttributes.Contains(PersonMatchedAttribute.NationalInsuranceNumber)); }
+                                @{ await RenderWithHighlightIfDifferent(match.NationalInsuranceNumber, !match.MatchedAttributes.Contains(PersonMatchedAttribute.NationalInsuranceNumber)); }
                             </govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                         @* <govuk-summary-list-row> *@

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml
@@ -1,5 +1,165 @@
 @page "/support-tasks/api-trn-requests/{supportTaskReference}/merge/{handler?}"
+@using static ResolveApiTrnRequestState
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.Merge
 @{
     ViewBag.Title = "Select the details to merge";
 }
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.ApiTrnRequestMatches(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)"/>
+}
+
+@functions {
+#pragma warning disable CS1998
+    private async Task RenderWithHighlightIfDifferent(string? value, bool different)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            value = UiDefaults.EmptyDisplayContent;
+        }
+
+        if (different)
+        {
+            <highlight>@value</highlight>
+        }
+        else
+        {
+            @value
+        }
+    }
+#pragma warning restore CS1998
+}
+
+<form action="@LinkGenerator.ApiTrnRequestMerge(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" method="post">
+    <span class="govuk-caption-l">Support tasks</span>
+    <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+    
+    <div style="display: flex">
+        <div class="govuk-heading-m govuk-!-width-one-half">
+            @Model.SourceApplicationUserName API request <govuk-tag class="govuk-tag--red">Potential duplicate</govuk-tag>
+        </div>
+        <div class="govuk-heading-m govuk-!-width-one-half">
+            Existing record
+        </div>
+    </div>
+
+    <table class="govuk-table">
+        <tbody class="govuk-table__body">
+            @* Annoyingly we can't wrap this markup into a function because there's no way to pass a ModelExpression to bind to
+              https://github.com/dotnet/aspnetcore/issues/45845
+             *@
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <govuk-radios asp-for="FirstNameSource" class="govuk-!-margin-bottom-0" radios-class="trs-radios--inline-two-column">
+                        <govuk-radios-fieldset>
+                            <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s"/>
+                            <govuk-radios-item value="@PersonAttributeSource.TrnRequest" disabled="@(!Model.FirstName!.Different)">
+                                @(Model.FirstName!.TrnRequestValue ?? UiDefaults.EmptyDisplayContent)
+                            </govuk-radios-item>
+                            <govuk-radios-item value="@PersonAttributeSource.ExistingRecord" disabled="@(!Model.FirstName!.Different)">
+                                @{ await RenderWithHighlightIfDifferent(Model.FirstName!.ExistingRecordValue, Model.FirstName.Different); }
+                            </govuk-radios-item>
+                        </govuk-radios-fieldset>
+                    </govuk-radios>
+                </td>
+            </tr>
+            
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <govuk-radios asp-for="MiddleNameSource" class="govuk-!-margin-bottom-0" radios-class="trs-radios--inline-two-column">
+                        <govuk-radios-fieldset>
+                            <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s"/>
+                            <govuk-radios-item value="@PersonAttributeSource.TrnRequest" disabled="@(!Model.MiddleName!.Different)">
+                                @(Model.MiddleName!.TrnRequestValue ?? UiDefaults.EmptyDisplayContent)
+                            </govuk-radios-item>
+                            <govuk-radios-item value="@PersonAttributeSource.ExistingRecord" disabled="@(!Model.MiddleName!.Different)">
+                                @{ await RenderWithHighlightIfDifferent(Model.MiddleName!.ExistingRecordValue, Model.MiddleName.Different); }
+                            </govuk-radios-item>
+                        </govuk-radios-fieldset>
+                    </govuk-radios>
+                </td>
+            </tr>
+            
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <govuk-radios asp-for="LastNameSource" class="govuk-!-margin-bottom-0" radios-class="trs-radios--inline-two-column">
+                        <govuk-radios-fieldset>
+                            <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s"/>
+                            <govuk-radios-item value="@PersonAttributeSource.TrnRequest" disabled="@(!Model.LastName!.Different)">
+                                @(Model.LastName!.TrnRequestValue ?? UiDefaults.EmptyDisplayContent)
+                            </govuk-radios-item>
+                            <govuk-radios-item value="@PersonAttributeSource.ExistingRecord" disabled="@(!Model.LastName!.Different)">
+                                @{ await RenderWithHighlightIfDifferent(Model.LastName!.ExistingRecordValue, Model.LastName.Different); }
+                            </govuk-radios-item>
+                        </govuk-radios-fieldset>
+                    </govuk-radios>
+                </td>
+            </tr>
+            
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <govuk-radios asp-for="DateOfBirthSource" class="govuk-!-margin-bottom-0" radios-class="trs-radios--inline-two-column">
+                        <govuk-radios-fieldset>
+                            <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s"/>
+                            <govuk-radios-item value="@PersonAttributeSource.TrnRequest" disabled="@(!Model.DateOfBirth!.Different)">
+                                @(Model.DateOfBirth!.TrnRequestValue?.ToString(UiDefaults.DateOnlyDisplayFormat) ?? UiDefaults.EmptyDisplayContent)
+                            </govuk-radios-item>
+                            <govuk-radios-item value="@PersonAttributeSource.ExistingRecord" disabled="@(!Model.DateOfBirth!.Different)">
+                                @{ await RenderWithHighlightIfDifferent(Model.DateOfBirth!.ExistingRecordValue?.ToString(UiDefaults.DateOnlyDisplayFormat), Model.DateOfBirth.Different); }
+                            </govuk-radios-item>
+                        </govuk-radios-fieldset>
+                    </govuk-radios>
+                </td>
+            </tr>
+            
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <govuk-radios asp-for="EmailAddressSource" class="govuk-!-margin-bottom-0" radios-class="trs-radios--inline-two-column">
+                        <govuk-radios-fieldset>
+                            <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s"/>
+                            <govuk-radios-item value="@PersonAttributeSource.TrnRequest" disabled="@(!Model.EmailAddress!.Different)">
+                                @(Model.EmailAddress!.TrnRequestValue ?? UiDefaults.EmptyDisplayContent)
+                            </govuk-radios-item>
+                            <govuk-radios-item value="@PersonAttributeSource.ExistingRecord" disabled="@(!Model.EmailAddress!.Different)">
+                                @{ await RenderWithHighlightIfDifferent(Model.EmailAddress!.ExistingRecordValue, Model.EmailAddress.Different); }
+                            </govuk-radios-item>
+                        </govuk-radios-fieldset>
+                    </govuk-radios>
+                </td>
+            </tr>
+            
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                    <govuk-radios asp-for="NationalInsuranceNumberSource" class="govuk-!-margin-bottom-0" radios-class="trs-radios--inline-two-column">
+                        <govuk-radios-fieldset>
+                            <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s"/>
+                            <govuk-radios-item value="@PersonAttributeSource.TrnRequest" disabled="@(!Model.NationalInsuranceNumber!.Different)">
+                                @(Model.NationalInsuranceNumber!.TrnRequestValue ?? UiDefaults.EmptyDisplayContent)
+                            </govuk-radios-item>
+                            <govuk-radios-item value="@PersonAttributeSource.ExistingRecord" disabled="@(!Model.NationalInsuranceNumber!.Different)">
+                                @{ await RenderWithHighlightIfDifferent(Model.NationalInsuranceNumber!.ExistingRecordValue, Model.NationalInsuranceNumber.Different); }
+                            </govuk-radios-item>
+                        </govuk-radios-fieldset>
+                    </govuk-radios>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <govuk-textarea asp-for="Comments" label-class="govuk-label--s" />
+    
+            <p class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold">Do you want to use these details in the primary record?</p>
+    
+            <govuk-warning-text>
+                The secondary record will be deactivated once it’s merged with the primary record, but you’ll still be able to view it.
+            </govuk-warning-text>
+    
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button type="submit" formaction="@LinkGenerator.ApiTrnRequestMergeCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary">Cancel</govuk-button>
+            </div>
+        </div>
+    </div>
+</form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml.cs
@@ -1,12 +1,204 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.ResolveApiTrnRequestState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
 
 [Journey(JourneyNames.ResolveApiTrnRequest), RequireJourneyInstance]
-public class Merge : PageModel
+public class Merge(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : PageModel
 {
+    [FromRoute]
+    public string? SupportTaskReference { get; set; }
+
+    public JourneyInstance<ResolveApiTrnRequestState>? JourneyInstance { get; set; }
+
+    public string? SourceApplicationUserName { get; set; }
+
+    public PersonAttribute<string?>? FirstName { get; set; }
+
+    public PersonAttribute<string?>? MiddleName { get; set; }
+
+    public PersonAttribute<string?>? LastName { get; set; }
+
+    public PersonAttribute<DateOnly?>? DateOfBirth { get; set; }
+
+    public PersonAttribute<string?>? EmailAddress { get; set; }
+
+    public PersonAttribute<string?>? NationalInsuranceNumber { get; set; }
+
+    [BindProperty]
+    [Display(Name = "First name")]
+    public PersonAttributeSource? FirstNameSource { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Middle name")]
+    public PersonAttributeSource? MiddleNameSource { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Last name")]
+    public PersonAttributeSource? LastNameSource { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Date of birth")]
+    public PersonAttributeSource? DateOfBirthSource { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Email")]
+    public PersonAttributeSource? EmailAddressSource { get; set; }
+
+    [BindProperty]
+    [Display(Name = "National Insurance number")]
+    public PersonAttributeSource? NationalInsuranceNumberSource { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Add comments")]
+    public string? Comments { get; set; }
+
     public void OnGet()
     {
-
+        FirstNameSource = JourneyInstance!.State.FirstNameSource;
+        MiddleNameSource = JourneyInstance!.State.MiddleNameSource;
+        LastNameSource = JourneyInstance!.State.LastNameSource;
+        DateOfBirthSource = JourneyInstance!.State.DateOfBirthSource;
+        EmailAddressSource = JourneyInstance!.State.EmailAddressSource;
+        NationalInsuranceNumberSource = JourneyInstance!.State.NationalInsuranceNumberSource;
+        Comments = JourneyInstance!.State.Comments;
     }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (FirstName!.Different && FirstNameSource is null)
+        {
+            ModelState.AddModelError(nameof(FirstNameSource), "Select a first name");
+        }
+
+        if (MiddleName!.Different && MiddleNameSource is null)
+        {
+            ModelState.AddModelError(nameof(MiddleNameSource), "Select a middle name");
+        }
+
+        if (LastName!.Different && LastNameSource is null)
+        {
+            ModelState.AddModelError(nameof(LastNameSource), "Select a last name");
+        }
+
+        if (DateOfBirth!.Different && DateOfBirthSource is null)
+        {
+            ModelState.AddModelError(nameof(DateOfBirthSource), "Select a date of birth");
+        }
+
+        if (EmailAddress!.Different && EmailAddressSource is null)
+        {
+            ModelState.AddModelError(nameof(EmailAddressSource), "Select an email");
+        }
+
+        if (NationalInsuranceNumber!.Different && NationalInsuranceNumberSource is null)
+        {
+            ModelState.AddModelError(nameof(NationalInsuranceNumberSource), "Select a National Insurance number");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.FirstNameSource = FirstNameSource;
+            state.MiddleNameSource = MiddleNameSource;
+            state.LastNameSource = LastNameSource;
+            state.DateOfBirthSource = DateOfBirthSource;
+            state.EmailAddressSource = EmailAddressSource;
+            state.NationalInsuranceNumberSource = NationalInsuranceNumberSource;
+            state.Comments = Comments;
+        });
+
+        return Redirect(linkGenerator.ApiTrnRequestCheckAnswers(SupportTaskReference!, JourneyInstance!.InstanceId));
+    }
+
+    public async Task<IActionResult> OnPostCancelAsync()
+    {
+        await JourneyInstance!.DeleteAsync();
+
+        return Redirect(linkGenerator.ApiTrnRequests());
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        var requestData = supportTask.TrnRequestMetadata!;
+
+        if (JourneyInstance!.State.PersonId is not Guid personId)
+        {
+            context.Result = Redirect(linkGenerator.ApiTrnRequestMatches(SupportTaskReference!, JourneyInstance!.InstanceId));
+            return;
+        }
+
+        if (JourneyInstance.State.PersonId == CreateNewRecordPersonIdSentinel)
+        {
+            context.Result = Redirect(linkGenerator.ApiTrnRequestCheckAnswers(SupportTaskReference!, JourneyInstance!.InstanceId));
+            return;
+        }
+
+        var personAttributes = await dbContext.Persons
+            .Where(p => p.PersonId == personId)
+            .Select(p => new
+            {
+                p.FirstName,
+                p.MiddleName,
+                p.LastName,
+                p.DateOfBirth,
+                p.NationalInsuranceNumber,
+                p.EmailAddress
+            })
+            .SingleAsync();
+
+        SourceApplicationUserName = requestData.ApplicationUser.Name;
+
+        var attributeDifferences = GetPersonAttributeDifferences(
+            requestData,
+            personAttributes.FirstName,
+            personAttributes.MiddleName,
+            personAttributes.LastName,
+            personAttributes.DateOfBirth,
+            personAttributes.EmailAddress,
+            personAttributes.NationalInsuranceNumber);
+
+        FirstName = new PersonAttribute<string?>(
+            personAttributes.FirstName,
+            requestData.FirstName,
+            Different: !attributeDifferences.Contains(PersonMatchedAttribute.FirstName));
+
+        MiddleName = new PersonAttribute<string?>(
+            personAttributes.MiddleName,
+            requestData.MiddleName,
+            Different: !attributeDifferences.Contains(PersonMatchedAttribute.MiddleName));
+
+        LastName = new PersonAttribute<string?>(
+            personAttributes.LastName,
+            requestData.LastName,
+            Different: !attributeDifferences.Contains(PersonMatchedAttribute.LastName));
+
+        DateOfBirth = new PersonAttribute<DateOnly?>(
+            personAttributes.DateOfBirth,
+            requestData.DateOfBirth,
+            Different: !attributeDifferences.Contains(PersonMatchedAttribute.DateOfBirth));
+
+        EmailAddress = new PersonAttribute<string?>(
+            personAttributes.EmailAddress,
+            requestData.EmailAddress,
+            Different: !attributeDifferences.Contains(PersonMatchedAttribute.EmailAddress));
+
+        NationalInsuranceNumber = new PersonAttribute<string?>(
+            personAttributes.NationalInsuranceNumber,
+            requestData.NationalInsuranceNumber,
+            Different: !attributeDifferences.Contains(PersonMatchedAttribute.NationalInsuranceNumber));
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+    }
+
+    public record PersonAttribute<T>(T ExistingRecordValue, T TrnRequestValue, bool Different);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
@@ -13,12 +13,6 @@ public class ResolveApiTrnRequestState : IRegisterJourney
         appendUniqueKey: true);
 
     public Guid? PersonId { get; set; }
-    public string? FirstName { get; set; }
-    public string? MiddleName { get; set; }
-    public string? LastName { get; set; }
-    public DateOnly? DateOfBirth { get; set; }
-    public string? EmailAddress { get; set; }
-    public string? NationalInsuranceNumber { get; set; }
     public PersonAttributeSource? FirstNameSource { get; set; }
     public PersonAttributeSource? MiddleNameSource { get; set; }
     public PersonAttributeSource? LastNameSource { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -404,6 +404,12 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string ApiTrnRequestMerge(string supportTaskReference, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Resolve/Merge", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
 
+    public string ApiTrnRequestMergeCancel(string supportTaskReference, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Resolve/Merge", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId, handler: "Cancel");
+
+    public string ApiTrnRequestCheckAnswers(string supportTaskReference, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+
     public string ConnectOneLoginUserSupportTask(string supportTaskReference) =>
         GetRequiredPathByPage("/SupportTasks/ConnectOneLoginUser/Index", routeValues: new { supportTaskReference });
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -255,3 +255,18 @@
     content: " [highlight end] ";
   }
 }
+
+.trs-radios--inline-two-column {
+  @extend .govuk-radios--inline;
+  
+  .govuk-radios__item {
+    @extend .govuk-\!-width-one-half;
+    @extend .govuk-\!-margin-right-0;
+  }
+  
+  // When there's an error there's 15px left padding applied;
+  // account for that to keep the two items at exactly 50%
+  .govuk-form-group--error & .govuk-radios__item:nth-of-type(1) {
+    margin-right: -15px !important;
+  }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MergeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MergeTests.cs
@@ -1,0 +1,486 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
+using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.ResolveApiTrnRequestState;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.ApiTrnRequests.Resolve;
+
+public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_NoPersonIdSelected_RedirectsToMatches()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState() { PersonId = null });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_CreateNewRecordSelected_RedirectsToCheckAnswers()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState() { PersonId = CreateNewRecordPersonIdSentinel });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [MemberData(nameof(AttributesAndFieldsData))]
+    public async Task Get_AttributeIsNotDifferent_RendersDisabledAndUnselectedRadioButtons(
+        PersonMatchedAttribute _,
+        string fieldName)
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var radios = doc.GetElementsByName(fieldName);
+
+        foreach (var radio in radios)
+        {
+            Assert.True(radio.IsDisabled());
+            Assert.False(radio.IsChecked());
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AttributesAndFieldsData))]
+    public async Task Get_AttributeIsDifferent_RendersRadioButtonsWithExistingValueHighlighted(
+        PersonMatchedAttribute attribute,
+        string fieldName)
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await CreateSupportWithSingleDifferenceToMatch(applicationUser.UserId, attribute);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var radios = doc.GetElementsByName(fieldName);
+
+        Assert.Collection(
+            radios,
+            fromRequestRadio =>
+            {
+                Assert.False(fromRequestRadio.IsDisabled());
+            },
+            fromExistingRecordRadio =>
+            {
+                Assert.False(fromExistingRecordRadio.IsDisabled());
+                Assert.NotEmpty(
+                    fromExistingRecordRadio.GetAncestor<IHtmlDivElement>()!.GetElementsByClassName("hods-highlight"));
+            });
+    }
+
+    [Theory]
+    [MemberData(nameof(AttributesAndFieldsData))]
+    public async Task Get_AttributeSourceSetToTrnRequestInState_RendersSelectedSourceRadioButton(
+        PersonMatchedAttribute _,
+        string fieldName)
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState
+            {
+                PersonId = supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId,
+                FirstNameSource = PersonAttributeSource.TrnRequest,
+                MiddleNameSource = PersonAttributeSource.TrnRequest,
+                LastNameSource = PersonAttributeSource.TrnRequest,
+                DateOfBirthSource = PersonAttributeSource.TrnRequest,
+                EmailAddressSource = PersonAttributeSource.TrnRequest,
+                NationalInsuranceNumberSource = PersonAttributeSource.TrnRequest,
+                Comments = null
+            });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var radios = doc.GetElementsByName(fieldName);
+        Assert.True(radios[0].IsChecked());
+    }
+
+    [Theory]
+    [MemberData(nameof(AttributesAndFieldsData))]
+    public async Task Get_AttributeSourceSetToExistingRecordInState_RendersSelectedSourceRadioButton(
+        PersonMatchedAttribute _,
+        string fieldName)
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState
+            {
+                PersonId = supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId,
+                FirstNameSource = PersonAttributeSource.ExistingRecord,
+                MiddleNameSource = PersonAttributeSource.ExistingRecord,
+                LastNameSource = PersonAttributeSource.ExistingRecord,
+                DateOfBirthSource = PersonAttributeSource.ExistingRecord,
+                EmailAddressSource = PersonAttributeSource.ExistingRecord,
+                NationalInsuranceNumberSource = PersonAttributeSource.ExistingRecord,
+                Comments = null
+            });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var radios = doc.GetElementsByName(fieldName);
+        Assert.True(radios[1].IsChecked());
+    }
+
+    [Fact]
+    public async Task Get_CommentsSetInState_RendersExistingValue()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var comments = "Some comments";
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState
+            {
+                PersonId = supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId,
+                Comments = comments
+            });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        Assert.Equal(comments, doc.GetElementsByName("Comments").Single().TextContent);
+    }
+
+    [Fact]
+    public async Task Post_NoPersonIdSelected_RedirectsToMatches()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState() { PersonId = null });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_CreateNewRecordSelected_RedirectsToCheckAnswers()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveApiTrnRequestState() { PersonId = CreateNewRecordPersonIdSentinel });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Theory]
+    [InlineData(PersonMatchedAttribute.FirstName, "FirstNameSource", "Select a first name")]
+    [InlineData(PersonMatchedAttribute.MiddleName, "MiddleNameSource", "Select a middle name")]
+    [InlineData(PersonMatchedAttribute.LastName, "LastNameSource", "Select a last name")]
+    [InlineData(PersonMatchedAttribute.DateOfBirth, "DateOfBirthSource", "Select a date of birth")]
+    [InlineData(PersonMatchedAttribute.EmailAddress, "EmailAddressSource", "Select an email")]
+    [InlineData(PersonMatchedAttribute.NationalInsuranceNumber, "NationalInsuranceNumberSource", "Select a National Insurance number")]
+    public async Task Post_AttributeSourceNotSelected_RendersError(
+        PersonMatchedAttribute differentAttribute,
+        string fieldName,
+        string expectedErrorMessage)
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await CreateSupportWithSingleDifferenceToMatch(applicationUser.UserId, differentAttribute);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, fieldName, expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_EmptyRequestWithNoDifferencesToSelect_Succeeds()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.True((int)response.StatusCode < 400);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatesStateAndRedirectsToCheckAnswers()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+
+        var supportTask = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            supportTask.TrnRequestMetadata!.Matches!.MatchedRecords.First().PersonId);
+
+        var firstNameSelection = Enum.GetValues<PersonAttributeSource>().RandomOne();
+        var middleNameSelection = Enum.GetValues<PersonAttributeSource>().RandomOne();
+        var lastNameSelection = Enum.GetValues<PersonAttributeSource>().RandomOne();
+        var dateOfBirthSelection = Enum.GetValues<PersonAttributeSource>().RandomOne();
+        var emailAddressSelection = Enum.GetValues<PersonAttributeSource>().RandomOne();
+        var nationalInsuranceNumberSelection = Enum.GetValues<PersonAttributeSource>().RandomOne();
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstNameSource", firstNameSelection },
+                { "MiddleNameSource", middleNameSelection },
+                { "LastNameSource", lastNameSelection },
+                { "DateOfBirthSource", dateOfBirthSelection },
+                { "EmailAddressSource", emailAddressSelection },
+                { "NationalInsuranceNumberSource", nationalInsuranceNumberSelection },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            response.Headers.Location?.OriginalString);
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(firstNameSelection, journeyInstance.State.FirstNameSource);
+        Assert.Equal(middleNameSelection, journeyInstance.State.MiddleNameSource);
+        Assert.Equal(lastNameSelection, journeyInstance.State.LastNameSource);
+        Assert.Equal(dateOfBirthSelection, journeyInstance.State.DateOfBirthSource);
+        Assert.Equal(emailAddressSelection, journeyInstance.State.EmailAddressSource);
+        Assert.Equal(nationalInsuranceNumberSelection, journeyInstance.State.NationalInsuranceNumberSource);
+    }
+
+    public static TheoryData<PersonMatchedAttribute, string> AttributesAndFieldsData { get; } = new()
+    {
+        { PersonMatchedAttribute.FirstName, "FirstNameSource" },
+        { PersonMatchedAttribute.MiddleName, "MiddleNameSource" },
+        { PersonMatchedAttribute.LastName, "LastNameSource" },
+        { PersonMatchedAttribute.DateOfBirth, "DateOfBirthSource" },
+        { PersonMatchedAttribute.EmailAddress, "EmailAddressSource" },
+        { PersonMatchedAttribute.NationalInsuranceNumber, "NationalInsuranceNumberSource" }
+    };
+
+    private async Task<SupportTask> CreateSupportTaskWithAllDifferences(Guid applicationUserId)
+    {
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+
+        return await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUserId,
+            t => t
+                .WithMatchedRecords(matchedPerson.PersonId)
+                .WithFirstName(TestData.GenerateChangedFirstName(matchedPerson.FirstName))
+                .WithMiddleName(TestData.GenerateChangedMiddleName(matchedPerson.MiddleName))
+                .WithLastName(TestData.GenerateChangedLastName(matchedPerson.LastName))
+                .WithDateOfBirth(TestData.GenerateChangedDateOfBirth(matchedPerson.DateOfBirth))
+                .WithEmailAddress(TestData.GenerateUniqueEmail())
+                .WithNationalInsuranceNumber(TestData.GenerateChangedNationalInsuranceNumber(matchedPerson.NationalInsuranceNumber!)));
+    }
+
+    private async Task<SupportTask> CreateSupportWithSingleDifferenceToMatch(Guid applicationUserId, PersonMatchedAttribute differentAttribute)
+    {
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+
+        return await TestData.CreateApiTrnRequestSupportTaskAsync(
+            applicationUserId,
+            t => t
+                .WithMatchedRecords(matchedPerson.PersonId)
+                .WithFirstName(
+                    differentAttribute != PersonMatchedAttribute.FirstName
+                        ? matchedPerson.FirstName
+                        : TestData.GenerateChangedFirstName(matchedPerson.FirstName))
+                .WithMiddleName(
+                    differentAttribute != PersonMatchedAttribute.MiddleName
+                        ? matchedPerson.MiddleName
+                        : TestData.GenerateChangedMiddleName(matchedPerson.MiddleName))
+                .WithLastName(
+                    differentAttribute != PersonMatchedAttribute.LastName
+                        ? matchedPerson.LastName
+                        : TestData.GenerateChangedLastName(matchedPerson.LastName))
+                .WithDateOfBirth(
+                    differentAttribute != PersonMatchedAttribute.DateOfBirth
+                        ? matchedPerson.DateOfBirth
+                        : TestData.GenerateChangedDateOfBirth(matchedPerson.DateOfBirth))
+                .WithEmailAddress(
+                    differentAttribute != PersonMatchedAttribute.EmailAddress
+                        ? matchedPerson.Email
+                        : TestData.GenerateUniqueEmail())
+                .WithNationalInsuranceNumber(
+                    differentAttribute != PersonMatchedAttribute.NationalInsuranceNumber
+                        ? matchedPerson.NationalInsuranceNumber
+                        : TestData.GenerateChangedNationalInsuranceNumber(matchedPerson.NationalInsuranceNumber!)));
+    }
+
+    private Task<JourneyInstance<ResolveApiTrnRequestState>> CreateJourneyInstance(
+            string supportTaskReference,
+            Guid personId) =>
+        CreateJourneyInstance(supportTaskReference, new ResolveApiTrnRequestState() { PersonId = personId });
+
+    private Task<JourneyInstance<ResolveApiTrnRequestState>> CreateJourneyInstance(
+            string supportTaskReference,
+            ResolveApiTrnRequestState state) =>
+        CreateJourneyInstance(
+            JourneyNames.ResolveApiTrnRequest,
+            state,
+            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
+}


### PR DESCRIPTION
This adds the UI for selecting which attributes should be retained on the selected record vs copied from the TRN request.

I've also fixed the Matches page to redirect the user to Check Answers if 'I want to create a new record ...' is selected.

There a few rough edges here (mostly around content) but the snagging session on the journey as a whole will address those.

![localhost_44321_support-tasks_api-trn-requests_DEV-1234_merge_ffiid=167f1298-6399-4daa-aef7-6045b64b0f4e](https://github.com/user-attachments/assets/bb948e78-192a-47b2-84f0-0c27fcd11e5d)
