### PR TITLE
Add end-to-end tests for edit person details journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CheckAnswers.cshtml
@@ -18,7 +18,7 @@
             <govuk-summary-card>
                 <govuk-summary-card-title>Personal details</govuk-summary-card-title>
                 <govuk-summary-card-actions>
-                    <govuk-summary-card-action href=@Model.ChangePersonalDetailsLink visually-hidden-text="personal details">Change</govuk-summary-card-action>
+                    <govuk-summary-card-action href=@Model.ChangePersonalDetailsLink data-testid="change-details-link" visually-hidden-text="personal details">Change</govuk-summary-card-action>
                 </govuk-summary-card-actions>
                 <govuk-summary-list>
                     <govuk-summary-list-row>
@@ -58,7 +58,7 @@
             <govuk-summary-card>
                 <govuk-summary-card-title>Reason for change</govuk-summary-card-title>
                 <govuk-summary-card-actions>
-                    <govuk-summary-card-action href=@Model.ChangeChangeReasonLink visually-hidden-text="reason for change">Change</govuk-summary-card-action>
+                    <govuk-summary-card-action href=@Model.ChangeChangeReasonLink data-testid="change-reason-link" visually-hidden-text="reason for change">Change</govuk-summary-card-action>
                 </govuk-summary-card-actions>
                 <govuk-summary-list>
                     <govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
@@ -6,7 +6,7 @@
     <govuk-summary-card-actions>
         @if (FeatureProvider.IsEnabled(FeatureNames.ContactsMigrated))
         {
-            <govuk-summary-card-action href=@LinkGenerator.EditDetailsIndex(Model.PersonId) visually-hidden-text="personal details">Change</govuk-summary-card-action>
+            <govuk-summary-card-action data-testid="change-details-link" href=@LinkGenerator.EditDetailsIndex(Model.PersonId) visually-hidden-text="personal details">Change</govuk-summary-card-action>
         }
     </govuk-summary-card-actions>
     <govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
@@ -7,5 +7,5 @@
       }
     }
   },
