### PR TITLE
Move contact creation and update to TrnRequestHelper

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateTrnRequest.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Microsoft.Extensions.Options;
+using Optional;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Implementation.Dtos;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -185,9 +186,9 @@ public class CreateTrnRequestHandler(
             FirstName = firstName,
             MiddleName = middleName,
             LastName = command.LastName,
-            StatedFirstName = command.FirstName,
-            StatedMiddleName = command.MiddleName ?? "",
-            StatedLastName = command.LastName,
+            StatedFirstName = Option.Some(command.FirstName),
+            StatedMiddleName = Option.Some(command.MiddleName ?? ""),
+            StatedLastName = Option.Some(command.LastName),
             DateOfBirth = command.DateOfBirth,
             Gender = command.Gender?.ConvertToContact_GenderCode() ?? Contact_GenderCode.Notavailable,
             EmailAddress = emailAddress,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateContactQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/CreateContactQuery.cs
@@ -1,3 +1,4 @@
+using Optional;
 using TeachingRecordSystem.Core.Services.DqtOutbox.Messages;
 
 namespace TeachingRecordSystem.Core.Dqt.Queries;
@@ -8,9 +9,9 @@ public record CreateContactQuery : ICrmQuery<Guid>
     public required string FirstName { get; init; }
     public required string MiddleName { get; init; }
     public required string LastName { get; init; }
-    public required string StatedFirstName { get; init; }
-    public required string StatedMiddleName { get; init; }
-    public required string StatedLastName { get; init; }
+    public Option<string> StatedFirstName { get; init; }
+    public Option<string> StatedMiddleName { get; init; }
+    public Option<string> StatedLastName { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public required Contact_GenderCode Gender { get; init; }
     public required string? EmailAddress { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateContactQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/UpdateContactQuery.cs
@@ -2,15 +2,15 @@ using Optional;
 
 namespace TeachingRecordSystem.Core.Dqt.Queries;
 
-public class UpdateContactQuery : ICrmQuery<bool>
+public record UpdateContactQuery : ICrmQuery<bool>
 {
     public required Guid ContactId { get; init; }
     public required Option<string> FirstName { get; init; }
     public required Option<string> MiddleName { get; init; }
     public required Option<string> LastName { get; init; }
-    public required Option<string> StatedFirstName { get; init; }
-    public required Option<string> StatedMiddleName { get; init; }
-    public required Option<string> StatedLastName { get; init; }
+    public Option<string> StatedFirstName { get; init; }
+    public Option<string> StatedMiddleName { get; init; }
+    public Option<string> StatedLastName { get; init; }
     public required Option<DateOnly> DateOfBirth { get; init; }
     public required Option<Contact_GenderCode> Gender { get; init; }
     public required Option<string?> EmailAddress { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/CreateContactHandler.cs
@@ -1,5 +1,7 @@
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk.Messages;
+using Optional;
+using Optional.Unsafe;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Services.DqtOutbox;
 
@@ -20,17 +22,27 @@ public class CreateContactHandler : ICrmQueryHandler<CreateContactQuery, Guid>
             FirstName = query.FirstName,
             MiddleName = query.MiddleName,
             LastName = query.LastName,
-            dfeta_StatedFirstName = query.StatedFirstName,
-            dfeta_StatedMiddleName = query.StatedMiddleName,
-            dfeta_StatedLastName = query.StatedLastName,
             BirthDate = query.DateOfBirth.ToDateTimeWithDqtBstFix(isLocalTime: false),
             GenderCode = query.Gender,
             dfeta_NINumber = query.NationalInsuranceNumber,
             EMailAddress1 = query.EmailAddress,
             dfeta_AllowPiiUpdatesFromRegister = query.AllowPiiUpdates,
             dfeta_TrnRequestID = query.TrnRequestId,
-            dfeta_TRN = query.Trn,
+            dfeta_TRN = query.Trn
         };
+
+        void SetAttributeIfSpecified<T>(Option<T> value, string attributeName)
+        {
+            if (value.HasValue)
+            {
+                object? attributeValue = value.ValueOrFailure();
+                contact.Attributes.Add(attributeName, attributeValue);
+            }
+        }
+
+        SetAttributeIfSpecified(query.StatedFirstName, Contact.Fields.dfeta_StatedFirstName);
+        SetAttributeIfSpecified(query.StatedMiddleName, Contact.Fields.dfeta_StatedMiddleName);
+        SetAttributeIfSpecified(query.StatedLastName, Contact.Fields.dfeta_StatedLastName);
 
         if (query.Trn is null)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnRequestHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnRequestHelper.cs
@@ -1,17 +1,20 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Options;
 using Microsoft.Xrm.Sdk.Query;
+using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.Core.Services.GetAnIdentity.Api.Models;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnGeneration;
 
 namespace TeachingRecordSystem.Core;
 
 public class TrnRequestHelper(
     TrsDbContext dbContext,
+    ITrnGenerator trnGenerator,
     ICrmQueryDispatcher crmQueryDispatcher,
     IGetAnIdentityApiClient idApiClient,
     IOptions<AccessYourTeachingQualificationsOptions> aytqOptionsAccessor)
@@ -94,6 +97,70 @@ public class TrnRequestHelper(
         }
 
         return result;
+    }
+
+    public async Task<Guid> CreateContactFromTrnRequestAsync(TrnRequestMetadata requestData)
+    {
+        var trn = await trnGenerator.GenerateTrnAsync();
+        var newContactId = Guid.NewGuid();
+
+        await crmQueryDispatcher.ExecuteQueryAsync(new CreateContactQuery()
+        {
+            ContactId = newContactId,
+            FirstName = requestData.FirstName!,
+            MiddleName = requestData.MiddleName ?? string.Empty,
+            LastName = requestData.LastName!,
+            DateOfBirth = requestData.DateOfBirth,
+            Gender = Contact_GenderCode.Notprovided, // TODO when we've sorted gender
+            EmailAddress = requestData.EmailAddress,
+            NationalInsuranceNumber = requestData.NationalInsuranceNumber,
+            ReviewTasks = [],
+            ApplicationUserName = requestData.ApplicationUser.Name,
+            Trn = trn,
+            TrnRequestId = GetCrmTrnRequestId(requestData.ApplicationUserId, requestData.RequestId),
+            TrnRequestMetadataMessage = null,
+            AllowPiiUpdates = false
+        });
+
+        return newContactId;
+    }
+
+    public async Task UpdateContactFromTrnRequestAsync(
+        TrnRequestMetadata requestData,
+        IReadOnlyCollection<PersonMatchedAttribute> attributesToUpdate)
+    {
+        if (requestData.ResolvedPersonId is not Guid contactId)
+        {
+            throw new InvalidOperationException("TRN request is not resolved.");
+        }
+
+        var query = new UpdateContactQuery()
+        {
+            ContactId = contactId,
+            FirstName = default,
+            MiddleName = default,
+            LastName = default,
+            DateOfBirth = default,
+            Gender = default,
+            EmailAddress = default,
+            NationalInsuranceNumber = default
+        };
+
+        foreach (var attribute in attributesToUpdate)
+        {
+            query = attribute switch
+            {
+                PersonMatchedAttribute.FirstName => query with { FirstName = Option.Some(requestData.FirstName!) },
+                PersonMatchedAttribute.MiddleName => query with { MiddleName = Option.Some(requestData.MiddleName!) },
+                PersonMatchedAttribute.LastName => query with { LastName = Option.Some(requestData.LastName!) },
+                PersonMatchedAttribute.DateOfBirth => query with { DateOfBirth = Option.Some(requestData.DateOfBirth!) },
+                PersonMatchedAttribute.EmailAddress => query with { EmailAddress = Option.Some(requestData.EmailAddress) },
+                PersonMatchedAttribute.NationalInsuranceNumber => query with { NationalInsuranceNumber = Option.Some(requestData.NationalInsuranceNumber) },
+                _ => throw new NotImplementedException()
+            };
+        }
+
+        await crmQueryDispatcher.ExecuteQueryAsync(query);
     }
 
     public static string GetCrmTrnRequestId(Guid currentApplicationUserId, string requestId) =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
@@ -67,6 +67,49 @@ public class ResolveApiTrnRequestState : IRegisterJourney
         }
     }
 
+    public IReadOnlyCollection<PersonMatchedAttribute> GetAttributesToUpdate()
+    {
+        if (!PersonAttributeSourcesSet)
+        {
+            throw new InvalidOperationException("Attribute sources not set.");
+        }
+
+        return Impl().AsReadOnly();
+
+        IEnumerable<PersonMatchedAttribute> Impl()
+        {
+            if (FirstNameSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.FirstName;
+            }
+
+            if (MiddleNameSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.MiddleName;
+            }
+
+            if (LastNameSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.LastName;
+            }
+
+            if (DateOfBirthSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.DateOfBirth;
+            }
+
+            if (EmailAddressSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.EmailAddress;
+            }
+
+            if (NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.NationalInsuranceNumber;
+            }
+        }
+    }
+
     public enum PersonAttributeSource
     {
         ExistingRecord = 0,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using FakeXrmEasy.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Optional.Unsafe;
 using TeachingRecordSystem.Api.V3.Implementation.Dtos;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Core.Dqt.Models;
@@ -62,9 +63,9 @@ public class CreateTrnRequestTests(OperationTestFixture operationTestFixture) : 
             // Assert
             var (createContactQuery, _) = CrmQueryDispatcherSpy.GetSingleQuery<CreateContactQuery, Guid>();
             Assert.Equal(firstName1, createContactQuery.FirstName);
-            Assert.Equal(firstName, createContactQuery.StatedFirstName);
+            Assert.Equal(firstName, createContactQuery.StatedFirstName.ValueOrFailure());
             Assert.Equal($"{firstName2} {middleName}", createContactQuery.MiddleName);
-            Assert.Equal(middleName, createContactQuery.StatedMiddleName);
+            Assert.Equal(middleName, createContactQuery.StatedMiddleName.ValueOrFailure());
         });
 
     [Fact]
