### PR TITLE
Return a different error code for deactivated records

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiError.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiError.cs
@@ -36,6 +36,7 @@ public sealed record ApiError(int ErrorCode, string Title, string? Detail = null
         public static int UnableToChangeFailProfessionalStatusStatus => 10055;
         public static int UnableToChangeWithdrawnProfessionalStatusStatus => 10056;
         public static int PiiUpdatesForbiddenPersonHasEyts => 10057;
+        public static int PersonInactive => 10058;
     }
 
     public static ApiError PersonNotFound(string trn, DateOnly? dateOfBirth = null, string? nationalInsuranceNumber = null)
@@ -53,6 +54,13 @@ public sealed record ApiError(int ErrorCode, string Title, string? Detail = null
         }
 
         return new ApiError(ErrorCodes.PersonNotFound, title, detail);
+    }
+
+    public static ApiError PersonInactive(string trn)
+    {
+        var title = $"Person is inactive.";
+
+        return new ApiError(ErrorCodes.PersonInactive, title);
     }
 
     public static ApiError SpecifiedResourceUrlDoesNotExist(string url) =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetPerson.cs
@@ -178,7 +178,7 @@ public class GetPersonHandler(
         }
 
         var contactDetail = await crmQueryDispatcher.ExecuteQueryAsync(
-            new GetActiveContactDetailByTrnQuery(
+            new GetContactDetailByTrnQuery(
                 command.Trn,
                 new ColumnSet(
                     Contact.Fields.FirstName,
@@ -201,6 +201,11 @@ public class GetPersonHandler(
         if (contactDetail is null)
         {
             return ApiError.PersonNotFound(command.Trn);
+        }
+
+        if (contactDetail.Contact.StateCode is ContactState.Inactive)
+        {
+            return ApiError.PersonInactive(command.Trn);
         }
 
         // If a DateOfBirth or NationalInsuranceNumber was provided, ensure the record we've retrieved with the TRN matches

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeacherController.cs
@@ -35,6 +35,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden)
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
@@ -36,7 +36,8 @@ public class TeachersController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
     }
 
     [HttpPost("name-changes")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeacherController.cs
@@ -35,6 +35,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status403Forbidden);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
@@ -37,6 +37,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
@@ -35,7 +35,8 @@ public class PersonController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status403Forbidden);
     }
 
     [HttpPost("name-changes")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonsController.cs
@@ -37,7 +37,8 @@ public class PersonsController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
     }
 
     [HttpGet("")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
@@ -35,6 +35,7 @@ public class PersonController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status403Forbidden);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
@@ -40,6 +40,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound)
             .MapErrorCode(ApiError.ErrorCodes.ForbiddenForAppropriateBody, StatusCodes.Status403Forbidden);
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/PersonController.cs
@@ -35,6 +35,7 @@ public class PersonController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status403Forbidden);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/PersonsController.cs
@@ -77,6 +77,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         return result
             .ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound)
             .MapErrorCode(ApiError.ErrorCodes.ForbiddenForAppropriateBody, StatusCodes.Status403Forbidden);
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonController.cs
@@ -35,6 +35,7 @@ public class PersonController(IMapper mapper) : ControllerBase
         var result = await handler.HandleAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status403Forbidden);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonsController.cs
@@ -49,6 +49,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         return result
             .ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)
+            .MapErrorCode(ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound)
             .MapErrorCode(ApiError.ErrorCodes.ForbiddenForAppropriateBody, StatusCodes.Status403Forbidden);
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByTrnQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByTrnQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetActiveContactDetailByTrnQuery(string Trn, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByTrnQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByTrnQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetContactDetailByTrnQuery(string Trn, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByTrnHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByTrnHandler.cs
@@ -5,16 +5,17 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetActiveContactDetailByTrnHandler : ICrmQueryHandler<GetActiveContactDetailByTrnQuery, ContactDetail?>
+public class GetContactDetailByTrnHandler : ICrmQueryHandler<GetContactDetailByTrnQuery, ContactDetail?>
 {
-    public async Task<ContactDetail?> ExecuteAsync(GetActiveContactDetailByTrnQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<ContactDetail?> ExecuteAsync(GetContactDetailByTrnQuery query, IOrganizationServiceAsync organizationService)
     {
+        var columns = query.ColumnSet.AllColumns ? query.ColumnSet : new ColumnSet(query.ColumnSet.Columns.Append(Contact.Fields.StateCode).ToArray());
+
         var contactFilter = new FilterExpression();
         contactFilter.AddCondition(Contact.Fields.dfeta_TRN, ConditionOperator.Equal, query.Trn);
-        contactFilter.AddCondition(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active);
         var contactQueryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
-            ColumnSet = query.ColumnSet,
+            ColumnSet = columns,
             Criteria = contactFilter
         };
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherByTrnTests.cs
@@ -311,4 +311,19 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
 
         await ValidRequestWithPreviousNames_ReturnsExpectedPreviousNamesContent(GetHttpClientWithApiKey(), baseUrl, contact);
     }
+
+    [Fact]
+    public async Task ValidRequest_ForInactiveContact_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithContactState(ContactState.Inactive));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsErrorAsync(response, ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/GetTeacherByTrnTests.cs
@@ -55,4 +55,19 @@ public class GetTeacherByTrnTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
     }
+
+    [Fact]
+    public async Task ValidRequest_ForInactiveContact_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithContactState(ContactState.Inactive));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsErrorAsync(response, ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonByTrnTests.cs
@@ -359,4 +359,19 @@ public class GetPersonByTrnTests : GetPersonTestBase
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
     }
+
+    [Fact]
+    public async Task ValidRequest_ForInactiveContact_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithContactState(ContactState.Inactive));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsErrorAsync(response, ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonByTrnTests.cs
@@ -258,6 +258,21 @@ public class GetPersonByTrnTests : TestBase
             responseItt);
     }
 
