### PR TITLE
Overhaul how we return a different API response based on role

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="NSign.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="NSign.Client" Version="1.1.0" />
     <PackageVersion Include="NSign.SignatureProviders" Version="1.1.0" />
+    <PackageVersion Include="OneOf" Version="3.0.271" />
     <PackageVersion Include="OpenIddict.AspNetCore" Version="5.2.0" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="5.2.0" />
     <PackageVersion Include="Optional" Version="4.0.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Mapping/OptionMapper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Mapping/OptionMapper.cs
@@ -1,5 +1,5 @@
+using OneOf;
 using Optional;
-using Optional.Unsafe;
 
 namespace TeachingRecordSystem.Api.Infrastructure.Mapping;
 
@@ -21,14 +21,20 @@ public class WrapWithOptionValueConverter<T> : IValueConverter<T, Option<T>>
         Option.Some(sourceMember);
 }
 
-public class UnwrapFromOptionValueConverter<TSource, TDestination> : IValueConverter<Option<TSource>, TDestination>
+public class OneOfToOneOfTypeConverter<T0Source, T1Source, T0Destination, T1Destination> : ITypeConverter<OneOf<T0Source, T1Source>, OneOf<T0Destination, T1Destination>>
 {
-    public TDestination Convert(Option<TSource> sourceMember, ResolutionContext context) =>
-        context.Mapper.Map<TDestination>(sourceMember.ValueOrFailure());
+    public OneOf<T0Destination, T1Destination> Convert(OneOf<T0Source, T1Source> source, OneOf<T0Destination, T1Destination> destination, ResolutionContext context)
+    {
+        return source.Match(
+            v => OneOf<T0Destination, T1Destination>.FromT0(context.Mapper.Map<T0Destination>(v)),
+            v => OneOf<T0Destination, T1Destination>.FromT1(context.Mapper.Map<T1Destination>(v)));
+    }
 }
 
-public class UnwrapFromOptionValueConverter<T> : IValueConverter<Option<T>, T>
+public class FromOneOfT0TypeConverter<T0Source, T1Source, TDestination> : ITypeConverter<OneOf<T0Source, T1Source>, TDestination>
 {
-    public T Convert(Option<T> sourceMember, ResolutionContext context) =>
-        sourceMember.ValueOrFailure();
+    public TDestination Convert(OneOf<T0Source, T1Source> source, TDestination destination, ResolutionContext context)
+    {
+        return context.Mapper.Map<TDestination>(source.AsT0);
+    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/OneOfSerializerDataContractResolver.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/OneOfSerializerDataContractResolver.cs
@@ -1,0 +1,19 @@
+using OneOf;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace TeachingRecordSystem.Api.Infrastructure.OpenApi;
+
+public class OneOfSerializerDataContractResolver(ISerializerDataContractResolver inner) : ISerializerDataContractResolver
+{
+    public DataContract GetDataContractForType(Type type)
+    {
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(OneOf<,>))
+        {
+            // By convention, use the schema of the T0 in OneOf<T0, T1>.
+
+            return inner.GetDataContractForType(type.GetGenericArguments()[0]);
+        }
+
+        return inner.GetDataContractForType(type);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/OpenApi/ServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ public static class ServiceCollectionExtensions
         });
 
         services.Decorate<ISerializerDataContractResolver, UnwrapOptionSerializerDataContractResolver>();
+        services.Decorate<ISerializerDataContractResolver, OneOfSerializerDataContractResolver>();
 
         services.AddSingleton<IStartupFilter, OpenApiEndpointsStartupFilter>();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using OneOf;
 using Optional;
 using TeachingRecordSystem.Api.Endpoints;
 using TeachingRecordSystem.Api.Endpoints.IdentityWebHooks;
@@ -129,13 +130,14 @@ public class Program
         .AddJsonOptions(options =>
         {
             options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+            options.JsonSerializerOptions.Converters.Add(new OneOfJsonConverterFactory());
 
             options.JsonSerializerOptions.TypeInfoResolver = new DefaultJsonTypeInfoResolver()
             {
                 Modifiers =
-                    {
-                        Modifiers.OptionProperties
-                    }
+                {
+                    Modifiers.OptionProperties
+                }
             };
         });
 
@@ -148,11 +150,10 @@ public class Program
             {
                 cfg.AddMaps(typeof(Program).Assembly);
                 cfg.CreateMap(typeof(Option<>), typeof(Option<>)).ConvertUsing(typeof(OptionToOptionTypeConverter<,>));
+                cfg.CreateMap(typeof(OneOf<,>), typeof(OneOf<,>)).ConvertUsing(typeof(OneOfToOneOfTypeConverter<,,,>));
             })
             .AddTransient(typeof(WrapWithOptionValueConverter<>))
