### PR TITLE
Fix Edit Induction journey to remember/delete previously uploaded files

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CommonJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CommonJourneyPage.cs
@@ -19,11 +19,10 @@ public abstract class CommonJourneyPage(
 
     [FromRoute]
     public Guid PersonId { get; set; }
+    public string? PersonName { get; set; }
 
     [FromQuery]
     public bool FromCheckAnswers { get; set; }
-
-    public string? PersonName { get; set; }
 
     public async Task<IActionResult> OnPostCancelAsync()
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CommonJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CommonJourneyPage.cs
@@ -1,19 +1,36 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditInduction;
 
-public abstract class CommonJourneyPage(TrsLinkGenerator linkGenerator) : PageModel
+public abstract class CommonJourneyPage(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService) : PageModel
 {
     public JourneyInstance<EditInductionState>? JourneyInstance { get; set; }
 
+    protected TrsDbContext DbContext { get; } = dbContext;
     protected TrsLinkGenerator LinkGenerator { get; } = linkGenerator;
+    protected IFileService FileService { get; } = fileService;
 
     [FromRoute]
     public Guid PersonId { get; set; }
+    public string? PersonName { get; set; }
+
+    [FromQuery]
+    public JourneyFromCheckYourAnswersPage? FromCheckAnswers { get; set; }
 
     public async Task<IActionResult> OnPostCancelAsync()
     {
+        if (JourneyInstance!.State.EvidenceFileId.HasValue)
+        {
+            await FileService.DeleteFileAsync(JourneyInstance!.State.EvidenceFileId.Value);
+        }
+
         await JourneyInstance!.DeleteAsync();
         return Redirect(LinkGenerator.PersonInduction(PersonId));
     }
@@ -31,4 +48,33 @@ public abstract class CommonJourneyPage(TrsLinkGenerator linkGenerator) : PageMo
             _ => LinkGenerator.PersonInduction(PersonId)
         };
     }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        OnPageHandlerExecuting(context);
+        await OnPageHandlerExecutingAsync(context);
+        if (context.Result == null)
+        {
+            var executedContext = await next();
+            OnPageHandlerExecuted(executedContext);
+            await OnPageHandlerExecutedAsync(executedContext);
+        }
+    }
+
+    protected virtual InductionJourneyPage StartPage { get => InductionJourneyPage.Status; }
+
+    protected virtual async Task OnPageHandlerExecutingAsync(PageHandlerExecutingContext context)
+    {
+        await JourneyInstance!.State.EnsureInitializedAsync(DbContext, PersonId, StartPage);
+
+        var personInfo = context.HttpContext.GetCurrentPersonFeature();
+        PersonId = personInfo.PersonId;
+        PersonName = personInfo.Name;
+    }
+
+    protected virtual Task OnPageHandlerExecutedAsync(PageHandlerExecutedContext context)
+        => Task.CompletedTask;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CompletedDate.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/CompletedDate.cshtml.cs
@@ -2,18 +2,18 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditInduction;
 
 [Journey(JourneyNames.EditInduction), ActivatesJourney, RequireJourneyInstance]
