### PR TITLE
Add tag helper for generating a sortable-table

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/SortDirection.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/SortDirection.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi;
+
+public enum SortDirection
+{
+    Ascending = 0,
+    Descending = 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/SortableTableColumnTagHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/SortableTableColumnTagHelper.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
+
+namespace TeachingRecordSystem.SupportUi.TagHelpers;
+
+[HtmlTargetElement("th", Attributes = "sort-direction")]
+public class SortableTableColumnTagHelper : TagHelper
+{
+    [HtmlAttributeName("sort-direction")]
+    public SortDirection? Direction { get; set; }
+
+    [HtmlAttributeName("link-template")]
+    public Func<SortDirection, string>? LinkTemplate { get; set; }
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var content = await output.GetChildContentAsync();
+
+        var ariaSort = Direction switch
+        {
+            null => "none",
+            SortDirection.Ascending => "ascending",
+            SortDirection.Descending => "descending",
+            _ => throw new InvalidOperationException("Direction is not valid.")
+        };
+
+        var directionOnClick = Direction is SortDirection.Ascending ? SortDirection.Descending : SortDirection.Ascending;
+        var linkTemplate = LinkTemplate!(directionOnClick);
+
+        var form = new TagBuilder("form");
+        form.Attributes.Add("method", "get");
+
+        string formAction;
+        Dictionary<string, StringValues> queryString;
+
+        if (linkTemplate.IndexOf('?') is var qsp && qsp >= 0)
+        {
+            formAction = linkTemplate[..qsp];
+            queryString = QueryHelpers.ParseQuery(linkTemplate[qsp..]);
+        }
+        else
+        {
+            formAction = linkTemplate;
+            queryString = new Dictionary<string, StringValues>();
+        }
+
+        // As we're submitting a GET form, we need all the query params to be inputs
+        foreach (var kvp in queryString)
+        {
+            var input = new TagBuilder("input");
+            input.Attributes.Add("type", "hidden");
+            input.Attributes.Add("name", kvp.Key);
+            input.Attributes.Add("value", kvp.Value);
+
+            form.InnerHtml.AppendHtml(input);
+        }
+
+        form.Attributes.Add("action", formAction);
+
+        var button = new TagBuilder("button");
+        button.Attributes.Add("type", "submit");
+        button.InnerHtml.AppendHtml(content);
+
+        form.InnerHtml.AppendHtml(button);
+
+        output.Attributes.Add("aria-sort", ariaSort);
+
+        output.Content.SetHtmlContent(form);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -7,6 +7,7 @@
 @import "../lib/ministryofjustice/frontend/moj/components/filter/_filter";
 @import "../lib/ministryofjustice/frontend/moj/components/password-reveal/_password-reveal";
 @import "../lib/ministryofjustice/frontend/moj/components/search/search";
+@import "../lib/ministryofjustice/frontend/moj/components/sortable-table/sortable-table";
 @import "../lib/ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
 @import "../lib/ministryofjustice/frontend/moj/components/timeline/timeline";
 


### PR DESCRIPTION
MOJ design system includes a `sortable-table` component but it runs client-side. We need it to work with pagination so we need it to run server side. This adds a tag helper to aid with setting it up.

I've noticed we're referencing a very old version of moj-frontend; when we update we'll likely need to update this tag helper.

A PR showing this in use is at https://github.com/DFE-Digital/teaching-record-system/pull/2006