-            .AddTransient(typeof(WrapWithOptionValueConverter<,>))
-            .AddTransient(typeof(UnwrapFromOptionValueConverter<>))
-            .AddTransient(typeof(UnwrapFromOptionValueConverter<,>));
+            .AddTransient(typeof(WrapWithOptionValueConverter<,>));
 
         services.Scan(scan =>
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/MapperProfile.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/MapperProfile.cs
@@ -1,3 +1,7 @@
+using OneOf;
+using TeachingRecordSystem.Api.Infrastructure.Mapping;
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Api.V3.V20240101.Responses;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos;
 
 namespace TeachingRecordSystem.Api.V3.V20240101;
@@ -9,6 +13,11 @@ public class MapperProfile : Profile
         CreateMap<Implementation.Dtos.Alert, AlertInfo>().ConvertUsing<AlertInfoTypeConverter>();
         CreateMap<Implementation.Dtos.NameInfo, NameInfo>();
         CreateMap<Implementation.Dtos.SanctionInfo, SanctionInfo>();
+        CreateMap<OneOf<GetPersonResultInitialTeacherTraining, GetPersonResultInitialTeacherTrainingForAppropriateBody>,
+                GetTeacherResponseInitialTeacherTraining>()
+            .ConvertUsing(
+                new FromOneOfT0TypeConverter<GetPersonResultInitialTeacherTraining, GetPersonResultInitialTeacherTrainingForAppropriateBody,
+                    GetTeacherResponseInitialTeacherTraining>());
     }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Responses/GetTeacherResponse.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 using AutoMapper.Configuration.Annotations;
 using Optional;
-using TeachingRecordSystem.Api.Infrastructure.Mapping;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos;
 
@@ -80,22 +79,14 @@ public record GetTeacherResponseInductionPeriodAppropriateBody
 [AutoMap(typeof(GetPersonResultInitialTeacherTraining))]
 public record GetTeacherResponseInitialTeacherTraining
 {
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<GetPersonResultInitialTeacherTrainingQualification, GetTeacherResponseInitialTeacherTrainingQualification>))]
     public required GetTeacherResponseInitialTeacherTrainingQualification? Qualification { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<DateOnly?>))]
     public required DateOnly? StartDate { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<DateOnly?>))]
     public required DateOnly? EndDate { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<TeachingRecordSystem.Api.V3.Implementation.Dtos.IttProgrammeType?, IttProgrammeType?>))]
     public required IttProgrammeType? ProgrammeType { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<string?>))]
     public required string? ProgrammeTypeDescription { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<TeachingRecordSystem.Api.V3.Implementation.Dtos.IttOutcome?, IttOutcome?>))]
     public required IttOutcome? Result { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<GetPersonResultInitialTeacherTrainingAgeRange, GetTeacherResponseInitialTeacherTrainingAgeRange>))]
     public required GetTeacherResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
     public required GetTeacherResponseInitialTeacherTrainingProvider? Provider { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<IReadOnlyCollection<GetPersonResultInitialTeacherTrainingSubject>, IReadOnlyCollection<GetTeacherResponseInitialTeacherTrainingSubject>>))]
     public required IReadOnlyCollection<GetTeacherResponseInitialTeacherTrainingSubject> Subjects { get; init; }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/MapperProfile.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/MapperProfile.cs
@@ -1,20 +1,18 @@
 using OneOf;
 using TeachingRecordSystem.Api.Infrastructure.Mapping;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
-using TeachingRecordSystem.Api.V3.V20240606.Responses;
-using TeachingRecordSystem.Core.ApiSchema.V3.V20240606.Dtos;
+using TeachingRecordSystem.Api.V3.V20240416.Responses;
 