-  "EnabledFeatures": [ "Alerts", "RoutesToProfessionalStatus", "NewUserRoles" ]
+  "EnabledFeatures": [ "Alerts", "RoutesToProfessionalStatus", "NewUserRoles", "ContactsMigrated" ]
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditDetailsTests.cs
@@ -1,0 +1,146 @@
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDetails;
+
+namespace TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests;
+
+public class EditDetailsTests : TestBase
+{
+    public EditDetailsTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task EditDetails_ChangeName()
+    {
+        var person = await TestData.CreatePersonAsync();
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonDetailPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-details-link");
+
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.FillNameInputsAsync("Alfred", "The", "Great");
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.SelectChangeReasonAsync("change-reason-options", EditDetailsChangeReasonOption.AnotherReason, "Some reason");
+        await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+        await page.ClickButtonAsync("Confirm changes");
+
+        await page.AssertOnPersonDetailPageAsync(person.PersonId);
+        await page.AssertFlashMessageAsync(expectedMessage: "Personal details have been updated successfully.");
+    }
+
+    [Fact]
+    public async Task EditDetails_ChangeName_NavigateBack()
+    {
+        var person = await TestData.CreatePersonAsync();
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonDetailPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-details-link");
+
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.FillNameInputsAsync("Alfred", "The", "Great");
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.SelectChangeReasonAsync("change-reason-options", EditDetailsChangeReasonOption.AnotherReason, "Some reason");
+        await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.AssertNameInputAsync("Alfred", "The", "Great");
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonDetailPageAsync(person.PersonId);
+    }
+
+    [Fact]
+    public async Task EditDetails_CYA_ChangeNameOrReason_ContinuesToCYA()
+    {
+        var person = await TestData.CreatePersonAsync();
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonDetailPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-details-link");
+
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.FillNameInputsAsync("Alfred", "The", "Great");
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.SelectChangeReasonAsync("change-reason-options", EditDetailsChangeReasonOption.AnotherReason, "Some reason");
+        await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-details-link");
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-reason-link");
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+    }
+
+    [Fact]
+    public async Task EditDetails_CYA_ChangeNameOrReason_NavigatesBackToCYA()
+    {
+        var person = await TestData.CreatePersonAsync();
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonDetailPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-details-link");
+
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.FillNameInputsAsync("Alfred", "The", "Great");
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.SelectChangeReasonAsync("change-reason-options", EditDetailsChangeReasonOption.AnotherReason, "Some reason");
+        await page.SelectReasonFileUploadAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-details-link");
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+        await page.ClickLinkForElementWithTestIdAsync("change-reason-link");
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonEditDetailsCheckAnswersPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonEditDetailsChangeReasonPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonEditDetailsPageAsync(person.PersonId);
+        await page.ClickBackLink();
+
+        await page.AssertOnPersonDetailPageAsync(person.PersonId);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -138,21 +138,6 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/change-requests/{caseReference}/reject");
     }
 
-    public static async Task AssertOnPersonDetailPageAsync(this IPage page, Guid personId)
-    {
-        await page.WaitForUrlPathAsync($"/persons/{personId}");
-    }
-
-    public static async Task AssertOnPersonAlertsPageAsync(this IPage page, Guid personId)
-    {
-        await page.WaitForUrlPathAsync($"/persons/{personId}/alerts");
-    }
-
-    public static async Task AssertOnPersonQualificationsPageAsync(this IPage page, Guid personId)
-    {
-        await page.WaitForUrlPathAsync($"/persons/{personId}/qualifications");
-    }
-
     public static async Task AssertOnAddAlertTypePageAsync(this IPage page)
     {
         await page.WaitForUrlPathAsync($"/alerts/add/type");
@@ -293,6 +278,21 @@ public static class PageExtensions
         await page.WaitForUrlPathAsync($"/alerts/{alertId}/delete/check-answers");
     }
 
+    public static async Task AssertOnPersonDetailPageAsync(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}");
+    }
+
+    public static async Task AssertOnPersonAlertsPageAsync(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}/alerts");
+    }
+
+    public static async Task AssertOnPersonQualificationsPageAsync(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}/qualifications");
+    }
+
     public static async Task AssertOnPersonEditNamePageAsync(this IPage page, Guid personId)
     {
         await page.WaitForUrlPathAsync($"/persons/{personId}/edit-name");
@@ -311,6 +311,21 @@ public static class PageExtensions
     public static async Task AssertOnPersonEditDateOfBirthConfirmPageAsync(this IPage page, Guid personId)
     {
         await page.WaitForUrlPathAsync($"/persons/{personId}/edit-date-of-birth/confirm");
+    }
+
+    public static async Task AssertOnPersonEditDetailsPageAsync(this IPage page, Guid personId)
+    {
+        await page.WaitForUrlPathAsync($"/persons/{personId}/edit-details");
+    }
+
+    public static Task AssertOnPersonEditDetailsChangeReasonPageAsync(this IPage page, Guid personId)
+    {
+        return page.WaitForUrlPathAsync($"/persons/{personId}/edit-details/change-reason");
+    }
+
+    public static Task AssertOnPersonEditDetailsCheckAnswersPageAsync(this IPage page, Guid personId)
+    {
+        return page.WaitForUrlPathAsync($"/persons/{personId}/edit-details/check-answers");
     }
 
     public static async Task AssertOnAddMqProviderPageAsync(this IPage page)
@@ -502,6 +517,14 @@ public static class PageExtensions
         Assert.Equal(date.Month.ToString(), await page.InputValueAsync("label:text-is('Month')"));
         Assert.Equal(date.Year.ToString(), await page.InputValueAsync("label:text-is('Year')"));
     }
+
+    public static async Task AssertNameInputAsync(this IPage page, string firstName, string middleName, string lastName)
+    {
+        Assert.Equal(firstName, await page.InputValueAsync("text=First Name"));
+        Assert.Equal(middleName, await page.InputValueAsync("text=Middle Name"));
+        Assert.Equal(lastName, await page.InputValueAsync("text=Last Name"));
+    }
+
     public static async Task AssertDateInputEmptyAsync(this IPage page)
     {
         Assert.Empty(await page.InputValueAsync("label:text-is('Day')"));
@@ -606,6 +629,20 @@ public static class PageExtensions
         if (addAdditionalDetail)
         {
             await page.FillAsync("label:text-is('Add additional detail')", details!);
+        }
+    }
+
+    public static async Task SelectChangeReasonAsync(this IPage page, string testId, Enum changeReason, string? details = null)
+    {
+        var section = page.GetByTestId(testId);
+        var option = section.Locator($".govuk-radios__item:has(input[type='radio'][value='{changeReason}'])");
+        var radioButton = option.Locator("input");
+        await radioButton.ClickAsync();
+
+        if (changeReason.ToString() == "AnotherReason")
+        {
+            var reason = option.Locator($":scope + .govuk-radios__conditional textarea");
+            await reason.FillAsync(details!);
         }
     }
 


### PR DESCRIPTION
### Context

Currently a user is only able to change the Name and Date of Birth on a record within TRS. We need to develop the functionality for a user to be able to change any and all PII fields through the console.

https://trello.com/c/JA0sdQWB/1146-build-journey-for-changing-pii-in-the-trs-console

### Changes proposed in this pull request

* Adds missing end-to-end tests for the above ticket

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
