### PR TITLE
Add change history for Edit Person Details journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -104,7 +104,7 @@ public class Person
             return;
         }
 
-        previousName = (changes & PersonDetailsUpdatedEventChanges.AnyNameChange) == PersonDetailsUpdatedEventChanges.None
+        previousName = !changes.HasAnyFlag(PersonDetailsUpdatedEventChanges.AnyNameChange)
             ? null
             : new PreviousName
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EnumHelper.cs
@@ -92,4 +92,10 @@ public static class EnumHelper
             }
         }
     }
+
+    public static bool HasAnyFlag<TEnum>(this TEnum enumValue, TEnum flags)
+        where TEnum : struct, Enum
+    {
+        return ((int)(object)enumValue & (int)(object)flags) > 0;
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
@@ -73,6 +73,7 @@ public class ChangeHistoryModel(
             nameof(DqtInductionReactivatedEvent),
             nameof(DqtContactInductionStatusChangedEvent),
             nameof(PersonInductionUpdatedEvent),
+            nameof(PersonDetailsUpdatedEvent)
         };
 
         var alertEventTypes = eventTypes.Where(et => et.StartsWith("Alert")).ToArray();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonDetailsUpdatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonDetailsUpdatedEvent.cshtml
@@ -1,0 +1,162 @@
+@using TeachingRecordSystem.Core.Events
+@using TeachingRecordSystem.Core.Services.Files
+@inject IFileService FileService
+@inject ReferenceDataCache ReferenceDataCache
+@model TimelineItem<TimelineEvent<PersonDetailsUpdatedEvent>>
+@{
+    var updatedEvent = Model.ItemModel.Event;
+    var details = updatedEvent.Details;
+    var oldDetails = updatedEvent.OldDetails;
+    var evidenceFileUrl = updatedEvent.EvidenceFile is not null 
+        ? await FileService.GetFileUrlAsync(updatedEvent.EvidenceFile!.FileId, TimeSpan.FromMinutes(15)) 
+        : null;
+    var name = StringHelper.JoinNonEmpty(' ', details.FirstName, details.MiddleName, details.LastName);
+    var oldName = StringHelper.JoinNonEmpty(' ', oldDetails.FirstName, oldDetails.MiddleName, oldDetails.LastName);
+    var email = EmailAddress.TryParse(details.EmailAddress, out var parsedEmail)
+        ? parsedEmail.ToDisplayString()
+        : details.EmailAddress;
+    var oldEmail = EmailAddress.TryParse(oldDetails.EmailAddress, out var oldParsedEmail)
+        ? oldParsedEmail.ToDisplayString()
+        : oldDetails.EmailAddress;
+    var mobile = MobileNumber.TryParse(details.MobileNumber, out var parsedMobile)
+        ? parsedMobile.ToDisplayString()
+        : details.MobileNumber;
+    var oldMobile = MobileNumber.TryParse(oldDetails.MobileNumber, out var oldParsedMobile)
+        ? oldParsedMobile.ToDisplayString()
+        : oldDetails.MobileNumber;
+    var nino = NationalInsuranceNumber.TryParse(details.NationalInsuranceNumber, out var parsedNino)
+        ? parsedNino.ToDisplayString()
+        : details.NationalInsuranceNumber;
+    var oldNino = NationalInsuranceNumber.TryParse(oldDetails.NationalInsuranceNumber, out var oldParsedNino)
+        ? oldParsedNino.ToDisplayString()
+        : oldDetails.NationalInsuranceNumber;
+}
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-details-updated-event">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">Personal details changed</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            @if (updatedEvent.Changes.HasAnyFlag(PersonDetailsUpdatedEventChanges.AnyNameChange))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="details-name" use-empty-fallback>@name</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+            @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.DateOfBirth))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="details-dob" use-empty-fallback>@details.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+            @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.EmailAddress))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="details-email" use-empty-fallback>@email</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+            @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.MobileNumber))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="details-mobile" use-empty-fallback>@mobile</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+            @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="details-nino" use-empty-fallback>@nino</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+        </govuk-summary-list>
+
+        <govuk-details class="govuk-!-margin-bottom-2">
+            <govuk-details-summary>Reason for change</govuk-details-summary>
+            <govuk-details-text>
+                <govuk-summary-list>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Reason</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="reason" use-empty-fallback>@updatedEvent.ChangeReason</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Reason details</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>
+                            @if (updatedEvent.ChangeReasonDetail is not null)
+                            {
+                                <multi-line-text text="@updatedEvent.ChangeReasonDetail" data-testid="reason-detail" />
+                            }
+                            else
+                            {
+                                <span use-empty-fallback data-testid="reason-detail"></span>
+                            }
+                        </govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Evidence</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>
+                            @if (evidenceFileUrl is not null)
+                            {
+                                <a href="@evidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{updatedEvent.EvidenceFile!.Name} (opens in new tab)")</a>
+                            }
+                            else
+                            {
+                                <span data-testid="uploaded-evidence-link" use-empty-fallback></span>
+                            }
+                        </govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                </govuk-summary-list>
+            </govuk-details-text>
+        </govuk-details>
+
+        <govuk-details class="govuk-!-margin-bottom-2" data-testid="previous-data">
+            <govuk-details-summary>Previous data</govuk-details-summary>
+            <govuk-details-text>
+                <govuk-summary-list>
+                    @if (updatedEvent.Changes.HasAnyFlag(PersonDetailsUpdatedEventChanges.AnyNameChange))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-details-name" use-empty-fallback>@oldName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+                    @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.DateOfBirth))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-details-dob" use-empty-fallback>@oldDetails.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+                    @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.EmailAddress))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-details-email" use-empty-fallback>@oldEmail</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+                    @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.MobileNumber))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-details-mobile" use-empty-fallback>@oldMobile</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+                    @if (updatedEvent.Changes.HasFlag(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-details-nino" use-empty-fallback>@oldNino</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+                </govuk-summary-list>
+            </govuk-details-text>
+        </govuk-details>
+    </div>
+</div>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogEditDetailsEventTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogEditDetailsEventTests.cs
@@ -1,0 +1,184 @@
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDetails;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
+
+public class ChangeLogEditDetailsEventTests : TestBase
+{
+    public ChangeLogEditDetailsEventTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        // Toggle between GMT and BST to ensure we're testing rendering dates in local time
+        var nows = new[]
+        {
+            new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
+            new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
+        };
+        Clock.UtcNow = nows.RandomOne();
+    }
+
+    [Theory]
+    [InlineData(PersonDetailsUpdatedEventChanges.FirstName, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.MiddleName, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.LastName, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.DateOfBirth, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.EmailAddress, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.EmailAddress, true, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.EmailAddress, false, true)]
+    [InlineData(PersonDetailsUpdatedEventChanges.MobileNumber, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.MobileNumber, true, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.MobileNumber, false, true)]
+    [InlineData(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber, false, true)]
+    [InlineData(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber, true, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.FirstName | PersonDetailsUpdatedEventChanges.MiddleName | PersonDetailsUpdatedEventChanges.LastName | PersonDetailsUpdatedEventChanges.DateOfBirth | PersonDetailsUpdatedEventChanges.EmailAddress | PersonDetailsUpdatedEventChanges.MobileNumber | PersonDetailsUpdatedEventChanges.NationalInsuranceNumber, false, false)]
+    [InlineData(PersonDetailsUpdatedEventChanges.FirstName | PersonDetailsUpdatedEventChanges.MiddleName | PersonDetailsUpdatedEventChanges.LastName | PersonDetailsUpdatedEventChanges.DateOfBirth | PersonDetailsUpdatedEventChanges.EmailAddress | PersonDetailsUpdatedEventChanges.MobileNumber | PersonDetailsUpdatedEventChanges.NationalInsuranceNumber, false, true)]
+    [InlineData(PersonDetailsUpdatedEventChanges.FirstName | PersonDetailsUpdatedEventChanges.MiddleName | PersonDetailsUpdatedEventChanges.LastName | PersonDetailsUpdatedEventChanges.DateOfBirth | PersonDetailsUpdatedEventChanges.EmailAddress | PersonDetailsUpdatedEventChanges.MobileNumber | PersonDetailsUpdatedEventChanges.NationalInsuranceNumber, true, false)]
+    public async Task Person_WithPersonDetailsUpdatedEvent_RendersExpectedContent(PersonDetailsUpdatedEventChanges changes, bool previousValueIsDefault, bool newValueIsDefault)
+    {
+        // Arrange
+        var createdByUser = await TestData.CreateUserAsync();
+        var person = await TestData.CreatePersonAsync();
+
+        string oldFirstName = "Alfred";
+        string oldMiddleName = "The";
+        string oldLastName = "Great";
+        DateOnly? oldDateOfBirth = Clock.Today.AddYears(-30);
+        string? oldEmailAddress = "old@email-address.com";
+        string? oldMobileNumber = "07654321098";
+        string? oldNationalInsuranceNumber = "AB 12 34 56 D";
+
+        string firstName = "Megan";
+        string middleName = "Thee";
+        string lastName = "Stallion";
+        DateOnly? dateOfBirth = Clock.Today.AddYears(-20);
+        string emailAddress = "new@email-address.com";
+        string? mobileNumber = "07890123456";
+        string? nationalInsuranceNumber = "XY 98 76 54 A";
+
+        var changeReason = EditDetailsChangeReasonOption.AnotherReason.GetDisplayName();
+        var changeReasonDetail = "Reason detail";
+        var evidenceFile = new EventModels.File
+        {
+            FileId = Guid.NewGuid(),
+            Name = "evidence.jpg"
+        };
+
+        var updatedFirstName = changes.HasFlag(PersonDetailsUpdatedEventChanges.FirstName) ? firstName : oldFirstName;
+        var updatedMiddleName = changes.HasFlag(PersonDetailsUpdatedEventChanges.MiddleName) ? middleName : oldMiddleName;
+        var updatedLastName = changes.HasFlag(PersonDetailsUpdatedEventChanges.LastName) ? lastName : oldLastName;
+
+        var details = new EventModels.PersonDetails
+        {
+            FirstName = updatedFirstName,
+            MiddleName = updatedMiddleName,
+            LastName = updatedLastName,
+            DateOfBirth = changes.HasFlag(PersonDetailsUpdatedEventChanges.DateOfBirth) ? dateOfBirth : oldDateOfBirth,
+            EmailAddress = changes.HasFlag(PersonDetailsUpdatedEventChanges.EmailAddress) && !newValueIsDefault ? emailAddress : null,
+            MobileNumber = changes.HasFlag(PersonDetailsUpdatedEventChanges.MobileNumber) && !newValueIsDefault ? mobileNumber : null,
+            NationalInsuranceNumber = changes.HasFlag(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber) && !newValueIsDefault ? nationalInsuranceNumber : null,
+        };
+
+        var oldDetails = new EventModels.PersonDetails
+        {
+            FirstName = oldFirstName,
+            MiddleName = oldMiddleName,
+            LastName = oldLastName,
+            DateOfBirth = oldDateOfBirth,
+            EmailAddress = changes.HasFlag(PersonDetailsUpdatedEventChanges.EmailAddress) && !previousValueIsDefault ? oldEmailAddress : null,
+            MobileNumber = changes.HasFlag(PersonDetailsUpdatedEventChanges.MobileNumber) && !previousValueIsDefault ? oldMobileNumber : null,
+            NationalInsuranceNumber = changes.HasFlag(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber) && !previousValueIsDefault ? oldNationalInsuranceNumber : null,
+        };
+
+        var updatedEvent = new PersonDetailsUpdatedEvent
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = Clock.UtcNow,
+            RaisedBy = createdByUser.UserId,
+            PersonId = person.PersonId,
+            Details = details,
+            OldDetails = oldDetails,
+            Changes = changes,
+            ChangeReason = changeReason,
+            ChangeReasonDetail = changeReasonDetail,
+            EvidenceFile = evidenceFile
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEventWithoutBroadcast(updatedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var item = doc.GetElementByTestId("timeline-item-details-updated-event");
+        Assert.NotNull(item);
+        Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TextContent.Trim());
+        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TextContent.Trim());
+
+        if (changes.HasAnyFlag(PersonDetailsUpdatedEventChanges.AnyNameChange))
+        {
+            Assert.Equal($"{updatedFirstName} {updatedMiddleName} {updatedLastName}", item.GetElementByTestId("details-name")?.TextContent.Trim());
+            Assert.Equal($"{oldFirstName} {oldMiddleName} {oldLastName}", item.GetElementByTestId("old-details-name")?.TextContent.Trim());
+        }
+        else
+        {
+            Assert.Null(item.GetElementByTestId("details-name"));
+            Assert.Null(item.GetElementByTestId("old-details-name"));
+        }
+
+        if (changes.HasFlag(PersonDetailsUpdatedEventChanges.DateOfBirth))
+        {
+            Assert.Equal(dateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("details-dob")?.TextContent.Trim());
+            Assert.Equal(oldDateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat), item.GetElementByTestId("old-details-dob")?.TextContent.Trim());
+        }
+        else
+        {
+            Assert.Null(item.GetElementByTestId("details-dob"));
+            Assert.Null(item.GetElementByTestId("old-details-dob"));
+        }
+
+        if (changes.HasFlag(PersonDetailsUpdatedEventChanges.EmailAddress))
+        {
+            Assert.Equal(newValueIsDefault ? UiDefaults.EmptyDisplayContent : emailAddress, item.GetElementByTestId("details-email")?.TextContent.Trim());
+            Assert.Equal(previousValueIsDefault ? UiDefaults.EmptyDisplayContent : oldEmailAddress, item.GetElementByTestId("old-details-email")?.TextContent.Trim());
+        }
+        else
+        {
+            Assert.Null(item.GetElementByTestId("details-email"));
+            Assert.Null(item.GetElementByTestId("old-details-email"));
+        }
+
+        if (changes.HasFlag(PersonDetailsUpdatedEventChanges.MobileNumber))
+        {
+            Assert.Equal(newValueIsDefault ? UiDefaults.EmptyDisplayContent : mobileNumber, item.GetElementByTestId("details-mobile")?.TextContent.Trim());
+            Assert.Equal(previousValueIsDefault ? UiDefaults.EmptyDisplayContent : oldMobileNumber, item.GetElementByTestId("old-details-mobile")?.TextContent.Trim());
+        }
+        else
+        {
+            Assert.Null(item.GetElementByTestId("details-mobile"));
+            Assert.Null(item.GetElementByTestId("old-details-mobile"));
+        }
+
+        if (changes.HasFlag(PersonDetailsUpdatedEventChanges.NationalInsuranceNumber))
+        {
+            Assert.Equal(newValueIsDefault ? UiDefaults.EmptyDisplayContent : nationalInsuranceNumber, item.GetElementByTestId("details-nino")?.TextContent.Trim());
+            Assert.Equal(previousValueIsDefault ? UiDefaults.EmptyDisplayContent : oldNationalInsuranceNumber, item.GetElementByTestId("old-details-nino")?.TextContent.Trim());
+        }
+        else
+        {
+            Assert.Null(item.GetElementByTestId("details-nino"));
+            Assert.Null(item.GetElementByTestId("old-details-nino"));
+        }
+
+        Assert.Equal(changeReason, item.GetElementByTestId("reason")?.TextContent.Trim());
+        Assert.Equal(changeReasonDetail, item.GetElementByTestId("reason-detail")?.TextContent.Trim());
+        Assert.Equal($"{evidenceFile.Name} (opens in new tab)", item.GetElementByTestId("uploaded-evidence-link")?.TextContent);
+    }
+}


### PR DESCRIPTION
### Context

We need to be able to view PII changes in the Change history section of the console for a record.
https://trello.com/c/z0Rvrr3l/1105-2-implement-change-history-functionality-for-changing-pii-in-the-trs-console

### Changes proposed in this pull request

* Adds change history entry for Edit Person Details

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
