### PR TITLE
Fix nullability annotations on navigation properties

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
@@ -68,7 +68,7 @@ public class ApiKeyAuthenticationHandler(
             return AuthenticateResult.Fail($"API key is expired.");
         }
 
-        var applicationUser = apiKey.ApplicationUser;
+        var applicationUser = apiKey.ApplicationUser!;
 
         var principal = CreatePrincipal(applicationUser.UserId, applicationUser.Name, applicationUser.ApiRoles ?? []);
         var ticket = new AuthenticationTicket(principal, Scheme.Name);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsBase.cs
@@ -65,9 +65,9 @@ public abstract class FindPersonsHandlerBase(
         var contactsById = matched.ToDictionary(r => r.Id, r => r);
 
         var getPersonsTask = dbContext.Persons
-            .Include(p => p.Alerts)
+            .Include(p => p.Alerts!)
             .ThenInclude(a => a.AlertType)
-            .ThenInclude(at => at.AlertCategory)
+            .ThenInclude(at => at!.AlertCategory)
             .AsSplitQuery()
             .Where(p => contactsById.Keys.Contains(p.PersonId))
             .ToDictionaryAsync(p => p.PersonId, p => p);
@@ -100,25 +100,25 @@ public abstract class FindPersonsHandlerBase(
                 FirstName = r.ResolveFirstName(),
                 MiddleName = r.ResolveMiddleName(),
                 LastName = r.ResolveLastName(),
-                Sanctions = persons[r.Id].Alerts
-                    .Where(a => Constants.LegacyExposableSanctionCodes.Contains(a.AlertType.DqtSanctionCode) && a.IsOpen)
+                Sanctions = persons[r.Id].Alerts!
+                    .Where(a => Constants.LegacyExposableSanctionCodes.Contains(a.AlertType!.DqtSanctionCode) && a.IsOpen)
                     .Select(a => new SanctionInfo()
                     {
-                        Code = a.AlertType.DqtSanctionCode!,
+                        Code = a.AlertType!.DqtSanctionCode!,
                         StartDate = a.StartDate
                     })
                     .AsReadOnly(),
-                Alerts = persons[r.Id].Alerts
-                    .Where(a => !a.AlertType.InternalOnly)
+                Alerts = persons[r.Id].Alerts!
+                    .Where(a => !a.AlertType!.InternalOnly)
                     .Select(a => new Alert()
                     {
                         AlertId = a.AlertId,
                         AlertType = new()
                         {
-                            AlertTypeId = a.AlertType.AlertTypeId,
+                            AlertTypeId = a.AlertType!.AlertTypeId,
                             AlertCategory = new()
                             {
-                                AlertCategoryId = a.AlertType.AlertCategory.AlertCategoryId,
+                                AlertCategoryId = a.AlertType.AlertCategory!.AlertCategoryId,
                                 Name = a.AlertType.AlertCategory.Name
                             },
                             Name = a.AlertType.Name,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetPerson.cs
@@ -342,7 +342,7 @@ public class GetPersonHandler(
             null;
 
         var getAlertsTask = command.Include.HasFlag(GetPersonCommandIncludes.Sanctions) || command.Include.HasFlag(GetPersonCommandIncludes.Alerts) ?
-            WithTrsDbLockAsync(() => dbContext.Alerts.Include(a => a.AlertType).ThenInclude(at => at.AlertCategory).Where(a => a.PersonId == contact.Id).ToArrayAsync()) :
+            WithTrsDbLockAsync(() => dbContext.Alerts.Include(a => a.AlertType).ThenInclude(at => at!.AlertCategory).Where(a => a.PersonId == contact.Id).ToArrayAsync()) :
             null;
 
         IEnumerable<NameInfo> previousNames = previousNameHelper.GetFullPreviousNames(contactDetail.PreviousNames, contactDetail.Contact)
@@ -416,10 +416,10 @@ public class GetPersonHandler(
                 default,
             Sanctions = command.Include.HasFlag(GetPersonCommandIncludes.Sanctions) ?
                 Option.Some((await getAlertsTask!)
-                    .Where(a => Constants.LegacyExposableSanctionCodes.Contains(a.AlertType.DqtSanctionCode) && a.IsOpen)
+                    .Where(a => Constants.LegacyExposableSanctionCodes.Contains(a.AlertType!.DqtSanctionCode) && a.IsOpen)
                     .Select(s => new SanctionInfo()
                     {
-                        Code = s.AlertType.DqtSanctionCode!,
+                        Code = s.AlertType!.DqtSanctionCode!,
                         StartDate = s.StartDate
                     })
                     .AsReadOnly()) :
@@ -431,20 +431,20 @@ public class GetPersonHandler(
                         // The Legacy behavior is to only return prohibition-type alerts
                         if (command.ApplyLegacyAlertsBehavior)
                         {
-                            return Constants.LegacyProhibitionSanctionCodes.Contains(a.AlertType.DqtSanctionCode);
+                            return Constants.LegacyProhibitionSanctionCodes.Contains(a.AlertType!.DqtSanctionCode);
                         }
 
-                        return !a.AlertType.InternalOnly;
+                        return !a.AlertType!.InternalOnly;
                     })
                     .Select(a => new Alert()
                     {
                         AlertId = a.AlertId,
                         AlertType = new()
                         {
-                            AlertTypeId = a.AlertType.AlertTypeId,
+                            AlertTypeId = a.AlertType!.AlertTypeId,
                             AlertCategory = new()
                             {
-                                AlertCategoryId = a.AlertType.AlertCategory.AlertCategoryId,
+                                AlertCategoryId = a.AlertType.AlertCategory!.AlertCategoryId,
                                 Name = a.AlertType.AlertCategory.Name
                             },
                             Name = a.AlertType.Name,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.WebhookEndpoint.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.WebhookEndpoint.cs
@@ -19,7 +19,7 @@ public partial class Commands
             {
                 e.WebhookEndpointId,
                 e.ApplicationUserId,
-                ApplicationUserName = e.ApplicationUser.Name,
+                ApplicationUserName = e.ApplicationUser!.Name,
                 e.ApiVersion,
                 e.Address,
                 e.CloudEventTypes,
@@ -226,7 +226,7 @@ public partial class Commands
                     await using var dbContext = TrsDbContext.Create(connectionString);
 
                     var endpoints = await dbContext.WebhookEndpoints
-                        .Where(e => e.ApplicationUser.Active)
+                        .Where(e => e.ApplicationUser!.Active)
                         .OrderBy(e => e.CreatedOn)
                         .Select(getEndpointOutputForDisplay)
                         .ToListAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/V20240920/Dtos/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/V20240920/Dtos/Alert.cs
@@ -27,7 +27,7 @@ public record Alert
                 AlertCategory = new()
                 {
                     AlertCategoryId = alertType.AlertCategoryId,
-                    Name = alertType.AlertCategory.Name,
+                    Name = alertType.AlertCategory!.Name,
                 }
             },
             Details = alert.Details,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Alert.cs
@@ -10,10 +10,10 @@ public class Alert
     public const string PersonForeignKeyName = "fk_alerts_person";
 
     public required Guid AlertId { get; init; }
-    public AlertType AlertType { get; } = null!;
+    public AlertType? AlertType { get; }
     public required Guid AlertTypeId { get; init; }
     public required Guid PersonId { get; init; }
-    public Person Person { get; } = null!;
+    public Person? Person { get; }
     public required string? Details { get; set; }
     public required string? ExternalLink { get; set; }
     public required DateOnly? StartDate { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/AlertType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/AlertType.cs
@@ -12,7 +12,7 @@ public class AlertType
 
     public required Guid AlertTypeId { get; init; }
     public required Guid AlertCategoryId { get; init; }
-    public AlertCategory AlertCategory { get; } = null!;
+    public AlertCategory? AlertCategory { get; }
     public required string Name { get; init; }
     public required string? DqtSanctionCode { get; init; }
     public required ProhibitionLevel ProhibitionLevel { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ApiKey.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ApiKey.cs
@@ -11,7 +11,7 @@ public class ApiKey
     public required DateTime CreatedOn { get; init; }
     public required DateTime UpdatedOn { get; set; }
     public required Guid ApplicationUserId { get; init; }
-    public ApplicationUser ApplicationUser { get; } = null!;
+    public ApplicationUser? ApplicationUser { get; }
     public required string Key { get; init; }
     public DateTime? Expires { get; set; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Establishment.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Establishment.cs
@@ -29,5 +29,4 @@ public class Establishment
     public required string? Town { get; set; }
     public required string? County { get; set; }
     public required string? Postcode { get; set; }
-
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -34,8 +34,8 @@ public class Person
     public DateTime? CpdInductionCpdModifiedOn { get; private set; }
     public DateOnly? QtsDate { get; set; }
     public DateOnly? EytsDate { get; set; }
-    public ICollection<Qualification> Qualifications { get; } = new List<Qualification>();
-    public ICollection<Alert> Alerts { get; } = new List<Alert>();
+    public ICollection<Qualification>? Qualifications { get; }
+    public ICollection<Alert>? Alerts { get; }
 
     public Guid? DqtContactId { get; init; }
     public DateTime? DqtFirstSync { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ProfessionalStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ProfessionalStatus.cs
@@ -12,7 +12,7 @@ public class ProfessionalStatus : Qualification
     public required Guid RouteToProfessionalStatusId { get; set; }
     public Guid? SourceApplicationUserId { get; init; }
     public string? SourceApplicationReference { get; init; }
-    public RouteToProfessionalStatus Route { get; } = null!;
+    public RouteToProfessionalStatus? Route { get; }
     public required ProfessionalStatusStatus Status { get; set; }
     public DateOnly? AwardedDate { get; set; }
     public required DateOnly? TrainingStartDate { get; set; }
@@ -102,7 +102,7 @@ public class ProfessionalStatus : Qualification
         updateAction(this);
 
         var changes = ProfessionalStatusUpdatedEventChanges.None |
-            (Route.RouteToProfessionalStatusId != oldEventModel.RouteToProfessionalStatusId ? ProfessionalStatusUpdatedEventChanges.Route : ProfessionalStatusUpdatedEventChanges.None) |
+            (Route!.RouteToProfessionalStatusId != oldEventModel.RouteToProfessionalStatusId ? ProfessionalStatusUpdatedEventChanges.Route : ProfessionalStatusUpdatedEventChanges.None) |
             (Status != oldEventModel.Status ? ProfessionalStatusUpdatedEventChanges.Status : ProfessionalStatusUpdatedEventChanges.None) |
             (AwardedDate != oldEventModel.AwardedDate ? ProfessionalStatusUpdatedEventChanges.AwardedDate : ProfessionalStatusUpdatedEventChanges.None) |
             (TrainingStartDate != oldEventModel.TrainingStartDate ? ProfessionalStatusUpdatedEventChanges.StartDate : ProfessionalStatusUpdatedEventChanges.None) |

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Qualification.cs
@@ -10,5 +10,5 @@ public abstract class Qualification
     public DateTime? DeletedOn { get; set; }
     public QualificationType QualificationType { get; protected set; }
     public required Guid PersonId { get; init; }
-    public Person Person { get; } = null!;
+    public Person? Person { get; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -3,7 +3,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 public class TrnRequestMetadata
 {
     public required Guid ApplicationUserId { get; init; }
-    public ApplicationUser ApplicationUser { get; } = null!;
+    public ApplicationUser? ApplicationUser { get; }
     public required string RequestId { get; init; }
     public required DateTime CreatedOn { get; init; }
     public required bool? IdentityVerified { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -43,7 +43,7 @@ public class ApplicationUser : UserBase
     public const string OneLoginAuthenticationSchemeNameUniqueIndexName = "ix_users_one_login_authentication_scheme_name";
 
     public string[]? ApiRoles { get; set; }
-    public ICollection<ApiKey> ApiKeys { get; } = null!;
+    public ICollection<ApiKey>? ApiKeys { get; }
     public bool IsOidcClient { get; set; }
     public string? ClientId { get; set; }
     public string? ClientSecret { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/WebhookEndpoint.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/WebhookEndpoint.cs
@@ -4,7 +4,7 @@ public class WebhookEndpoint
 {
     public required Guid WebhookEndpointId { get; init; }
     public required Guid ApplicationUserId { get; init; }
-    public virtual ApplicationUser ApplicationUser { get; } = null!;
+    public ApplicationUser? ApplicationUser { get; }
     public required string Address { get; set; }
     public required string ApiVersion { get; set; }
     public required List<string> CloudEventTypes { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/WebhookMessage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/WebhookMessage.cs
@@ -6,7 +6,7 @@ public class WebhookMessage
 {
     public required Guid WebhookMessageId { get; init; }
     public required Guid WebhookEndpointId { get; init; }
-    public virtual WebhookEndpoint WebhookEndpoint { get; internal set; } = null!;
+    public WebhookEndpoint? WebhookEndpoint { get; internal set; }
     public required string CloudEventId { get; init; }
     public required string CloudEventType { get; init; }
     public required DateTimeOffset Timestamp { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookDeliveryService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookDeliveryService.cs
@@ -81,7 +81,7 @@ public class WebhookDeliveryService(
                 limit {BatchSize + 1}
                 for update skip locked
             """)
-            .Where(m => m.WebhookEndpoint.Enabled)
+            .Where(m => m.WebhookEndpoint!.Enabled)
             .Include(m => m.WebhookEndpoint)
             .ToArrayAsync();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
@@ -38,7 +38,7 @@ public class WebhookMessageFactory(EventMapperRegistry eventMapperRegistry, IClo
 
                 return await dbContext.WebhookEndpoints
                     .AsNoTracking()
-                    .Where(e => e.Enabled && e.ApplicationUser.Active)
+                    .Where(e => e.Enabled && e.ApplicationUser!.Active)
                     .ToArrayAsync();
             });
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnRequestHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnRequestHelper.cs
@@ -125,7 +125,7 @@ public class TrnRequestHelper(
             EmailAddress = requestData.EmailAddress,
             NationalInsuranceNumber = requestData.NationalInsuranceNumber,
             ReviewTasks = [],
-            ApplicationUserName = requestData.ApplicationUser.Name,
+            ApplicationUserName = requestData.ApplicationUser!.Name,
             Trn = trn,
             TrnRequestId = GetCrmTrnRequestId(requestData.ApplicationUserId, requestData.RequestId),
             TrnRequestMetadataMessage = null,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
@@ -30,7 +30,7 @@ public class CheckAlertExistsFilter(Permissions.Alerts requiredPermissionType, T
         var currentAlert = await dbContext.Alerts
             .FromSql($"select * from alerts where alert_id = {alertId} for update")  // https://github.com/dotnet/efcore/issues/26042
             .Include(a => a.AlertType)
-            .ThenInclude(at => at.AlertCategory)
+            .ThenInclude(at => at!.AlertCategory)
             .Include(a => a.Person)
             .SingleOrDefaultAsync();
 
@@ -52,7 +52,7 @@ public class CheckAlertExistsFilter(Permissions.Alerts requiredPermissionType, T
         }
 
         context.HttpContext.SetCurrentAlertFeature(new(currentAlert));
-        context.HttpContext.SetCurrentPersonFeature(currentAlert.Person);
+        context.HttpContext.SetCurrentPersonFeature(currentAlert.Person!);
 
         await next();
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckMandatoryQualificationExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckMandatoryQualificationExistsFilter.cs
@@ -36,7 +36,7 @@ public class CheckMandatoryQualificationExistsFilter(TrsDbContext dbContext) : I
         }
 
         context.HttpContext.SetCurrentMandatoryQualificationFeature(new(currentMq));
-        context.HttpContext.SetCurrentPersonFeature(currentMq.Person);
+        context.HttpContext.SetCurrentPersonFeature(currentMq.Person!);
 
         await next();
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckProfessionalStatusExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckProfessionalStatusExistsFilter.cs
@@ -28,7 +28,7 @@ public class CheckProfessionalStatusExistsFilter(TrsDbContext dbContext) : IAsyn
             .Include(ps => ps.Person)
             .Include(ps => ps.TrainingProvider)
             .Include(ps => ps.TrainingCountry)
-            .Include(ps => ps.Route)
+            .Include(ps => ps.Route!)
                 .ThenInclude(r => r.InductionExemptionReason)
             .Include(ps => ps.DegreeType);
 
@@ -42,7 +42,7 @@ public class CheckProfessionalStatusExistsFilter(TrsDbContext dbContext) : IAsyn
         }
 
         context.HttpContext.SetCurrentProfessionalStatusFeature(new(currentProfessionalStatus));
-        context.HttpContext.SetCurrentPersonFeature(currentProfessionalStatus.Person);
+        context.HttpContext.SetCurrentPersonFeature(currentProfessionalStatus.Person!);
         await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
@@ -1,7 +1,7 @@
 @page "/alerts/{alertId}"
 @model AlertDetailModel
 @{
-    ViewBag.Title = Model.Alert!.AlertType.Name;
+    ViewBag.Title = Model.Alert!.AlertType!.Name;
 }
 
 @section BeforeContent {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -106,7 +106,7 @@ public class CheckAnswersModel(
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        AlertTypeName = alertInfo.Alert.AlertType.Name;
+        AlertTypeName = alertInfo.Alert.AlertType!.Name;
         Details = alertInfo.Alert.Details;
         Link = alertInfo.Alert.ExternalLink;
         LinkUri = TrsUriHelper.TryCreateWebsiteUri(Link, out var linkUri) ? linkUri : null;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
@@ -87,7 +87,7 @@ public class CheckAnswersModel(
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        AlertTypeName = alertInfo.Alert.AlertType.Name;
+        AlertTypeName = alertInfo.Alert.AlertType!.Name;
         Details = alertInfo.Alert.Details;
         Link = alertInfo.Alert.ExternalLink;
         LinkUri = TrsUriHelper.TryCreateWebsiteUri(Link, out var linkUri) ? linkUri : null;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml.cs
@@ -135,7 +135,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        AlertTypeName = alertInfo.Alert.AlertType.Name;
+        AlertTypeName = alertInfo.Alert.AlertType!.Name;
         EndDate = alertInfo.Alert.EndDate;
         EvidenceFileId = JourneyInstance!.State.EvidenceFileId;
         EvidenceFileName = JourneyInstance!.State.EvidenceFileName;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
@@ -95,7 +95,7 @@ public class CheckAnswersModel(
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        AlertTypeName = alertInfo.Alert.AlertType.Name;
+        AlertTypeName = alertInfo.Alert.AlertType!.Name;
         Details = alertInfo.Alert.Details;
         Link = alertInfo.Alert.ExternalLink;
         LinkUri = TrsUriHelper.TryCreateWebsiteUri(Link, out var linkUri) ? linkUri : null;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey.cshtml.cs
@@ -69,7 +69,7 @@ public class EditApiKeyModel(TrsDbContext dbContext, TrsLinkGenerator linkGenera
         }
 
         ApplicationUserId = _apiKey.ApplicationUserId;
-        ApplicationUserName = _apiKey.ApplicationUser.Name;
+        ApplicationUserName = _apiKey.ApplicationUser!.Name;
         Expires = _apiKey.Expires;
         Key = _apiKey.Key;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
@@ -250,7 +250,7 @@ public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator l
             return;
         }
 
-        ApiKeys = _user.ApiKeys
+        ApiKeys = _user.ApiKeys!
             .OrderBy(k => k.CreatedOn)
             .Select(k => new ApiKeyInfo(k.ApiKeyId, k.Key, k.Expires)).ToArray();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -36,7 +36,7 @@
         @foreach (var (alert, externalLinkUri, canWrite) in Model.OpenAlerts)
         {
             <govuk-summary-card data-testid="open-alert">
-                <govuk-summary-card-title heading-level="3">@alert.AlertType.Name</govuk-summary-card-title>
+                <govuk-summary-card-title heading-level="3">@alert.AlertType!.Name</govuk-summary-card-title>
                 @if (canWrite)
                 {
                     <govuk-summary-card-actions>
@@ -137,7 +137,7 @@
                 @foreach (var (alert, externalLinkUri, canWrite) in Model.ClosedAlerts!)
                 {
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell"><a href="@LinkGenerator.AlertDetail(alert.AlertId)" class="govuk-link">@alert.AlertType.Name</a></td>
+                        <td class="govuk-table__cell"><a href="@LinkGenerator.AlertDetail(alert.AlertId)" class="govuk-link">@alert.AlertType!.Name</a></td>
                         <td class="govuk-table__cell">@alert.StartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</td>
                         <td class="govuk-table__cell">@alert.EndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</td>
                         <td class="govuk-table__cell">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -30,7 +30,7 @@
                 <govuk-summary-list>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Route</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value data-testid="training-route-@professionalStatus.QualificationId">@(professionalStatus.Route.Name)</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="training-route-@professionalStatus.QualificationId">@(professionalStatus.Route!.Name)</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AwardDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AwardDate.cshtml.cs
@@ -88,7 +88,7 @@ public class AwardDateModel(
 
         var routeFeature = context.HttpContext.GetCurrentProfessionalStatusFeature();
         RouteToProfessionalStatus = routeFeature.ProfessionalStatus.Route;
-        var inductionexemptionReason = RouteToProfessionalStatus.InductionExemptionReason;
+        var inductionexemptionReason = RouteToProfessionalStatus!.InductionExemptionReason;
         base.OnPageHandlerExecuting(context);
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/InductionExemption.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/InductionExemption.cshtml.cs
@@ -72,7 +72,7 @@ public class InductionExemptionModel(TrsLinkGenerator linkGenerator) : PageModel
         PersonName = personInfo.Name;
         PersonId = personInfo.PersonId;
         var professionalStatusFeature = context.HttpContext.GetCurrentProfessionalStatusFeature();
-        Route = professionalStatusFeature!.ProfessionalStatus.Route;
+        Route = professionalStatusFeature!.ProfessionalStatus.Route!;
 
         if (Route.InductionExemptionRequired == FieldRequirement.NotApplicable
         || Route.InductionExemptionReason is not null && Route.InductionExemptionReason.RouteImplicitExemption)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml.cs
@@ -73,7 +73,7 @@ public class Index(TrsDbContext dbContext) : PageModel
         }
         else if (sortBy == ApiTrnRequestsSortByOption.Source)
         {
-            tasks = tasks.OrderBy(sortDirection, t => t.TrnRequestMetadata!.ApplicationUser.Name);
+            tasks = tasks.OrderBy(sortDirection, t => t.TrnRequestMetadata!.ApplicationUser!.Name);
         }
 
         Results = await tasks
@@ -86,7 +86,7 @@ public class Index(TrsDbContext dbContext) : PageModel
                 t.TrnRequestMetadata!.LastName!,
                 t.TrnRequestMetadata!.EmailAddress,
                 t.CreatedOn,
-                t.TrnRequestMetadata.ApplicationUser.Name))
+                t.TrnRequestMetadata.ApplicationUser!.Name))
             .ToArrayAsync();
 
         return Page();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -161,7 +161,7 @@ public class CheckAnswers(
         }
 
         Comments = state.Comments;
-        SourceApplicationUserName = requestData.ApplicationUser.Name;
+        SourceApplicationUserName = requestData.ApplicationUser!.Name;
 
         await base.OnPageHandlerExecutionAsync(context, next);
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
@@ -16,7 +16,7 @@ public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : R
 
     public TrnRequestMetadata? RequestData { get; set; }
 
-    public string SourceApplicationUserName => RequestData!.ApplicationUser.Name;
+    public string SourceApplicationUserName => RequestData!.ApplicationUser!.Name;
 
     public PotentialDuplicate[]? PotentialDuplicates { get; set; }
 
@@ -102,7 +102,7 @@ public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : R
                     Trn = p.Trn!,
                     HasQts = p.QtsDate != null,
                     HasEyts = p.EytsDate != null,
-                    HasActiveAlerts = p.Alerts.Any(a => a.IsOpen)
+                    HasActiveAlerts = p.Alerts!.Any(a => a.IsOpen)
                 })
                 .ToArrayAsync())
             // matchedPersonIds is ordered by best match first; ensure we maintain that order

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml.cs
@@ -144,7 +144,7 @@ public class Merge(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : Res
 
         var personAttributes = await GetPersonAttributesAsync(personId);
 
-        SourceApplicationUserName = requestData.ApplicationUser.Name;
+        SourceApplicationUserName = requestData.ApplicationUser!.Name;
 
         var attributeMatches = GetPersonAttributeMatches(
             personAttributes.FirstName,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
@@ -132,7 +132,7 @@ public class FindTeachersTests : TestBase
                         {
                             new
                             {
-                                code = person1.Alerts.First().AlertType.DqtSanctionCode,
+                                code = person1.Alerts.First().AlertType!.DqtSanctionCode,
                                 startDate = person1.Alerts.First().StartDate
                             }
                         },
@@ -149,7 +149,7 @@ public class FindTeachersTests : TestBase
                         {
                             new
                             {
-                                code = person2.Alerts.First().AlertType.DqtSanctionCode,
+                                code = person2.Alerts.First().AlertType!.DqtSanctionCode,
                                 startDate = person2.Alerts.First().StartDate
                             }
                         },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherByTrnTests.cs
@@ -259,7 +259,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
             {
                 new
                 {
-                    code = alert.AlertType.DqtSanctionCode,
+                    code = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate
                 }
             },
@@ -295,7 +295,7 @@ public class GetTeacherByTrnTests : GetTeacherTestBase
                 new
                 {
                     alertType = "Prohibition",
-                    dqtSanctionCode = alert.AlertType.DqtSanctionCode,
+                    dqtSanctionCode = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate,
                     endDate = alert.EndDate
                 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherTests.cs
@@ -347,7 +347,7 @@ public class GetTeacherTests : GetTeacherTestBase
             {
                 new
                 {
-                    code = alert.AlertType.DqtSanctionCode,
+                    code = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate
                 }
             },
@@ -383,7 +383,7 @@ public class GetTeacherTests : GetTeacherTestBase
                 new
                 {
                     alertType = "Prohibition",
-                    dqtSanctionCode = alert.AlertType.DqtSanctionCode,
+                    dqtSanctionCode = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate,
                     endDate = alert.EndDate
                 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -130,7 +130,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
                         {
                             new
                             {
-                                code = person1.Alerts.First().AlertType.DqtSanctionCode,
+                                code = person1.Alerts.First().AlertType!.DqtSanctionCode,
                                 startDate = person1.Alerts.First().StartDate
                             }
                         },
@@ -147,7 +147,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
                         {
                             new
                             {
-                                code = person2.Alerts.First().AlertType.DqtSanctionCode,
+                                code = person2.Alerts.First().AlertType!.DqtSanctionCode,
                                 startDate = person2.Alerts.First().StartDate
                             }
                         },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonByTrnTests.cs
@@ -258,7 +258,7 @@ public class GetPersonByTrnTests : GetPersonTestBase
             {
                 new
                 {
-                    code = alert.AlertType.DqtSanctionCode,
+                    code = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate
                 }
             },
@@ -294,7 +294,7 @@ public class GetPersonByTrnTests : GetPersonTestBase
                 new
                 {
                     alertType = "Prohibition",
-                    dqtSanctionCode = alert.AlertType.DqtSanctionCode,
+                    dqtSanctionCode = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate,
                     endDate = alert.EndDate
                 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonTests.cs
@@ -342,7 +342,7 @@ public class GetPersonTests(HostFixture hostFixture) : GetPersonTestBase(hostFix
             {
                 new
                 {
-                    code = alert.AlertType.DqtSanctionCode,
+                    code = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate
                 }
             },
@@ -378,7 +378,7 @@ public class GetPersonTests(HostFixture hostFixture) : GetPersonTestBase(hostFix
                 new
                 {
                     alertType = "Prohibition",
-                    dqtSanctionCode = alert.AlertType.DqtSanctionCode,
+                    dqtSanctionCode = alert.AlertType!.DqtSanctionCode,
                     startDate = alert.StartDate,
                     endDate = alert.EndDate
                 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -133,7 +133,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
                         {
                             new
                             {
-                                code = person1.Alerts.Single().AlertType.DqtSanctionCode,
+                                code = person1.Alerts.Single().AlertType!.DqtSanctionCode,
                                 startDate = person1.Alerts.Single().StartDate
                             }
                         },
@@ -165,7 +165,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
                         {
                             new
                             {
-                                code = person2.Alerts.Single().AlertType.DqtSanctionCode,
+                                code = person2.Alerts.Single().AlertType!.DqtSanctionCode,
                                 startDate = person2.Alerts.Single().StartDate
                             }
                         },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -168,7 +168,7 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
                         {
                             new
                             {
-                                code = person.Alerts.Single().AlertType.DqtSanctionCode,
+                                code = person.Alerts.Single().AlertType!.DqtSanctionCode,
                                 startDate = person.Alerts.Single().StartDate
                             }
                         },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -46,11 +46,11 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
                     alertId = alert.AlertId,
                     alertType = new
                     {
-                        alertTypeId = alert.AlertType.AlertTypeId,
+                        alertTypeId = alert.AlertType!.AlertTypeId,
                         name = alert.AlertType.Name,
                         alertCategory = new
                         {
-                            alertCategoryId = alert.AlertType.AlertCategory.AlertCategoryId,
+                            alertCategoryId = alert.AlertType.AlertCategory!.AlertCategoryId,
                             name = alert.AlertType.AlertCategory.Name
                         }
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -57,11 +57,11 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
                     alertId = alert.AlertId,
                     alertType = new
                     {
-                        alertTypeId = alert.AlertType.AlertTypeId,
+                        alertTypeId = alert.AlertType!.AlertTypeId,
                         name = alert.AlertType.Name,
                         alertCategory = new
                         {
-                            alertCategoryId = alert.AlertType.AlertCategory.AlertCategoryId,
+                            alertCategoryId = alert.AlertType.AlertCategory!.AlertCategoryId,
                             name = alert.AlertType.AlertCategory.Name
                         }
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonByTrnTests.cs
@@ -119,11 +119,11 @@ public class GetPersonByTrnTests : TestBase
                     alertId = alert.AlertId,
                     alertType = new
                     {
-                        alertTypeId = alert.AlertType.AlertTypeId,
+                        alertTypeId = alert.AlertType!.AlertTypeId,
                         name = alert.AlertType.Name,
                         alertCategory = new
                         {
-                            alertCategoryId = alert.AlertType.AlertCategory.AlertCategoryId,
+                            alertCategoryId = alert.AlertType.AlertCategory!.AlertCategoryId,
                             name = alert.AlertType.AlertCategory.Name
                         }
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonTests.cs
@@ -34,11 +34,11 @@ public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
                     alertId = alert.AlertId,
                     alertType = new
                     {
-                        alertTypeId = alert.AlertType.AlertTypeId,
+                        alertTypeId = alert.AlertType!.AlertTypeId,
                         name = alert.AlertType.Name,
                         alertCategory = new
                         {
-                            alertCategoryId = alert.AlertType.AlertCategory.AlertCategoryId,
+                            alertCategoryId = alert.AlertType.AlertCategory!.AlertCategoryId,
                             name = alert.AlertType.AlertCategory.Name
                         }
                     },

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/VNext/WebhookData/AlertCreatedNotificationMapperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/VNext/WebhookData/AlertCreatedNotificationMapperTests.cs
@@ -27,9 +27,9 @@ public class AlertCreatedNotificationMapperTests(EventMapperFixture fixture) : E
             Assert.Equal(person.Trn, notification.Trn);
             Assert.Equal(alert.AlertId, notification.Alert.AlertId);
             Assert.Equal(alert.AlertTypeId, notification.Alert.AlertType.AlertTypeId);
-            Assert.Equal(alert.AlertType.Name, notification.Alert.AlertType.Name);
+            Assert.Equal(alert.AlertType!.Name, notification.Alert.AlertType.Name);
             Assert.Equal(alert.AlertType.AlertCategoryId, notification.Alert.AlertType.AlertCategory.AlertCategoryId);
-            Assert.Equal(alert.AlertType.AlertCategory.Name, notification.Alert.AlertType.AlertCategory.Name);
+            Assert.Equal(alert.AlertType!.AlertCategory!.Name, notification.Alert.AlertType.AlertCategory.Name);
             Assert.Equal(alert.Details, notification.Alert.Details);
             Assert.Equal(alert.StartDate, notification.Alert.StartDate);
             Assert.Equal(alert.EndDate, notification.Alert.EndDate);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/VNext/WebhookData/AlertDeletedNotificationMapperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/VNext/WebhookData/AlertDeletedNotificationMapperTests.cs
@@ -43,9 +43,9 @@ public class AlertDeletedNotificationMapperTests(EventMapperFixture fixture) : E
             Assert.Equal(person.Trn, notification.Trn);
             Assert.Equal(alert.AlertId, notification.Alert.AlertId);
             Assert.Equal(alert.AlertTypeId, notification.Alert.AlertType.AlertTypeId);
-            Assert.Equal(alert.AlertType.Name, notification.Alert.AlertType.Name);
+            Assert.Equal(alert.AlertType!.Name, notification.Alert.AlertType.Name);
             Assert.Equal(alert.AlertType.AlertCategoryId, notification.Alert.AlertType.AlertCategory.AlertCategoryId);
-            Assert.Equal(alert.AlertType.AlertCategory.Name, notification.Alert.AlertType.AlertCategory.Name);
+            Assert.Equal(alert.AlertType!.AlertCategory!.Name, notification.Alert.AlertType.AlertCategory.Name);
             Assert.Equal(alert.Details, notification.Alert.Details);
             Assert.Equal(alert.StartDate, notification.Alert.StartDate);
             Assert.Equal(alert.EndDate, notification.Alert.EndDate);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/VNext/WebhookData/AlertUpdatedNotificationMapperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/VNext/WebhookData/AlertUpdatedNotificationMapperTests.cs
@@ -45,9 +45,9 @@ public class AlertUpdatedNotificationMapperTests(EventMapperFixture fixture) : E
             Assert.Equal(person.Trn, notification.Trn);
             Assert.Equal(alert.AlertId, notification.Alert.AlertId);
             Assert.Equal(alert.AlertTypeId, notification.Alert.AlertType.AlertTypeId);
-            Assert.Equal(alert.AlertType.Name, notification.Alert.AlertType.Name);
+            Assert.Equal(alert.AlertType!.Name, notification.Alert.AlertType.Name);
             Assert.Equal(alert.AlertType.AlertCategoryId, notification.Alert.AlertType.AlertCategory.AlertCategoryId);
-            Assert.Equal(alert.AlertType.AlertCategory.Name, notification.Alert.AlertType.AlertCategory.Name);
+            Assert.Equal(alert.AlertType.AlertCategory!.Name, notification.Alert.AlertType.AlertCategory.Name);
             Assert.Equal(alert.Details, notification.Alert.Details);
             Assert.Equal(alert.StartDate, notification.Alert.StartDate);
             Assert.Equal(alert.EndDate, notification.Alert.EndDate);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AlertDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AlertDetailsTests.cs
@@ -60,7 +60,7 @@ public class AlertDetailsTests : TestBase
         var doc = await AssertEx.HtmlResponseAsync(response);
 
         var h1 = doc.GetElementsByTagName("h1").Single();
-        Assert.Equal(alert.AlertType.Name, h1.TextContent);
+        Assert.Equal(alert.AlertType!.Name, h1.TextContent);
 
         Assert.Equal(alert.Details, doc.GetSummaryListValueForKey("Details"));
         Assert.Equal(alert.StartDate?.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("Start date"));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -91,7 +91,7 @@ public class CheckAnswersTests : CloseAlertTestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        Assert.Equal(alert.AlertType.Name, doc.GetSummaryListValueForKey("Alert type"));
+        Assert.Equal(alert.AlertType!.Name, doc.GetSummaryListValueForKey("Alert type"));
         Assert.Equal(alert.Details, doc.GetSummaryListValueForKey("Details"));
         Assert.Equal(populateOptional ? $"{alert.ExternalLink} (opens in new tab)" : UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Link"));
         Assert.Equal(alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("Start date"));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/CheckAnswersTests.cs
@@ -80,7 +80,7 @@ public class CheckAnswersTests : DeleteAlertTestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        Assert.Equal(alert.AlertType.Name, doc.GetSummaryListValueForKey("Alert type"));
+        Assert.Equal(alert.AlertType!.Name, doc.GetSummaryListValueForKey("Alert type"));
         Assert.Equal(alert.Details, doc.GetSummaryListValueForKey("Details"));
         Assert.Equal(populateOptional ? $"{alert.ExternalLink} (opens in new tab)" : UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Link"));
         Assert.Equal(alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("Start date"));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
@@ -93,7 +93,7 @@ public class CheckAnswersTests : ReopenAlertTestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        Assert.Equal(alert.AlertType.Name, doc.GetSummaryListValueForKey("Alert type"));
+        Assert.Equal(alert.AlertType!.Name, doc.GetSummaryListValueForKey("Alert type"));
         Assert.Equal(alert.Details, doc.GetSummaryListValueForKey("Details"));
         Assert.Equal(populateOptional ? $"{alert.ExternalLink} (opens in new tab)" : UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Link"));
         Assert.Equal(alert.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("Start date"));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
@@ -58,7 +58,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
             card =>
             {
                 var title = card.GetElementsByClassName("govuk-summary-card__title").SingleOrDefault();
-                Assert.Equal(alert.AlertType.Name, title?.TextContent);
+                Assert.Equal(alert.AlertType!.Name, title?.TextContent);
 
                 Assert.Equal(alert.Details, card.GetSummaryListValueForKey("Details"));
                 Assert.Equal(alert.ExternalLink, card.GetSummaryListValueElementForKey("Link")?.GetElementsByTagName("a").FirstOrDefault()?.TextContent);
@@ -108,7 +108,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
             closedAlertsTable.GetElementsByTagName("tbody").Single().GetElementsByTagName("tr"),
             row => Assert.Collection(
                 row.GetElementsByTagName("td"),
-                column => Assert.Equal(alert.AlertType.Name, column.TextContent),
+                column => Assert.Equal(alert.AlertType!.Name, column.TextContent),
                 column => Assert.Equal(alert.StartDate?.ToString(UiDefaults.DateOnlyDisplayFormat), column.TextContent),
                 column => Assert.Equal(alert.EndDate?.ToString(UiDefaults.DateOnlyDisplayFormat), column.TextContent),
                 column => { }));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -552,9 +552,9 @@ public partial class TestData
                 await dbContext.SaveChangesAsync();
 
                 person = await dbContext.Persons
-                    .Include(p => p.Alerts)
+                    .Include(p => p.Alerts!)
                     .ThenInclude(a => a.AlertType)
-                    .ThenInclude(at => at.AlertCategory)
+                    .ThenInclude(at => at!.AlertCategory)
                     .AsSplitQuery()
                     .SingleAsync(p => p.PersonId == contact.Id);
 
@@ -571,7 +571,7 @@ public partial class TestData
 
                 // Get MQs and Alerts that we've added *in the same order they were specified*.
                 var mqs = mqIds.Select(id => personMqs.Single(q => q.QualificationId == id)).AsReadOnly();
-                var alerts = alertIds.Select(id => person.Alerts.Single(a => a.AlertId == id)).AsReadOnly();
+                var alerts = alertIds.Select(id => person.Alerts!.Single(a => a.AlertId == id)).AsReadOnly();
                 var routesToProfessionalStatus = routeIds.Select(id => personProfessionalStatuses.Single(q => q.QualificationId == id)).AsReadOnly();
 
                 return (mqs, alerts, person, routesToProfessionalStatus);


### PR DESCRIPTION
Thanks to EF these properties can be `null` even if the foreign key is actually populated in the DB.