-namespace TeachingRecordSystem.Api.V3.V20240606;
+namespace TeachingRecordSystem.Api.V3.V20240416;
 
 public class MapperProfile : Profile
 {
     public MapperProfile()
     {
-        CreateMap<Implementation.Dtos.TrnRequestInfo, TrnRequestInfo>();
         CreateMap<OneOf<GetPersonResultInitialTeacherTraining, GetPersonResultInitialTeacherTrainingForAppropriateBody>,
-                GetPersonResponseInitialTeacherTraining>()
+                GetTeacherResponseInitialTeacherTraining>()
             .ConvertUsing(
                 new FromOneOfT0TypeConverter<GetPersonResultInitialTeacherTraining, GetPersonResultInitialTeacherTrainingForAppropriateBody,
-                    GetPersonResponseInitialTeacherTraining>());
+                    GetTeacherResponseInitialTeacherTraining>());
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Responses/GetTeacherResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Responses/GetTeacherResponse.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 using AutoMapper.Configuration.Annotations;
 using Optional;
-using TeachingRecordSystem.Api.Infrastructure.Mapping;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos;
 
@@ -80,22 +79,14 @@ public record GetTeacherResponseInductionPeriodAppropriateBody
 [AutoMap(typeof(GetPersonResultInitialTeacherTraining))]
 public record GetTeacherResponseInitialTeacherTraining
 {
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<GetPersonResultInitialTeacherTrainingQualification, GetTeacherResponseInitialTeacherTrainingQualification>))]
     public required GetTeacherResponseInitialTeacherTrainingQualification? Qualification { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<DateOnly?>))]
     public required DateOnly? StartDate { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<DateOnly?>))]
     public required DateOnly? EndDate { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<TeachingRecordSystem.Api.V3.Implementation.Dtos.IttProgrammeType?, IttProgrammeType?>))]
     public required IttProgrammeType? ProgrammeType { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<string?>))]
     public required string? ProgrammeTypeDescription { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<TeachingRecordSystem.Api.V3.Implementation.Dtos.IttOutcome?, IttOutcome?>))]
     public required IttOutcome? Result { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<GetPersonResultInitialTeacherTrainingAgeRange, GetTeacherResponseInitialTeacherTrainingAgeRange>))]
     public required GetTeacherResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
     public required GetTeacherResponseInitialTeacherTrainingProvider? Provider { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<IReadOnlyCollection<GetPersonResultInitialTeacherTrainingSubject>, IReadOnlyCollection<GetTeacherResponseInitialTeacherTrainingSubject>>))]
     public required IReadOnlyCollection<GetTeacherResponseInitialTeacherTrainingSubject> Subjects { get; init; }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Responses/GetPersonResponse.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 using AutoMapper.Configuration.Annotations;
 using Optional;
-using TeachingRecordSystem.Api.Infrastructure.Mapping;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos;
 
@@ -79,22 +78,14 @@ public record GetPersonResponseInductionPeriodAppropriateBody
 [AutoMap(typeof(GetPersonResultInitialTeacherTraining))]
 public record GetPersonResponseInitialTeacherTraining
 {
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<GetPersonResultInitialTeacherTrainingQualification, GetPersonResponseInitialTeacherTrainingQualification>))]
     public required GetPersonResponseInitialTeacherTrainingQualification? Qualification { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<DateOnly?>))]
     public required DateOnly? StartDate { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<DateOnly?>))]
     public required DateOnly? EndDate { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<TeachingRecordSystem.Api.V3.Implementation.Dtos.IttProgrammeType?, IttProgrammeType?>))]
     public required IttProgrammeType? ProgrammeType { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<string?>))]
     public required string? ProgrammeTypeDescription { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<TeachingRecordSystem.Api.V3.Implementation.Dtos.IttOutcome?, IttOutcome?>))]
     public required IttOutcome? Result { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<GetPersonResultInitialTeacherTrainingAgeRange, GetPersonResponseInitialTeacherTrainingAgeRange>))]
     public required GetPersonResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
     public required GetPersonResponseInitialTeacherTrainingProvider? Provider { get; init; }
-    [ValueConverter(typeof(UnwrapFromOptionValueConverter<IReadOnlyCollection<GetPersonResultInitialTeacherTrainingSubject>, IReadOnlyCollection<GetPersonResponseInitialTeacherTrainingSubject>>))]
     public required IReadOnlyCollection<GetPersonResponseInitialTeacherTrainingSubject> Subjects { get; init; }
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/GetPersonResponse.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Responses/GetPersonResponse.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using AutoMapper.Configuration.Annotations;
+using OneOf;
 using Optional;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
 using TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos;
@@ -23,7 +24,7 @@ public record GetPersonResponse
     public required GetPersonResponseEyts? Eyts { get; init; }
     [SourceMember(nameof(GetPersonResult.DqtInduction))]
     public required Option<GetPersonResponseInduction?> Induction { get; init; }
