### PR TITLE
Disable API endpoints that write routes via configuration

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/RequireRouteWritesEnabledAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/RequireRouteWritesEnabledAttribute.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace TeachingRecordSystem.Api;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class RequireRouteWritesEnabledAttribute : Attribute, IFilterFactory
+{
+    public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+    {
+        var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+        return new RequireRouteWritesEnabledFilter(configuration);
+    }
+
+    public bool IsReusable => true;
+}
+
+public class RequireRouteWritesEnabledFilter(IConfiguration configuration) : IActionFilter
+{
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (configuration["DisableRouteWrites"]?.Equals("true", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            context.Result = new StatusCodeResult(StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240912/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240912/Controllers/PersonsController.cs
@@ -11,6 +11,7 @@ namespace TeachingRecordSystem.Api.V3.V20240912.Controllers;
 [Route("persons")]
 public class PersonsController(IMapper mapper) : ControllerBase
 {
+    [RequireRouteWritesEnabled]
     [HttpPut("{trn}/qtls")]
     [SwaggerOperation(
         OperationId = "SetQtls",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250425/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250425/Controllers/PersonsController.cs
@@ -13,6 +13,7 @@ namespace TeachingRecordSystem.Api.V3.V20250425.Controllers;
 [Route("persons")]
 public class PersonsController(IMapper mapper) : ControllerBase
 {
+    [RequireRouteWritesEnabled]
     [HttpPut("{trn}/professional-statuses/{reference}")]
     [SwaggerOperation(
         OperationId = "SetProfessionalStatus",


### PR DESCRIPTION
During routes migration we want to be sure we're not getting any route writes coming through the API. Although we should have a block in place in CRM this gives us an extra layer of protection.

I've tested this locally but not added automated tests as we can't easily override configuration there currently.