### PR TITLE
Add View/Edit permissions to Routes pages

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserPermissionTypes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserPermissionTypes.cs
@@ -23,6 +23,9 @@ public static class UserPermissionTypes
     [Display(Name = "Support tasks", Description = "Access to the Support tasks area of the console")]
     public const string SupportTasks = nameof(SupportTasks);
 
+    [Display(Name = "Routes and qualifications")]
+    public const string Routes = nameof(Routes);
+
     public static IReadOnlyCollection<string> All { get; } = new[]
     {
         PersonData,
@@ -30,7 +33,8 @@ public static class UserPermissionTypes
         NonDbsAlerts,
         DbsAlerts,
         ManageUsers,
-        SupportTasks
+        SupportTasks,
+        Routes
     };
 
     public static string GetDisplayNameForPermissionType(string permissionType)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserRoles.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/UserRoles.cs
@@ -12,6 +12,7 @@ public static class UserRoles
         new(UserPermissionTypes.PersonData, UserPermissionLevel.View),
         new(UserPermissionTypes.NonPersonOrAlertData, UserPermissionLevel.View),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.View),
+        new(UserPermissionTypes.Routes, UserPermissionLevel.View),
     ];
 
     [Display(Name = "Record manager")]
@@ -21,7 +22,8 @@ public static class UserRoles
         new(UserPermissionTypes.PersonData, UserPermissionLevel.Edit),
         new(UserPermissionTypes.NonPersonOrAlertData, UserPermissionLevel.Edit),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.View),
-        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.Edit)
+        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.Edit),
+        new(UserPermissionTypes.Routes, UserPermissionLevel.Edit),
     ];
 
     [Display(Name = "Alerts manager (TRA decisions)")]
@@ -32,6 +34,7 @@ public static class UserRoles
         new(UserPermissionTypes.NonPersonOrAlertData, UserPermissionLevel.View),
         new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.View),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.Edit),
+        new(UserPermissionTypes.Routes, UserPermissionLevel.View),
     ];
 
     [Display(Name = "Alerts manager (TRA and DBS decisions)")]
@@ -42,6 +45,7 @@ public static class UserRoles
         new(UserPermissionTypes.NonPersonOrAlertData, UserPermissionLevel.View),
         new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.Edit),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.Edit),
+        new(UserPermissionTypes.Routes, UserPermissionLevel.View),
     ];
 
     [Display(Name = "Access manager")]
@@ -52,7 +56,7 @@ public static class UserRoles
         new(UserPermissionTypes.NonPersonOrAlertData, UserPermissionLevel.Edit),
         new(UserPermissionTypes.NonDbsAlerts, UserPermissionLevel.View),
         new(UserPermissionTypes.ManageUsers, UserPermissionLevel.Edit),
