### PR TITLE
Generate a TRN token on request resolution

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnRequestHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnRequestHelper.cs
@@ -14,7 +14,6 @@ namespace TeachingRecordSystem.Core;
 
 public class TrnRequestHelper(
     TrsDbContext dbContext,
-    ITrnGenerator trnGenerator,
     ICrmQueryDispatcher crmQueryDispatcher,
     IGetAnIdentityApiClient idApiClient,
     IOptions<AccessYourTeachingQualificationsOptions> aytqOptionsAccessor)
@@ -99,7 +98,7 @@ public class TrnRequestHelper(
         return result;
     }
 
-    public async Task CreateContactFromTrnRequestAsync(Guid applicationUserId, string requestId, Guid newContactId)
+    public async Task CreateContactFromTrnRequestAsync(Guid applicationUserId, string requestId, Guid newContactId, string trn)
     {
         var result = await GetTrnRequestInfoAsync(applicationUserId, requestId);
         if (result is null)
@@ -107,13 +106,11 @@ public class TrnRequestHelper(
             throw new ArgumentException("TRN request does not exist.");
         }
 
-        await CreateContactFromTrnRequestAsync(result.Metadata, newContactId);
+        await CreateContactFromTrnRequestAsync(result.Metadata, newContactId, trn);
     }
 
-    public async Task CreateContactFromTrnRequestAsync(TrnRequestMetadata requestData, Guid newContactId)
+    public async Task CreateContactFromTrnRequestAsync(TrnRequestMetadata requestData, Guid newContactId, string trn)
     {
-        var trn = await trnGenerator.GenerateTrnAsync();
-
         await crmQueryDispatcher.ExecuteQueryAsync(new CreateContactQuery()
         {
             ContactId = newContactId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Models.SupportTaskData;
+using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.WebCommon;
 using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.ResolveApiTrnRequestState;
 
@@ -13,6 +14,8 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resol
 public class CheckAnswers(
     TrsDbContext dbContext,
     IBackgroundJobScheduler backgroundJobScheduler,
+    TrnRequestHelper trnRequestHelper,
+    ITrnGenerator trnGenerator,
     TrsLinkGenerator linkGenerator) :
     ResolveApiTrnRequestPageModel(dbContext)
 {
@@ -48,17 +51,30 @@ public class CheckAnswers(
         var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
         var requestData = supportTask.TrnRequestMetadata!;
         var state = JourneyInstance!.State;
-        var supportTaskData = supportTask.GetData<ApiTrnRequestData>();
 
         ApiTrnRequestDataPersonAttributes? selectedPersonAttributes;
+
+        async Task<string?> GenerateTrnTokenIfHaveEmailAsync(string trn)
+        {
+            if (string.IsNullOrEmpty(requestData.EmailAddress))
+            {
+                return null;
+            }
+
+            return await trnRequestHelper.CreateTrnTokenAsync(trn, requestData.EmailAddress);
+        }
 
         if (CreatingNewRecord)
         {
             var newContactId = Guid.NewGuid();
             requestData.ResolvedPersonId = newContactId;
 
+            var trn = await trnGenerator.GenerateTrnAsync();
+            var trnToken = await GenerateTrnTokenIfHaveEmailAsync(trn);
+            requestData.TrnToken = trnToken;
+
             await backgroundJobScheduler.EnqueueAsync<TrnRequestHelper>(
-                trnRequestHelper => trnRequestHelper.CreateContactFromTrnRequestAsync(requestData, newContactId));
+                trnRequestHelper => trnRequestHelper.CreateContactFromTrnRequestAsync(requestData, newContactId, trn));
             selectedPersonAttributes = null;
         }
         else
@@ -66,6 +82,10 @@ public class CheckAnswers(
             Debug.Assert(state.PersonId is not null);
             var existingContactId = state.PersonId!.Value;
             requestData.ResolvedPersonId = existingContactId;
+
+            Debug.Assert(Trn is not null);
+            requestData.TrnToken = await GenerateTrnTokenIfHaveEmailAsync(Trn!);
+
             selectedPersonAttributes = await GetPersonAttributesAsync(existingContactId);
             var attributesToUpdate = GetAttributesToUpdate();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -6,6 +6,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure.Security;
@@ -64,6 +65,8 @@ public abstract class TestBase : IDisposable
     public ReferenceDataCache ReferenceDataCache => HostFixture.Services.GetRequiredService<ReferenceDataCache>();
 
     public Mock<IFileService> FileServiceMock => _testServices.BlobStorageFileServiceMock;
+
+    public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock => _testServices.GetAnIdentityApiClientMock;
 
     public async Task<JourneyInstance<TState>> CreateJourneyInstance<TState>(
             string journeyName,


### PR DESCRIPTION
The TRN request API responses include a magic link for the person's registration with ID. The magic link is generated from a TRN token stored on the request metadata. This updates the support task resolution journey to populate the TRN token.