### PR TITLE
Don't publish wwwroot/lib folders

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_ContentIncludedByDefault Remove="wwwroot\lib\**\*" />
+    <Content Update="wwwroot\lib\**\*" CopyToPublishDirectory="Never" />
   </ItemGroup>
 
 </Project>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <_ContentIncludedByDefault Remove="wwwroot\lib\**\*" />
+    <Content Update="wwwroot\lib\**\*" CopyToPublishDirectory="Never" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The contents of the lib folder that we need are included into our stylesheet so we don't need these files publishing.