### PR TITLE
Add mechanism for creating a TransactionScope around an endpoint

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -31,6 +31,7 @@ using TeachingRecordSystem.SupportUi.Services;
 using TeachingRecordSystem.SupportUi.TagHelpers;
 using TeachingRecordSystem.WebCommon;
 using TeachingRecordSystem.WebCommon.Filters;
+using TeachingRecordSystem.WebCommon.Infrastructure;
 using TeachingRecordSystem.WebCommon.Infrastructure.Logging;
 using TeachingRecordSystem.WebCommon.Middleware;
 
@@ -92,7 +93,10 @@ builder.Services.AddAuthorizationBuilder()
     .AddInductionPolicies();
 
 builder.Services
-    .AddRazorPages()
+    .AddRazorPages(options =>
+    {
+        options.Conventions.Add(new TransactionScopeEndpointConventions());
+    })
     .AddMvcOptions(options =>
     {
         var policy = new AuthorizationPolicyBuilder()
@@ -219,6 +223,8 @@ app.UseRouting();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.UseMiddleware<TransactionScopeMiddleware>();
 
 app.MapRazorPages();
 app.MapControllers();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Infrastructure/TransactionScopeEndpoint.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Infrastructure/TransactionScopeEndpoint.cs
@@ -1,0 +1,40 @@
+using System.Transactions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace TeachingRecordSystem.WebCommon.Infrastructure;
+
+public class TransactionScopeEndpointConventions : IPageApplicationModelConvention
+{
+    public void Apply(PageApplicationModel model)
+    {
+        if (model.HandlerTypeAttributes.OfType<TransactionScopeAttribute>().Any())
+        {
+            model.EndpointMetadata.Add(TransactionScopeEndpointMetadataMarker.Instance);
+        }
+    }
+}
+
+internal sealed class TransactionScopeEndpointMetadataMarker
+{
+    private TransactionScopeEndpointMetadataMarker() { }
+
+    public static TransactionScopeEndpointMetadataMarker Instance { get; } = new();
+}
+
+public class TransactionScopeMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.GetEndpoint()?.Metadata.GetMetadata<TransactionScopeEndpointMetadataMarker>() is not null)
+        {
+            using var scope = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled);
+            await next(context);
+            scope.Complete();
+        }
+        else
+        {
+            await next(context);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/TransactionScopeAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/TransactionScopeAttribute.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.WebCommon;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class TransactionScopeAttribute : Attribute
+{
+}
+


### PR DESCRIPTION
We have places where we want to enqueue a Hangfire job and update our DB atomically. We can do this if both of those operations are within a `TransactionScope`.

The challenge is we have a request-scoped `DbContext` so creating a `TransactionScope` in a Razor page handler is too late (since the `DbContext` may already be up and running for the request if it's been used in a filter).

This adds a mechanism for decorating a Razor page with `[TransactionScope]`; if that's present a `TransactionScope` will be setup immediately after the route has been identified. With that, all our filters and the page handlers will all share a `TransactionScope`.