### PR TITLE
Sync QTS/EYTS to TRS from TestData methods

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
@@ -3,15 +3,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Dqt.Models;
-using TeachingRecordSystem.Core.Dqt.Queries;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
 public class InductionModel(
     TrsDbContext dbContext,
-    ICrmQueryDispatcher crmQueryDispatcher,
     IClock clock,
     ReferenceDataCache referenceDataCache,
     IAuthorizationService authorizationService,
@@ -64,12 +61,6 @@ public class InductionModel(
             .Include(p => p.Qualifications)
             .SingleAsync(q => q.PersonId == PersonId);
 
-        GetActiveContactDetailByIdQuery query = new(
-            person.PersonId,
-            ColumnSet: new ColumnSet(Contact.Fields.dfeta_QTSDate));
-
-        var result = await crmQueryDispatcher.ExecuteQueryAsync(query);
-
         Status = person.InductionStatus;
         StartDate = person.InductionStartDate;
         CompletedDate = person.InductionCompletedDate;
@@ -80,7 +71,7 @@ public class InductionModel(
             .Select(i => i.Name)
             .OrderDescending();
         _statusIsManagedByCpd = person.InductionStatusManagedByCpd(clock.Today);
-        HasQts = result!.Contact.dfeta_QTSDate is not null;
+        HasQts = person.QtsDate is not null;
 
         if (featureProvider.IsEnabled(FeatureNames.RoutesToProfessionalStatus))
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -92,7 +92,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null))
             .WithInductionStatus(i => i.WithStatus(InductionStatus.Passed).WithStartDate(new(2022, 1, 1)).WithCompletedDate(new DateOnly(2023, 1, 1)))
-            .WithQts(qtsDate: new(2021, 7, 1))
+            .WithQts(holdsFrom: new(2021, 7, 1))
             .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
 
         var person2 = await TestData.CreatePersonAsync(p => p

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -83,7 +83,7 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithDateOfBirth(dateOfBirth)
-            .WithQts(qtsDate: new(2021, 7, 1))
+            .WithQts(holdsFrom: new(2021, 7, 1))
             .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
@@ -128,7 +128,7 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null))
             .WithInductionStatus(i => i.WithStatus(InductionStatus.Passed).WithStartDate(new(2022, 1, 1)).WithCompletedDate(new DateOnly(2023, 1, 1)))
-            .WithQts(qtsDate: new(2021, 7, 1))
+            .WithQts(holdsFrom: new(2021, 7, 1))
             .WithEyts(eytsDate: new(2021, 8, 1), eytsStatusValue: "222"));
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -79,8 +79,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithLastName(lastName)
-            .WithQtlsDateInDqt(qtlsDate)
-            .WithDateOfBirth(dateOfBirth));
+            .WithDateOfBirth(dateOfBirth)
+            .WithQtls(qtlsDate));
 
         var entity = new Microsoft.Xrm.Sdk.Entity() { Id = person.PersonId, LogicalName = Contact.EntityLogicalName };
         entity[Contact.Fields.dfeta_qtlsdate] = null;
@@ -110,8 +110,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithLastName(lastName)
-            .WithQtlsDateInDqt(qtlsDate)
-            .WithDateOfBirth(dateOfBirth));
+            .WithDateOfBirth(dateOfBirth)
+            .WithQtls(qtlsDate));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -132,6 +132,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         // Arrange
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
+
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithLastName(lastName)
@@ -160,12 +161,13 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var qtsDate = DateOnly.Parse(qtsDateStr);
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
+
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithQts(qtsDate)
-            .WithQtlsDateInDqt(qtlsDate));
+            .WithQtls(qtlsDate));
 
         var status = await ReferenceCache.GetTeacherStatusByValueAsync("71"); //qualified teacher
         var qtsRegistration = new dfeta_qtsregistration() { dfeta_QTSDate = qtsDate.ToDateTime(), dfeta_TeacherStatusId = status.ToEntityReference() };

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -100,9 +100,9 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
-            .WithQtlsDateInDqt(qtlsDate)
             .WithLastName(lastName)
-            .WithDateOfBirth(dateOfBirth));
+            .WithDateOfBirth(dateOfBirth)
+            .WithQtls(qtlsDate));
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/v3/persons/find")
         {
@@ -174,9 +174,9 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
-            .WithQtlsDateInDqt(qtlsDate)
             .WithLastName(lastName)
-            .WithDateOfBirth(dateOfBirth));
+            .WithDateOfBirth(dateOfBirth)
+            .WithQtls(qtlsDate));
 
         var entity = new Microsoft.Xrm.Sdk.Entity() { Id = person.PersonId, LogicalName = Contact.EntityLogicalName };
         entity[Contact.Fields.dfeta_qtlsdate] = null;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonByTrnTests.cs
@@ -151,8 +151,7 @@ public class GetPersonByTrnTests : TestBase
         var qtlsDate = new DateOnly(2020, 01, 01);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQtlsDateInDqt(qtlsDate));
