### PR TITLE
Fix flaky tests caused by apostrophes in selectors

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/PageExtensions.cs
@@ -33,5 +33,5 @@ public static class PageExtensions
     }
 
     public static Task ClickButtonAsync(this IPage page, string text) =>
-        page.ClickAsync($".govuk-button:text-is('{text.Replace("'", "\\'")}')");
+        page.ClickAsync($".govuk-button{TestBase.TextIsSelector(text)}");
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/TestBase.cs
@@ -23,4 +23,10 @@ public abstract class TestBase(HostFixture hostFixture)
         var currentUserProvider = HostFixture.Services.GetRequiredService<OneLoginCurrentUserProvider>();
         currentUserProvider.CurrentUser = user;
     }
+
+    public static string TextSelector(string? text) => $":text(\"{text}\")";
+
+    public static string TextIsSelector(string? text) => $":text-is(\"{text}\")";
+
+    public static string HasTextSelector(string? text) => $":has-text(\"{text}\")";
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/AlertTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/AlertTests.cs
@@ -34,13 +34,13 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnAddAlertTypePageAsync();
 
-        await page.CheckAsync($"label:text-is('{alertType.Name.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(alertType.Name)}");
 
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnAddAlertDetailsPageAsync();
 
-        await page.FillAsync($"label:text-is('Enter details about the alert type: {alertType.Name.Replace("'", "\\'")}')", details);
+        await page.FillAsync($"label{TextIsSelector($"Enter details about the alert type: {alertType.Name}")}", details);
 
         await page.ClickContinueButtonAsync();
 
@@ -60,7 +60,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnAddAlertReasonPageAsync();
 
-        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{reason.GetDisplayName()?.Replace("'", "\\'")}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label{TextIsSelector(reason.GetDisplayName())}").CheckAsync();
         await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re adding this alert?')").Locator("label:text-is('Yes')").CheckAsync();
         await page.FillAsync("label:text-is('Add additional detail')", reasonDetail);
         await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
@@ -112,7 +112,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditAlertDetailsChangeReasonPageAsync(alertId);
 
-        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{reason.GetDisplayName()?.Replace("'", "\\'")}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label{TextIsSelector(reason.GetDisplayName())}").CheckAsync();
         await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re changing the alert details?')").Locator("label:text-is('Yes')").CheckAsync();
         await page.FillAsync("label:text-is('Add additional detail')", reasonDetail);
         await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
@@ -163,7 +163,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditAlertStartDateChangeReasonPageAsync(alertId);
 
-        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{reason.GetDisplayName()?.Replace("'", "\\'")}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label{TextIsSelector(reason.GetDisplayName())}").CheckAsync();
         await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re changing the start date?')").Locator("label:text-is('Yes')").CheckAsync();
         await page.FillAsync("label:text-is('Add additional detail')", reasonDetail);
         await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
@@ -215,7 +215,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditAlertEndDateChangeReasonPageAsync(alertId);
 
-        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{reason.GetDisplayName()?.Replace("'", "\\'")}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label{TextIsSelector(reason.GetDisplayName())}").CheckAsync();
         await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re changing the end date?')").Locator("label:text-is('Yes')").CheckAsync();
         await page.FillAsync("label:text-is('Add additional detail')", reasonDetail);
         await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
@@ -278,7 +278,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditAlertLinkChangeReasonPageAsync(alertId);
 
-        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{changeReason.GetDisplayName()?.Replace("'", "\\'")}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label{TextIsSelector(changeReason.GetDisplayName())}").CheckAsync();
         await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re changing the panel outcome link?')").Locator("label:text-is('Yes')").CheckAsync();
         await page.FillAsync("label:text-is('Add additional detail')", changeReasonDetail);
         await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
@@ -329,7 +329,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnCloseAlertChangeReasonPageAsync(alertId);
 
