### PR TITLE
Add TRN Request resolution details to SupportTask data

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -26,7 +26,7 @@ public class SupportTask
     public required object Data
     {
         get => JsonSerializer.Deserialize(_data, GetDataType(), SerializerOptions)!;
-        set => _data = JsonSerializer.SerializeToDocument(value, GetDataType(), SerializerOptions);
+        init => _data = JsonSerializer.SerializeToDocument(value, GetDataType(), SerializerOptions);
     }
 
     public static string GenerateSupportTaskReference()
@@ -76,6 +76,16 @@ public class SupportTask
 
             return _validReferenceChars[checkCodePoint];
         }
+    }
+
+    public T GetData<T>() => (T)Data;
+
+    public T UpdateData<T>(Func<T, T> update)
+    {
+        var currentValue = GetData<T>();
+        var newValue = update(currentValue);
+        _data = JsonSerializer.SerializeToDocument(newValue, GetDataType(), SerializerOptions);
+        return newValue;
     }
 
     internal static Type GetDataType(SupportTaskType supportTaskType) => supportTaskType switch

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ApiTrnRequestData.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ApiTrnRequestData.cs
@@ -2,5 +2,16 @@ namespace TeachingRecordSystem.Core.Models.SupportTaskData;
 
 public record ApiTrnRequestData
 {
+    public ApiTrnRequestDataPersonAttributes? SelectedPersonAttributes { get; init; }
+    public ApiTrnRequestDataPersonAttributes? ResolvedAttributes { get; init; }
 }
 