+            .WithTrn().WithQtls(qtlsDate));
 
         // Arrange
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=Induction");
@@ -173,8 +172,7 @@ public class GetPersonByTrnTests : TestBase
         var qtlsDate = new DateOnly(2020, 01, 01);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQtlsDateInDqt(qtlsDate));
+            .WithTrn().WithQtls(qtlsDate));
 
         var entity = new Microsoft.Xrm.Sdk.Entity() { Id = person.PersonId, LogicalName = Contact.EntityLogicalName };
         entity[Contact.Fields.dfeta_qtlsdate] = null;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonTests.cs
@@ -71,8 +71,7 @@ public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var qtlsDate = new DateOnly(2020, 01, 01);
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQtlsDateInDqt(qtlsDate));
+            .WithTrn().WithQtls(qtlsDate));
 
         // Arrange
         var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person");
@@ -111,8 +110,7 @@ public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var qtlsDate = new DateOnly(2020, 01, 01);
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQtlsDateInDqt(qtlsDate));
+            .WithTrn().WithQtls(qtlsDate));
 
         var entity = new Microsoft.Xrm.Sdk.Entity() { Id = person.PersonId, LogicalName = Contact.EntityLogicalName };
         entity[Contact.Fields.dfeta_qtlsdate] = null;
@@ -141,8 +139,7 @@ public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var activeHeQualificationWithNoSubjectsId = Guid.NewGuid();
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
-            .WithQts(qtsDate)
-            .WithQtlsDateInDqt(qtlsDate));
+            .WithQts(qtsDate).WithQtls(qtlsDate));
         var status = await ReferenceCache.GetTeacherStatusByValueAsync("71"); //qualified teacher
         var qtsRegistration = new dfeta_qtsregistration() { dfeta_QTSDate = qtsDate.ToDateTime(), dfeta_TeacherStatusId = status.ToEntityReference() };
         DataverseAdapterMock.Setup(x => x.GetQtsRegistrationsByTeacherAsync(It.IsAny<Guid>(), It.IsAny<string[]>())).ReturnsAsync(new[] { qtsRegistration });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
@@ -12,12 +12,10 @@ public class GetPersonByTrnTests : TestBase
     public async Task Get_PersonWithQtlsAndQtsViaAnotherRoute_ReturnsExpectedAwardedOrApprovedCount()
     {
         // Arrange
-
-
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
             .WithQts()
-            .WithQtlsDateInDqt(Clock.Today));
+            .WithQtls(Clock.Today));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests_Dqt.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests_Dqt.cs
@@ -51,7 +51,7 @@ public partial class GetQtlsTests
 
             var qtlsDate = new DateOnly(2025, 5, 1);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithQtlsDateInDqt(qtlsDate));
+            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithQtls(qtlsDate));
 
             var command = new GetQtlsCommand(person.Trn!);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests_Dqt.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests_Dqt.cs
@@ -36,7 +36,15 @@ public partial class SetQtlsTests
             DateOnly? existingQtlsDate = hasExistingDate ? new DateOnly(2025, 4, 1) : null;
             DateOnly? newQtlsDate = hasNewDate ? new DateOnly(2025, 4, 10) : null;
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithQtlsDateInDqt(existingQtlsDate));
+            var person = await TestData.CreatePersonAsync(p =>
+            {
+                p.WithTrn();
+
+                if (existingQtlsDate is DateOnly qtlsDate)
+                {
+                    p.WithQtls(qtlsDate);
+                }
+            });
 
             var command = new SetQtlsCommand(person.Trn!, QtsDate: newQtlsDate);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/HostFixture.cs
@@ -12,7 +12,6 @@ using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
-using TeachingRecordSystem.TestCommon.Infrastructure;
 using TeachingRecordSystem.UiTestCommon.Infrastructure.FormFlow;
 using TeachingRecordSystem.WebCommon.FormFlow.State;
 
@@ -98,7 +97,6 @@ public sealed class HostFixture(IConfiguration configuration) : IAsyncDisposable
                     services.AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>();
                     services.AddSingleton(GetMockFileService());
                     services.AddSingleton<IGetAnIdentityApiClient>(Mock.Of<IGetAnIdentityApiClient>());
-                    services.AddStartupTask<SeedLookupData>();
 
                     IFileService GetMockFileService()
                     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/PluginTests/QTSRegistrationDeleteTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/PluginTests/QTSRegistrationDeleteTests.cs
@@ -28,7 +28,7 @@ public class QTSRegistrationDeleteTests : IAsyncLifetime
         // Act
         var createPersonResult = await _dataScope.TestData.CreatePersonAsync(x =>
         {
-            x.WithQtlsDateInDqt(new DateOnly(2021, 01, 1));
+            x.WithQtls(new DateOnly(2021, 01, 1));
         });
         var person = await _crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByIdQuery(createPersonResult.PersonId, ColumnSet: new(
             Contact.Fields.dfeta_QTSDate)));