-        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{changeReason.GetDisplayName()?.Replace("'", "\\'")}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label{TextIsSelector(changeReason.GetDisplayName())}").CheckAsync();
         await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re adding an end date?')").Locator("label:text-is('Yes')").CheckAsync();
         await page.FillAsync("label:text-is('Add additional detail')", changeReasonDetail);
         await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();
@@ -374,7 +374,7 @@ public class AlertTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnReopenAlertPageAsync(alertId);
 
-        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label:text-is('{changeReason.GetDisplayName()?.Replace("'", "\\'")}')").CheckAsync();
+        await page.Locator("div.govuk-form-group:has-text('Select a reason')").Locator($"label{TextIsSelector(changeReason.GetDisplayName())}").CheckAsync();
         await page.Locator("div.govuk-form-group:has-text('Do you want to add more information about why you’re removing the end date?')").Locator("label:text-is('Yes')").CheckAsync();
         await page.FillAsync("label:text-is('Add additional detail')", changeReasonDetail);
         await page.Locator("div.govuk-form-group:has-text('Do you want to upload evidence?')").Locator("label:text-is('Yes')").CheckAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ApiTrnRequestSupportTaskTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ApiTrnRequestSupportTaskTests.cs
@@ -18,11 +18,11 @@ public class ApiTrnRequestSupportTaskTests(HostFixture hostFixture) : TestBase(h
 
         await page.GotoAsync("/support-tasks/api-trn-requests");
 
-        await page.ClickAsync($"a:text-is('{requestData.FirstName?.Replace("'", "\\'")} {requestData.MiddleName?.Replace("'", "\\'")} {requestData.LastName?.Replace("'", "\\'")}')");
+        await page.ClickAsync($"a{TextIsSelector($"{requestData.FirstName} {requestData.MiddleName} {requestData.LastName}")}");
 
         await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches");
 
-        await page.CheckAsync($"label:text-is('I want to create a new record from the {applicationUser.Name.Replace("'", "\\'")} request')");
+        await page.CheckAsync($"label{TextIsSelector($"I want to create a new record from the {applicationUser.Name} request")}");
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers");
@@ -61,7 +61,7 @@ public class ApiTrnRequestSupportTaskTests(HostFixture hostFixture) : TestBase(h
 
         await page.GotoAsync("/support-tasks/api-trn-requests");
 
-        await page.ClickAsync($"a:text-is('{requestData.FirstName?.Replace("'", "\\'")} {requestData.MiddleName?.Replace("'", "\\'")} {requestData.LastName?.Replace("'", "\\'")}')");
+        await page.ClickAsync($"a{TextIsSelector($"{requestData.FirstName} {requestData.MiddleName} {requestData.LastName}")}");
 
         await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches");
 
@@ -69,7 +69,7 @@ public class ApiTrnRequestSupportTaskTests(HostFixture hostFixture) : TestBase(h
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge");
-        await page.CheckAsync($"label:text-is('{requestData.MiddleName?.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(requestData.MiddleName)}");
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ApplicationUserTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ApplicationUserTests.cs
@@ -63,8 +63,8 @@ public class ApplicationUserTests(HostFixture hostFixture) : TestBase(hostFixtur
         await page.AssertOnEditApplicationUserPageAsync(applicationUserId);
 
         await page.FillAsync("text=Name", newApplicationUserName);
-        await page.SetCheckedAsync($"label:text-is('{ApiRoles.GetPerson}')", true);
-        await page.SetCheckedAsync($"label:text-is('{ApiRoles.UpdatePerson}')", true);
+        await page.SetCheckedAsync($"label{TextIsSelector(ApiRoles.GetPerson)}", true);
+        await page.SetCheckedAsync($"label{TextIsSelector(ApiRoles.UpdatePerson)}", true);
         await page.SetCheckedAsync($"label:text-is('OIDC client')", true);
         await page.FillAsync("text=Client ID", newClientId);
         await page.FillAsync("text=Client secret", newClientSecret);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/MqTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/MqTests.cs
@@ -39,7 +39,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnAddMqSpecialismPageAsync();
 
-        await page.CheckAsync($"label:text-is('{specialism.dfeta_name?.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(specialism.dfeta_name)}");
 
         await page.ClickContinueButtonAsync();
 
@@ -51,7 +51,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnAddMqStatusPageAsync();
 
-        await page.CheckAsync($"label:text-is('{result}')");
+        await page.CheckAsync($"label{TextIsSelector(result.ToString())}");
 
         await page.FillDateInputAsync(endDate);
 
@@ -95,7 +95,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditMqProviderReasonPageAsync(qualificationId);
 
-        await page.CheckAsync($"label:text-is('{changeReason.GetDisplayName()?.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(changeReason.GetDisplayName())}");
 
         await page.FillAsync("label:text-is('More detail about the reason for change')", changeReasonDetail);
 
@@ -143,15 +143,15 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditMqSpecialismPageAsync(qualificationId);
 
-        await page.IsCheckedAsync($"label:text-is('{oldSpecialism.GetTitle()?.Replace("'", "\\'")}')");
+        await page.IsCheckedAsync($"label{TextIsSelector(oldSpecialism.GetTitle())}");
 
-        await page.CheckAsync($"label:text-is('{newSpecialism.GetTitle()?.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(newSpecialism.GetTitle())}");
 
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnEditMqSpecialismReasonPageAsync(qualificationId);
 
-        await page.CheckAsync($"label:text-is('{changeReason.GetDisplayName()?.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(changeReason.GetDisplayName())}");
 
         await page.FillAsync("label:text-is('More detail about the reason for change')", changeReasonDetail);
 
@@ -205,7 +205,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditMqStartDateReasonPageAsync(qualificationId);
 
-        await page.CheckAsync($"label:text-is('{changeReason.GetDisplayName()?.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(changeReason.GetDisplayName())}");
 
         await page.FillAsync("label:text-is('More detail about the reason for change')", changeReasonDetail);
 
@@ -291,9 +291,9 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         if (isStatusChange)
         {
-            await page.IsCheckedAsync($"label:text-is('{oldStatus.GetTitle()?.Replace("'", "\\'")}')");
+            await page.IsCheckedAsync($"label{TextIsSelector(oldStatus.GetTitle())}");
 
-            await page.CheckAsync($"label:text-is('{newStatus.GetTitle()?.Replace("'", "\\'")}')");
+            await page.CheckAsync($"label{TextIsSelector(newStatus.GetTitle())}");
         }
 
         if (isEndDateChange)
@@ -305,7 +305,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditMqStatusReasonPageAsync(qualificationId);
 
-        await page.CheckAsync($"label:text-is('{changeReason.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(changeReason)}");
 
         await page.FillAsync("label:text-is('More detail about the reason for change')", changeReasonDetail);
 
@@ -351,7 +351,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnDeleteMqPageAsync(qualificationId);
 
-        await page.CheckAsync($"label:text-is('{deletionReason.GetDisplayName()?.Replace("'", "\\'")}')");
+        await page.CheckAsync($"label{TextIsSelector(deletionReason.GetDisplayName())}");
 
         await page.FillAsync("label:text-is('More detail about the reason for deleting')", deletionReasonDetail);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTaskTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTaskTests.cs
@@ -5,7 +5,7 @@ public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task ConnectOneLoginUser_WithSuggestion()
     {
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName("O'Reilly"));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -13,10 +13,10 @@ public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
         var page = await context.NewPageAsync();
 
         await page.GotoAsync("/support-tasks");
-        await page.ClickAsync($"a:text-is('{supportTask.SupportTaskReference.Replace("'", "\\'")}')");
+        await page.ClickAsync($"a{TextIsSelector(supportTask.SupportTaskReference)}");
 
-        await page.WaitForUrlPathAsync($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference.Replace("'", "\\'")}");
-        await page.ClickAsync($"label:text-is('{person.FirstName.Replace("'", "\\'")} {person.MiddleName.Replace("'", "\\'")} {person.LastName.Replace("'", "\\'")}')");
+        await page.WaitForUrlPathAsync($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}");
+        await page.ClickAsync($"label{TextIsSelector($"{person.FirstName} {person.MiddleName} {person.LastName}")}");
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}/connect");
@@ -36,7 +36,7 @@ public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
         var page = await context.NewPageAsync();
 
         await page.GotoAsync("/support-tasks");
-        await page.ClickAsync($"a:text-is('{supportTask.SupportTaskReference.Replace("'", "\\'")}')");
+        await page.ClickAsync($"a{TextIsSelector(supportTask.SupportTaskReference)}");
 
         await page.WaitForUrlPathAsync($"/support-tasks/connect-one-login-user/{supportTask.SupportTaskReference}");
         await page.FillAsync($"label:text-is('Connect to TRN (optional)')", person.Trn!);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -91,7 +91,7 @@ public static class PageExtensions
         page.GetByTestId(testId).ClickAsync();
 
     public static Task ClickChangeLinkForSummaryListRowWithKeyAsync(this IPage page, string key) =>
-        page.Locator($".govuk-summary-list__row:has(> dt:text('{key.Replace("'", "\\'")}'))").GetByText("Change").ClickAsync();
+        page.Locator($".govuk-summary-list__row:has(> dt{TestBase.TextSelector(key)})").GetByText("Change").ClickAsync();
 
     public static async Task ClickAddAlertPersonAlertsPageAsync(this IPage page)
     {
@@ -120,7 +120,7 @@ public static class PageExtensions
 
     public static async Task ClickCaseReferenceLinkChangeRequestsPageAsync(this IPage page, string caseReference)
     {
-        await page.ClickAsync($"a:text-is('{caseReference.Replace("'", "\\'")}')");
+        await page.ClickAsync($"a{TestBase.TextIsSelector(caseReference)}");
     }
 
     public static async Task AssertOnChangeRequestDetailPageAsync(this IPage page, string caseReference)
@@ -502,11 +502,11 @@ public static class PageExtensions
     {
         if (expectedHeader != null)
         {
-            Assert.Equal(expectedHeader, await page.InnerTextAsync($".govuk-notification-banner__heading:text-is('{expectedHeader.Replace("'", "\\'")}')"));
+            Assert.Equal(expectedHeader, await page.InnerTextAsync($".govuk-notification-banner__heading{TestBase.TextIsSelector(expectedHeader)}"));
         }
         if (expectedMessage != null)
         {
-            Assert.Equal(expectedMessage, await page.InnerTextAsync($".govuk-notification-banner p:text-is('{expectedMessage.Replace("'", "\\'")}')"));
+            Assert.Equal(expectedMessage, await page.InnerTextAsync($".govuk-notification-banner p{TestBase.TextIsSelector(expectedMessage)}"));
         }
     }
 
@@ -570,14 +570,14 @@ public static class PageExtensions
 
     public static Task<string> FindContentForLabel(this IPage page, string label)
     {
-        var dtElement = page.Locator($"dt:has-text('{label.Replace("'", "\\'")}')");
+        var dtElement = page.Locator($"dt{TestBase.HasTextSelector(label)}");
         var ddElement = dtElement.Locator("xpath=following-sibling::dd[1]");
         return ddElement.InnerTextAsync();
     }
 
     public static async Task AssertNoListElementAsync(this IPage page, string label)
     {
-        var element = page.Locator($"dt:has-text('{label.Replace("'", "\\'")}')");
+        var element = page.Locator($"dt{TestBase.HasTextSelector(label)}");
         Assert.False(await element.IsVisibleAsync());
     }
 
@@ -620,7 +620,7 @@ public static class PageExtensions
         => ClickButtonAsync(page, "Remove inactive status");
 
     public static Task ClickButtonAsync(this IPage page, string text) =>
-        page.ClickAsync($".govuk-button:text-is('{text.Replace("'", "\\'")}')");
+        page.ClickAsync($".govuk-button{TestBase.TextIsSelector(text)}");
 
     public static Task ClickBackLink(this IPage page) =>
         page.ClickAsync($".govuk-back-link");
@@ -629,7 +629,7 @@ public static class PageExtensions
         page.ClickAsync("a.govuk-link:contains('Cancel')");
 
     public static Task ClickRadioAsync(this IPage page, string value) =>
-        page.Locator($"input[type='radio'][value='{value.Replace("'", "\\'")}']")
+        page.Locator($"input[type='radio'][value=\"{value}\"]")
         .Locator("xpath=following-sibling::label")
         .ClickAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/RouteToProfessionalStatusPageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/RouteToProfessionalStatusPageExtensions.cs
@@ -24,7 +24,7 @@ public static class RouteToProfessionalStatusPageExtensions
 
     public static Task SelectRouteChangeReasonOption(this IPage page, string reason)
     {
-        var radioButton = page.Locator($"input[type='radio'][value='{reason?.Replace("'", "\\'")}']");
+        var radioButton = page.Locator($"input[type='radio'][value='{reason}']");
         return radioButton.Locator("xpath=following-sibling::label").ClickAsync();
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/TestBase.cs
@@ -29,4 +29,10 @@ public abstract class TestBase
         var currentUserProvider = HostFixture.Services.GetRequiredService<CurrentUserProvider>();
         currentUserProvider.CurrentUser = user;
     }
+
+    public static string TextSelector(string? text) => $":text(\"{text}\")";
+
+    public static string TextIsSelector(string? text) => $":text-is(\"{text}\")";
+
+    public static string HasTextSelector(string? text) => $":has-text(\"{text}\")";
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditExemptionReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditExemptionReasonTests.cs
@@ -72,7 +72,7 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         Assert.All(exemptionReasonsElement, checkbox =>
         {
             Assert.Contains(checkbox.Value, exemptionReasonsForDisplay.Select(e => e.guid.ToString()));
-            Assert.Contains(checkbox.ParentElement!.QuerySelector<IHtmlLabelElement>($"label[for='{checkbox.Id.Replace("'", "\\'")}']")!.TextContent.Trim(), exemptionReasonsForDisplay.Select(e => e.Name));
+            Assert.Contains(checkbox.ParentElement!.QuerySelector<IHtmlLabelElement>($"label[for='{checkbox.Id}']")!.TextContent.Trim(), exemptionReasonsForDisplay.Select(e => e.Name));
         });
     }
 
@@ -111,7 +111,7 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         Assert.All(exemptionReasonsElement, checkbox =>
         {
             Assert.Contains(checkbox.Value, exemptionReasons.Select(e => e.InductionExemptionReasonId.ToString()));
-            Assert.Contains(checkbox.ParentElement!.QuerySelector<IHtmlLabelElement>($"label[for='{checkbox.Id.Replace("'", "\\'")}']")!.TrimmedText(), exemptionReasons.Select(e => e.Name));
+            Assert.Contains(checkbox.ParentElement!.QuerySelector<IHtmlLabelElement>($"label[for='{checkbox.Id}']")!.TrimmedText(), exemptionReasons.Select(e => e.Name));
         });
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
@@ -12,7 +12,7 @@ public static class AngleSharpExtensions
     }
 
     public static IReadOnlyList<IElement> GetAllElementsByTestId(this IElement element, string testId) =>
-        element.QuerySelectorAll($"*[data-testid='{testId?.Replace("'", "\\'")}']").ToList();
+        element.QuerySelectorAll($"*[data-testid='{testId}']").ToList();
 
     public static IElement? GetElementByTestId(this IElement element, string testId) =>
         element.GetAllElementsByTestId(testId).SingleOrDefault();


### PR DESCRIPTION
Escapes apostrophes in string interpolations for test selectors containing apostrophes. There's probably a DRY-er way to do this, couldn't think of one other than creating an extension method for each different selector type - suggestions welcome