### PR TITLE
Add a job to resync all Persons

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -235,8 +235,12 @@ public static class HostApplicationBuilderExtensions
                 recurringJobManager.AddOrUpdate<AppendTrainingProvidersFromCrmJob>(
                     nameof(AppendTrainingProvidersFromCrmJob),
                     job => job.ExecuteAsync(CancellationToken.None),
-                    Cron.Never
-                    );
+                    Cron.Never);
+
+                recurringJobManager.AddOrUpdate<ResyncAllPersonsJob>(
+                    nameof(ResyncAllPersonsJob),
+                    job => job.ExecuteAsync(new DateTime(2025, 6, 6, 0, 0, 0, DateTimeKind.Utc), CancellationToken.None),
+                    Cron.Never);
 
                 return Task.CompletedTask;
             });

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ResyncAllPersonsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ResyncAllPersonsJob.cs
@@ -1,0 +1,23 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.TrsDataSync;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class ResyncAllPersonsJob(TrsDataSyncHelper syncHelper, IDbContextFactory<TrsDbContext> dbContextFactory)
+{
+    public async Task ExecuteAsync(DateTime lastSyncedBefore, CancellationToken cancellationToken)
+    {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        dbContext.Database.SetCommandTimeout(0);
+
+        var personsToSync = dbContext.Persons
+            .Where(p => p.DqtLastSync < lastSyncedBefore)
+            .Select(p => p.PersonId)
+            .AsAsyncEnumerable();
+
+        await foreach (var personIds in personsToSync.ChunkAsync(50).WithCancellation(cancellationToken))
+        {
+            await syncHelper.SyncPersonsAsync(personIds, syncAudit: false, cancellationToken: cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
We've added a fair few fields to the Person sync recently and we need to back-fill them. This adds a job that runs through all `Person`s already in TRS DB and resyncs them. There's a  date filter passed in so any that have been synced since the last set of fields were added to the sync can be excluded (and so that it can retry without re-processing rows).