@@ -66,7 +66,7 @@ public class QTSRegistrationDeleteTests : IAsyncLifetime
         var createPersonResult = await _dataScope.TestData.CreatePersonAsync(x =>
         {
             x.WithQts(qtsDate);
-            x.WithQtlsDateInDqt(qtlsDate);
+            x.WithQtls(qtlsDate);
         });
         var person = await _crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByIdQuery(createPersonResult.PersonId, ColumnSet: new(
             Contact.Fields.dfeta_QTSDate)));
@@ -86,7 +86,7 @@ public class QTSRegistrationDeleteTests : IAsyncLifetime
         var createPersonResult = await _dataScope.TestData.CreatePersonAsync(x =>
         {
             x.WithQts(qtsDate);
-            x.WithQtlsDateInDqt(qtlsDate);
+            x.WithQtls(qtlsDate);
         });
         var person = await _crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByIdQuery(createPersonResult.PersonId, ColumnSet: new(
             Contact.Fields.dfeta_QTSDate)));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/PluginTests/UpdateQtlsDateSetTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/PluginTests/UpdateQtlsDateSetTests.cs
@@ -28,7 +28,7 @@ public class UpdateQtlsDateSetTests : IAsyncLifetime
         // Act
         var createPersonResult = await _dataScope.TestData.CreatePersonAsync(x =>
         {
-            x.WithQtlsDateInDqt(new DateOnly(2021, 01, 1));
+            x.WithQtls(new DateOnly(2021, 01, 1));
         });
         var person = await _crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByIdQuery(createPersonResult.PersonId, ColumnSet: new(
             Contact.Fields.dfeta_QtlsDateHasBeenSet)));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/SetQtlsDateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/SetQtlsDateTests.cs
@@ -41,7 +41,7 @@ public class SetQtlsDateTests : IAsyncLifetime
         var qtlsDate = new DateOnly(2021, 01, 01);
         var createPersonResult = await _dataScope.TestData.CreatePersonAsync(x =>
         {
-            x.WithQtlsDateInDqt(qtlsDate);
+            x.WithQtls(qtlsDate);
         });
 
         // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
