### PR TITLE
Standardize additional reasons and file uploads

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
@@ -107,7 +107,7 @@ public class CheckAnswersModel(
         AddReasonDetail = JourneyInstance!.State.AddReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml
@@ -13,7 +13,7 @@
         <form action="@LinkGenerator.AlertAddDetails(Model.PersonId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <span class="govuk-caption-l">Add an alert - @Model.PersonName</span>
 
-            <govuk-character-count asp-for="Details" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" data-testid="details">
+            <govuk-character-count asp-for="Details" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" data-testid="details">
                 <govuk-character-count-label class="govuk-label--l" is-page-heading="true">
                     @ViewBag.Title
                 </govuk-character-count-label>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Details.cshtml.cs
@@ -22,7 +22,7 @@ public class DetailsModel(TrsLinkGenerator linkGenerator) : PageModel
 
     [BindProperty]
     [Display(Description = "For example, include any restrictions it places on a teacher.")]
-    [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Details must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Details {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? Details { get; set; }
 
     public void OnGet()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Reason.cshtml
@@ -35,7 +35,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="AddReasonDetail" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="AddReasonDetail" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/Reason.cshtml.cs
@@ -33,7 +33,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [Display(Name = "Add additional detail")]
-    [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? AddReasonDetail { get; set; }
 
     [BindProperty]
@@ -43,7 +43,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(AlertDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }
@@ -60,7 +60,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
         AddReasonDetail = JourneyInstance!.State.AddReasonDetail;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDefaults.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDefaults.cs
@@ -1,9 +1,0 @@
-namespace TeachingRecordSystem.SupportUi.Pages.Alerts;
-
-public static class AlertDefaults
-{
-    public const int MaxFileUploadSizeMb = 50;
-    public const int DetailMaxCharacterCount = 4000;
-    public const int DetailTextAreaMinimumRows = 10;
-    public static TimeSpan FileUrlExpiry { get; } = TimeSpan.FromMinutes(15);
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml.cs
@@ -58,7 +58,7 @@ public class AlertDetailModel(
         ChangeReasonDetail = changeReasonInfo?.ChangeReasonDetail;
         EvidenceFileName = changeReasonInfo?.EvidenceFileName;
         UploadedEvidenceFileUrl = changeReasonInfo?.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(changeReasonInfo.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(changeReasonInfo.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
         ExternalLinkUri = TrsUriHelper.TryCreateWebsiteUri(Alert.ExternalLink, out var linkUri) ? linkUri : null;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -116,7 +116,7 @@ public class CheckAnswersModel(
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
@@ -38,7 +38,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
@@ -35,7 +35,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [Display(Name = "Add additional detail")]
-    [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
@@ -45,7 +45,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(AlertDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }
@@ -63,7 +63,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
@@ -96,7 +96,7 @@ public class CheckAnswersModel(
         DeleteReasonDetail = JourneyInstance.State.DeleteReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml
@@ -20,7 +20,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="DeleteReasonDetail" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="DeleteReasonDetail" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml.cs
@@ -34,7 +34,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
 
     [BindProperty]
     [Display(Name = "Add additional detail")]
-    [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? DeleteReasonDetail { get; set; }
 
     [BindProperty]
@@ -44,7 +44,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(AlertDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }
@@ -61,7 +61,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
         DeleteReasonDetail = JourneyInstance!.State.DeleteReasonDetail;
         UploadEvidence = JourneyInstance!.State.UploadEvidence;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
@@ -95,7 +95,7 @@ public class CheckAnswersModel(
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Index.cshtml
@@ -13,7 +13,7 @@
         <form action="@LinkGenerator.AlertEditDetails(Model.AlertId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post">
             <span class="govuk-caption-l">Change an alert - @Model.PersonName</span>
 
-            <govuk-character-count asp-for="Details" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" data-testid="details">
+            <govuk-character-count asp-for="Details" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" data-testid="details">
                 <govuk-character-count-label class="govuk-label--l" is-page-heading="true">
                     @ViewBag.Title
                 </govuk-character-count-label>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml
@@ -35,7 +35,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml.cs
@@ -35,7 +35,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [Display(Name = "Add additional detail")]
-    [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
@@ -45,7 +45,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(AlertDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }
@@ -63,7 +63,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         ChangeReasonDetail = JourneyInstance!.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
@@ -95,7 +95,7 @@ public class CheckAnswersModel(
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
@@ -35,7 +35,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
@@ -66,7 +66,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
@@ -101,7 +101,7 @@ public class CheckAnswersModel(
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml
@@ -35,7 +35,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" label-class="govuk-label--m" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml.cs
@@ -66,7 +66,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         ChangeReasonDetail = JourneyInstance!.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
@@ -95,7 +95,7 @@ public class CheckAnswersModel(
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml
@@ -35,7 +35,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
@@ -35,7 +35,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [Display(Name = "Add additional detail")]
-    [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
@@ -45,7 +45,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(AlertDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }
@@ -63,7 +63,7 @@ public class ReasonModel(TrsLinkGenerator linkGenerator, IFileService fileServic
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
@@ -104,7 +104,7 @@ public class CheckAnswersModel(
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFileName = JourneyInstance.State.EvidenceFileName;
         UploadedEvidenceFileUrl = JourneyInstance!.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance!.State.EvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
 
         await next();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
@@ -32,7 +32,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
-                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="AlertDefaults.DetailMaxCharacterCount" rows="AlertDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="ChangeReasonDetail" max-length="FileUploadDefaults.DetailMaxCharacterCount" rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
@@ -35,7 +35,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
 
     [BindProperty]
     [Display(Name = "Add additional detail")]
-    [MaxLength(AlertDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
@@ -45,7 +45,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(AlertDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }
@@ -63,7 +63,7 @@ public class IndexModel(TrsLinkGenerator linkGenerator, IFileService fileService
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
         UploadEvidence = JourneyInstance?.State.UploadEvidence;
         UploadedEvidenceFileUrl = JourneyInstance?.State.EvidenceFileId is not null ?
-            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, AlertDefaults.FileUrlExpiry) :
+            await fileService.GetFileUrlAsync(JourneyInstance.State.EvidenceFileId.Value, FileUploadDefaults.FileUrlExpiry) :
             null;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/FileUploadDefaults.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/FileUploadDefaults.cs
@@ -5,5 +5,7 @@ public static class FileUploadDefaults
     public const int MaxFileUploadSizeMb = 50;
     public const int DetailMaxCharacterCount = 4000;
     public const int DetailTextAreaMinimumRows = 10;
+    public const string MaxFileUploadSizeErrorMessage = "must be smaller than 50MB";
+    public const string DetailMaxCharacterCountErrorMessage = "must be 4000 characters or less";
     public static TimeSpan FileUrlExpiry { get; } = TimeSpan.FromMinutes(15);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/InductionChangeReason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/InductionChangeReason.cshtml.cs
@@ -32,7 +32,7 @@ public class InductionChangeReasonModel(
 
     [BindProperty]
     [Display(Name = "Add additional detail")]
-    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
@@ -42,7 +42,7 @@ public class InductionChangeReasonModel(
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/ChangeReason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/ChangeReason.cshtml.cs
@@ -36,7 +36,7 @@ public class ChangeReasonModel(TrsLinkGenerator linkGenerator,
 
     [BindProperty]
     [Display(Name = "Add more information")]
-    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = "Additional detail must be 4000 characters or less")]
+    [MaxLength(FileUploadDefaults.DetailMaxCharacterCount, ErrorMessage = $"Additional detail {FileUploadDefaults.DetailMaxCharacterCountErrorMessage}")]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
@@ -46,7 +46,7 @@ public class ChangeReasonModel(TrsLinkGenerator linkGenerator,
 
     [BindProperty]
     [EvidenceFile]
-    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 50MB")]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
     public IFormFile? EvidenceFile { get; set; }
 
     public Guid? EvidenceFileId { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml
@@ -1,6 +1,5 @@
 ﻿@page "/users/{userId}/deactivate/{handler?}"
 @using TeachingRecordSystem.Core
-@using TeachingRecordSystem.SupportUi.Pages.EditUser
 @model TeachingRecordSystem.SupportUi.Pages.Users.EditUser.DeactivateModel
 @{
     ViewBag.Title = "Why are you deactivating this user?";
@@ -25,10 +24,11 @@
                         Another reason
 
                         <govuk-radios-item-conditional>
-                            <govuk-textarea textarea-class="govuk-!-width-one-half" 
-                                            label-class="govuk-label--s" 
-                                            asp-for="AdditionalReasonDetail" 
-                                            rows="DeactivateDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="AdditionalReasonDetail" 
+                                                   textarea-class="govuk-!-width-one-half" 
+                                                   label-class="govuk-label--s" 
+                                                   max-length="FileUploadDefaults.DetailMaxCharacterCount" 
+                                                   rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
@@ -43,10 +43,11 @@
                         Yes
 
                         <govuk-radios-item-conditional>
-                            <govuk-textarea textarea-class="govuk-!-width-one-half" 
-                                            label-class="govuk-label--s" 
-                                            asp-for="MoreInformationDetail" 
-                                            rows="DeactivateDefaults.DetailTextAreaMinimumRows" />
+                            <govuk-character-count asp-for="MoreInformationDetail" 
+                                                   textarea-class="govuk-!-width-one-half" 
+                                                   label-class="govuk-label--s" 
+                                                   max-length="FileUploadDefaults.DetailMaxCharacterCount" 
+                                                   rows="FileUploadDefaults.DetailTextAreaMinimumRows" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                     <govuk-radios-item value="@false">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/Deactivate.cshtml.cs
@@ -8,7 +8,6 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.SupportUi.Infrastructure.DataAnnotations;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
-using TeachingRecordSystem.SupportUi.Pages.EditUser;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Users.EditUser
 {
@@ -49,7 +48,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.Users.EditUser
 
         [BindProperty]
         [EvidenceFile]
-        [FileSize(DeactivateDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = "The selected file must be smaller than 100MB")]
+        [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
         public IFormFile? EvidenceFile { get; set; }
 
         [BindProperty]
@@ -115,7 +114,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.Users.EditUser
                     var fileId = await fileService.UploadFileAsync(stream, EvidenceFile.ContentType);
                     EvidenceFileName = EvidenceFile?.FileName;
                     EvidenceFileSizeDescription = EvidenceFile?.Length.Bytes().Humanize();
-                    UploadedEvidenceFileUrl = await fileService.GetFileUrlAsync(fileId, DeactivateDefaults.FileUrlExpiry);
+                    UploadedEvidenceFileUrl = await fileService.GetFileUrlAsync(fileId, FileUploadDefaults.FileUrlExpiry);
                     EvidenceFileId = fileId;
                 }
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/DeactivateDefaults.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Users/EditUser/DeactivateDefaults.cs
@@ -1,8 +1,0 @@
-namespace TeachingRecordSystem.SupportUi.Pages.EditUser;
-
-public static class DeactivateDefaults
-{
-    public const int MaxFileUploadSizeMb = 100;
-    public const int DetailTextAreaMinimumRows = 5;
-    public static TimeSpan FileUrlExpiry { get; } = TimeSpan.FromMinutes(15);
-}


### PR DESCRIPTION
* Removes separate `AlertDefaults` and `DeactivateDefaults` classes - file uploads and additional reasons should have the same max sizes
* Pulls out common error messages
* Changes Deactivate User to use `<govuk-character-count>` for consistency with other journeys
