### PR TITLE
Add optional 'short name' to application user

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
@@ -47,6 +47,7 @@ public class ApplicationUserMapping : IEntityTypeConfiguration<ApplicationUser>
         builder.HasIndex(e => e.OneLoginAuthenticationSchemeName).IsUnique().HasDatabaseName(ApplicationUser.OneLoginAuthenticationSchemeNameUniqueIndexName)
             .HasFilter("one_login_authentication_scheme_name is not null");
         builder.HasIndex(e => e.ClientId).IsUnique().HasDatabaseName(ApplicationUser.ClientIdUniqueIndexName).HasFilter("client_id is not null");
+        builder.Property(e => e.ShortName).HasMaxLength(ApplicationUser.ShortNameMaxLength);
     }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250513102656_ApplicationUserShortName.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250513102656_ApplicationUserShortName.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250513102656_ApplicationUserShortName")]
+    partial class ApplicationUserShortName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250513102656_ApplicationUserShortName.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250513102656_ApplicationUserShortName.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class ApplicationUserShortName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "short_name",
+                table: "users",
+                type: "character varying(25)",
+                maxLength: 25,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "short_name",
+                table: "users");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -38,6 +38,7 @@ public class ApplicationUser : UserBase
     public const int ClientSecretMaxLength = 200;
     public const int ClientSecretMinLength = 16;
     public const int OneLoginClientIdMaxLength = 50;
+    public const int ShortNameMaxLength = 25;
     public const string NameUniqueIndexName = "ix_users_application_user_name";
     public const string ClientIdUniqueIndexName = "ix_users_client_id";
     public const string OneLoginAuthenticationSchemeNameUniqueIndexName = "ix_users_one_login_authentication_scheme_name";
@@ -54,6 +55,7 @@ public class ApplicationUser : UserBase
     public string? OneLoginAuthenticationSchemeName { get; set; }
     public string? OneLoginRedirectUriPath { get; set; }
     public string? OneLoginPostLogoutRedirectUriPath { get; set; }
