### PR TITLE
add reference code to subjects

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -22,8 +22,14 @@
     {
         @foreach (var professionalStatus in Model.ProfessionalStatuses)
         {
+            var statusTitle = ProfessionalStatusStatusRegistry.GetTitle(professionalStatus.Status);
+            var cardTitle = $"{professionalStatus.RouteToProfessionalStatusType?.Name} {statusTitle}" +
+            (professionalStatus.HoldsFrom.HasValue && professionalStatus.TrainingEndDate.HasValue
+            ? $" {professionalStatus.TrainingEndDate.Value.ToString(UiDefaults.DateOnlyDisplayFormat)}"
+            : "");
+
             <govuk-summary-card data-testid="professionalstatus-id-@professionalStatus.QualificationId">
-                <govuk-summary-card-title></govuk-summary-card-title>
+                <govuk-summary-card-title>@cardTitle</govuk-summary-card-title>
                 <govuk-summary-card-actions>
                     <govuk-summary-card-action href="@LinkGenerator.RouteEditDetail(professionalStatus.QualificationId, null)" visually-hidden-text="edit route" data-testid="edit-route-link-@professionalStatus.QualificationId">Edit route</govuk-summary-card-action>
                     <govuk-summary-card-action href="@LinkGenerator.DeleteRouteChangeReason(professionalStatus.QualificationId, null)" visually-hidden-text="delete route" data-testid="delete-route-link-@professionalStatus.QualificationId">Delete route</govuk-summary-card-action>
@@ -31,9 +37,13 @@
                 <govuk-summary-list>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Route</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value data-testid="training-route-@professionalStatus.QualificationId">@(professionalStatus.RouteToProfessionalStatusType!.Name)</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="route-type-@professionalStatus.QualificationId">@(professionalStatus.RouteToProfessionalStatusType!.Name)</govuk-summary-list-row-value>
                     </govuk-summary-list-row>
-                    <govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="route-status-@professionalStatus.QualificationId">@statusTitle</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value data-testid="training-start-date-@professionalStatus.QualificationId">@(professionalStatus.TrainingStartDate.HasValue ? professionalStatus.TrainingStartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : string.Empty)</govuk-summary-list-row-value>
                     </govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
@@ -35,7 +35,7 @@ public class QualificationsModel(TrsDbContext dbContext, ReferenceDataCache refe
             .Distinct()
             .ToArray();
         var trainingSubjectsLookup = (await referenceDataCache.GetTrainingSubjectsAsync())
-            .ToDictionary(subject => subject.TrainingSubjectId, subject => subject.Name);
+            .ToDictionary(subject => subject.TrainingSubjectId, subject => $"{subject.Reference} - {subject.Name}");
         TrainingSubjects = uniqueSubjectIds.ToDictionary(
             id => id,
             id => trainingSubjectsLookup[id]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusCreatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusCreatedEvent.cshtml
@@ -1,4 +1,5 @@
-﻿@using TeachingRecordSystem.Core.Events
+@using TeachingRecordSystem.Core.Events
+@using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus
 @inject ReferenceDataCache ReferenceDataCache
 @model TimelineItem<TimelineEvent<RouteToProfessionalStatusCreatedEvent>>
 @{
@@ -11,11 +12,7 @@
     var ageRangeType = professionalStatus.TrainingAgeSpecialismType;
     var ageRangeFromTo = (professionalStatus.TrainingAgeSpecialismRangeFrom is not null && professionalStatus.TrainingAgeSpecialismRangeTo is not null) ?
         $"From {professionalStatus.TrainingAgeSpecialismRangeFrom} to {professionalStatus.TrainingAgeSpecialismRangeTo}" : null;
-    var subjects = professionalStatus.TrainingSubjectIds is not null ?
-            professionalStatus.TrainingSubjectIds
-                .Join((await ReferenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+    var subjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(professionalStatus.TrainingSubjectIds, ReferenceDataCache);
 }
 
 <div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-route-created-event">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusDeletedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusDeletedEvent.cshtml
@@ -1,5 +1,6 @@
-﻿@using TeachingRecordSystem.Core.Events
+@using TeachingRecordSystem.Core.Events
 @using TeachingRecordSystem.Core.Services.Files
+@using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus
 @inject ReferenceDataCache ReferenceDataCache
 @inject IFileService FileService
 @model TimelineItem<TimelineEvent<RouteToProfessionalStatusDeletedEvent>>
@@ -13,11 +14,7 @@
     var ageRangeType = professionalStatus.TrainingAgeSpecialismType;
     var ageRangeFromTo = (professionalStatus.TrainingAgeSpecialismRangeFrom is not null && professionalStatus.TrainingAgeSpecialismRangeTo is not null) ?
         $"From {professionalStatus.TrainingAgeSpecialismRangeFrom} to {professionalStatus.TrainingAgeSpecialismRangeTo}" : null;
-    var subjects = professionalStatus.TrainingSubjectIds is not null ?
-            professionalStatus.TrainingSubjectIds
-                .Join((await ReferenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+    var subjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(professionalStatus.TrainingSubjectIds, ReferenceDataCache);
     var evidenceFileUrl = deletedEvent.EvidenceFile is not null ? await FileService.GetFileUrlAsync(deletedEvent.EvidenceFile!.FileId, TimeSpan.FromMinutes(15)) : null;
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusUpdatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusUpdatedEvent.cshtml
@@ -1,5 +1,6 @@
-﻿@using TeachingRecordSystem.Core.Events
+@using TeachingRecordSystem.Core.Events
 @using TeachingRecordSystem.Core.Services.Files
+@using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus
 @inject ReferenceDataCache ReferenceDataCache
 @inject IFileService FileService
 @model TimelineItem<TimelineEvent<RouteToProfessionalStatusUpdatedEvent>>
@@ -14,22 +15,26 @@
     var ageRangeType = professionalStatus.TrainingAgeSpecialismType;
     var ageRangeFromTo = (professionalStatus.TrainingAgeSpecialismRangeFrom is not null && professionalStatus.TrainingAgeSpecialismRangeTo is not null) ?
         $"From {professionalStatus.TrainingAgeSpecialismRangeFrom} to {professionalStatus.TrainingAgeSpecialismRangeTo}" : null;
-    var subjects = professionalStatus.TrainingSubjectIds is not null ?
-            professionalStatus.TrainingSubjectIds
-                .Join((await ReferenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+    // var subjects = professionalStatus.TrainingSubjectIds is not null
+    //      ? professionalStatus.TrainingSubjectIds
+    //          .Join(
+    //              await ReferenceDataCache.GetTrainingSubjectsAsync(),
+    //              id => id,
+    //              subject => subject.TrainingSubjectId,
+    //              (id, subject) => subject
+    //          )
+    //          .OrderBy(subject => subject.Name)
+    //          .Select(subject => $"{subject.Reference} - {subject.Name}")
+    //          .ToArray()
+    //          : null;
+    var subjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(professionalStatus.TrainingSubjectIds, ReferenceDataCache);
     var oldTrainingProvider = oldDetails.TrainingProviderId.HasValue ? await ReferenceDataCache.GetTrainingProviderByIdAsync(oldDetails.TrainingProviderId.Value) : null;
     var oldCountry = !string.IsNullOrEmpty(oldDetails.TrainingCountryId) ? await ReferenceDataCache.GetTrainingCountryByIdAsync(oldDetails.TrainingCountryId) : null;
     var oldDegreeType = oldDetails.DegreeTypeId.HasValue ? await ReferenceDataCache.GetDegreeTypeByIdAsync(oldDetails.DegreeTypeId.Value) : null;
     var oldAgeRangeType = oldDetails.TrainingAgeSpecialismType;
     var oldAgeRangeFromTo = (oldDetails.TrainingAgeSpecialismRangeFrom is not null && oldDetails.TrainingAgeSpecialismRangeTo is not null) ?
         $"From {oldDetails.TrainingAgeSpecialismRangeFrom} to {oldDetails.TrainingAgeSpecialismRangeTo}" : null;
-    var oldSubjects = oldDetails.TrainingSubjectIds is not null ?
-            oldDetails.TrainingSubjectIds
-                .Join((await ReferenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+    var oldSubjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(oldDetails.TrainingSubjectIds, ReferenceDataCache);
     var evidenceFileUrl = updatedEvent.EvidenceFile is not null ? await FileService.GetFileUrlAsync(updatedEvent.EvidenceFile!.FileId, TimeSpan.FromMinutes(15)) : null;
 }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/CheckYourAnswers.cshtml.cs
@@ -29,11 +29,7 @@ public class CheckYourAnswersModel(TrsLinkGenerator linkGenerator,
         RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is not null ? (await ReferenceDataCache.GetTrainingProviderByIdAsync(RouteDetail.TrainingProviderId!.Value))?.Name : null;
         RouteDetail.TrainingCountry = RouteDetail.TrainingCountryId is not null ? (await ReferenceDataCache.GetTrainingCountryByIdAsync(RouteDetail.TrainingCountryId))?.Name : null;
         RouteDetail.DegreeType = RouteDetail.DegreeTypeId is not null ? (await ReferenceDataCache.GetDegreeTypeByIdAsync(RouteDetail.DegreeTypeId!.Value))?.Name : null;
-        RouteDetail.TrainingSubjects = RouteDetail.TrainingSubjectIds is not null ?
-            RouteDetail.TrainingSubjectIds
-                .Join((await ReferenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+        RouteDetail.TrainingSubjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(RouteDetail.TrainingSubjectIds, ReferenceDataCache);
     }
 
     public async Task<IActionResult> OnPostAsync()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/Route.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/Route.cshtml.cs
@@ -68,7 +68,8 @@ public class RouteModel(TrsLinkGenerator linkGenerator,
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        Routes = await referenceDataCache.GetRouteToProfessionalStatusTypesAsync();
+        var allRoutes = await referenceDataCache.GetRouteToProfessionalStatusTypesAsync();
+        Routes = allRoutes.Where(r => r.IsActive).ToArray();
         ArchivedRoutes = Routes.Where(r => !r.IsActive).ToArray();
         var preselectedRouteId = JourneyInstance!.State.RouteToProfessionalStatusId;
         if (!Routes.Any(r => r.InductionExemptionReasonId == preselectedRouteId))

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers.cshtml.cs
@@ -35,11 +35,7 @@ public class CheckYourAnswersModel(
         RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is not null ? (await referenceDataCache.GetTrainingProviderByIdAsync(RouteDetail.TrainingProviderId!.Value))?.Name : null;
         RouteDetail.TrainingCountry = RouteDetail.TrainingCountryId is not null ? (await referenceDataCache.GetTrainingCountryByIdAsync(RouteDetail.TrainingCountryId))?.Name : null;
         RouteDetail.DegreeType = RouteDetail.DegreeTypeId is not null ? (await referenceDataCache.GetDegreeTypeByIdAsync(RouteDetail.DegreeTypeId!.Value))?.Name : null;
-        RouteDetail.TrainingSubjects = RouteDetail.TrainingSubjectIds is not null ?
-            RouteDetail.TrainingSubjectIds
-                .Join((await referenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+        RouteDetail.TrainingSubjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(RouteDetail.TrainingSubjectIds, referenceDataCache);
     }
 
     public async Task<IActionResult> OnPostAsync()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
@@ -39,11 +39,7 @@ public class CheckYourAnswersModel(
         RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is not null ? (await referenceDataCache.GetTrainingProviderByIdAsync(RouteDetail.TrainingProviderId!.Value))?.Name : null;
         RouteDetail.TrainingCountry = RouteDetail.TrainingCountryId is not null ? (await referenceDataCache.GetTrainingCountryByIdAsync(RouteDetail.TrainingCountryId))?.Name : null;
         RouteDetail.DegreeType = RouteDetail.DegreeTypeId is not null ? (await referenceDataCache.GetDegreeTypeByIdAsync(RouteDetail.DegreeTypeId!.Value))?.Name : null;
-        RouteDetail.TrainingSubjects = RouteDetail.TrainingSubjectIds is not null ?
-            RouteDetail.TrainingSubjectIds
-                .Join((await referenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+        RouteDetail.TrainingSubjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(RouteDetail.TrainingSubjectIds, referenceDataCache);
     }
 
     public async Task<IActionResult> OnPostAsync()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
@@ -30,11 +30,7 @@ public class DetailModel(
         RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is not null ? (await referenceDataCache.GetTrainingProviderByIdAsync(RouteDetail.TrainingProviderId!.Value))?.Name : null;
         RouteDetail.TrainingCountry = RouteDetail.TrainingCountryId is not null ? (await referenceDataCache.GetTrainingCountryByIdAsync(RouteDetail.TrainingCountryId))?.Name : null;
         RouteDetail.DegreeType = RouteDetail.DegreeTypeId is not null ? (await referenceDataCache.GetDegreeTypeByIdAsync(RouteDetail.DegreeTypeId!.Value))?.Name : null;
-        RouteDetail.TrainingSubjects = RouteDetail.TrainingSubjectIds is not null ?
-            RouteDetail.TrainingSubjectIds
-                .Join((await referenceDataCache.GetTrainingSubjectsAsync()), id => id, subject => subject.TrainingSubjectId, (_, subject) => subject.Name)
-                .OrderByDescending(name => name)
-                .ToArray() : null;
+        RouteDetail.TrainingSubjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(RouteDetail.TrainingSubjectIds, referenceDataCache);
     }
 
     public async Task<IActionResult> OnPostCancelAsync()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/SubjectDisplayHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/SubjectDisplayHelper.cs
@@ -1,0 +1,27 @@
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus;
+
+public static class SubjectDisplayHelper
+{
+    public static async Task<string[]?> GetFormattedSubjectNamesAsync(
+        IEnumerable<Guid>? subjectIds,
+        ReferenceDataCache referenceDataCache)
+    {
+        if (subjectIds == null)
+        {
+            return null;
+        }
+
+        var allSubjects = await referenceDataCache.GetTrainingSubjectsAsync();
+
+        return subjectIds
+            .Join(
+                allSubjects,
+                id => id,
+                subject => subject.TrainingSubjectId,
+                (id, subject) => subject
+            )
+            .OrderBy(subject => subject.Name)
+            .Select(subject => $"{subject.Reference} - {subject.Name}")
+            .ToArray();
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
@@ -61,7 +61,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         Assert.Equal(degreeType.Name, timelineItem.GetElementByTestId("degree-type")?.TrimmedText());
         Assert.Equal(country.Name, timelineItem.GetElementByTestId("country")?.TrimmedText());
         Assert.Equal(ageRange.GetDisplayName(), timelineItem.GetElementByTestId("age-range-type")?.TrimmedText());
-        Assert.Equal(subjects.Single().Name, timelineItem.GetElementByTestId("subjects")?.TrimmedText());
+        Assert.Equal($"{subjects.Single().Reference} - {subjects.Single().Name}", timelineItem.GetElementByTestId("subjects")?.TrimmedText());
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         Assert.Equal(degreeType.Name, timelineItem.GetElementByTestId("degree-type")?.TrimmedText());
         Assert.Equal(country.Name, timelineItem.GetElementByTestId("country")?.TrimmedText());
         Assert.Equal(ageRange.GetDisplayName(), timelineItem.GetElementByTestId("age-range-type")?.TrimmedText());
-        Assert.Equal(subject.Name, timelineItem.GetElementByTestId("subjects")?.TrimmedText());
+        Assert.Equal($"{subject.Reference} - {subject.Name}", timelineItem.GetElementByTestId("subjects")?.TrimmedText());
 
         Assert.Equal(oldAwardDate.ToString(UiDefaults.DateOnlyDisplayFormat), timelineItem.GetElementByTestId("old-award-date")?.TrimmedText());
         Assert.Null(timelineItem.GetElementByTestId("status"));
@@ -208,7 +208,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         Assert.Equal(oldDegreeType.Name, timelineItem.GetElementByTestId("old-degree-type")?.TrimmedText());
         Assert.Equal(oldCountry.Name, timelineItem.GetElementByTestId("old-country")?.TrimmedText());
         Assert.Equal(oldAgeRange.GetDisplayName(), timelineItem.GetElementByTestId("old-age-range-type")?.TrimmedText());
-        Assert.Equal(oldSubject.Name, timelineItem.GetElementByTestId("old-subjects")?.TrimmedText());
+        Assert.Equal($"{oldSubject.Reference} - {oldSubject.Name}", timelineItem.GetElementByTestId("old-subjects")?.TrimmedText());
     }
 
     [Fact]
@@ -443,7 +443,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         Assert.Equal(degreeType.Name, timelineItem.GetElementByTestId("degree-type")?.TrimmedText());
         Assert.Equal(country.Name, timelineItem.GetElementByTestId("country")?.TrimmedText());
         Assert.Equal(ageRange.GetDisplayName(), timelineItem.GetElementByTestId("age-range-type")?.TrimmedText());
-        Assert.Equal(subjects.Single().Name, timelineItem.GetElementByTestId("subjects")?.TrimmedText());
+        Assert.Equal($"{subjects.Single().Reference} - {subjects.Single().Name}", timelineItem.GetElementByTestId("subjects")?.TrimmedText());
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
@@ -141,7 +141,7 @@ public class QualificationsTests(HostFixture hostFixture) : TestBase(hostFixture
 
         var professionalStatus = doc.GetElementByTestId($"professionalstatus-id-{qualificationid}");
         Assert.NotNull(professionalStatus);
-        Assert.Equal(route.Name, professionalStatus.GetElementByTestId($"training-route-{qualificationid}")!.TrimmedText());
+        Assert.Equal(route.Name, professionalStatus.GetElementByTestId($"route-type-{qualificationid}")!.TrimmedText());
         Assert.Equal(startDate.Value.ToString(UiDefaults.DateOnlyDisplayFormat), professionalStatus.GetElementByTestId($"training-start-date-{qualificationid}")!.TrimmedText());
         Assert.Equal(endDate.Value.ToString(UiDefaults.DateOnlyDisplayFormat), professionalStatus.GetElementByTestId($"training-end-date-{qualificationid}")!.TrimmedText());
         Assert.Equal(holdsFrom.ToString(UiDefaults.DateOnlyDisplayFormat), professionalStatus.GetElementByTestId($"award-date-{qualificationid}")!.TrimmedText());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
@@ -149,7 +149,7 @@ public class QualificationsTests(HostFixture hostFixture) : TestBase(hostFixture
         Assert.Contains(degreeType.Name, professionalStatus.GetElementByTestId($"training-degreetype-{qualificationid}")!.TrimmedText());
         Assert.Equal(country.Name, professionalStatus.GetElementByTestId($"training-country-{qualificationid}")!.TrimmedText());
         Assert.Equal(ageRange.GetDisplayName(), professionalStatus.GetElementByTestId($"training-agespecialism-{qualificationid}")!.TrimmedText());
-        doc.AssertRowContentMatches("Subjects", subjects.Select(s => s.Name));
+        doc.AssertRowContentMatches("Subjects", subjects.Select(s => $"{s.Reference} - {s.Name}"));
     }
 
     [Theory]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/CheckYourAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/CheckYourAnswersTests.cs
@@ -122,7 +122,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         doc.AssertRowContentMatches("Degree type", degreeType.Name);
         doc.AssertRowContentMatches("Country of training", country.Name);
         doc.AssertRowContentMatches("Age range", "Foundation stage");
-        doc.AssertRowContentMatches("Subjects", subjects.Select(s => s.Name));
+        doc.AssertRowContentMatches("Subjects", subjects.Select(s => $"{s.Reference} - {s.Name}"));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
@@ -140,7 +140,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         doc.AssertRowContentMatches("Degree type", degreeType.Name);
         doc.AssertRowContentMatches("Country of training", country.Name);
         doc.AssertRowContentMatches("Age range", "Foundation stage");
-        doc.AssertRowContentMatches("Subjects", subjects.Select(s => s.Name));
+        doc.AssertRowContentMatches("Subjects", subjects.Select(s => $"{s.Reference} - {s.Name}"));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/CheckYourAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/CheckYourAnswersTests.cs
@@ -143,7 +143,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         doc.AssertRowContentMatches("Degree type", degreeType.Name);
         doc.AssertRowContentMatches("Country of training", country.Name);
         doc.AssertRowContentMatches("Age range", "Foundation stage");
-        doc.AssertRowContentMatches("Subjects", subjects.Select(s => s.Name));
+        doc.AssertRowContentMatches("Subjects", subjects.Select(s => $"{s.Reference} - {s.Name}"));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
@@ -145,7 +145,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         doc.AssertChangeLinkExists("Degree type");
         doc.AssertRowContentMatches("Country of training", country.Name);
         doc.AssertRowContentMatches("Age range", ageRange.GetDisplayName()!);
-        doc.AssertRowContentMatches("Subjects", subjects.Select(s => s.Name));
+        doc.AssertRowContentMatches("Subjects", subjects.Select(s => $"{s.Reference} - {s.Name}"));
     }
 
     [Fact]


### PR DESCRIPTION
### Context

Add reference code to subjects wherever they're listed:
in edit details page, 
cya pages,
change history, 
qualifications tab

### Changes proposed in this pull request
https://trello.com/c/eGPo4QFp/1243-routes-subject-specialisms-not-differentiatable

### Guidance to review
Also additions to the qualification tab Routes card - but not the coloured statuses
bug fix - don't list archived routes in the main routes drop-down 
