### PR TITLE
Routes 'holds' date validation

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/HoldsFrom.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/HoldsFrom.cshtml.cs
@@ -4,12 +4,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute;
 
 [Journey(JourneyNames.AddRouteToProfessionalStatus), RequireJourneyInstance]
-public class HoldsFromModel : AddRouteCommonPageModel
+public class HoldsFromModel(IClock clock, TrsLinkGenerator linkGenerator, ReferenceDataCache referenceDataCache) : AddRouteCommonPageModel(linkGenerator, referenceDataCache)
 {
-    public HoldsFromModel(TrsLinkGenerator linkGenerator, ReferenceDataCache referenceDataCache) : base(linkGenerator, referenceDataCache)
-    {
-    }
-
     [BindProperty]
     [DateInput(ErrorMessagePrefix = "Award date")]
     [Required(ErrorMessage = "Enter the professional status award date")]
@@ -27,6 +23,10 @@ public class HoldsFromModel : AddRouteCommonPageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (HoldsFrom > clock.Today)
+        {
+            ModelState.AddModelError(nameof(HoldsFrom), "Professional Status Date must not be in the future");
+        }
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/HoldsFrom.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/HoldsFrom.cshtml.cs
@@ -7,7 +7,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
 [Journey(JourneyNames.EditRouteToProfessionalStatus), RequireJourneyInstance]
-public class HoldsFromModel(TrsLinkGenerator linkGenerator) : PageModel
+public class HoldsFromModel(IClock clock, TrsLinkGenerator linkGenerator) : PageModel
 {
     public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
 
@@ -36,6 +36,10 @@ public class HoldsFromModel(TrsLinkGenerator linkGenerator) : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (HoldsFrom > clock.Today)
+        {
+            ModelState.AddModelError(nameof(HoldsFrom), "Professional Status Date must not be in the future");
+        }
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/HoldsFromTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/HoldsFromTests.cs
@@ -49,7 +49,7 @@ public class AwardDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenAwardDateIsEntered_SavesDateAndRedirectsToInductionExemptionPage()
     {
         // Arrange
-        var holdsFrom = new DateOnly(2024, 01, 01);
+        var holdsFrom = Clock.Today.AddYears(-1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory
                 && r.InductionExemptionRequired == FieldRequirement.Mandatory
@@ -95,7 +95,7 @@ public class AwardDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ImplicitExemptionRoute_WhenAwardDateIsEntered_SavesDateAndRedirectsToNextPage()
     {
         // Arrange
-        var holdsFrom = new DateOnly(2024, 01, 01);
+        var holdsFrom = Clock.Today.AddYears(-1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.InductionExemptionReason is not null && r.InductionExemptionReason.RouteImplicitExemption)
             .RandomOne();
@@ -138,7 +138,7 @@ public class AwardDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_FromCya_WhenAwardDateIsEntered_RedirectsToCya()
     {
         // Arrange
-        var holdsFrom = new DateOnly(2024, 01, 01);
+        var holdsFrom = Clock.Today.AddYears(-1);
         var newAwardDate = holdsFrom.AddMonths(1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/HoldsFromTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/HoldsFromTests.cs
@@ -53,8 +53,8 @@ public class AwardDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_NotStatusHoldsJourney_HoldsFromIsEntered_SavesDateAndRedirectsToDetail()
     {
         // Arrange
-        var startDate = new DateOnly(2024, 01, 01);
-        var endDate = new DateOnly(2025, 01, 01);
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = startDate.AddMonths(1);
         var holdsFrom = endDate;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory)
@@ -105,8 +105,8 @@ public class AwardDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var status = RouteToProfessionalStatusStatus.Holds;
-        var startDate = new DateOnly(2024, 01, 01);
-        var endDate = new DateOnly(2025, 01, 01);
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = startDate.AddMonths(1);
         var holdsFrom = endDate;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == "NI R") // an induction exemption route that requires the exemption question
@@ -157,8 +157,8 @@ public class AwardDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var status = RouteToProfessionalStatusStatus.Holds;
-        var startDate = new DateOnly(2024, 01, 01);
-        var endDate = new DateOnly(2025, 01, 01);
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = startDate.AddMonths(1);
         var holdsFrom = endDate;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()) // an induction exemption route who's exemption is implicit and therefore doesn't require the exemption question
             .Where(r => r.InductionExemptionReasonId.HasValue)
@@ -255,9 +255,9 @@ public class AwardDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenFutureHoldsFromDateIsEntered_ReturnsError()
     {
         // Arrange
-        var startDate = new DateOnly(2024, 01, 01);
-        var endDate = new DateOnly(2025, 01, 01);
-        var holdsFrom = Clock.Today.AddDays(1);
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = startDate.AddMonths(1);
+        var holdsFrom = endDate;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory)
             .RandomOne();


### PR DESCRIPTION
A 'holds' aka awarded date can't be in the future

### Changes proposed in this pull request
https://trello.com/c/N9lPhjuK/1232-routes-professional-status-date-validation-rules