@@ -530,9 +531,9 @@ public class CreateTrnRequestTests(OperationTestFixture operationTestFixture) : 
     {
         var (applicationUserId, _) = CurrentUserProvider.GetCurrentApplicationUser();
 
-        Assert.Equal(command.FirstName, query.StatedFirstName);
-        Assert.Equal(command.MiddleName, query.StatedMiddleName);
-        Assert.Equal(command.LastName, query.StatedLastName);
+        Assert.Equal(command.FirstName, query.StatedFirstName.ValueOrFailure());
+        Assert.Equal(command.MiddleName, query.StatedMiddleName.ValueOrFailure());
+        Assert.Equal(command.LastName, query.StatedLastName.ValueOrFailure());
         Assert.Equal(command.DateOfBirth, query.DateOfBirth);
         Assert.Equal(command.Gender?.ConvertToContact_GenderCode(), query.Gender);
         Assert.Equal(command.NationalInsuranceNumber, query.NationalInsuranceNumber);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
@@ -10,6 +10,7 @@ using TeachingRecordSystem.AuthorizeAccess.EndToEndTests.Infrastructure.Security
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.TestCommon.Infrastructure;
 using TeachingRecordSystem.UiTestCommon.Infrastructure.FormFlow;
@@ -92,6 +93,7 @@ public sealed class HostFixture(IConfiguration configuration) : IAsyncDisposable
                     services.AddFakeXrm();
                     services.AddSingleton<FakeTrnGenerator>();
                     services.AddSingleton<TrsDataSyncHelper>();
+                    services.AddSingleton<ITrnGenerator>(sp => sp.GetRequiredService<FakeTrnGenerator>());
                     services.AddSingleton<IAuditRepository, TestableAuditRepository>();
                     services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
                     services.AddSingleton(GetMockFileService());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/HostFixture.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.TestHost;
 using TeachingRecordSystem.AuthorizeAccess.Tests.Infrastructure.Security;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.TestCommon.Infrastructure;
 using TeachingRecordSystem.UiTestCommon.Infrastructure.FormFlow;
@@ -62,6 +63,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddFakeXrm();
             services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
             services.AddSingleton<FakeTrnGenerator>();
+            services.AddSingleton<ITrnGenerator>(sp => sp.GetRequiredService<FakeTrnGenerator>());
             services.AddSingleton<IAuditRepository, TestableAuditRepository>();
             services.AddSingleton<TrsDataSyncHelper>();
             services.AddSingleton(GetMockFileService());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/CreateContactTests.cs
@@ -1,3 +1,4 @@
+using Optional;
 using TeachingRecordSystem.Core.Services.DqtOutbox.Messages;
 
 namespace TeachingRecordSystem.Core.Dqt.CrmIntegrationTests.QueryTests;
@@ -39,9 +40,9 @@ public class CreateContactTests : IAsyncLifetime
             FirstName = firstName,
             MiddleName = middleName,
             LastName = lastName,
-            StatedFirstName = firstName,
-            StatedMiddleName = middleName,
-            StatedLastName = lastName,
+            StatedFirstName = Option.Some(firstName),
+            StatedMiddleName = Option.Some(middleName),
+            StatedLastName = Option.Some(lastName),
             EmailAddress = email,
             NationalInsuranceNumber = nino,
             DateOfBirth = dateOfBirth,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Playwright;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.EndToEndTests.Infrastructure.Security;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
@@ -77,6 +78,7 @@ public sealed class HostFixture : IAsyncDisposable, IStartupTask
                         sp => ActivatorUtilities.CreateInstance<TestData>(sp, TestDataSyncConfiguration.Sync(sp.GetRequiredService<TrsDataSyncHelper>())));
                     services.AddFakeXrm();
                     services.AddSingleton<FakeTrnGenerator>();