-public class CompletedDateModel(TrsLinkGenerator linkGenerator, TrsDbContext dbContext, IClock clock)
-    : CommonJourneyPage(linkGenerator)
+public class CompletedDateModel(
+    TrsLinkGenerator linkGenerator,
+    TrsDbContext dbContext,
+    IClock clock,
+    IFileService fileService)
+    : CommonJourneyPage(dbContext, linkGenerator, fileService)
 {
-    public string? PersonName { get; set; }
-
-    [FromQuery]
-    public JourneyFromCheckYourAnswersPage? FromCheckAnswers { get; set; }
-
     [BindProperty]
     [DateInput(ErrorMessagePrefix = "Completed date")]
     [Required(ErrorMessage = "Enter an induction completed date")]
@@ -79,20 +79,16 @@ public class CompletedDateModel(TrsLinkGenerator linkGenerator, TrsDbContext dbC
         return Redirect(GetPageLink(NextPage));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    protected override InductionJourneyPage StartPage => InductionJourneyPage.CompletedDate;
+
+    protected override async Task OnPageHandlerExecutingAsync(PageHandlerExecutingContext context)
     {
-        await JourneyInstance!.State.EnsureInitializedAsync(dbContext, PersonId, InductionJourneyPage.CompletedDate);
+        await base.OnPageHandlerExecutingAsync(context);
 
         if (!JourneyInstance!.State.InductionStatus.RequiresCompletedDate() || !JourneyInstance!.State.StartDate.HasValue)
         {
             context.Result = Redirect(GetPageLink(JourneyInstance!.State.JourneyStartPage));
             return;
         }
-
-        var personInfo = context.HttpContext.GetCurrentPersonFeature();
-        PersonId = personInfo.PersonId;
-        PersonName = personInfo.Name;
-
-        await next();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/InductionChangeReason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/InductionChangeReason.cshtml
@@ -32,7 +32,7 @@
 
             <govuk-radios asp-for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
                 <govuk-radios-fieldset>
-                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" data-testid="has-additional-reason_detail-options-legend" />
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional data-testid="additional-detail">
@@ -47,7 +47,7 @@
 
             <govuk-radios asp-for="UploadEvidence" data-testid="upload-evidence-options">
                 <govuk-radios-fieldset>
-                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" data-testid="upload-evidence-options-legend" />
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional>
@@ -55,11 +55,18 @@
                             {
                                 <span class="govuk-caption-m">Currently uploaded file</span>
                                 <p class="govuk-body">
-                                    <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-link">@($"{Model.EvidenceFileName} ({Model.EvidenceFileSizeDescription})")</a>
+                                    <a href="@Model.UploadedEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="uploaded-evidence-file-link">@($"{Model.EvidenceFileName} ({Model.EvidenceFileSizeDescription})")</a>
                                 </p>
+                                <input type="hidden" asp-for="EvidenceFileId" />
+                                <input type="hidden" asp-for="EvidenceFileName" />
+                                <input type="hidden" asp-for="EvidenceFileSizeDescription" />
+                                <input type="hidden" asp-for="UploadedEvidenceFileUrl" />
                             }
-                            <govuk-file-upload asp-for="EvidenceFile" input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+                            <govuk-file-upload asp-for="EvidenceFile" 
+                                               label-class="govuk-label--m"
+                                               input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
                                 <govuk-file-upload-label>Upload a file</govuk-file-upload-label>
+                                <govuk-file-upload-hint>Must be smaller than 50MB</govuk-file-upload-hint>
                             </govuk-file-upload>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CommonPageTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CommonPageTests.cs
@@ -8,6 +8,7 @@ public class CommonPageTests : TestBase
     public CommonPageTests(HostFixture hostFixture) : base(hostFixture)
     {
         TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.ContactsMigrated);
+        FileServiceMock.Invocations.Clear();
     }
 
     public override void Dispose()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStateBuilder.cs
@@ -69,12 +69,12 @@ public class EditInductionStateBuilder
         return this;
     }
 
-    public EditInductionStateBuilder WithFileUploadChoice(bool uploadFile)
+    public EditInductionStateBuilder WithFileUploadChoice(bool uploadFile, Guid? evidenceFileId = null)
     {
         FileUpload = uploadFile;
         if (uploadFile)
         {
-            EvidenceFileId = Guid.NewGuid();
+            EvidenceFileId = evidenceFileId ?? Guid.NewGuid();
             EvidenceFileName = "evidence.jpeg";
             EvidenceFileSizeDescription = "5MB";
         }


### PR DESCRIPTION
Fixes a couple of issues with the Edit Induction journey:
1. If a user uploaded an evidence file but other fields were invalid on the page, the uploaded file would not be remembered when validation errors are displayed and the user would have to re-upload it
2. If the journey was cancelled any uploaded file would not be deleted
3. If an additional reason detail was previously given and the additional reason choice was later changed to "No", the additional reason detail would still be persisted to the journey

### Checklist

-   [N/A] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [N/A] Run DQT integration tests locally (if appropriate)
