### PR TITLE
Proactively sync matched Person before comparing attributes

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageModelExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageModelExtensions.cs
@@ -1,8 +1,45 @@
+using System.Transactions;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.SupportUi;
 
 public static class PageModelExtensions
 {
+    private static readonly TimeSpan _defaultSyncThreshold = TimeSpan.FromSeconds(5);
+
     public static PageResult PageWithErrors(this PageModel pageModel) => new PageResult() { StatusCode = StatusCodes.Status400BadRequest };
+
+    public static async Task SyncPersonAsync(
+        this PageModel pageModel,
+        Guid personId,
+        CancellationToken cancellationToken = default)
+    {
+        var syncHelper = pageModel.HttpContext.RequestServices.GetRequiredService<TrsDataSyncHelper>();
+
+        using var txn = new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled);
+        await syncHelper.SyncPersonAsync(personId, syncAudit: false, cancellationToken: cancellationToken);
+    }
+
+    public static async Task<bool> TrySyncPersonAsync(
+        this PageModel pageModel,
+        Guid personId,
+        TimeSpan? threshold = null)
+    {
+        var logger = pageModel.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(PageModelExtensions));
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(threshold ?? _defaultSyncThreshold);
+
+        try
+        {
+            await SyncPersonAsync(pageModel, personId, cts.Token);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed syncing person.");
+            return false;
+        }
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -156,6 +156,13 @@ public class CheckAnswers(
         }
         else
         {
+            Debug.Assert(state.PersonId is not null);
+
+            if (Request.Method == HttpMethod.Get.Method)
+            {
+                await this.TrySyncPersonAsync(personId);
+            }
+
             var selectedPerson = await DbContext.Persons
                 .Where(p => p.PersonId == state.PersonId)
                 .Select(p => new

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml.cs
@@ -142,6 +142,11 @@ public class Merge(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : Res
             return;
         }
 
+        if (Request.Method == HttpMethod.Get.Method)
+        {
+            await this.TrySyncPersonAsync(personId);
+        }
+
         var personAttributes = await GetPersonAttributesAsync(personId);
 
         SourceApplicationUserName = requestData.ApplicationUser!.Name;


### PR DESCRIPTION
The process to resolve a TRN request uses Person data from the TRS DB. This is synced in _near_ real time but can lag. Showing stale data on these pages, particularly when the user is choosing what person data to use, is not ideal.

This adds a proactive sync to GET requests for the pages that compare the matched record to the request and show the resolved person attributes. If the sync fails for whatever reason we won't block progress; we don't want a transient error or CRM slow-ness to prevent the journey being completed when 99% of time the data won't have changed.

Once this is live we can monitor and adjust when/where we do this sync and whether the 5 second threshold is sufficient.

We don't need a sync on the PersonDetail page (that we link to once the request is resolved) since that's getting Person data from CRM so will never be showing stale data.