### PR TITLE
Fix Postgres replication for non-HA environments

### DIFF
--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -48,7 +48,7 @@ resource "azurerm_postgresql_flexible_server_configuration" "wal_level" {
 resource "azurerm_postgresql_flexible_server_configuration" "shared_preload_libraries" {
   name      = "shared_preload_libraries"
   server_id = module.postgres.azure_server_id
-  value     = "pg_cron,pg_stat_statements,pg_failover_slots"
+  value     = "pg_cron,pg_stat_statements${var.postgres_enable_high_availability ? ",pg_failover_slots" : ""}"
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "hot_standby_feedback" {


### PR DESCRIPTION
There's a bug in Azure where if `pg_failover_slots` is enabled on an environment that doesn't have HA enabled then replication does not work. This turns off that option for all environments that don't have HA enabled.