### PR TITLE
Handle badly-formatted mobile numbers in sync

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -1706,7 +1706,7 @@ public class TrsDataSyncHelper(
             DateOfBirth = c.BirthDate.ToDateOnlyWithDqtBstFix(isLocalTime: false),
             EmailAddress = c.EMailAddress1.NormalizeString(),
             NationalInsuranceNumber = c.dfeta_NINumber.NormalizeString(),
-            MobileNumber = c.MobilePhone.NormalizeString(),
+            MobileNumber = c.MobilePhone.NormalizeMobileNumber(),
             QtsDate = c.dfeta_QTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             EytsDate = c.dfeta_EYTSDate.ToDateOnlyWithDqtBstFix(isLocalTime: true),
             DqtContactId = c.Id,
@@ -2086,4 +2086,7 @@ file static class Extensions
     /// Returns <c>null</c> if <paramref name="value"/> is empty or whitespace.
     /// </summary>
     public static string? NormalizeString(this string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    public static string? NormalizeMobileNumber(this string? value) =>
+        MobileNumber.TryParse(value, out var mobileNumber) ? mobileNumber.ToString() : null;
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/IndexTests.cs
@@ -123,7 +123,6 @@ public class IndexTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
             .WithEmail("invalid")
-            .WithMobileNumber("invalid")
             .WithNationalInsuranceNumber("invalid"));
 
         var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person));
@@ -141,11 +140,9 @@ public class IndexTests : TestBase
 
         var doc = await AssertEx.HtmlResponseAsync(redirectResponse);
         var emailAddress = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-email-address", "input");
-        var mobileNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-mobile-number", "input");
         var nationalInsuranceNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-national-insurance-number", "input");
 
         Assert.Equal("invalid", emailAddress.Value.Trim());
-        Assert.Equal("invalid", mobileNumber.Value.Trim());
         Assert.Equal("invalid", nationalInsuranceNumber.Value.Trim());
     }
 


### PR DESCRIPTION
Live sync is currently broken due to a phone number that's more than 15 characters long. From a quick scan of the reporting DB there's a lot of bad data in the mobile number field.

This change will ensure we're not getting mobile numbers that are too long. We'll have to re-visit what to do about the bad values when we get to migrating the contact record.