-    public required Option<IReadOnlyCollection<GetPersonResponseInitialTeacherTraining>> InitialTeacherTraining { get; init; }
+    public required Option<IReadOnlyCollection<OneOf<GetPersonResponseInitialTeacherTraining, GetPersonResponseInitialTeacherTrainingForAppropriateBody>>> InitialTeacherTraining { get; init; }
     public required Option<IReadOnlyCollection<GetPersonResponseNpqQualification>> NpqQualifications { get; init; }
     public required Option<IReadOnlyCollection<GetPersonResponseMandatoryQualification>> MandatoryQualifications { get; init; }
     public required Option<IReadOnlyCollection<GetPersonResponseHigherEducationQualification>> HigherEducationQualifications { get; init; }
@@ -54,7 +55,7 @@ public record GetPersonResponseInduction
 {
     public required DateOnly? StartDate { get; init; }
     public required DateOnly? EndDate { get; init; }
-    public required TeachingRecordSystem.Core.ApiSchema.V3.V20240101.Dtos.DqtInductionStatus? Status { get; init; }
+    public required DqtInductionStatus? Status { get; init; }
     public required string? StatusDescription { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? CertificateUrl { get; init; }
@@ -64,14 +65,20 @@ public record GetPersonResponseInduction
 public record GetPersonResponseInitialTeacherTraining
 {
     public required GetPersonResponseInitialTeacherTrainingProvider? Provider { get; init; }
-    public required Option<GetPersonResponseInitialTeacherTrainingQualification?> Qualification { get; init; }
-    public required Option<DateOnly?> StartDate { get; init; }
-    public required Option<DateOnly?> EndDate { get; init; }
-    public required Option<IttProgrammeType?> ProgrammeType { get; init; }
-    public required Option<string?> ProgrammeTypeDescription { get; init; }
-    public required Option<IttOutcome?> Result { get; init; }
-    public required Option<GetPersonResponseInitialTeacherTrainingAgeRange?> AgeRange { get; init; }
-    public required Option<IReadOnlyCollection<GetPersonResponseInitialTeacherTrainingSubject>> Subjects { get; init; }
+    public required GetPersonResponseInitialTeacherTrainingQualification? Qualification { get; init; }
+    public required DateOnly? StartDate { get; init; }
+    public required DateOnly? EndDate { get; init; }
+    public required IttProgrammeType? ProgrammeType { get; init; }
+    public required string? ProgrammeTypeDescription { get; init; }
+    public required IttOutcome? Result { get; init; }
+    public required GetPersonResponseInitialTeacherTrainingAgeRange? AgeRange { get; init; }
+    public required IReadOnlyCollection<GetPersonResponseInitialTeacherTrainingSubject> Subjects { get; init; }
+}
+
+[AutoMap(typeof(GetPersonResultInitialTeacherTrainingForAppropriateBody))]
+public record GetPersonResponseInitialTeacherTrainingForAppropriateBody
+{
+    public required GetPersonResponseInitialTeacherTrainingProvider? Provider { get; init; }
 }
 
 [AutoMap(typeof(GetPersonResultInitialTeacherTrainingQualification))]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250425/Validators/CreateTrnRequestRequestValidator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250425/Validators/CreateTrnRequestRequestValidator.cs
@@ -30,7 +30,7 @@ public class CreateTrnRequestRequestValidator : AbstractValidator<CreateTrnReque
             .NotEmpty()
             .Custom((value, ctx) =>
             {
-                if (value >= DateOnly.FromDateTime(clock.UtcNow) || value < new DateOnly(1940, 1, 1))
+                if (value >= clock.Today || value < new DateOnly(1940, 1, 1))
                 {
                     ctx.AddFailure(ctx.PropertyName, StringResources.ErrorMessages_BirthDateIsOutOfRange);
                 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/packages.lock.json
@@ -2310,6 +2310,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2782,6 +2783,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
@@ -2409,6 +2409,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2881,6 +2882,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/packages.lock.json
@@ -2070,6 +2070,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2481,6 +2482,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Infrastructure/Json/Modifiers.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Infrastructure/Json/Modifiers.cs
@@ -8,7 +8,7 @@ namespace TeachingRecordSystem.Core.Infrastructure.Json;
 public static class Modifiers
 {
     /// <summary>
-    /// Only serialize Option<T> properties if they have a value.
+    /// Only serialize Option{T} properties if they have a value.
     /// </summary>
     public static void OptionProperties(JsonTypeInfo typeInfo)
     {
@@ -19,12 +19,12 @@ public static class Modifiers
 
         foreach (var property in typeInfo.Properties)
         {
-            var isOptionType = property.PropertyType?.IsGenericType == true &&
+            var isOptionType = property.PropertyType.IsGenericType &&
                 property.PropertyType.GetGenericTypeDefinition() == typeof(Option<>);
 
             if (isOptionType)
             {
-                var underlyingType = property.PropertyType!.GenericTypeArguments[0];
+                var underlyingType = property.PropertyType.GenericTypeArguments[0];
 
                 property.ShouldSerialize = CreateShouldSerializePredicate(property.PropertyType);
                 property.CustomConverter = (JsonConverter)Activator.CreateInstance(typeof(OptionJsonConverter<>).MakeGenericType(underlyingType))!;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Infrastructure/Json/OneOfJsonConverter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Infrastructure/Json/OneOfJsonConverter.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OneOf;
+
+namespace TeachingRecordSystem.Core.Infrastructure.Json;
+
+public class OneOfJsonConverter<T0, T1> : JsonConverter<OneOf<T0, T1>>
+{
+    public override OneOf<T0, T1> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, OneOf<T0, T1> value, JsonSerializerOptions options)
+    {
+        value.Switch(
+            v => JsonSerializer.Serialize(writer, v, options),
+            v => JsonSerializer.Serialize(writer, v, options));
+    }
+}
+
+public class OneOfJsonConverterFactory : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(OneOf<,>);
+    }
+
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var converterType = typeof(OneOfJsonConverter<,>).MakeGenericType(typeToConvert.GetGenericArguments());
+        return (JsonConverter)Activator.CreateInstance(converterType)!;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -241,6 +241,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="NSign.Client" />
     <PackageReference Include="NSign.SignatureProviders" />
+    <PackageReference Include="OneOf" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" />
     <PackageReference Include="Optional" />
     <PackageReference Include="Parquet.Net" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/packages.lock.json
@@ -416,6 +416,12 @@
           "NSign.Abstractions": "1.1.0"
         }
       },
+      "OneOf": {
+        "type": "Direct",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
+      },
       "OpenIddict.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[5.2.0, )",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/packages.lock.json
@@ -2364,6 +2364,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2836,6 +2837,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/packages.lock.json
@@ -2207,6 +2207,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2618,6 +2619,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Worker/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Worker/packages.lock.json
@@ -2109,6 +2109,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2520,6 +2521,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/packages.lock.json
@@ -2307,6 +2307,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2853,6 +2854,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
@@ -2250,6 +2250,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2806,6 +2807,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/packages.lock.json
@@ -2404,6 +2404,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2985,6 +2986,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.AspNetCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
@@ -2388,6 +2388,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2969,6 +2970,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.AspNetCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/packages.lock.json
@@ -2105,6 +2105,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2530,6 +2531,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/packages.lock.json
@@ -2103,6 +2103,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2559,6 +2560,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
@@ -2461,6 +2461,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -3088,6 +3089,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
@@ -2466,6 +2466,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -3079,6 +3080,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/packages.lock.json
@@ -2026,6 +2026,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2446,6 +2447,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
@@ -2038,6 +2038,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2555,6 +2556,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.WebCommon.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.WebCommon.Tests/packages.lock.json
@@ -2246,6 +2246,7 @@
           "NSign.SignatureProviders": "[1.1.0, )",
           "Npgsql.DependencyInjection": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.10, )",
+          "OneOf": "[3.0.271, )",
           "OpenIddict.EntityFrameworkCore": "[5.2.0, )",
           "Optional": "[4.0.0, )",
           "Parquet.Net": "[4.24.0, )",
@@ -2718,6 +2719,12 @@
         "dependencies": {
           "NSign.Abstractions": "1.1.0"
         }
+      },
+      "OneOf": {
+        "type": "CentralTransitive",
+        "requested": "[3.0.271, )",
+        "resolved": "3.0.271",
+        "contentHash": "pqpqeK8xQGggExhr4tesVgJkjdn+9HQAO0QgrYV2hFjE3y90okzk1kQMntMiUOGfV7FrCUfKPaVvPBD4IANqKg=="
       },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",


### PR DESCRIPTION
The `/v3/persons/<trn>` endpoint returns a different `initialTeacherTraining` object if the calling user has the `AppropriateBody` role. The way we did this before wan't great; we wrapped every property in `Option<>` then had to apply custom type converters to get things to AutoMap.

This changes that process to use a discriminated union type (`OneOf` in this case).