+                    services.AddSingleton<ITrnGenerator>(sp => sp.GetRequiredService<FakeTrnGenerator>());
                     services.AddSingleton<TrsDataSyncHelper>();
                     services.AddSingleton<IAuditRepository, TestableAuditRepository>();
                     services.AddSingleton(GetMockFileService());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
@@ -52,6 +53,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<IEventObserver>(_ => new ForwardToTestScopedEventObserver());
             services.AddTestScoped<IClock>(tss => tss.Clock);
             services.AddTestScoped<IDataverseAdapter>(tss => tss.DataverseAdapterMock.Object);
+            services.AddTestScoped<IGetAnIdentityApiClient>(tss => tss.GetAnIdentityApiClientMock.Object);
             services.AddTestScoped<IAadUserService>(tss => tss.AzureActiveDirectoryUserServiceMock.Object);
             services.AddTestScoped<IFeatureProvider>(tss => tss.FeatureProvider);
             services.AddSingleton<TestData>(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
@@ -365,9 +365,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         Assert.Equal(requestData.FirstName, crmContact.FirstName);
         Assert.Equal(requestData.MiddleName, crmContact.MiddleName);
         Assert.Equal(requestData.LastName, crmContact.LastName);
-        Assert.Equal(requestData.FirstName, crmContact.dfeta_StatedFirstName);
-        Assert.Equal(requestData.MiddleName, crmContact.dfeta_StatedMiddleName);
-        Assert.Equal(requestData.LastName, crmContact.dfeta_StatedLastName);
         Assert.Equal(requestData.DateOfBirth, crmContact.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false));
         Assert.Equal(requestData.EmailAddress, crmContact.EMailAddress1);
         Assert.Equal(requestData.NationalInsuranceNumber, crmContact.dfeta_NINumber);
