### PR TITLE
Amended code to avoid conflicts with EF dbContext reading and writing

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/WorkforceData/TpsCsvExtractProcessor.cs
@@ -14,7 +14,11 @@ public class TpsCsvExtractProcessor(
     {
         int i = 0;
         using var dbContext = dbContextFactory.CreateDbContext();
-        foreach (var item in dbContext.TpsCsvExtractItems.Where(r => r.TpsCsvExtractId == tpsCsvExtractId && !dbContext.Persons.Any(p => p.Trn == r.Trn)))
+        var invalidTrns = await dbContext.TpsCsvExtractItems
+            .Where(r => r.TpsCsvExtractId == tpsCsvExtractId && !dbContext.Persons.Any(p => p.Trn == r.Trn))
+            .ToListAsync();
+
+        foreach (var item in invalidTrns)
         {
             item.Result = TpsCsvExtractItemResult.InvalidTrn;
             i++;


### PR DESCRIPTION
### Context

The TPS import job is currently failing with a `Connection is busy` error.
This can sometimes happen when using the same EF DBContext to read and write data so the code has been amended to avoid this.
