### PR TITLE
Wait for background job to finish before rendering list of tasks

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/Scheduling/ExecuteImmediatelyJobScheduler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/Scheduling/ExecuteImmediatelyJobScheduler.cs
@@ -25,4 +25,9 @@ public class ExecuteImmediatelyJobScheduler : IBackgroundJobScheduler
     {
         return EnqueueAsync(expression);
     }
+
+    public Task WaitForJobToCompleteAsync(string jobId, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/Scheduling/HangfireBackgroundJobScheduler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/Scheduling/HangfireBackgroundJobScheduler.cs
@@ -1,26 +1,50 @@
 using System.Linq.Expressions;
 using Hangfire;
+using Hangfire.States;
+using Npgsql;
 
 namespace TeachingRecordSystem.Core.Jobs.Scheduling;
 
-public class HangfireBackgroundJobScheduler : IBackgroundJobScheduler
+public class HangfireBackgroundJobScheduler(IBackgroundJobClient jobClient, NpgsqlDataSource dataSource) : IBackgroundJobScheduler
 {
-    private readonly IBackgroundJobClient _jobClient;
-
-    public HangfireBackgroundJobScheduler(IBackgroundJobClient jobClient)
-    {
-        _jobClient = jobClient;
-    }
-
     public Task<string> EnqueueAsync<T>(Expression<Func<T, Task>> expression) where T : notnull
     {
-        var jobId = _jobClient.Enqueue(expression);
+        var jobId = jobClient.Enqueue(expression);
         return Task.FromResult(jobId);
     }
 
     public Task<string> ContinueJobWithAsync<T>(string parentId, Expression<Func<T, Task>> expression) where T : notnull
     {
-        var jobId = _jobClient.ContinueJobWith(parentId, expression);
+        var jobId = jobClient.ContinueJobWith(parentId, expression);
         return Task.FromResult(jobId);
+    }
+
+    public async Task WaitForJobToCompleteAsync(string jobId, CancellationToken cancellationToken)
+    {
+        await using var conn = dataSource.CreateConnection();
+        await conn.OpenAsync(cancellationToken);
+
+        await using var cmd = dataSource.CreateCommand();
+        cmd.CommandText = "select statename from hangfire.job where id = @id";
+        cmd.Parameters.AddWithValue("@id", long.Parse(jobId));
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                throw new ArgumentException("Job does not exist.");
+            }
+
+            var stateName = reader.GetString(0);
+
+            if (stateName == FailedState.StateName || stateName == SucceededState.StateName)
+            {
+                return;
+            }
+
+            await Task.Delay(100, cancellationToken);
+        }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/Scheduling/IBackgroundJobScheduler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/Scheduling/IBackgroundJobScheduler.cs
@@ -7,4 +7,6 @@ public interface IBackgroundJobScheduler
     Task<string> EnqueueAsync<T>(Expression<Func<T, Task>> expression) where T : notnull;
 
     Task<string> ContinueJobWithAsync<T>(string parentId, Expression<Func<T, Task>> expression) where T : notnull;
+
+    Task WaitForJobToCompleteAsync(string jobId, CancellationToken cancellationToken);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml.cs
@@ -2,12 +2,13 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.SupportUi.Pages.Common;
 using TeachingRecordSystem.SupportUi.Pages.Shared;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests;
 
-public class Index(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : PageModel
+public class Index(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IBackgroundJobScheduler backgroundJobScheduler) : PageModel
 {
     private const int TasksPerPage = 20;
 
@@ -28,12 +29,24 @@ public class Index(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : Pag
     [FromQuery(Name = "page")]
     public int? PageNumber { get; set; }
 
+    [BindProperty(SupportsGet = true)]
+    [FromQuery]
+    public string? WaitForJobId { get; set; }
+
     public ResultPage<Result>? Results { get; set; }
 
     public PaginationViewModel? Pagination { get; set; }
 
     public async Task<IActionResult> OnGetAsync()
     {
+        if (WaitForJobId is not null)
+        {
+            using var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+            await backgroundJobScheduler.WaitForJobToCompleteAsync(WaitForJobId, cts.Token)
+                .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+
         var sortDirection = SortDirection ??= SupportUi.SortDirection.Ascending;
         var sortBy = SortBy ??= ApiTrnRequestsSortByOption.Name;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -385,8 +385,8 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
             _ => throw new ArgumentException($"Unknown {nameof(SupportTaskType)}: '{supportTaskType}'.", nameof(supportTaskType))
         };
 
-    public string ApiTrnRequests(string? search = null, ApiTrnRequestsSortByOption? sortBy = null, SortDirection? sortDirection = null, int? page = null) =>
-        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Index", routeValues: new { search, sortBy, sortDirection, page });
+    public string ApiTrnRequests(string? search = null, ApiTrnRequestsSortByOption? sortBy = null, SortDirection? sortDirection = null, int? page = null, string? waitForJobId = null) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Index", routeValues: new { search, sortBy, sortDirection, page, waitForJobId });
 
     public string ApiTrnRequestMatches(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null) =>
         GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Resolve/Matches", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
@@ -371,7 +371,7 @@ public class CheckAnswersTests : ResolveApiTrnRequestTestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal("/support-tasks/api-trn-requests", response.Headers.Location?.OriginalString);
+        Assert.StartsWith("/support-tasks/api-trn-requests?waitForJobId=", response.Headers.Location?.OriginalString);
 
         var expectedCrmRequestId = TrnRequestHelper.GetCrmTrnRequestId(applicationUser.UserId, requestData.RequestId);
         var crmContact = XrmFakedContext.CreateQuery<Contact>().Single(c => c.dfeta_TrnRequestID == expectedCrmRequestId);
@@ -431,7 +431,7 @@ public class CheckAnswersTests : ResolveApiTrnRequestTestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal("/support-tasks/api-trn-requests", response.Headers.Location?.OriginalString);
+        Assert.StartsWith("/support-tasks/api-trn-requests?waitForJobId=", response.Headers.Location?.OriginalString);
 
         var crmContact = XrmFakedContext.CreateQuery<Contact>().Single(c => c.Id == matchedPerson.ContactId);
         Assert.Equal(requestData.MiddleName, crmContact.MiddleName);


### PR DESCRIPTION
When an API TRN request is resolved, the update to the DQT record is done in a background job. It's somewhat likely that a user will navigate to the created/updated record immediately after resolving the task so they may see stale data if the job hasn't yet completed.

This change passes the background job ID to the page that renders the link to the created/updated record so that it can wait for a bit for the job to complete. It'll only wait for up to 5 seconds; that should be sufficient most of the time.