### PR TITLE
Remove DQT sanction tables from reporting sync

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/appsettings.json
@@ -48,8 +48,6 @@
       "dfeta_profileamendrequest",
       "dfeta_qtsregistration",
       "dfeta_qualification",
-      "dfeta_sanction",
-      "dfeta_sanctioncode",
       "dfeta_schooldirectinitiative",
       "dfeta_serviceannouncement",
       "dfeta_specialism",


### PR DESCRIPTION
We've got an error on pre-prod trying to sync `dfeta_sanction` records from DQT into the reporting database as we've deleted that table. This removes `dfeta_sanction` and `dfeta_sanctioncode` from the reporting service configuration as they're not used any more.