### PR TITLE
Increase timeout for tests action in PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -174,7 +174,7 @@ jobs:
           dotnet_test_args: >-
             --no-build
             -e ConnectionStrings__DefaultConnection="Host=localhost;Username=postgres;Password=trs;Database=trs"
-        timeout-minutes: 20
+        timeout-minutes: 30
 
   package:
     name: Package application


### PR DESCRIPTION
Tests action for PR workflow has started timing out, increases timeout value