@@ -387,7 +387,7 @@ public class InductionImporterTests : IAsyncLifetime
         });
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithQtlsDateInDqt(new DateOnly(2024, 01, 01));
+            x.WithQtls(new DateOnly(2024, 01, 01));
         });
         var row = GetDefaultRow(x =>
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -10,7 +10,6 @@ using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.EndToEndTests.Infrastructure.Security;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
-using TeachingRecordSystem.TestCommon.Infrastructure;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
@@ -85,7 +84,6 @@ public sealed class HostFixture : IAsyncDisposable, IStartupTask
                     services.AddSingleton(GetMockFileService());
                     services.AddSingleton(GetMockAdUserService());
                     services.AddSingleton(GetMockGetAnIdentityApiClient());
-                    services.AddStartupTask<SeedLookupData>();
 
                     IFileService GetMockFileService()
                     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/InductionTests.cs
@@ -502,18 +502,15 @@ public class InductionTests : TestBase
         var routeType = (await TestData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.InductionExemptionReasonId == exemptionReasonId)
             .Single();
-        var person = await TestData.CreatePersonAsync(
-                personBuilder => personBuilder
-                .WithQts()
-                .WithInductionStatus(inductionBuilder => inductionBuilder
-                    .WithStatus(InductionStatus.Exempt)
-                    .WithExemptionReasons(exemptionReasonId))
-                .WithRouteToProfessionalStatus(r => r
-                    .WithRouteType(routeType.RouteToProfessionalStatusTypeId)
-                    .WithStatus(RouteToProfessionalStatusStatus.Holds)
-                    .WithInductionExemption(true)
-                    .WithHoldsFrom(holdsFromDate))
-                );
+        var person = await TestData.CreatePersonAsync(personBuilder => personBuilder
+            .WithRouteToProfessionalStatus(r => r
+                .WithRouteType(routeType.RouteToProfessionalStatusTypeId)
+                .WithStatus(RouteToProfessionalStatusStatus.Holds)
+                .WithInductionExemption(true)
+                .WithHoldsFrom(holdsFromDate))
+            .WithInductionStatus(inductionBuilder => inductionBuilder
+                .WithStatus(InductionStatus.Exempt)
+                .WithExemptionReasons(exemptionReasonId)));
         var personId = person.ContactId;
 
         await using var context = await HostFixture.CreateBrowserContext();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -47,7 +47,6 @@ public class HostFixture : WebApplicationFactory<Program>
             // Publish events synchronously
             PublishEventsDbCommandInterceptor.ConfigureServices(services);
 
-            services.AddStartupTask<SeedLookupData>();
             services.AddSingleton<CurrentUserProvider>();
             services.AddSingleton<TestUsers>();
             services.AddSingleton<IEventObserver>(_ => new ForwardToTestScopedEventObserver());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
@@ -256,7 +256,7 @@ public class IndexTests : TestBase
         Assert.Null(doc.GetSummaryListValueForKey("EYTS held since"));
         Assert.Null(doc.GetSummaryListValueForKey("PQTS held since"));
         Assert.Equal("No", doc.GetSummaryListValueForKey("Early years practitioner status (EYPS)"));
-        Assert.Null(doc.GetSummaryListValueForKey("Induction status"));
+        Assert.NotNull(doc.GetSummaryListValueForKey("Induction status"));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -290,6 +290,15 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
         await WithDbContext(async dbContext =>
         {
             dbContext.Attach(person.Person);
+
+            // Force status to `None` so that the SetCpdInductionStatus() call below always has a change to status
+            person.Person.UnsafeSetInductionStatus(
+                InductionStatus.None,
+                InductionStatus.None,
+                startDate: null,
+                completedDate: null,
+                exemptionReasonIds: []);
+
             person.Person.SetCpdInductionStatus(
                 status,
                 startDate: status.RequiresStartDate() ? lessThanSevenYearsAgo.AddYears(-1) : null,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
@@ -246,7 +246,6 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var status = RouteToProfessionalStatusStatus.Holds;
         var qtsDate = Clock.Today.AddYears(-1);
         var person = await TestData.CreatePersonAsync(p => p
-            .WithQts(qtsDate)
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(status)
@@ -302,7 +301,6 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var holdsFromEarliest = Clock.Today.AddYears(-1);
         var holdsFromLatest = holdsFromEarliest.AddMonths(1);
         var person = await TestData.CreatePersonAsync(p => p
-            .WithQts(holdsFromEarliest)
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Holds)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Respawn;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.TestCommon.Infrastructure;
 using SystemUser = TeachingRecordSystem.Core.DataStore.Postgres.Models.SystemUser;
 
 namespace TeachingRecordSystem.TestCommon;
@@ -23,6 +24,7 @@ public class DbHelper(IDbContextFactory<TrsDbContext> dbContextFactory)
         services.AddSingleton<DbHelper>();
 
         services.AddStartupTask(sp => sp.GetRequiredService<DbHelper>().EnsureSchemaAsync());
+        services.AddStartupTask<SeedLookupData>();
     }
 
     public async Task ClearDataAsync()
@@ -111,7 +113,8 @@ public class DbHelper(IDbContextFactory<TrsDbContext> dbContextFactory)
                     "route_to_professional_status_types",
                     "countries",
                     "training_subjects",
-                    "degree_types"
+                    "degree_types",
+                    "training_providers"
                 ]
             });
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/SeedLookupData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/SeedLookupData.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.TestCommon.Infrastructure;
 
-public class SeedLookupData(TrsDbContext dbContext) : IStartupTask
+public class SeedLookupData(IDbContextFactory<TrsDbContext> dbContextFactory) : IStartupTask
 {
     Task IStartupTask.ExecuteAsync()
     {
@@ -12,20 +12,29 @@ public class SeedLookupData(TrsDbContext dbContext) : IStartupTask
 
     private async Task AddTrainingProvidersAsync()
     {
-        await dbContext.TrainingProviders.AddAsync(new TrainingProvider()
+        using var dbContext = dbContextFactory.CreateDbContext();
+
+        if (await dbContext.TrainingProviders.AnyAsync())
+        {
+            return;
+        }
+
+        dbContext.TrainingProviders.Add(new TrainingProvider()
         {
             IsActive = true,
             Name = "TestProviderName",
             TrainingProviderId = Guid.NewGuid(),
             Ukprn = "11111111"
         });
-        await dbContext.TrainingProviders.AddAsync(new TrainingProvider()
+
+        dbContext.TrainingProviders.Add(new TrainingProvider()
         {
             IsActive = false,
             Name = "TestProviderNameInactive",
             TrainingProviderId = Guid.NewGuid(),
             Ukprn = "23456789"
         });
+
         await dbContext.SaveChangesAsync();
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -16,11 +16,18 @@ namespace TeachingRecordSystem.TestCommon;
 
 public partial class TestData
 {
-    public Task<CreatePersonResult> CreatePersonAsync(Action<CreatePersonBuilder>? configure = null)
+    public async Task<CreatePersonResult> CreatePersonAsync(Action<CreatePersonBuilder>? configure = null)
     {
-        var builder = new CreatePersonBuilder();
+        var referenceData = new CreatePersonBuilder.ReferenceData(
+            await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync(),
+            await ReferenceDataCache.GetDegreeTypesAsync(),
+            await ReferenceDataCache.GetTrainingProvidersAsync(),
+            await ReferenceDataCache.GetTrainingSubjectsAsync(),
+            await ReferenceDataCache.GetTrainingCountriesAsync());
+
+        var builder = new CreatePersonBuilder(referenceData);
         configure?.Invoke(builder);
-        return builder.ExecuteAsync(this);
+        return await builder.ExecuteAsync(this);
     }
 
     public class CreatePersonBuilder
@@ -29,6 +36,7 @@ public partial class TestData
 
         private static readonly DateOnly _defaultQtsDate = new DateOnly(2022, 9, 1);
 
+        private readonly ReferenceData _referenceData;
         private bool? _syncEnabledOverride;
         private DateOnly? _dateOfBirth;
         private bool? _hasTrn;
@@ -44,8 +52,7 @@ public partial class TestData
         private readonly List<QtsRegistration> _qtsRegistrations = new();
         private readonly List<CreatePersonAlertBuilder> _alertBuilders = [];
         private readonly List<CreatePersonMandatoryQualificationBuilder> _mqBuilders = [];
-        private readonly List<CreatePersonProfessionalStatusBuilder> _professionalStatusBuilders = [];
-        private readonly List<ProfessionalStatusType> _awardedProfessionalStatuses = [];
+        private readonly List<CreatePersonRouteToProfessionalStatusBuilder> _routeToProfessionalStatusBuilders = [];
         private readonly List<(string FirstName, string MiddleName, string LastName, DateTime Created)> _previousNames = [];
         private DateOnly? _qtlsDate;
         private (Guid ApplicationUserId, string RequestId, bool WriteMetadata, bool? IdentityVerified, string? OneLoginUserSubject, bool? PotentialDuplicate)? _trnRequest;
@@ -53,6 +60,11 @@ public partial class TestData
         private string? _slugId;
         private int? _loginFailedCounter;
         private CreatePersonInductionBuilder? _inductionBuilder;
+
+        internal CreatePersonBuilder(ReferenceData referenceData)
+        {
+            _referenceData = referenceData;
+        }
 
         public Guid PersonId { get; } = Guid.NewGuid();
 
@@ -137,22 +149,86 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithRouteToProfessionalStatus(Action<CreatePersonProfessionalStatusBuilder>? configure = null)
+        public CreatePersonBuilder WithRouteToProfessionalStatus(Action<CreatePersonRouteToProfessionalStatusBuilder> configure)
         {
             EnsureTrn();
 
-            var builder = new CreatePersonProfessionalStatusBuilder();
-            configure?.Invoke(builder);
-            _professionalStatusBuilders.Add(builder);
+            var builder = new CreatePersonRouteToProfessionalStatusBuilder();
+            configure.Invoke(builder);
+            _routeToProfessionalStatusBuilders.Add(builder);
 
             return this;
         }
 
-        public CreatePersonBuilder WithHoldsRouteToProfessionalStatus(ProfessionalStatusType professionalStatusType)
+        public CreatePersonBuilder WithHoldsRouteToProfessionalStatus(ProfessionalStatusType professionalStatusType) =>
+            WithHoldsRouteToProfessionalStatus(professionalStatusType, _defaultQtsDate);
+
+        public CreatePersonBuilder WithHoldsRouteToProfessionalStatus(
+            ProfessionalStatusType professionalStatusType,
+            DateOnly holdsFrom)
+        {
+            var routeType = _referenceData.RouteTypes
+                .Where(r => r.ProfessionalStatusType == professionalStatusType)
+                .RandomOne();
+
+            return WithHoldsRouteToProfessionalStatus(routeType.RouteToProfessionalStatusTypeId, holdsFrom);
+        }
+
+        public CreatePersonBuilder WithHoldsRouteToProfessionalStatus(
+            Guid routeToProfessionalStatusTypeId,
+            DateOnly holdsFrom)
         {
             EnsureTrn();
-            _awardedProfessionalStatuses.Add(professionalStatusType);
-            return this;
+
+            var routeType = _referenceData.RouteTypes.Single(r => r.RouteToProfessionalStatusTypeId == routeToProfessionalStatusTypeId);
+
+            return WithRouteToProfessionalStatus(b =>
+            {
+                b
+                    .WithRouteType(routeToProfessionalStatusTypeId)
+                    .WithStatus(RouteToProfessionalStatusStatus.Holds)
+                    .WithHoldsFrom(holdsFrom);
+
+                ConfigureUnlessNotApplicable(
+                    routeType.TrainingStartDateRequired,
+                    () => b.WithTrainingStartDate(new(2021, 10, 1)));
+
+                ConfigureUnlessNotApplicable(
+                    routeType.TrainingEndDateRequired,
+                    () => b.WithTrainingEndDate(new(2022, 7, 5)));
+
+                ConfigureUnlessNotApplicable(
+                    routeType.TrainingSubjectsRequired,
+                    () => b.WithTrainingSubjectIds([_referenceData.TrainingSubjects.RandomOne().TrainingSubjectId]));
+
+                ConfigureUnlessNotApplicable(
+                    routeType.TrainingAgeSpecialismTypeRequired,
+                    () => b.WithTrainingAgeSpecialismType(TrainingAgeSpecialismType.FoundationStage));
+
+                ConfigureUnlessNotApplicable(
+                    routeType.TrainingCountryRequired,
+                    () => b.WithTrainingCountryId(_referenceData.Countries.RandomOne().CountryId));
+
+                ConfigureUnlessNotApplicable(
+                    routeType.TrainingProviderRequired,
+                    () => b.WithTrainingProviderId(_referenceData.TrainingProviders.RandomOne().TrainingProviderId));
+
+                ConfigureUnlessNotApplicable(
+                    routeType.DegreeTypeRequired,
+                    () => b.WithDegreeTypeId(_referenceData.DegreeTypes.RandomOne().DegreeTypeId));
+
+                ConfigureUnlessNotApplicable(
+                    routeType.InductionExemptionRequired,
+                    () => b.WithInductionExemption(false));
+
+                void ConfigureUnlessNotApplicable(FieldRequirement requirement, Action configure)
+                {
+                    if (requirement is not FieldRequirement.NotApplicable)
+                    {
+                        configure();
+                    }
+                }
+            });
         }
 
         public CreatePersonBuilder WithoutTrn()
@@ -162,6 +238,7 @@ public partial class TestData
                 _qtlsDate.HasValue ||
                 _qtsRegistrations.Any() ||
                 _qualifications.Any() ||
+                _routeToProfessionalStatusBuilders.Any() ||
                 _inductionBuilder?.HasStatusRequiringQts == true)
             {
                 throw new InvalidOperationException("Person requires a TRN.");
@@ -202,26 +279,50 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithQts(DateOnly? qtsDate = null)
+        public CreatePersonBuilder WithQts() => WithQts(_defaultQtsDate);
+
+        public CreatePersonBuilder WithQts(DateOnly holdsFrom)
         {
             EnsureTrn();
 
             _qtsRegistrations.Add(
                 new QtsRegistration(
-                    qtsDate ?? _defaultQtsDate,
+                    holdsFrom,
                     TeacherStatusValue: TeacherStatusQualifiedTeacherTrained,
                     CreatedOn: null,
                     EytsDate: null,
                     EytsStatusValue: null));
 
+            WithHoldsRouteToProfessionalStatus(
+                routeToProfessionalStatusTypeId: new("4163C2FB-6163-409F-85FD-56E7C70A54DD"),
+                holdsFrom);
+
             return this;
         }
 
-        public CreatePersonBuilder WithQtlsDateInDqt(DateOnly? qtlsDate)
+        public CreatePersonBuilder WithQtls() => WithQtls(_defaultQtsDate);
+
+        public CreatePersonBuilder WithQtls(DateOnly holdsFrom)
         {
             EnsureTrn();
 
-            _qtlsDate = qtlsDate;
+            _qtlsDate = holdsFrom;
+
+            WithRouteToProfessionalStatus(p => p
+                .WithStatus(RouteToProfessionalStatusStatus.Holds)
+                .WithHoldsFrom(holdsFrom)
+                .WithRouteType(RouteToProfessionalStatusType.QtlsAndSetMembershipId));
+
+            return this;
+        }
+
+        public CreatePersonBuilder WithEyts(DateOnly holdsFrom)
+        {
+            EnsureTrn();
+
+            _qtsRegistrations.Add(new QtsRegistration(null, null, null, holdsFrom, "222"));
+
+            WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.EarlyYearsTeacherStatus, holdsFrom);
 
             return this;
         }
@@ -243,12 +344,6 @@ public partial class TestData
 
             return this;
         }
-
-        public CreatePersonBuilder WithQtls(DateOnly holdsFrom) =>
-            WithRouteToProfessionalStatus(p => p
-                .WithStatus(RouteToProfessionalStatusStatus.Holds)
-                .WithHoldsFrom(holdsFrom)
-                .WithRouteType(RouteToProfessionalStatusType.QtlsAndSetMembershipId));
 
         public CreatePersonBuilder WithTrnRequest(
             Guid applicationUserId,
@@ -571,8 +666,7 @@ public partial class TestData
                 _inductionBuilder?.Execute(person, this, testData, dbContext);
                 var mqIds = await AddMqsAsync();
                 var alertIds = await AddAlertsAsync();
-                var professionalStatusIds = await AddProfessionalStatusRoutesAsync(person);
-                var awardedProfessionalStatusIds = await AddAwardedProfessionalStatusRoutesAsync();
+                var routeIds = await AddProfessionalStatusRoutesAsync(person);
                 var previousNameIds = await AddPreviousNamesAsync();
 
                 await dbContext.SaveChangesAsync();
@@ -589,15 +683,15 @@ public partial class TestData
                     .Where(q => q.PersonId == PersonId)
                     .ToArrayAsync();
 
-                var personProfessionalStatuses = await dbContext.RouteToProfessionalStatuses
+                var personRoutes = await dbContext.RouteToProfessionalStatuses
                     .Where(p => p.PersonId == PersonId)
                     .ToArrayAsync();
 
                 // Get MQs, Alerts and Professional Statuses that we've added *in the same order they were specified*.
                 var mqs = mqIds.Select(id => personMqs.Single(q => q.QualificationId == id)).AsReadOnly();
                 var alerts = alertIds.Select(id => person.Alerts!.Single(a => a.AlertId == id)).AsReadOnly();
-                var routesToProfessionalStatus = professionalStatusIds.Concat(awardedProfessionalStatusIds)
-                    .Select(id => personProfessionalStatuses.Single(q => q.QualificationId == id))
+                var routesToProfessionalStatus = routeIds
+                    .Select(id => personRoutes.Single(q => q.QualificationId == id))
                     .AsReadOnly();
                 var previousNames = previousNameIds.Select(id => person.PreviousNames!.Single(a => a.PreviousNameId == id)).AsReadOnly();
 
@@ -621,7 +715,7 @@ public partial class TestData
                 {
                     var routeIds = new List<Guid>();
 
-                    foreach (var builder in _professionalStatusBuilders)
+                    foreach (var builder in _routeToProfessionalStatusBuilders)
                     {
                         var (routeId, createdEvents) = await builder.ExecuteAsync(this, person, testData, dbContext);
                         routeIds.Add(routeId);
@@ -629,52 +723,6 @@ public partial class TestData
                     }
 
                     return routeIds;
-                }
-
-                async Task<IReadOnlyCollection<Guid>> AddAwardedProfessionalStatusRoutesAsync()
-                {
-                    var allRoutes = await testData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync(activeOnly: false);
-                    var allSubjects = await testData.ReferenceDataCache.GetTrainingSubjectsAsync();
-                    var allCountries = await testData.ReferenceDataCache.GetTrainingCountriesAsync();
-                    var allProviders = await testData.ReferenceDataCache.GetTrainingProvidersAsync();
-                    var allDegreeTypes = await testData.ReferenceDataCache.GetDegreeTypesAsync();
-
-                    var createdProfessionalStatusIds = new List<Guid>();
-
-                    foreach (var professionalStatusType in _awardedProfessionalStatuses)
-                    {
-                        var route = allRoutes.Where(r => r.ProfessionalStatusType == professionalStatusType).RandomOne();
-
-                        var professionalStatus = RouteToProfessionalStatus.Create(
-                                person,
-                                allRoutes,
-                                route.RouteToProfessionalStatusTypeId,
-                                RouteToProfessionalStatusStatus.Holds,
-                                testData.GenerateDate(min: new(2022, 8, 1), max: new(2025, 1, 1)),
-                                route.TrainingStartDateRequired is not FieldRequirement.NotApplicable ? new(2021, 10, 1) : null,
-                                route.TrainingEndDateRequired is not FieldRequirement.NotApplicable ? new(2022, 7, 5) : null,
-                                route.TrainingSubjectsRequired is not FieldRequirement.NotApplicable ?
-                                new[] { allSubjects.RandomOne().TrainingSubjectId } :
-                                [],
-                                route.TrainingAgeSpecialismTypeRequired is not FieldRequirement.NotApplicable ? TrainingAgeSpecialismType.FoundationStage : null,
-                                null,
-                                null,
-                                route.TrainingCountryRequired is not FieldRequirement.NotApplicable ? allCountries.RandomOne().CountryId : null,
-                                allProviders.RandomOne().TrainingProviderId,
-                                route.DegreeTypeRequired is not FieldRequirement.NotApplicable ? allDegreeTypes.RandomOne().DegreeTypeId : null,
-                                route.InductionExemptionRequired is not FieldRequirement.NotApplicable ? false : null,
-                                EventModels.RaisedByUserInfo.FromUserId(Core.DataStore.Postgres.Models.SystemUser.SystemUserId),
-                                DateTime.UtcNow,
-                                out var @createdEvent
-                                );
-
-                        dbContext.RouteToProfessionalStatuses.Add(professionalStatus);
-                        dbContext.AddEventWithoutBroadcast(createdEvent);
-
-                        createdProfessionalStatusIds.Add(professionalStatus.QualificationId);
-                    }
-
-                    return createdProfessionalStatusIds;
                 }
 
                 async Task<IReadOnlyCollection<Guid>> AddAlertsAsync()
@@ -818,6 +866,13 @@ public partial class TestData
 
         internal DateOnly EnsureQts() => GetQtsDate() ??
             throw new InvalidOperationException("Person requires QTS.");
+
+        internal record ReferenceData(
+            IReadOnlyCollection<RouteToProfessionalStatusType> RouteTypes,
+            IReadOnlyCollection<DegreeType> DegreeTypes,
+            IReadOnlyCollection<TrainingProvider> TrainingProviders,
+            IReadOnlyCollection<TrainingSubject> TrainingSubjects,
+            IReadOnlyCollection<Country> Countries);
     }
 
     public class CreatePersonAlertBuilder

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonRouteToProfessionalStatusBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonRouteToProfessionalStatusBuilder.cs
@@ -5,9 +5,8 @@ namespace TeachingRecordSystem.TestCommon;
 
 public partial class TestData
 {
-    public class CreatePersonProfessionalStatusBuilder
+    public class CreatePersonRouteToProfessionalStatusBuilder
     {
-        private Guid? _personId = null;
         private Guid? _routeToProfessionalStatusTypeId;
         private RouteToProfessionalStatusStatus _status;
         private DateOnly? _holdsFrom;
@@ -23,96 +22,85 @@ public partial class TestData
         private bool? _exemptFromInduction;
         private EventModels.RaisedByUserInfo? _createdByUser;
 
-        public CreatePersonProfessionalStatusBuilder WithPersonId(Guid personId)
-        {
-            if (_personId is not null && _personId != personId)
-            {
-                throw new InvalidOperationException("PersonId has already been set");
-            }
-
-            _personId = personId;
-            return this;
-        }
-
-        public CreatePersonProfessionalStatusBuilder WithStatus(RouteToProfessionalStatusStatus status)
+        public CreatePersonRouteToProfessionalStatusBuilder WithStatus(RouteToProfessionalStatusStatus status)
         {
             _status = status;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithHoldsFrom(DateOnly holdsFrom)
+        public CreatePersonRouteToProfessionalStatusBuilder WithHoldsFrom(DateOnly holdsFrom)
         {
             _holdsFrom = holdsFrom;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingStartDate(DateOnly trainingStartDate)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingStartDate(DateOnly trainingStartDate)
         {
             _trainingStartDate = trainingStartDate;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingEndDate(DateOnly trainingEndDate)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingEndDate(DateOnly trainingEndDate)
         {
             _trainingEndDate = trainingEndDate;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingSubjectIds(Guid[] trainingSubjectIds)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingSubjectIds(Guid[] trainingSubjectIds)
         {
             _trainingSubjectIds = trainingSubjectIds;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingAgeSpecialismType(TrainingAgeSpecialismType trainingAgeSpecialismType)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingAgeSpecialismType(TrainingAgeSpecialismType trainingAgeSpecialismType)
         {
             _trainingAgeSpecialismType = trainingAgeSpecialismType;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingAgeSpecialismRangeFrom(int trainingAgeSpecialismRangeFrom)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingAgeSpecialismRangeFrom(int trainingAgeSpecialismRangeFrom)
         {
             _trainingAgeSpecialismRangeFrom = trainingAgeSpecialismRangeFrom;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingAgeSpecialismRangeTo(int trainingAgeSpecialismRangeTo)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingAgeSpecialismRangeTo(int trainingAgeSpecialismRangeTo)
         {
             _trainingAgeSpecialismRangeTo = trainingAgeSpecialismRangeTo;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithRouteType(Guid routeTypeId)
+        public CreatePersonRouteToProfessionalStatusBuilder WithRouteType(Guid routeTypeId)
         {
             _routeToProfessionalStatusTypeId = routeTypeId;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingCountryId(string trainingCountryId)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingCountryId(string trainingCountryId)
         {
             _trainingCountryId = trainingCountryId;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithTrainingProviderId(Guid trainingProviderId)
+        public CreatePersonRouteToProfessionalStatusBuilder WithTrainingProviderId(Guid trainingProviderId)
         {
             _trainingProviderId = trainingProviderId;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithDegreeTypeId(Guid degreeTypeId)
+        public CreatePersonRouteToProfessionalStatusBuilder WithDegreeTypeId(Guid degreeTypeId)
         {
             _degreeTypeId = degreeTypeId;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithInductionExemption(bool? isExempt)
+        public CreatePersonRouteToProfessionalStatusBuilder WithInductionExemption(bool? isExempt)
         {
             _exemptFromInduction = isExempt;
             return this;
         }
 
-        public CreatePersonProfessionalStatusBuilder WithCreatedByUser(EventModels.RaisedByUserInfo user)
+        public CreatePersonRouteToProfessionalStatusBuilder WithCreatedByUser(EventModels.RaisedByUserInfo user)
         {
             _createdByUser = user;
             return this;
@@ -130,10 +118,9 @@ public partial class TestData
             }
             if (_createdByUser is null)
             {
-                _createdByUser = EventModels.RaisedByUserInfo.FromUserId(Core.DataStore.Postgres.Models.SystemUser.SystemUserId);
+                _createdByUser = EventModels.RaisedByUserInfo.FromUserId(SystemUser.SystemUserId);
             }
 
-            var personId = createPersonBuilder.PersonId;
             var allRouteTypes = await testData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync();
 
             var professionalStatus = RouteToProfessionalStatus.Create(


### PR DESCRIPTION
Our current `WithQts`, `WithQtls` and `WithEyts` methods only write data to CRM. This changes them to also write to TRS. I've tidied up the overloads while I was at it.