+public record ApiTrnRequestDataPersonAttributes
+{
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required DateOnly? DateOfBirth { get; init; }
+    public required string? EmailAddress { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestPageModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestPageModel.cs
@@ -1,0 +1,181 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.ResolveApiTrnRequestState;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
+
+public abstract class ResolveApiTrnRequestPageModel(TrsDbContext dbContext) : PageModel
+{
+    public JourneyInstance<ResolveApiTrnRequestState>? JourneyInstance { get; set; }
+
+    protected TrsDbContext DbContext => dbContext;
+
+    protected TrnRequestMetadata GetRequestData()
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        return supportTask.TrnRequestMetadata!;
+    }
+
+    protected IReadOnlyCollection<PersonMatchedAttribute> GetPersonAttributeMatches(
+        string firstName,
+        string middleName,
+        string lastName,
+        DateOnly? dateOfBirth,
+        string? emailAddress,
+        string? nationalInsuranceNumber)
+    {
+        return Impl().AsReadOnly();
+
+        IEnumerable<PersonMatchedAttribute> Impl()
+        {
+            var requestData = GetRequestData();
+
+            if (firstName == requestData.FirstName)
+            {
+                yield return PersonMatchedAttribute.FirstName;
+            }
+
+            if (middleName == requestData.MiddleName)
+            {
+                yield return PersonMatchedAttribute.MiddleName;
+            }
+
+            if (lastName == requestData.LastName)
+            {
+                yield return PersonMatchedAttribute.LastName;
+            }
+
+            if (dateOfBirth == requestData.DateOfBirth)
+            {
+                yield return PersonMatchedAttribute.DateOfBirth;
+            }
+
+            if (emailAddress == requestData.EmailAddress)
+            {
+                yield return PersonMatchedAttribute.EmailAddress;
+            }
+
+            if (nationalInsuranceNumber == requestData.NationalInsuranceNumber)
+            {
+                yield return PersonMatchedAttribute.NationalInsuranceNumber;
+            }
+        }
+    }
+
+    protected IReadOnlyCollection<PersonMatchedAttribute> GetAttributesToUpdate()
+    {
+        var state = JourneyInstance!.State;
+
+        if (!state.PersonAttributeSourcesSet)
+        {
+            throw new InvalidOperationException("Attribute sources not set.");
+        }
+
+        return Impl().AsReadOnly();
+
+        IEnumerable<PersonMatchedAttribute> Impl()
+        {
+            if (state.FirstNameSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.FirstName;
+            }
+
+            if (state.MiddleNameSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.MiddleName;
+            }
+
+            if (state.LastNameSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.LastName;
+            }
+
+            if (state.DateOfBirthSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.DateOfBirth;
+            }
+
+            if (state.EmailAddressSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.EmailAddress;
+            }
+
+            if (state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest)
+            {
+                yield return PersonMatchedAttribute.NationalInsuranceNumber;
+            }
+        }
+    }
+
+    protected async Task<ApiTrnRequestDataPersonAttributes> GetPersonAttributesAsync(Guid personId)
+    {
+        var personAttributes = await dbContext.Persons
+            .Where(p => p.PersonId == personId)
+            .Select(p => new
+            {
+                p.FirstName,
+                p.MiddleName,
+                p.LastName,
+                p.DateOfBirth,
+                p.NationalInsuranceNumber,
+                p.EmailAddress
+            })
+            .SingleAsync();
+
+        return new ApiTrnRequestDataPersonAttributes()
+        {
+            FirstName = personAttributes.FirstName,
+            MiddleName = personAttributes.MiddleName,
+            LastName = personAttributes.LastName,
+            DateOfBirth = personAttributes.DateOfBirth,
+            EmailAddress = personAttributes.EmailAddress,
+            NationalInsuranceNumber = personAttributes.NationalInsuranceNumber
+        };
+    }
+
+    protected ApiTrnRequestDataPersonAttributes GetPersonAttributesFromRequestData()
+    {
+        var requestData = GetRequestData();
+
+        return new ApiTrnRequestDataPersonAttributes()
+        {
+            FirstName = requestData.FirstName!,
+            MiddleName = requestData.MiddleName ?? string.Empty,
+            LastName = requestData.LastName!,
+            DateOfBirth = requestData.DateOfBirth,
+            EmailAddress = requestData.EmailAddress,
+            NationalInsuranceNumber = requestData.NationalInsuranceNumber
+        };
+    }
+
+    protected ApiTrnRequestDataPersonAttributes GetResolvedPersonAttributes(
+        ApiTrnRequestDataPersonAttributes? selectedPersonAttributes)
+    {
+        var state = JourneyInstance!.State;
+        var trnRequestPersonAttributes = GetPersonAttributesFromRequestData();
+
+        if (state.PersonId == CreateNewRecordPersonIdSentinel)
+        {
+            Debug.Assert(selectedPersonAttributes is null);
+            return trnRequestPersonAttributes;
+        }
+        else
+        {
+            Debug.Assert(selectedPersonAttributes is not null);
+
+            return new ApiTrnRequestDataPersonAttributes()
+            {
+                FirstName = state.FirstNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.FirstName : trnRequestPersonAttributes.FirstName,
+                MiddleName = state.MiddleNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.MiddleName : trnRequestPersonAttributes.MiddleName,
+                LastName = state.LastNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.LastName : trnRequestPersonAttributes.LastName,
+                DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.DateOfBirth : trnRequestPersonAttributes.DateOfBirth,
+                EmailAddress = state.EmailAddressSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.EmailAddress : trnRequestPersonAttributes.EmailAddress,
+                NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.NationalInsuranceNumber : trnRequestPersonAttributes.NationalInsuranceNumber
+            };
+        }
+    }
+}
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
@@ -1,5 +1,3 @@
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
 
 public class ResolveApiTrnRequestState : IRegisterJourney
@@ -21,94 +19,6 @@ public class ResolveApiTrnRequestState : IRegisterJourney
     public PersonAttributeSource? EmailAddressSource { get; set; }
     public PersonAttributeSource? NationalInsuranceNumberSource { get; set; }
     public string? Comments { get; set; }
-
-    public static IReadOnlyCollection<PersonMatchedAttribute> GetPersonAttributeDifferences(
-        TrnRequestMetadata requestMetadata,
-        string firstName,
-        string middleName,
-        string lastName,
-        DateOnly? dateOfBirth,
-        string? emailAddress,
-        string? nationalInsuranceNumber)
-    {
-        return Impl().AsReadOnly();
-
-        IEnumerable<PersonMatchedAttribute> Impl()
-        {
-            if (firstName == requestMetadata.FirstName)
-            {
-                yield return PersonMatchedAttribute.FirstName;
-            }
-
-            if (middleName == requestMetadata.MiddleName)
-            {
-                yield return PersonMatchedAttribute.MiddleName;
-            }
-
-            if (lastName == requestMetadata.LastName)
-            {
-                yield return PersonMatchedAttribute.LastName;
-            }
-
-            if (dateOfBirth == requestMetadata.DateOfBirth)
-            {
-                yield return PersonMatchedAttribute.DateOfBirth;
-            }
-
-            if (emailAddress == requestMetadata.EmailAddress)
-            {
-                yield return PersonMatchedAttribute.EmailAddress;
-            }
-
-            if (nationalInsuranceNumber == requestMetadata.NationalInsuranceNumber)
-            {
-                yield return PersonMatchedAttribute.NationalInsuranceNumber;
-            }
-        }
-    }
-
-    public IReadOnlyCollection<PersonMatchedAttribute> GetAttributesToUpdate()
-    {
-        if (!PersonAttributeSourcesSet)
-        {
-            throw new InvalidOperationException("Attribute sources not set.");
-        }
-
-        return Impl().AsReadOnly();
-
-        IEnumerable<PersonMatchedAttribute> Impl()
-        {
-            if (FirstNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.FirstName;
-            }
-
-            if (MiddleNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.MiddleName;
-            }
-
-            if (LastNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.LastName;
-            }
-
-            if (DateOfBirthSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.DateOfBirth;
-            }
-
-            if (EmailAddressSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.EmailAddress;
-            }
-
-            if (NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.NationalInsuranceNumber;
-            }
-        }
-    }
 
     public enum PersonAttributeSource
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ConnectOneLoginUser/Connect.cshtml.cs
@@ -29,17 +29,16 @@ public class ConnectModel(TrsDbContext dbContext, IPersonMatchingService personM
 
     public async Task<IActionResult> OnPostAsync()
     {
-        var data = (ConnectOneLoginUserData)_supportTask!.Data;
-        _supportTask.Data = data with
+        var data = _supportTask!.UpdateData<ConnectOneLoginUserData>(data => data with
         {
             PersonId = PersonDetail!.PersonId
-        };
+        });
         _supportTask.Status = SupportTaskStatus.Closed;
 
         var matchedAttributes = (await personMatchingService
             .GetMatchedAttributesAsync(
                 new(data.VerifiedNames!, data.VerifiedDatesOfBirth!, data.StatedNationalInsuranceNumber, data.StatedTrn, data.TrnTokenTrn),
-                PersonDetail.PersonId))
+                PersonDetail!.PersonId))
             .ToArray();
 
         var oneLoginUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == data.OneLoginUserSubject);


### PR DESCRIPTION
This adds the resolved person attributes to the `SupportTask`s data. As part of this I've had to fix up how we're updating `Data` (it's a bit different since it's stored as JSON in the DB).

I've also pulled some of the common methods into a `PageModel` base class for the journey.