@@ -507,7 +504,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             PersonMatchedAttribute.FirstName,
             "FirstName",
             "First name",
-            [Contact.Fields.FirstName, Contact.Fields.dfeta_StatedFirstName],
+            [Contact.Fields.FirstName],
             d => d.FirstName,
             p => p.FirstName
         ),
@@ -515,7 +512,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             PersonMatchedAttribute.MiddleName,
             "MiddleName",
             "Middle name",
-            [Contact.Fields.MiddleName, Contact.Fields.dfeta_StatedMiddleName],
+            [Contact.Fields.MiddleName],
             d => d.MiddleName,
             p => p.MiddleName
         ),
@@ -523,7 +520,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             PersonMatchedAttribute.LastName,
             "LastName",
             "Last name",
-            [Contact.Fields.LastName, Contact.Fields.dfeta_StatedLastName],
+            [Contact.Fields.LastName],
             d => d.LastName,
             p => p.LastName
         ),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure;
 
@@ -25,6 +26,7 @@ public class TestScopedServices
         BlobStorageFileServiceMock
             .Setup(s => s.GetFileUrlAsync(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
             .ReturnsAsync((Guid id, TimeSpan time) => $"{FakeBlobStorageFileUrlBase}{id}");
+        GetAnIdentityApiClientMock = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -51,4 +53,6 @@ public class TestScopedServices
     public TestableFeatureProvider FeatureProvider { get; }
 
     public Mock<IFileService> BlobStorageFileServiceMock { get; }
+
+    public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock { get; }
 }


### PR DESCRIPTION
This will allow us to share the logic between the SupportUi and API. It should also make it simpler to run from Hangfire jobs.

I've removed the name normalization bits as we won't need it by the time this goes live.