### PR TITLE
Add an interface for events that can possibly have a related Person

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Event.cs
@@ -28,7 +28,7 @@ public class Event
             Inserted = inserted ?? @event.CreatedUtc,
             Payload = payload,
             Key = (@event as IEventWithKey)?.Key,
-            PersonId = (@event as IEventWithPersonId)?.PersonId,
+            PersonId = @event.TryGetPersonId(out var personId) ? personId : null,
             QualificationId = (@event as IEventWithMandatoryQualification)?.MandatoryQualification.QualificationId,
             AlertId = (@event as IEventWithAlert)?.Alert.AlertId
         };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
@@ -3,7 +3,7 @@ using File = TeachingRecordSystem.Core.Events.Models.File;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record class AlertCreatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
+public record AlertCreatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
 {
     public string? Key { get; init; }
     public required Guid PersonId { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDeletedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertDeletedEvent.cs
@@ -3,7 +3,7 @@ using File = TeachingRecordSystem.Core.Events.Models.File;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record class AlertDeletedEvent : EventBase, IEventWithPersonId, IEventWithAlert
+public record AlertDeletedEvent : EventBase, IEventWithPersonId, IEventWithAlert
 {
     public required Guid PersonId { get; init; }
     public required Alert Alert { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
@@ -3,7 +3,7 @@ using File = TeachingRecordSystem.Core.Events.Models.File;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record class AlertUpdatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
+public record AlertUpdatedEvent : EventBase, IEventWithPersonId, IEventWithAlert, IEventWithKey
 {
     public string? Key { get; init; }
     public required Guid PersonId { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/EventBase.cs
@@ -49,4 +49,22 @@ public abstract record EventBase
 
         return (EventBase)JsonSerializer.Deserialize(payload, eventType, JsonSerializerOptions)!;
     }
+
+    public bool TryGetPersonId(out Guid personId)
+    {
+        if (this is IEventWithPersonId { PersonId: var eventPersonId })
+        {
+            personId = eventPersonId;
+            return true;
+        }
+
+        if (this is IEventWithOptionalPersonId { PersonId: { } eventOptionalPersonId })
+        {
+            personId = eventOptionalPersonId;
+            return true;
+        }
+
+        personId = Guid.Empty;
+        return false;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithOptionalPersonId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithOptionalPersonId.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public interface IEventWithOptionalPersonId
+{
+    Guid? PersonId { get; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/SupportTaskCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/SupportTaskCreatedEvent.cs
@@ -1,8 +1,12 @@
+using System.Text.Json.Serialization;
 using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record SupportTaskCreatedEvent : EventBase
+public record SupportTaskCreatedEvent : EventBase, IEventWithOptionalPersonId
 {
     public required SupportTask SupportTask { get; init; }
+
+    [JsonIgnore]
+    public Guid? PersonId => SupportTask.PersonId;
 }


### PR DESCRIPTION
We have an `IEventWithPerson` interface that's used for extracting the `PersonId` when we're saving events so we can populate the `person_id` column. This column is indexed and exists for querying events by person efficiently.

We have a few places coming up where events of the same type _might_ relate to a person but don't always. The `Guid PersonId` spec on `IEventWithPerson` doesn't work in that case.

This adds `IEventWithOptionalPerson` where `PersonId` is nullable.

I considered making `IEventWithPerson` have a `Nullable<Guid>` instead but it implies all our existing `IEventWithPerson` events can have null `PersonId` set, which isn't valid.

Another alternative would be to use `Guid.Empty` or some other well-known GUID but that seemed a little weird.