### PR TITLE
Add skeleton of next version of GetPerson API endpoint with routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## vNext
 
+### `GET /v3/persons/<trn>` and `GET /v3/person` changes
+- The `awarded` property in each member of `mandatoryQualifications` has been renamed to `endDate`.
+- A `qualificationId` property has been added to each member of `mandatoryQualifications`.
+- `NpqQualifications` and `InitialTeacherTraining` can no longer be requested in the `include` query parameter.
+- `RoutesToProfessionalStatuses` can be requested in the `include` query parameter.
+- An `exemptions` property has been added to the `induction` property.
+
+### `GET /v3/persons?findBy=LastNameAndDateOfBirth` and `GET /v3/persons/find`
+- The `inductionStatus` property has been replaced by an `induction` object.
+
 The following new endpoints have been added:
 - `PUT /v3/persons/<trn>/welsh-induction` - to set a person's induction for teachers in Wales.
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Api.Infrastructure.ModelBinding;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Api.V3.VNext.Responses;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
+
+[Route("person")]
+public class PersonController : ControllerBase
+{
+    [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
+    [HttpGet]
+    [SwaggerOperation(
+        OperationId = "GetCurrentPerson",
+        Summary = "Get the authenticated person's details",
+        Description = "Gets the details for the authenticated person.")]
+    [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+    public Task<IActionResult> GetAsync(
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
+        [FromServices] GetPersonHandler handler)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.EwcWales.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.EwcWales.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Api.V3.VNext.Requests;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
+
+public partial class PersonsController
+{
+    [HttpPut("{trn}/welsh-induction")]
+    [SwaggerOperation(
+        OperationId = "SetPersonWelshInductionStatus",
+        Summary = "Set person induction status",
+        Description = "Sets the induction details of the person with the given TRN.")]
+    [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.SetWelshInduction)]
+    public async Task<IActionResult> SetWelshInductionStatusAsync(
+        [FromRoute] string trn,
+        [FromBody] SetWelshInductionStatusRequest request,
+        [FromServices] SetWelshInductionStatusHandler handler)
+    {
+        var command = new SetWelshInductionStatusCommand(
+            trn,
+            request.Passed,
+            request.StartDate,
+            request.CompletedDate);
+
+        var result = await handler.HandleAsync(command);
+
+        return result.ToActionResult(_ => NoContent())
+            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.cs
@@ -1,38 +1,63 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using TeachingRecordSystem.Api.Infrastructure.ModelBinding;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Api.V3.VNext.Responses;
 
 namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
 
 [Route("persons")]
-public class PersonsController : ControllerBase
+public partial class PersonsController : ControllerBase
 {
-    [HttpPut("{trn}/welsh-induction")]
+    [HttpGet("{trn}")]
     [SwaggerOperation(
-        OperationId = "SetPersonWelshInductionStatus",
-        Summary = "Set person induction status",
-        Description = "Sets the induction details of the person with the given TRN.")]
-    [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        OperationId = "GetPersonByTrn",
+        Summary = "Get person details by TRN",
+        Description = "Gets the details of the person corresponding to the given TRN.")]
+    [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.SetWelshInduction)]
-    public async Task<IActionResult> SetWelshInductionStatusAsync(
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = $"{ApiRoles.GetPerson},{ApiRoles.AppropriateBody}")]
+    public Task<IActionResult> GetAsync(
         [FromRoute] string trn,
-        [FromBody] SetWelshInductionStatusRequest request,
-        [FromServices] SetWelshInductionStatusHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
+        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth,
+        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified nationalInsuranceNumber, if provided.")] string? nationalInsuranceNumber,
+        [FromServices] GetPersonHandler handler)
     {
-        var command = new SetWelshInductionStatusCommand(
-            trn,
-            request.Passed,
-            request.StartDate,
-            request.CompletedDate);
+        throw new NotImplementedException();
+    }
 
-        var result = await handler.HandleAsync(command);
+    [HttpPost("find")]
+    [SwaggerOperation(
+        OperationId = "FindPersons",
+        Summary = "Find persons",
+        Description = "Finds persons matching the specified criteria.")]
+    [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
+    public Task<IActionResult> FindPersonsAsync(
+        [FromBody] FindPersonsRequest request,
+        [FromServices] FindPersonsByTrnAndDateOfBirthHandler handler)
+    {
+        throw new NotImplementedException();
+    }
 
-        return result.ToActionResult(_ => NoContent())
-            .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
+    [HttpGet("")]
+    [SwaggerOperation(
+        OperationId = "FindPerson",
+        Summary = "Find person",
+        Description = "Finds a person matching the specified criteria.")]
+    [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
+    public Task<IActionResult> FindPersonsAsync(
+        FindPersonRequest request,
+        [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonRequest.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+
+public record FindPersonRequest
+{
+    [FromQuery(Name = "findBy")]
+    public FindPersonFindBy FindBy { get; init; }
+    [FromQuery(Name = "lastName")]
+    public string? LastName { get; init; }
+    [FromQuery(Name = "dateOfBirth")]
+    public DateOnly? DateOfBirth { get; init; }
+}
+
+public enum FindPersonFindBy
+{
+    LastNameAndDateOfBirth = 1
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonsRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/FindPersonsRequest.cs
@@ -1,0 +1,12 @@
+namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+
+public record FindPersonsRequest
+{
+    public required IReadOnlyCollection<FindPersonsRequestPerson> Persons { get; init; }
+}
+
+public record FindPersonsRequestPerson
+{
+    public required string Trn { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/GetPersonRequestIncludes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Requests/GetPersonRequestIncludes.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Requests;
+
+[Flags]
+[Description("Comma-separated list of data to include in response.")]
+public enum GetPersonRequestIncludes
+{
+    None = 0,
+
+    Induction = 1 << 0,
+    MandatoryQualifications = 1 << 3,
+    PendingDetailChanges = 1 << 4,
+    Alerts = 1 << 7,
+    PreviousNames = 1 << 8,
+    [ExcludeFromSchema]
+    _AllowIdSignInWithProhibitions = 1 << 9,
+    RoutesToProfessionalStatuses = 1 << 10,
+
+    All = Induction | RoutesToProfessionalStatuses | MandatoryQualifications | PendingDetailChanges | Alerts | PreviousNames
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonResponse.cs
@@ -1,0 +1,32 @@
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Api.V3.VNext.Requests;
+using TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos;
+using TeachingRecordSystem.Core.ApiSchema.V3.V20240920.Dtos;
+using TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+using QtlsStatus = TeachingRecordSystem.Core.ApiSchema.V3.V20250203.Dtos.QtlsStatus;
+using QtsInfo = TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos.QtsInfo;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+
+public record FindPersonResponse
+{
+    public required int Total { get; init; }
+    public required FindPersonRequest Query { get; init; }
+    public required IReadOnlyCollection<FindPersonResponseResult> Results { get; init; }
+}
+
+[AutoMap(typeof(FindPersonsResultItem))]
+public record FindPersonResponseResult
+{
+    public required string Trn { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required IReadOnlyCollection<NameInfo> PreviousNames { get; init; }
+    public required QtsInfo? Qts { get; init; }
+    public required EytsInfo? Eyts { get; init; }
+    public required IReadOnlyCollection<Alert> Alerts { get; init; }
+    public required InductionInfo? Induction { get; init; }
+    public required QtlsStatus QtlsStatus { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonsResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/FindPersonsResponse.cs
@@ -1,0 +1,33 @@
+using AutoMapper.Configuration.Annotations;
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+using Alert = TeachingRecordSystem.Core.ApiSchema.V3.V20240920.Dtos.Alert;
+using NameInfo = TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos.NameInfo;
+using QtlsStatus = TeachingRecordSystem.Core.ApiSchema.V3.V20250203.Dtos.QtlsStatus;
+using QtsInfo = TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos.QtsInfo;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+
+[AutoMap(typeof(FindPersonsResult))]
+public record FindPersonsResponse
+{
+    public required int Total { get; init; }
+    [SourceMember(nameof(FindPersonsResult.Items))]
+    public required IReadOnlyCollection<FindPersonsResponseResult> Results { get; init; }
+}
+
+[AutoMap(typeof(FindPersonsResultItem))]
+public record FindPersonsResponseResult
+{
+    public required string Trn { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required IReadOnlyCollection<NameInfo> PreviousNames { get; init; }
+    public required QtsInfo? Qts { get; init; }
+    public required EytsInfo? Eyts { get; init; }
+    public required IReadOnlyCollection<Alert> Alerts { get; init; }
+    public required InductionInfo? Induction { get; init; }
+    public required QtlsStatus QtlsStatus { get; set; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Responses/GetPersonResponse.cs
@@ -1,0 +1,57 @@
+using Optional;
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+using Alert = TeachingRecordSystem.Core.ApiSchema.V3.V20240920.Dtos.Alert;
+using InductionInfo = TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos.InductionInfo;
+using NameInfo = TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos.NameInfo;
+using ProfessionalStatusStatus = TeachingRecordSystem.Core.ApiSchema.V3.V20250425.Dtos.ProfessionalStatusStatus;
+using QtlsStatus = TeachingRecordSystem.Core.ApiSchema.V3.V20250203.Dtos.QtlsStatus;
+using QtsInfo = TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos.QtsInfo;
+
+namespace TeachingRecordSystem.Api.V3.VNext.Responses;
+
+[AutoMap(typeof(GetPersonResult))]
+public record GetPersonResponse
+{
+    public required string Trn { get; init; }
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
+    public required Option<bool> PendingNameChange { get; init; }
+    public required Option<bool> PendingDateOfBirthChange { get; init; }
+    public required string? EmailAddress { get; init; }
+    public required QtsInfo? Qts { get; init; }
+    public required EytsInfo? Eyts { get; init; }
+    public required InductionInfo Induction { get; init; }
+    public required Option<IReadOnlyCollection<GetPersonResponseRouteToProfessionalStatus>> RoutesToProfessionalStatuses { get; init; }
+    public required Option<IReadOnlyCollection<GetPersonResponseMandatoryQualification>> MandatoryQualifications { get; init; }
+    public required Option<IReadOnlyCollection<Alert>> Alerts { get; init; }
+    public required Option<IReadOnlyCollection<NameInfo>> PreviousNames { get; init; }
+    public required Option<bool> AllowIdSignInWithProhibitions { get; init; }
+    public required QtlsStatus QtlsStatus { get; set; }
+}
+
+[AutoMap(typeof(GetPersonResultMandatoryQualification))]
+public record GetPersonResponseMandatoryQualification
+{
+    public required Guid QualificationId { get; init; }
+    public required DateOnly EndDate { get; init; }
+    public required string Specialism { get; init; }
+}
+
+public record GetPersonResponseRouteToProfessionalStatus
+{
+    public required Guid QualificationId { get; init; }
+    public required RouteToProfessionalStatus RouteToProfessionalStatus { get; init; }
+    public required ProfessionalStatusStatus Status { get; init; }
+    public required DateOnly? AwardedDate { get; init; }
+    public required DateOnly? TrainingStartDate { get; init; }
+    public required DateOnly? TrainingEndDate { get; init; }
+    public required IReadOnlyCollection<TrainingSubject> TrainingSubjects { get; init; }
+    public required TrainingAgeSpecialism? TrainingAgeSpecialism { get; init; }
+    public required TrainingCountry? TrainingCountry { get; init; }
+    public required TrainingProvider? TrainingProvider { get; init; }
+    public required DegreeType? DegreeType { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/DegreeType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/DegreeType.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record DegreeType
+{
+    public required Guid DegreeTypeId { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/EytsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/EytsInfo.cs
@@ -1,0 +1,13 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record EytsInfo
+{
+    public required DateOnly AwardedDate { get; init; }
+    public required IReadOnlyCollection<EytsInfoAwardedRoute> AwardedRoutes { get; init; }
+}
+
+public record EytsInfoAwardedRoute
+{
+    public required RouteToProfessionalStatus RouteToProfessionalStatus { get; init; }
+    public required DateOnly AwardedDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/InductionExemptionReason.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/InductionExemptionReason.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record InductionExemptionReason
+{
+    public required Guid InductionExemptionReasonId { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/InductionInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/InductionInfo.cs
@@ -1,0 +1,17 @@
+using InductionStatus = TeachingRecordSystem.Core.ApiSchema.V3.V20250203.Dtos.InductionStatus;
+
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record InductionInfo
+{
+    public required InductionStatus Status { get; init; }
+    public required DateOnly? StartDate { get; init; }
+    public required DateOnly? CompletedDate { get; init; }
+    public required IReadOnlyCollection<InductionInfoExemption> Exemptions { get; init; }
+}
+
+public record InductionInfoExemption
+{
+    public required InductionExemptionReason? InductionExemptionReason { get; init; }
+    public required Guid? QualificationId { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/ProfessionalStatusType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/ProfessionalStatusType.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public enum ProfessionalStatusType
+{
+    QualifiedTeacherStatus = 0,
+    EarlyYearsTeacherStatus = 1,
+    EarlyYearsProfessionalStatus = 2,
+    PartialQualifiedTeacherStatus = 3
+}
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/QtsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/QtsInfo.cs
@@ -1,0 +1,13 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record QtsInfo
+{
+    public required DateOnly AwardedDate { get; init; }
+    public required IReadOnlyCollection<QtsInfoAwardedRoute> AwardedRoutes { get; init; }
+}
+
+public record QtsInfoAwardedRoute
+{
+    public required RouteToProfessionalStatus RouteToProfessionalStatus { get; init; }
+    public required DateOnly AwardedDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/RouteToProfessionalStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/RouteToProfessionalStatus.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record RouteToProfessionalStatus
+{
+    public required Guid RouteTypeId { get; init; }
+    public required string Name { get; init; }
+    public required ProfessionalStatusType ProfessionalStatusType { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingAgeSpecialism.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingAgeSpecialism.cs
@@ -1,0 +1,11 @@
+using Optional;
+using TrainingAgeSpecialismType = TeachingRecordSystem.Core.ApiSchema.V3.V20250425.Dtos.TrainingAgeSpecialismType;
+
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record TrainingAgeSpecialism
+{
+    public required TrainingAgeSpecialismType Type { get; init; }
+    public required Option<int> From { get; init; }
+    public required Option<int> To { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingCountry.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingCountry.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record TrainingCountry
+{
+    public required string Reference { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingProvider.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record TrainingProvider
+{
+    public required string Ukprn { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingSubject.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ApiSchema/V3/VNext/Dtos/TrainingSubject.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.ApiSchema.V3.VNext.Dtos;
+
+public record TrainingSubject
+{
+    public required string Reference { get; init; }
+    public required string Name { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -249,8 +249,4 @@
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="ApiSchema\V3\VNext\Dtos\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This also removes the `NpqQualifications` and `InitialTeacherTraining` `Includes`.

I've also added some additional information to `Induction` as CTR/AYTQ will need it.

https://trello.com/c/k8jCATfI/1177-routes-v3-get-api-endpoint