+    public string? ShortName { get; set; }
 
     [MemberNotNull(
         nameof(OneLoginClientId),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ApplicationUserUpdatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ApplicationUserUpdatedEvent.cs
@@ -24,4 +24,5 @@ public enum ApplicationUserUpdatedEventChanges
     ClientSecret = 1 << 9,
     RedirectUris = 1 << 10,
     PostLogoutRedirectUris = 1 << 11,
+    ShortName = 1 << 12
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ApplicationUser.cs
@@ -15,6 +15,7 @@ public record ApplicationUser
     public string? OneLoginAuthenticationSchemeName { get; init; }
     public string? OneLoginRedirectUriPath { get; init; }
     public string? OneLoginPostLogoutRedirectUriPath { get; init; }
+    public string? ShortName { get; init; }
 
     public static ApplicationUser FromModel(DataStore.Postgres.Models.ApplicationUser user) => new()
     {
@@ -30,6 +31,7 @@ public record ApplicationUser
         OneLoginPrivateKeyPem = user.OneLoginPrivateKeyPem,
         OneLoginAuthenticationSchemeName = user.OneLoginAuthenticationSchemeName,
         OneLoginRedirectUriPath = user.OneLoginRedirectUriPath,
-        OneLoginPostLogoutRedirectUriPath = user.OneLoginPostLogoutRedirectUriPath
+        OneLoginPostLogoutRedirectUriPath = user.OneLoginPostLogoutRedirectUriPath,
+        ShortName = user.ShortName
     };
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser.cshtml
@@ -14,6 +14,8 @@
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <govuk-input asp-for="Name" label-class="govuk-label--m" autocomplete="off" />
+            
+            <govuk-input asp-for="ShortName" input-class="govuk-input--width-10" label-class="govuk-label--m" autocomplete="off" />
 
             <govuk-button type="submit">Save</govuk-button>
         </form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser.cshtml.cs
@@ -17,6 +17,11 @@ public class AddApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator li
     [MaxLength(UserBase.NameMaxLength, ErrorMessage = "Name must be 200 characters or less")]
     public string? Name { get; set; }
 
+    [BindProperty]
+    [Display(Name = "Short name")]
+    [MaxLength(ApplicationUser.ShortNameMaxLength, ErrorMessage = "Short name must be 25 characters or less")]
+    public string? ShortName { get; set; }
+
     public void OnGet()
     {
     }
@@ -33,6 +38,7 @@ public class AddApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator li
             ApiRoles = [],
             Name = Name!,
             UserId = Guid.NewGuid(),
+            ShortName = ShortName
         };
 
         dbContext.ApplicationUsers.Add(newUser);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml
@@ -16,6 +16,8 @@
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <govuk-input asp-for="Name" label-class="govuk-label--m" autocomplete="off" />
+            
+            <govuk-input asp-for="ShortName" input-class="govuk-input--width-10" label-class="govuk-label--m" autocomplete="off" />
 
             <govuk-checkboxes asp-for="ApiRoles">
                 <govuk-checkboxes-fieldset>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser.cshtml.cs
@@ -31,6 +31,11 @@ public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator l
     [MaxLength(UserBase.NameMaxLength, ErrorMessage = "Name must be 200 characters or less")]
     public string? Name { get; set; }
 
+    [BindProperty]
+    [Display(Name = "Short name")]
+    [MaxLength(ApplicationUser.ShortNameMaxLength, ErrorMessage = "Short name must be 25 characters or less")]
+    public string? ShortName { get; set; }
+
     [Display(Name = "API roles")]
     public string[]? ApiRoles { get; set; }
 
@@ -98,6 +103,7 @@ public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator l
         OneLoginPrivateKeyPem = _user.OneLoginPrivateKeyPem;
         OneLoginRedirectUriPath = _user.OneLoginRedirectUriPath;
         OneLoginPostLogoutRedirectUriPath = _user.OneLoginPostLogoutRedirectUriPath;
+        ShortName = _user.ShortName;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -173,6 +179,7 @@ public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator l
 
         var changes = ApplicationUserUpdatedEventChanges.None |
             (Name != _user!.Name ? ApplicationUserUpdatedEventChanges.Name : 0) |
+            (ShortName != _user!.ShortName ? ApplicationUserUpdatedEventChanges.ShortName : 0) |
             (!new HashSet<string>(_user.ApiRoles ?? []).SetEquals(new HashSet<string>(newApiRoles)) ? ApplicationUserUpdatedEventChanges.ApiRoles : 0) |
             (IsOidcClient != _user.IsOidcClient ? ApplicationUserUpdatedEventChanges.IsOidcClient : 0);
 
@@ -203,6 +210,7 @@ public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator l
             var oldApplicationUser = EventModels.ApplicationUser.FromModel(_user);
 
             _user.Name = Name!;
+            _user.ShortName = ShortName;
             _user.ApiRoles = newApiRoles;
             _user.IsOidcClient = IsOidcClient;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUserTests.cs
@@ -102,12 +102,14 @@ public class AddApplicationUserTests(HostFixture hostFixture) : TestBase(hostFix
     {
         // Arrange
         var name = TestData.GenerateApplicationUserName();
+        var shortName = TestData.GenerateApplicationUserShortName();
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/application-users/add")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "Name", name }
+                { "Name", name },
+                { "ShortName", shortName }
             }
         };
 
@@ -121,6 +123,7 @@ public class AddApplicationUserTests(HostFixture hostFixture) : TestBase(hostFix
         {
             var applicationUser = await dbContext.ApplicationUsers.SingleAsync(a => a.Name == name);
             Assert.NotNull(applicationUser);
+            Assert.Equal(shortName, applicationUser.ShortName);
 
             return applicationUser;
         });
@@ -134,6 +137,7 @@ public class AddApplicationUserTests(HostFixture hostFixture) : TestBase(hostFix
                 Assert.Equal(Clock.UtcNow, applicationUserCreatedEvent.CreatedUtc);
                 Assert.Equal(GetCurrentUserId(), applicationUserCreatedEvent.RaisedBy.UserId);
                 Assert.Equal(name, applicationUserCreatedEvent.ApplicationUser.Name);
+                Assert.Equal(shortName, applicationUserCreatedEvent.ApplicationUser.ShortName);
             });
 
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUserTests.cs
@@ -215,9 +215,10 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
     public async Task Post_ValidRequest_UpdatesNameAndRolesAndOneLoginSettingsAndCreatesEventAndRedirectsWithFlashMessage()
     {
         // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync(apiRoles: [], isOidcClient: false);
+        var applicationUser = await TestData.CreateApplicationUserAsync(shortName: "", apiRoles: [], isOidcClient: false);
         var originalName = applicationUser.Name;
         var newName = TestData.GenerateChangedApplicationUserName(originalName);
+        var newShortName = TestData.GenerateApplicationUserShortName();
         var newRoles = new[] { ApiRoles.GetPerson, ApiRoles.UpdatePerson };
         var clientId = "client-id";
         var clientSecret = "Secret0123456789";
@@ -234,6 +235,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
             Content = new FormUrlEncodedContentBuilder()
             {
                 { "Name", newName },
+                { "ShortName", newShortName },
                 { "ApiRoles", newRoles },
                 { "IsOidcClient", bool.TrueString },
                 { "ClientId", clientId },
@@ -271,6 +273,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
                 Assert.Equal(GetCurrentUserId(), applicationUserUpdatedEvent.RaisedBy.UserId);
                 Assert.Equal(originalName, applicationUserUpdatedEvent.OldApplicationUser.Name);
                 Assert.Equal(newName, applicationUserUpdatedEvent.ApplicationUser.Name);
+                Assert.Equal(newShortName, applicationUserUpdatedEvent.ApplicationUser.ShortName);
                 Assert.True((applicationUserUpdatedEvent.ApplicationUser.ApiRoles ?? []).SequenceEqual(newRoles));
                 Assert.Empty(applicationUserUpdatedEvent.OldApplicationUser.ApiRoles ?? []);
                 Assert.False(applicationUserUpdatedEvent.OldApplicationUser.IsOidcClient);
@@ -296,6 +299,7 @@ public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFi
                 Assert.Equal(
                     ApplicationUserUpdatedEventChanges.ApiRoles |
                         ApplicationUserUpdatedEventChanges.Name |
+                        ApplicationUserUpdatedEventChanges.ShortName |
                         ApplicationUserUpdatedEventChanges.IsOidcClient |
                         ApplicationUserUpdatedEventChanges.ClientId |
                         ApplicationUserUpdatedEventChanges.ClientSecret |

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApplicationUser.cs
@@ -7,12 +7,14 @@ public partial class TestData
 {
     public async Task<ApplicationUser> CreateApplicationUserAsync(
         string? name = null,
+        string? shortName = null,
         string[]? apiRoles = null,
         bool? isOidcClient = false)
     {
         var user = await WithDbContextAsync(async dbContext =>
         {
             name ??= GenerateApplicationUserName();
+            shortName ??= GenerateApplicationUserShortName();
             apiRoles ??= [];
             isOidcClient ??= false;
             string? clientId = null;
@@ -41,6 +43,7 @@ public partial class TestData
             var user = new ApplicationUser()
             {
                 Name = name,
+                ShortName = shortName,
                 UserId = Guid.NewGuid(),
                 ApiRoles = apiRoles,
                 IsOidcClient = isOidcClient.Value,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
@@ -12,6 +12,7 @@ public partial class TestData
     private static readonly object _gate = new();
     private static readonly HashSet<string> _emails = [];
     private static readonly HashSet<string> _mobileNumbers = [];
+    private static int _applicationUserNumber = 1;
 
     private readonly Func<Task<string>> _generateTrn;
 
@@ -90,6 +91,8 @@ public partial class TestData
     }
 
     public string GenerateApplicationUserName() => Faker.Company.Name();
+
+    public string GenerateApplicationUserShortName() => $"app-{Interlocked.Increment(ref _applicationUserNumber)}";
 
     public string GenerateChangedApplicationUserName(string currentName)
     {


### PR DESCRIPTION
We have places on our UI where we want to show a tag with an application user's name but some of our names are very long. This adds an optional 'short name' to `ApplicationUser` which we can use in tags.