-        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.Edit)
+        new(UserPermissionTypes.SupportTasks, UserPermissionLevel.Edit),
     ];
 
     [Display(Name = "Administrator")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/RoutesEditAuthorizationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/RoutesEditAuthorizationHandler.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security.AuthorizationHandlers;
+
+public class RoutesEditAuthorizationHandler : AuthorizationHandler<RoutesEditRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, RoutesEditRequirement requirement)
+    {
+        if (context.User.HasMinimumPermission(new(UserPermissionTypes.Routes, UserPermissionLevel.Edit)))
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/RoutesViewAuthorizationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/RoutesViewAuthorizationHandler.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security.AuthorizationHandlers;
+
+public class RoutesViewAuthorizationHandler : AuthorizationHandler<RoutesViewRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, RoutesViewRequirement requirement)
+    {
+        if (context.User.HasMinimumPermission(new(UserPermissionTypes.Routes, UserPermissionLevel.View)))
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationPolicies.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationPolicies.cs
@@ -14,4 +14,6 @@ public static class AuthorizationPolicies
     public const string AlertWrite = nameof(AlertWrite);
     public const string InductionReadWrite = nameof(InductionReadWrite);
     public const string PersonDataEdit = nameof(PersonDataEdit);
+    public const string RoutesView = nameof(RoutesView);
+    public const string RoutesEdit = nameof(RoutesEdit);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/Requirements/RoutesEditRequirement.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/Requirements/RoutesEditRequirement.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+public class RoutesEditRequirement : IAuthorizationRequirement
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/Requirements/RoutesViewRequirement.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/Requirements/RoutesViewRequirement.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+public class RoutesViewRequirement : IAuthorizationRequirement
+{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/RoutesAuthorization.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/RoutesAuthorization.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Authorization;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security.AuthorizationHandlers;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security;
+
+public static class RoutesAuthorization
+{
+    public static AuthorizationBuilder AddRoutesPolicies(this AuthorizationBuilder builder)
+    {
+        builder.AddPolicy(
+            AuthorizationPolicies.RoutesView,
+            policy => policy
+                .RequireAuthenticatedUser()
+                .AddRequirements(new RoutesViewRequirement()));
+
+        builder.AddPolicy(
+            AuthorizationPolicies.RoutesEdit,
+            policy => policy
+                .RequireAuthenticatedUser()
+                .AddRequirements(new RoutesEditRequirement()));
+
+        builder.Services
+            .AddSingleton<IAuthorizationHandler, RoutesViewAuthorizationHandler>()
+            .AddSingleton<IAuthorizationHandler, RoutesEditAuthorizationHandler>();
+
+        return builder;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -1,10 +1,14 @@
 @page "/persons/{personId}/qualifications"
 @using TeachingRecordSystem.SupportUi.Pages.Common;
+@using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+@using Microsoft.AspNetCore.Authorization;
+@inject IAuthorizationService AuthorizationService
 @model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.QualificationsModel
 @{
     Layout = "Layout";
     ViewBag.SelectedTab = PersonDetailSubNavigationTab.Qualifications;
     var person = HttpContext.Features.GetRequiredFeature<CurrentPersonFeature>();
+    var canEdit = (await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.RoutesEdit)).Succeeded;
 }
 
 @section BeforeContent {
@@ -31,8 +35,11 @@
             <govuk-summary-card data-testid="professionalstatus-id-@professionalStatus.QualificationId">
                 <govuk-summary-card-title>@cardTitle</govuk-summary-card-title>
                 <govuk-summary-card-actions>
-                    <govuk-summary-card-action href="@LinkGenerator.RouteEditDetail(professionalStatus.QualificationId, null)" visually-hidden-text="edit route" data-testid="edit-route-link-@professionalStatus.QualificationId">Edit route</govuk-summary-card-action>
-                    <govuk-summary-card-action href="@LinkGenerator.DeleteRouteChangeReason(professionalStatus.QualificationId, null)" visually-hidden-text="delete route" data-testid="delete-route-link-@professionalStatus.QualificationId">Delete route</govuk-summary-card-action>
+                    @if (canEdit)
+                    {
+                        <govuk-summary-card-action href="@LinkGenerator.RouteEditDetail(professionalStatus.QualificationId, null)" visually-hidden-text="edit route" data-testid="edit-route-link-@professionalStatus.QualificationId">Edit route</govuk-summary-card-action>
+                        <govuk-summary-card-action href="@LinkGenerator.DeleteRouteChangeReason(professionalStatus.QualificationId, null)" visually-hidden-text="delete route" data-testid="delete-route-link-@professionalStatus.QualificationId">Delete route</govuk-summary-card-action>
+                    }
                 </govuk-summary-card-actions>
                 <govuk-summary-list>
                     <govuk-summary-list-row>
@@ -100,7 +107,11 @@
             </govuk-summary-card>
         }
     }
-    <govuk-button-link href="@LinkGenerator.RouteAdd(Model.PersonId)" class="govuk-button" data-testid="add-route">Add a route</govuk-button-link>
+
+    @if (canEdit)
+    {
+        <govuk-button-link href="@LinkGenerator.RouteAdd(Model.PersonId)" class="govuk-button" data-testid="add-route">Add a route</govuk-button-link>
+    }
 
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 }
@@ -116,47 +127,67 @@ else
         <govuk-summary-card data-testid="mq-@mq.QualificationId">
             <govuk-summary-card-title>Mandatory qualification@(mq.Specialism is not null ? $" for {mq.Specialism?.GetName()}" : "")</govuk-summary-card-title>
             <govuk-summary-card-actions>
-                <govuk-summary-card-action href="@LinkGenerator.MqDelete(mq.QualificationId, null)" visually-hidden-text="delete qualification" data-testid="delete-link-@mq.QualificationId">Delete qualification</govuk-summary-card-action>
+                @if (canEdit)
+                {
+                    <govuk-summary-card-action href="@LinkGenerator.MqDelete(mq.QualificationId, null)" visually-hidden-text="delete qualification" data-testid="delete-link-@mq.QualificationId">Delete qualification</govuk-summary-card-action>
+                }
             </govuk-summary-card-actions>
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="mq-provider-@mq.QualificationId">@(mq.Provider?.Name ?? "None")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.MqEditProvider(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="change training provider" data-testid="provider-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        @if (canEdit)
+                        {
+                            <govuk-summary-list-row-action href="@LinkGenerator.MqEditProvider(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="change training provider" data-testid="provider-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        }
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Specialism</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="mq-specialism-@mq.QualificationId">@(mq.Specialism is not null ? mq.Specialism?.GetTitle() : "None")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.MqEditSpecialism(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="change specialism" data-testid="specialism-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        @if (canEdit)
+                        {
+                            <govuk-summary-list-row-action href="@LinkGenerator.MqEditSpecialism(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="change specialism" data-testid="specialism-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        }
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="mq-start-date-@mq.QualificationId">@(mq.StartDate.HasValue ? mq.StartDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : "None")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.MqEditStartDate(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="change start date" data-testid="start-date-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        @if (canEdit)
+                        {
+                            <govuk-summary-list-row-action href="@LinkGenerator.MqEditStartDate(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="change start date" data-testid="start-date-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        }
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="mq-status-@mq.QualificationId">@(mq.Status.HasValue ? mq.Status?.GetTitle() : "None")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.MqEditStatus(mq.QualificationId, null)" visually-hidden-text="change status" data-testid="status-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        @if (canEdit)
+                        {
+                            <govuk-summary-list-row-action href="@LinkGenerator.MqEditStatus(mq.QualificationId, null)" visually-hidden-text="change status" data-testid="status-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        }
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value data-testid="mq-end-date-@mq.QualificationId">@(mq.EndDate.HasValue ? mq.EndDate!.Value.ToString(UiDefaults.DateOnlyDisplayFormat) : "None")</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.MqEditStatus(mq.QualificationId, null)" visually-hidden-text="change end date" data-testid="end-date-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        @if (canEdit)
+                        {
+                            <govuk-summary-list-row-action href="@LinkGenerator.MqEditStatus(mq.QualificationId, null)" visually-hidden-text="change end date" data-testid="end-date-change-link-@mq.QualificationId">Change</govuk-summary-list-row-action>
+                        }
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>
         </govuk-summary-card>
     }
 }
-
-<govuk-button-link href="@LinkGenerator.MqAdd(Model.PersonId)" class="govuk-button" data-testid="add-mandatory-qualification">Add a mandatory qualification</govuk-button-link>
+@if (canEdit)
+{
+    <govuk-button-link href="@LinkGenerator.MqAdd(Model.PersonId)" class="govuk-button" data-testid="add-mandatory-qualification">Add a mandatory qualification</govuk-button-link>
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
@@ -1,11 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt.Models;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
+[Authorize(Policy = AuthorizationPolicies.RoutesView)]
 public class QualificationsModel(TrsDbContext dbContext, ReferenceDataCache referenceDataCache) : PageModel
 {
     [FromRoute]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Conventions.cs
@@ -1,9 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
-namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute;
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
 public class Conventions : IConfigureFolderConventions
 {
@@ -13,7 +12,6 @@ public class Conventions : IConfigureFolderConventions
             this.GetFolderPathFromNamespace(),
             model =>
             {
-                model.Filters.Add(new CheckPersonExistsFilterFactory());
                 model.EndpointMetadata.Add(new AuthorizeAttribute()
                 {
                     Policy = AuthorizationPolicies.RoutesEdit

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialism.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialism.cshtml.cs
@@ -1,12 +1,15 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 using TeachingRecordSystem.SupportUi.ValidationAttributes;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
 [Journey(JourneyNames.EditRouteToProfessionalStatus), RequireJourneyInstance]
+[Authorize(Policy = AuthorizationPolicies.RoutesEdit)]
 public class AgeRangeSpecialismModel(
     TrsLinkGenerator linkGenerator) : PageModel
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Conventions.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
@@ -12,6 +14,10 @@ public class Conventions : IConfigureFolderConventions
             model =>
             {
                 model.Filters.Add(new CheckRouteToProfessionalStatusExistsFilterFactory());
+                model.EndpointMetadata.Add(new AuthorizeAttribute()
+                {
+                    Policy = AuthorizationPolicies.RoutesEdit
+                });
             });
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
@@ -1,10 +1,14 @@
 @using TeachingRecordSystem.SupportUi.Pages.Common
+@using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+@using Microsoft.AspNetCore.Authorization;
+@inject IAuthorizationService AuthorizationService
 @model PersonDetailViewModel
 
 <govuk-summary-card>
     <govuk-summary-card-title>Personal details</govuk-summary-card-title>
     <govuk-summary-card-actions>
-        @if (FeatureProvider.IsEnabled(FeatureNames.ContactsMigrated))
+        @if (FeatureProvider.IsEnabled(FeatureNames.ContactsMigrated) &&
+           (await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.PersonDataEdit)).Succeeded)
         {
             <govuk-summary-card-action data-testid="change-details-link" href=@LinkGenerator.PersonEditDetailsPersonalDetails(Model.PersonId) visually-hidden-text="personal details">Change</govuk-summary-card-action>
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -92,7 +92,8 @@ builder.Services.AddAuthorizationBuilder()
     .AddUserManagementPolicies()
     .AddAlertPolicies()
     .AddInductionPolicies()
-    .AddPersonDataPolicies();
+    .AddPersonDataPolicies()
+    .AddRoutesPolicies();
 
 builder.Services
     .AddRazorPages(options =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/PermissionsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/PermissionsTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
+using TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.AddRoute;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.EditRoute;
+
+[Collection(nameof(DisableParallelization))]
+public class PermissionsTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyncLifetime
+{
+    private static readonly IReadOnlyCollection<(string? UserRole, bool CanEdit)> RoleAccess = [
+        (null, false),
+        (UserRoles.AccessManager, false),
+        (UserRoles.Viewer, false),
+        (UserRoles.AlertsManagerTra, false),
+        (UserRoles.AlertsManagerTraDbs, false),
+        (UserRoles.RecordManager, true),
+        (UserRoles.Administrator, true),
+    ];
+
+    private static readonly IReadOnlyCollection<(string, string)> PageFormats = [
+        // {0}: qualification ID
+        // {1}: journey ID
+        // {2}: person ID
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/age-range?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/change-reason?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/check-answers?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/country?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/degree-type?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/holds-from?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/induction-exemption?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/route?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/start-and-end-date?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/status?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/subjects?{1}&personId={2}"),
+        (JourneyNames.AddRouteToProfessionalStatus, "/route/add/training-provider?{1}&personId={2}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/change-reason?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/check-answers?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/country?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/degree-type?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/detail?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/holds-from?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/induction-exemption?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/start-and-end-date?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/status?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/subjects?{1}"),
+        (JourneyNames.EditRouteToProfessionalStatus, "/route/{0}/edit/training-provider?{1}"),
+        (JourneyNames.DeleteRouteToProfessionalStatus, "/route/{0}/delete/change-reason?{1}"),
+        (JourneyNames.DeleteRouteToProfessionalStatus, "/route/{0}/delete/check-answers?{1}"),
+    ];
+
+    Guid _personId;
+    Guid _qualificationId;
+    RouteToProfessionalStatusType? _route;
+    RouteToProfessionalStatusStatus _status;
+
+    public async Task InitializeAsync()
+    {
+        FeatureProvider.Features.Add(FeatureNames.ContactsMigrated);
+        FeatureProvider.Features.Add(FeatureNames.RoutesToProfessionalStatus);
+
+        _route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
+            .Where(r => r.TrainingAgeSpecialismTypeRequired == FieldRequirement.Optional && r.InductionExemptionRequired != FieldRequirement.NotApplicable)
+            .RandomOne();
+
+        _status = ProfessionalStatusStatusRegistry.All
+            .Where(s => s.TrainingAgeSpecialismTypeRequired == FieldRequirement.Optional && s.HoldsFromRequired == FieldRequirement.NotApplicable)
+            .RandomOne()
+            .Value;
+
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithRouteToProfessionalStatus(r => r
+                .WithRouteType(_route.RouteToProfessionalStatusTypeId)
+                .WithStatus(_status)));
+
+        _personId = person.PersonId;
+        _qualificationId = person.ProfessionalStatuses.First().QualificationId;
+    }
+
+    public Task DisposeAsync()
+    {
+        FeatureProvider.Features.Remove(FeatureNames.ContactsMigrated);
+        FeatureProvider.Features.Remove(FeatureNames.RoutesToProfessionalStatus);
+
+        return Task.CompletedTask;
+    }
+
+    [Theory]
+    [MemberData(nameof(GetData))]
+    public async Task Get_RoutesPage_UserRoles_CanViewPageAsExpected(string journeyName, string pageFormat, string? userRole, bool canViewPage)
+    {
+        // Arrange
+        SetCurrentUser(TestUsers.GetUser(userRole));
+
+        JourneyInstance journey = journeyName switch
+        {
+            JourneyNames.EditRouteToProfessionalStatus => await CreateJourneyInstance(
+                JourneyNames.EditRouteToProfessionalStatus,
+                new EditRouteStateBuilder()
+                    .WithRouteToProfessionalStatusId(_route!.RouteToProfessionalStatusTypeId)
+                    .WithStatus(_status)
+                    .Build(),
+                new KeyValuePair<string, object>("qualificationId", _qualificationId)),
+
+            JourneyNames.AddRouteToProfessionalStatus => await CreateJourneyInstance(
+                JourneyNames.AddRouteToProfessionalStatus,
+                new AddRouteStateBuilder()
+                    .WithRouteToProfessionalStatusId(_route!.RouteToProfessionalStatusTypeId)
+                    .WithStatus(_status)
+                    .Build(),
+                new KeyValuePair<string, object>("personId", _personId)),
+
+            _ => await CreateJourneyInstance(
+                JourneyNames.DeleteRouteToProfessionalStatus,
+                new DeleteRouteState()
+                {
+                    ChangeReason = Pages.RoutesToProfessionalStatus.DeleteRoute.ChangeReasonOption.RemovedQtlsStatus,
+                    ChangeReasonDetail = new ChangeReasonStateBuilder()
+                        .WithValidChangeReasonDetail()
+                        .Build()
+                },
+                new KeyValuePair<string, object>("qualificationId", _qualificationId))
+        };
+
+        var page = string.Format(pageFormat, _qualificationId, journey.GetUniqueIdQueryParameter(), _personId);
+        var request = new HttpRequestMessage(HttpMethod.Get, page);
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        if (canViewPage)
+        {
+            Assert.Contains(response.StatusCode, new HttpStatusCode[] { HttpStatusCode.OK, HttpStatusCode.Found });
+        }
+        else
+        {
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+    }
+
+    public static TheoryData<string, string, string?, bool> GetData()
+    {
+        var data = new TheoryData<string, string, string?, bool>();
+
+        foreach (var (journeyName, pageFormat) in PageFormats)
+        {
+            foreach (var (role, canEdit) in RoleAccess)
+            {
+                data.Add(journeyName, pageFormat, role, canEdit);
+            }
+        }
+
+        return data;
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
@@ -11,14 +11,15 @@ public static class AngleSharpExtensions
         return element as T;
     }
 
-    public static IReadOnlyList<IElement> GetAllElementsByTestId(this IElement element, string testId) =>
-        element.QuerySelectorAll($"*[data-testid='{testId}']").ToList();
+    public static IReadOnlyList<IElement> GetAllElementsByTestId(this IElement element, params string[] testIds) =>
+        //element.QuerySelectorAll(string.Join(',', testIds.Select(testId => $"*[data-testid='{testId}']"))).ToList();
+        testIds.SelectMany(testId => element.QuerySelectorAll($"*[data-testid='{testId}']")).ToList();
 
     public static IElement? GetElementByTestId(this IElement element, string testId) =>
         element.GetAllElementsByTestId(testId).SingleOrDefault();
 
-    public static IReadOnlyList<IElement> GetAllElementsByTestId(this IHtmlDocument doc, string testId) =>
-        doc.Body!.GetAllElementsByTestId(testId);
+    public static IReadOnlyList<IElement> GetAllElementsByTestId(this IHtmlDocument doc, params string[] testIds) =>
+        doc.Body!.GetAllElementsByTestId(testIds);
 
     public static IElement? GetElementByLabel(this IHtmlDocument doc, string label)
     {


### PR DESCRIPTION
### Context

We are rolling out new Access Permissions functionality to the TRS console, following the permissions given here [TRS console permissions v1.1.xlsx](https://educationgovuk.sharepoint.com/:x:/s/TRATransformationTeamDocs/ESDUojMQEwFPsEdvjlm0SC0BkTQHCI-04KIUQMzuvFEZlw?e=ygFp7I). We need to ensure that the Routes functionality is fully established in this new process.

https://trello.com/c/kFOmgVRE/1216-ensure-routes-functionality-is-added-to-the-access-permissions

### Changes proposed in this pull request

* Adds `Routes` permission type, and view/edit policies
* Adds authorization to routes pages

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
