### PR TITLE
Assert on response to surface test failure caused by timeout

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
@@ -507,9 +507,10 @@ public class CheckAnswersTests : ResolveApiTrnRequestTestBase
         var matchedCrmContact = XrmFakedContext.CreateQuery<Contact>().Single(c => c.Id == matchedPerson.ContactId).Clone();
 
         // Act
-        await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);
 
         // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         var updatedContact = XrmFakedContext.CreateQuery<Contact>().Single(c => c.Id == matchedPerson.ContactId);
 
         static object? FormatValue(object? value) =>


### PR DESCRIPTION
Test was failing due to request timeout which caused a race condition in FakeXrmEasy - assert on response status to make the cause of failure more explicit