+    [Fact]
+    public async Task ValidRequest_ForInactiveContact_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithContactState(ContactState.Inactive));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsErrorAsync(response, ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
+    }
+
     private static dfeta_initialteachertraining CreateIttEntity(Guid contactId, string ittProviderUkprn, string ittProviderName)
     {
         var ittStartDate = new DateOnly(2021, 9, 7);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonByTrnTests.cs
@@ -235,4 +235,19 @@ public class GetPersonByTrnTests : TestBase
             },
             responseInduction);
     }
+
+    [Fact]
+    public async Task ValidRequest_ForInactiveContact_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithContactState(ContactState.Inactive));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsErrorAsync(response, ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
@@ -12,8 +12,6 @@ public class GetPersonByTrnTests : TestBase
     public async Task Get_PersonWithQtlsAndQtsViaAnotherRoute_ReturnsExpectedAwardedOrApprovedCount()
     {
         // Arrange
-
-
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithQts()
@@ -30,5 +28,20 @@ public class GetPersonByTrnTests : TestBase
         var responseJson = await AssertEx.JsonResponseAsync(response);
         var awardedOrApprovedCount = responseJson.RootElement.GetProperty("qts").GetProperty("awardedOrApprovedCount").GetInt32();
         Assert.Equal(2, awardedOrApprovedCount);
+    }
+
+    [Fact]
+    public async Task ValidRequest_ForInactiveContact_ReturnsNotFound()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithContactState(ContactState.Inactive));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        await AssertEx.JsonResponseIsErrorAsync(response, ApiError.ErrorCodes.PersonInactive, StatusCodes.Status404NotFound);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactDetailByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/GetActiveContactDetailByTrnTests.cs
@@ -24,7 +24,7 @@ public class GetActiveContactDetailByTrnTests : IAsyncLifetime
         var trn = "DodgyTrn";
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByTrnQuery(trn, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQueryAsync(new GetContactDetailByTrnQuery(trn, new ColumnSet()));
 
         // Assert
         Assert.Null(result);
@@ -37,7 +37,7 @@ public class GetActiveContactDetailByTrnTests : IAsyncLifetime
         var person = await _dataScope.TestData.CreatePersonAsync(p => p.WithTrn());
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQueryAsync(new GetContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
 
         // Assert
         Assert.NotNull(result);
@@ -56,7 +56,7 @@ public class GetActiveContactDetailByTrnTests : IAsyncLifetime
         await _dataScope.TestData.UpdatePersonAsync(b => b.WithPersonId(person.ContactId).WithUpdatedName(updatedFirstName, updatedMiddleName, updatedLastName));
 
         // Act
-        var result = await _crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
+        var result = await _crmQueryDispatcher.ExecuteQueryAsync(new GetContactDetailByTrnQuery(person.Trn!, new ColumnSet()));
 
         // Assert
         Assert.NotNull(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -50,6 +50,7 @@ public partial class TestData
         private string? _slugId;
         private int? _loginFailedCounter;
         private CreatePersonInductionBuilder? _inductionBuilder;
+        private ContactState? _contactState;
 
         public Guid PersonId { get; } = Guid.NewGuid();
 
@@ -299,6 +300,12 @@ public partial class TestData
             return this;
         }
 
+        public CreatePersonBuilder WithContactState(ContactState contactState)
+        {
+            _contactState = contactState;
+            return this;
+        }
+
         internal async Task<CreatePersonResult> ExecuteAsync(TestData testData)
         {
             var trn = _hasTrn == true ? await testData.GenerateTrnAsync() : null;
@@ -509,6 +516,16 @@ public partial class TestData
                         }
                     });
                 }
+            }
+
+            if (_contactState is ContactState.Inactive)
+            {
+                txnRequestBuilder.AddRequest<SetStateResponse>(new SetStateRequest()
+                {
+                    EntityMoniker = PersonId.ToEntityReference(Contact.EntityLogicalName),
+                    State = new OptionSetValue((int)TaskState.Completed),
+                    Status = new OptionSetValue((int)Task_StatusCode.Completed)
+                });
             }
 
             var retrieveContactHandle = txnRequestBuilder.AddRequest<RetrieveResponse>(new RetrieveRequest()


### PR DESCRIPTION
For the `GET /v3/persons/<trn>` endpoint, there's currently there's no way to know the difference between an invalid TRN and a deactivated record; we return a `404` and a 'Person does not exist' error in both cases.

This change returns a different error code - `10058` - for deactivated records. In future we should roll this out across all endpoints.