### PR TITLE
Hide not applicable fields from Edit CYA page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -36,7 +36,7 @@
                     @if (canEdit)
                     {
                         <govuk-summary-card-action href="@LinkGenerator.RouteEditDetail(professionalStatus.QualificationId, null)" visually-hidden-text="edit route" data-testid="edit-route-link-@professionalStatus.QualificationId">Edit route</govuk-summary-card-action>
-                        <govuk-summary-card-action href="@LinkGenerator.DeleteRouteChangeReason(professionalStatus.QualificationId, null)" visually-hidden-text="delete route" data-testid="delete-route-link-@professionalStatus.QualificationId">Delete route</govuk-summary-card-action>
+                        <govuk-summary-card-action href="@LinkGenerator.RouteDeleteChangeReason(professionalStatus.QualificationId, null)" visually-hidden-text="delete route" data-testid="delete-route-link-@professionalStatus.QualificationId">Delete route</govuk-summary-card-action>
                     }
                 </govuk-summary-card-actions>
                 <govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/AddRouteCommonPageModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/AddRouteCommonPageModel.cs
@@ -40,11 +40,6 @@ public abstract class AddRouteCommonPageModel(TrsLinkGenerator linkGenerator, Re
         return PageDriver.PreviousPage(Route, Status, currentPage);
     }
 
-    public bool IsLastPage(AddRoutePage currentPage)
-    {
-        return PageDriver.IsLastPage(currentPage);
-    }
-
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         if (!(JourneyInstance!.State.RouteToProfessionalStatusId.HasValue && JourneyInstance!.State.Status.HasValue))

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/HoldsFrom.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/HoldsFrom.cshtml.cs
@@ -14,7 +14,7 @@ public class HoldsFromModel(IClock clock, TrsLinkGenerator linkGenerator, Refere
 
     public string BackLink => FromCheckAnswers ?
         LinkGenerator.RouteAddCheckYourAnswers(PersonId, JourneyInstance!.InstanceId) :
-        LinkGenerator.RouteAddPage(PreviousPage(AddRoutePage.AwardDate) ?? AddRoutePage.Status, PersonId, JourneyInstance!.InstanceId);
+        LinkGenerator.RouteAddPage(PreviousPage(AddRoutePage.HoldsFrom) ?? AddRoutePage.Status, PersonId, JourneyInstance!.InstanceId);
 
     public void OnGet()
     {
@@ -35,6 +35,6 @@ public class HoldsFromModel(IClock clock, TrsLinkGenerator linkGenerator, Refere
 
         return Redirect(FromCheckAnswers ?
             LinkGenerator.RouteAddCheckYourAnswers(PersonId, JourneyInstance.InstanceId) :
-            LinkGenerator.RouteAddPage(NextPage(AddRoutePage.AwardDate) ?? AddRoutePage.CheckYourAnswers, PersonId, JourneyInstance!.InstanceId));
+            LinkGenerator.RouteAddPage(NextPage(AddRoutePage.HoldsFrom) ?? AddRoutePage.CheckYourAnswers, PersonId, JourneyInstance!.InstanceId));
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/PageDriver.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/PageDriver.cs
@@ -30,6 +30,7 @@ public static class PageDriver
                 }
             }
         }
+
         return null;
     }
 
@@ -63,21 +64,12 @@ public static class PageDriver
         return null;
     }
 
-    public static bool IsLastPage(AddRoutePage currentPage)
-    {
-        var lastPage = Enum.GetValues(typeof(AddRoutePage))
-            .Cast<AddRoutePage>()
-            .OrderByDescending(p => p)
-            .First();
-        return lastPage == currentPage;
-    }
-
     public static FieldRequirement FieldRequirementForPage(this AddRoutePage page, RouteToProfessionalStatusType Route, RouteToProfessionalStatusStatus Status)
     {
         return page switch
         {
             AddRoutePage.StartAndEndDate => QuestionDriverHelper.FieldRequired(Route.TrainingEndDateRequired, Status.GetEndDateRequirement()),
-            AddRoutePage.AwardDate => QuestionDriverHelper.FieldRequired(Route.HoldsFromRequired, Status.GetAwardDateRequirement()),
+            AddRoutePage.HoldsFrom => QuestionDriverHelper.FieldRequired(Route.HoldsFromRequired, Status.GetAwardDateRequirement()),
             AddRoutePage.InductionExemption => QuestionDriverHelper.FieldRequired(Route.InductionExemptionRequired, Status.GetInductionExemptionRequirement()),
             AddRoutePage.Route => FieldRequirement.Mandatory,
             AddRoutePage.Status => FieldRequirement.Mandatory,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/_RouteDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/_RouteDetail.cshtml
@@ -4,26 +4,33 @@
         <govuk-summary-list-row-key>Route</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.RouteToProfessionalStatusType.Name</govuk-summary-list-row-value>
     </govuk-summary-list-row>
+
     <govuk-summary-list-row>
         <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.Status.GetTitle()</govuk-summary-list-row-value>
     </govuk-summary-list-row>
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="add-start-date-link" href="@LinkGenerator.RouteAddStartAndEndDate(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="start date">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
+    @if (Model.StartDateRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="add-start-date-link" href="@LinkGenerator.RouteAddStartAndEndDate(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="start date">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="add-end-date-link" href="@LinkGenerator.RouteAddStartAndEndDate(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
+    @if (Model.EndDateRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="add-end-date-link" href="@LinkGenerator.RouteAddStartAndEndDate(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
 
     @if (Model.AwardDateRequired != FieldRequirement.NotApplicable)
     {
@@ -35,6 +42,7 @@
             </govuk-summary-list-row-actions>
         </govuk-summary-list-row>
     }
+
     @if (Model.HasInductionExemptionRequired != FieldRequirement.NotApplicable)
     {
         <govuk-summary-list-row>
@@ -49,67 +57,82 @@
         </govuk-summary-list-row>
     }
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingProvider</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="add-training-provider-link" href="@LinkGenerator.RouteAddTrainingProvider(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training provider">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
-
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Degree type</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.DegreeType</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="add-degree-type-link" href="@LinkGenerator.RouteAddDegreeType(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="degree type">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
-
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Country of training</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingCountry</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="add-country-link" href="@LinkGenerator.RouteAddCountry(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training country">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
-
-    <govuk-summary-list-row>
-    <govuk-summary-list-row-key>Age range</govuk-summary-list-row-key>
-    @if (Model.TrainingAgeSpecialismRangeFrom is not null && Model.TrainingAgeSpecialismRangeTo is not null)
+    @if (Model.TrainingProviderRequired != FieldRequirement.NotApplicable)
     {
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismRange</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-                <govuk-summary-list-row-action data-testid="add-age-range-link" href="@LinkGenerator.RouteAddAgeRangeSpecialism(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingProvider</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="add-training-provider-link" href="@LinkGenerator.RouteAddTrainingProvider(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training provider">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
     }
-    else
-    {
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismType?.GetDisplayName()</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-                <govuk-summary-list-row-action data-testid="add-age-range-link" href="@LinkGenerator.RouteAddAgeRangeSpecialism(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-        }
-    </govuk-summary-list-row>
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value>
-            @if (Model.TrainingSubjects is not null && Model.TrainingSubjects.Any())
+    @if (Model.DegreeTypeRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Degree type</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.DegreeType</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="add-degree-type-link" href="@LinkGenerator.RouteAddDegreeType(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="degree type">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
+
+    @if (Model.TrainingCountryRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Country of training</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingCountry</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="add-country-link" href="@LinkGenerator.RouteAddCountry(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training country">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
+
+    @if (Model.AgeSpecialismRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Age range</govuk-summary-list-row-key>
+            @if (Model.TrainingAgeSpecialismRangeFrom is not null && Model.TrainingAgeSpecialismRangeTo is not null)
             {
-                <ul class="govuk-list">
-                    @foreach (var subject in Model.TrainingSubjects)
-                    {
-                        <li>@subject</li>
-                    }
-                </ul>
+                <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismRange</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action data-testid="add-age-range-link" href="@LinkGenerator.RouteAddAgeRangeSpecialism(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
             }
             else
             {
-                <span use-empty-fallback></span>
+                <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismType?.GetDisplayName()</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action data-testid="add-age-range-link" href="@LinkGenerator.RouteAddAgeRangeSpecialism(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
             }
-        </govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="add-subjects-link" href="@LinkGenerator.RouteAddSubjectSpecialisms(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training subjects">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
+        </govuk-summary-list-row>
+    }
+
+    @if (Model.TrainingSubjectsRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>
+                @if (Model.TrainingSubjects is not null && Model.TrainingSubjects.Any())
+                {
+                    <ul class="govuk-list">
+                        @foreach (var subject in Model.TrainingSubjects)
+                        {
+                            <li>@subject</li>
+                        }
+                    </ul>
+                }
+                else
+                {
+                    <span use-empty-fallback></span>
+                }
+            </govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="add-subjects-link" href="@LinkGenerator.RouteAddSubjectSpecialisms(Model.PersonId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training subjects">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
 </govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoutePage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoutePage.cs
@@ -5,7 +5,7 @@ public enum AddRoutePage
     Route = 0,
     Status,
     StartAndEndDate,
-    AwardDate,
+    HoldsFrom,
     InductionExemption,
     TrainingProvider,
     DegreeType,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/ChangeReason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/ChangeReason.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/route/{qualificationId}/delete/change-reason/{handler?}"
+@page "/route/{qualificationId}/delete/change-reason/{handler?}"
 @model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute.ChangeReasonModel
 @{
     ViewBag.Title = "Change reason";
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.DeleteRouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
+        <form action="@LinkGenerator.RouteDeleteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
             <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
             <govuk-radios asp-for="ChangeReason" data-testid="reason-options">
                 <govuk-radios-fieldset>
@@ -68,7 +68,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.DeleteRouteChangeReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteDeleteChangeReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/ChangeReason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/ChangeReason.cshtml.cs
@@ -56,10 +56,10 @@ public class ChangeReasonModel(TrsLinkGenerator linkGenerator,
 
     public string? UploadedEvidenceFileUrl { get; set; }
 
-    public string NextPage => linkGenerator.DeleteRouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId);
+    public string NextPage => linkGenerator.RouteDeleteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId);
 
     public string BackLink => FromCheckAnswers == true
-        ? linkGenerator.DeleteRouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId)
+        ? linkGenerator.RouteDeleteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId)
         : linkGenerator.PersonQualifications(PersonId);
 
     public async Task OnGetAsync()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.DeleteRouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+        <form action="@LinkGenerator.RouteDeleteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
             <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
             <partial name="_RouteDetail" model="@Model.RouteDetail" />
@@ -21,7 +21,7 @@
                     <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.ChangeReason?.GetDisplayName()</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.DeleteRouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                        <govuk-summary-list-row-action href="@LinkGenerator.RouteDeleteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
                                                        visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
@@ -29,7 +29,7 @@
                     <govuk-summary-list-row-key>Additional information</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.ChangeReasonDetail.ChangeReasonDetail</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.DeleteRouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                        <govuk-summary-list-row-action href="@LinkGenerator.RouteDeleteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
                                                        visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
@@ -46,7 +46,7 @@
                         }
                     </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.DeleteRouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                        <govuk-summary-list-row-action href="@LinkGenerator.RouteDeleteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
                                                        visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
 
@@ -54,7 +54,7 @@
             </govuk-summary-list>
             <div class="govuk-button-group">
                 <govuk-button class="govuk-button--warning" type="submit" data-testid="confirm-button">Delete route</govuk-button>
-                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.DeleteRouteCheckYourAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteDeleteCheckYourAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers.cshtml.cs
@@ -25,7 +25,7 @@ public class CheckYourAnswersModel(
     public ChangeReasonOption? ChangeReason;
     public ChangeReasonDetailsState ChangeReasonDetail { get; set; } = new();
 
-    public string BackLink => linkGenerator.RouteChangeReason(QualificationId, JourneyInstance!.InstanceId);
+    public string BackLink => linkGenerator.RouteDeleteChangeReason(QualificationId, JourneyInstance!.InstanceId);
 
     [FromRoute]
     public Guid QualificationId { get; set; }
@@ -42,7 +42,7 @@ public class CheckYourAnswersModel(
     {
         if (!JourneyInstance!.State.Completed)
         {
-            return Redirect(linkGenerator.DeleteRouteChangeReason(QualificationId, JourneyInstance!.InstanceId, fromCheckAnswers: true));
+            return Redirect(linkGenerator.RouteDeleteChangeReason(QualificationId, JourneyInstance!.InstanceId, fromCheckAnswers: true));
         }
         var professionalStatus = HttpContext.GetCurrentProfessionalStatusFeature().RouteToProfessionalStatus;
         var allRoutes = await referenceDataCache.GetRouteToProfessionalStatusTypesAsync(activeOnly: false);
@@ -85,7 +85,7 @@ public class CheckYourAnswersModel(
     {
         if (!JourneyInstance!.State.ChangeReasonIsComplete)
         {
-            context.Result = Redirect(linkGenerator.DeleteRouteChangeReason(QualificationId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.RouteDeleteChangeReason(QualificationId, JourneyInstance.InstanceId));
             return;
         }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialism.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialism.cshtml
@@ -4,7 +4,7 @@
     ViewBag.Title = "Edit age range specialism";
 }
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == false ? LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == false ? LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialism.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialism.cshtml.cs
@@ -47,7 +47,7 @@ public class AgeRangeSpecialismModel(
                 s.TrainingAgeSpecialismType = TrainingAgeSpecialism!.AgeRangeType.ToTrainingAgeSpecialismType();
             });
         return Redirect(FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance!.InstanceId));
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/ChangeReason.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/ChangeReason.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
+        <form action="@LinkGenerator.RouteEditChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers)" method="post" enctype="multipart/form-data">
             <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
             <govuk-radios asp-for="ChangeReason" data-testid="reason-options">
                 <govuk-radios-fieldset>
@@ -71,7 +71,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteChangeReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteEditChangeReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/ChangeReason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/ChangeReason.cshtml.cs
@@ -56,10 +56,10 @@ public class ChangeReasonModel(TrsLinkGenerator linkGenerator,
 
     public string? UploadedEvidenceFileUrl { get; set; }
 
-    public string NextPage => linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId);
+    public string NextPage => linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId);
 
     public string BackLink => FromCheckAnswers == true
-        ? linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId)
+        ? linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId)
         : linkGenerator.RouteEditDetail(QualificationId, JourneyInstance!.InstanceId);
 
     public async Task OnGetAsync()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
+        <form action="@LinkGenerator.RouteEditCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId)" method="post">
             <span class="govuk-caption-l">Routes and professional status - @Model.PersonName</span>
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
             <partial name="_RouteDetail" model="@Model.RouteDetail" />
@@ -21,7 +21,7 @@
                     <govuk-summary-list-row-key>Reason for change</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.ChangeReason?.GetDisplayName()</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.RouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                        <govuk-summary-list-row-action href="@LinkGenerator.RouteEditChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
                                                         visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
@@ -29,7 +29,7 @@
                     <govuk-summary-list-row-key>Additional information</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.ChangeReasonDetail.ChangeReasonDetail</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.RouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                        <govuk-summary-list-row-action href="@LinkGenerator.RouteEditChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
                                                        visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
@@ -46,7 +46,7 @@
                         }
                     </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.RouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                        <govuk-summary-list-row-action href="@LinkGenerator.RouteEditChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
                                                        visually-hidden-text="reason for change">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
 
@@ -54,7 +54,7 @@
             </govuk-summary-list>
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="confirm-button">Confirm and update route</govuk-button>
-                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteCheckYourAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteEditCheckYourAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers.cshtml.cs
@@ -28,7 +28,7 @@ public class CheckYourAnswersModel(
     public ChangeReasonDetailsState ChangeReasonDetail { get; set; } = new();
     public string? UploadedEvidenceFileUrl { get; set; }
 
-    public string BackLink => linkGenerator.RouteChangeReason(QualificationId, JourneyInstance!.InstanceId);
+    public string BackLink => linkGenerator.RouteEditChangeReason(QualificationId, JourneyInstance!.InstanceId);
 
     [FromRoute]
     public Guid QualificationId { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Country.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Country.cshtml
@@ -36,7 +36,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteEditCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Country.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Country.cshtml.cs
@@ -51,7 +51,7 @@ public class CountryModel(
         await JourneyInstance!.UpdateStateAsync(s => s.TrainingCountryId = TrainingCountryId);
 
         return Redirect(FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance.InstanceId));
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/DegreeType.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/DegreeType.cshtml
@@ -36,7 +36,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteEditCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/DegreeType.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/DegreeType.cshtml.cs
@@ -53,7 +53,7 @@ public class DegreeTypeModel(
         await JourneyInstance!.UpdateStateAsync(s => s.DegreeTypeId = DegreeTypeId);
 
         return Redirect(FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance.InstanceId));
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml
@@ -15,7 +15,7 @@
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
             <partial name="_RouteDetail" model="@Model.RouteDetail" />
             <div class="govuk-button-group">
-                <govuk-button-link data-testid="continue-button" href="@LinkGenerator.RouteChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)">Continue</govuk-button-link>
+                <govuk-button-link data-testid="continue-button" href="@LinkGenerator.RouteEditChangeReason(Model.QualificationId, Model.JourneyInstance!.InstanceId)">Continue</govuk-button-link>
                 <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RouteEditDetailCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/HoldsFrom.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/HoldsFrom.cshtml.cs
@@ -48,7 +48,7 @@ public class HoldsFromModel(IClock clock, TrsLinkGenerator linkGenerator) : Page
         var nextPage = JourneyInstance!.State.IsCompletingRoute ?
             NextCompletingRoutePage :
             FromCheckAnswers ?
-                linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
+                linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
                 linkGenerator.RouteEditDetail(QualificationId, JourneyInstance!.InstanceId);
 
         if (JourneyInstance!.State.IsCompletingRoute) // if user has set the status to 'holds' from another status
@@ -95,7 +95,7 @@ public class HoldsFromModel(IClock clock, TrsLinkGenerator linkGenerator) : Page
     }
 
     public string BackLink => FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
             JourneyInstance!.State.IsCompletingRoute ?
                 linkGenerator.RouteEditStatus(QualificationId, JourneyInstance!.InstanceId) :
                 linkGenerator.RouteEditDetail(QualificationId, JourneyInstance!.InstanceId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/InductionExemption.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/InductionExemption.cshtml.cs
@@ -55,7 +55,7 @@ public class InductionExemptionModel(TrsLinkGenerator linkGenerator) : PageModel
         }
 
         return Redirect(FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance.InstanceId));
     }
 
@@ -82,7 +82,7 @@ public class InductionExemptionModel(TrsLinkGenerator linkGenerator) : PageModel
     }
 
     public string BackLink => FromCheckAnswers ?
-        linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
+        linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
         JourneyInstance!.State.IsCompletingRoute ?
             linkGenerator.RouteEditHoldsFrom(QualificationId, JourneyInstance!.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance!.InstanceId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartAndEndDates.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartAndEndDates.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == false ? LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == false ? LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId) : LinkGenerator.RouteEditCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartAndEndDates.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/StartAndEndDates.cshtml.cs
@@ -58,7 +58,7 @@ public class StartAndEndDateModel(
         return Redirect(JourneyInstance!.State.IsCompletingRoute ?
             NextCompletingRoutePage() :
             FromCheckAnswers ?
-                linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+                linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
                 linkGenerator.RouteEditDetail(QualificationId, JourneyInstance.InstanceId));
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Status.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Status.cshtml.cs
@@ -80,7 +80,7 @@ public class StatusModel(
         return Redirect(CompletingRoute ?
             linkGenerator.RouteEditHoldsFrom(QualificationId, JourneyInstance!.InstanceId) :
             FromCheckAnswers ?
-                linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+                linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
                 linkGenerator.RouteEditDetail(QualificationId, JourneyInstance.InstanceId));
     }
 
@@ -103,7 +103,7 @@ public class StatusModel(
 
     public string BackLink =>
          FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance!.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance!.InstanceId);
 
     private bool CompletingRoute => Status is RouteToProfessionalStatusStatus.Holds && (JourneyInstance!.State.CurrentStatus is not RouteToProfessionalStatusStatus.Holds);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/SubjectSpecialisms.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/SubjectSpecialisms.cshtml
@@ -42,7 +42,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteEditCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/SubjectSpecialisms.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/SubjectSpecialisms.cshtml.cs
@@ -66,7 +66,7 @@ public class SubjectSpecialismsModel(TrsLinkGenerator linkGenerator, ReferenceDa
         await JourneyInstance!.UpdateStateAsync(s => s.TrainingSubjectIds = subjects);
 
         return Redirect(FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance.InstanceId));
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/TrainingProvider.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/TrainingProvider.cshtml
@@ -36,7 +36,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.RouteEditCheckYourAnswers(Model.QualificationId, Model.JourneyInstance!.InstanceId) :LinkGenerator.RouteEditDetail(Model.QualificationId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/TrainingProvider.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/TrainingProvider.cshtml.cs
@@ -52,7 +52,7 @@ public class TrainingProviderModel(
         await JourneyInstance!.UpdateStateAsync(s => s.TrainingProviderId = TrainingProviderId);
 
         return Redirect(FromCheckAnswers ?
-            linkGenerator.RouteCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
+            linkGenerator.RouteEditCheckYourAnswers(QualificationId, JourneyInstance.InstanceId) :
             linkGenerator.RouteEditDetail(QualificationId, JourneyInstance.InstanceId));
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/_RouteDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/_RouteDetail.cshtml
@@ -4,6 +4,7 @@
         <govuk-summary-list-row-key>Route</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.RouteToProfessionalStatusType.Name</govuk-summary-list-row-value>
     </govuk-summary-list-row>
+
     <govuk-summary-list-row>
         <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
         <govuk-summary-list-row-value>@Model.Status.GetTitle()</govuk-summary-list-row-value>
@@ -12,21 +13,27 @@
         </govuk-summary-list-row-actions>
     </govuk-summary-list-row>
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-start-date-link" href="@LinkGenerator.RouteEditStartAndEndDate(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="start date">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
+    @if (Model.StartDateRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="edit-start-date-link" href="@LinkGenerator.RouteEditStartAndEndDate(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="start date">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-end-date-link" href="@LinkGenerator.RouteEditStartAndEndDate(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
+    @if (Model.EndDateRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="edit-end-date-link" href="@LinkGenerator.RouteEditStartAndEndDate(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="end date">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
 
     @if (Model.AwardDateRequired != FieldRequirement.NotApplicable)
     {
@@ -38,6 +45,7 @@
             </govuk-summary-list-row-actions>
         </govuk-summary-list-row>
     }
+
     @if (Model.HasInductionExemptionRequired != FieldRequirement.NotApplicable)
     {
         <govuk-summary-list-row>
@@ -52,67 +60,82 @@
         </govuk-summary-list-row>
     }
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingProvider</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-training-provider-link" href="@LinkGenerator.RouteEditTrainingProvider(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training provider">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
-
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Degree type</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.DegreeType</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-degree-type-link" href="@LinkGenerator.RouteEditDegreeType(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="degree type">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
-
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Country of training</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingCountry</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-country-link" href="@LinkGenerator.RouteEditTrainingCountry(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training country">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
-
-    <govuk-summary-list-row>
-    <govuk-summary-list-row-key>Age range</govuk-summary-list-row-key>
-    @if (Model.TrainingAgeSpecialismRangeFrom is not null && Model.TrainingAgeSpecialismRangeTo is not null)
+    @if (Model.TrainingProviderRequired != FieldRequirement.NotApplicable)
     {
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismRange</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-age-range-link" href="@LinkGenerator.RouteEditAgeRangeSpecialism(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingProvider</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="edit-training-provider-link" href="@LinkGenerator.RouteEditTrainingProvider(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training provider">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
     }
-    else
-    {
-        <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismType?.GetDisplayName()</govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-age-range-link" href="@LinkGenerator.RouteEditAgeRangeSpecialism(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-        }
-    </govuk-summary-list-row>
 
-    <govuk-summary-list-row>
-        <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
-        <govuk-summary-list-row-value>
-            @if (Model.TrainingSubjects is not null && Model.TrainingSubjects.Any())
+    @if (Model.DegreeTypeRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Degree type</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.DegreeType</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="edit-degree-type-link" href="@LinkGenerator.RouteEditDegreeType(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="degree type">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
+
+    @if (Model.TrainingCountryRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Country of training</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingCountry</govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="edit-country-link" href="@LinkGenerator.RouteEditTrainingCountry(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training country">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
+
+    @if (Model.AgeSpecialismRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Age range</govuk-summary-list-row-key>
+            @if (Model.TrainingAgeSpecialismRangeFrom is not null && Model.TrainingAgeSpecialismRangeTo is not null)
             {
-                <ul class="govuk-list">
-                    @foreach (var subject in Model.TrainingSubjects)
-                    {
-                        <li>@subject</li>
-                    }
-                </ul>
+                <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismRange</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action data-testid="edit-age-range-link" href="@LinkGenerator.RouteEditAgeRangeSpecialism(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
             }
             else
             {
-                <span use-empty-fallback></span>
+                <govuk-summary-list-row-value use-empty-fallback>@Model.TrainingAgeSpecialismType?.GetDisplayName()</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action data-testid="edit-age-range-link" href="@LinkGenerator.RouteEditAgeRangeSpecialism(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="age range">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
             }
-        </govuk-summary-list-row-value>
-        <govuk-summary-list-row-actions>
-            <govuk-summary-list-row-action data-testid="edit-subjects-link" href="@LinkGenerator.RouteEditTrainingSubjects(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training subjects">Change</govuk-summary-list-row-action>
-        </govuk-summary-list-row-actions>
-    </govuk-summary-list-row>
+        </govuk-summary-list-row>
+    }
+
+    @if (Model.TrainingSubjectsRequired != FieldRequirement.NotApplicable)
+    {
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>
+                @if (Model.TrainingSubjects is not null && Model.TrainingSubjects.Any())
+                {
+                    <ul class="govuk-list">
+                        @foreach (var subject in Model.TrainingSubjects)
+                        {
+                            <li>@subject</li>
+                        }
+                    </ul>
+                }
+                else
+                {
+                    <span use-empty-fallback></span>
+                }
+            </govuk-summary-list-row-value>
+            <govuk-summary-list-row-actions>
+                <govuk-summary-list-row-action data-testid="edit-subjects-link" href="@LinkGenerator.RouteEditTrainingSubjects(Model.QualificationId, Model.JourneyInstanceId, Model.FromCheckAnswers)" visually-hidden-text="training subjects">Change</govuk-summary-list-row-action>
+            </govuk-summary-list-row-actions>
+        </govuk-summary-list-row>
+    }
 </govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
@@ -7,29 +7,31 @@ public partial class TrsLinkGenerator
     public string PersonRoute(Guid personId) =>
         GetRequiredPathByPage("/Persons/PersonDetail/Route", routeValues: new { personId });
 
-    public string DeleteRouteChangeReason(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
+    public string RouteDeleteChangeReason(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/ChangeReason", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-    public string DeleteRouteChangeReasonCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+    public string RouteDeleteChangeReasonCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/ChangeReason", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string DeleteRouteCheckYourAnswers(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+    public string RouteDeleteCheckYourAnswers(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string DeleteRouteCheckYourAnswersCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+    public string RouteDeleteCheckYourAnswersCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
 
     public string RouteEditDetail(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromInductions = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Detail", routeValues: new { qualificationId, fromInductions }, journeyInstanceId: journeyInstanceId);
     public string RouteEditDetailCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Detail", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string RouteChangeReason(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
+    public string RouteEditChangeReason(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/ChangeReason", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-    public string RouteChangeReasonCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+    public string RouteEditChangeReasonCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/ChangeReason", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string RouteCheckYourAnswers(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+    public string RouteEditCheckYourAnswers(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string RouteCheckYourAnswersCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
+    public string RouteEditCheckYourAnswersCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/CheckYourAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string RouteAdd(Guid personId) =>
-        GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Index", routeValues: new { personId });
+    public string RouteEditRoute(Guid qualificationId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Route", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string RouteEditRouteCancel(Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Route", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
     public string RouteEditStatus(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Status", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteEditStatusCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
@@ -46,6 +48,14 @@ public partial class TrsLinkGenerator
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/DegreeType", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteEditDegreeTypeCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/DegreeType", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string RouteEditCountry(Guid qualificationId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Country", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string RouteEditCountryCancel(Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Country", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string RouteEditSubjectSpecialisms(Guid qualificationId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/SubjectSpecialisms", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string RouteEditSubjectSpecialismsCancel(Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/SubjectSpecialisms", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
     public string RouteEditTrainingProvider(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/TrainingProvider", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteEditTrainingProviderCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
@@ -67,6 +77,8 @@ public partial class TrsLinkGenerator
     public string RouteEditInductionExemptionCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/InductionExemption", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
 
+    public string RouteAdd(Guid personId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Index", routeValues: new { personId });
     public string RouteAddRoute(Guid personId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Route", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteAddRouteCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>
@@ -96,13 +108,13 @@ public partial class TrsLinkGenerator
     public string RouteAddTrainingProviderCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/TrainingProvider", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
     public string RouteAddDegreeType(Guid personId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-    GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/DegreeType", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/DegreeType", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteAddDegreeTypeCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/DegreeType", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
     public string RouteAddCountry(Guid personId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Country", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteAddCountryCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>
-    GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Country", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/Country", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
     public string RouteAddSubjectSpecialisms(Guid personId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/AddRoute/SubjectSpecialisms", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteAddSubjectSpecialismsCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>
@@ -122,15 +134,33 @@ public partial class TrsLinkGenerator
             AddRoutePage.Route => RouteAddRoute(personId, journeyInstanceId),
             AddRoutePage.Status => RouteAddStatus(personId, journeyInstanceId),
             AddRoutePage.StartAndEndDate => RouteAddStartAndEndDate(personId, journeyInstanceId),
-            AddRoutePage.AwardDate => RouteAddHoldsFrom(personId, journeyInstanceId),
+            AddRoutePage.HoldsFrom => RouteAddHoldsFrom(personId, journeyInstanceId),
             AddRoutePage.InductionExemption => RouteAddInductionExemption(personId, journeyInstanceId),
             AddRoutePage.TrainingProvider => RouteAddTrainingProvider(personId, journeyInstanceId),
             AddRoutePage.DegreeType => RouteAddDegreeType(personId, journeyInstanceId),
             AddRoutePage.Country => RouteAddCountry(personId, journeyInstanceId),
             AddRoutePage.AgeRangeSpecialism => RouteAddAgeRangeSpecialism(personId, journeyInstanceId),
-            AddRoutePage.CheckYourAnswers => RouteAddCheckYourAnswers(personId, journeyInstanceId),
             AddRoutePage.SubjectSpecialisms => RouteAddSubjectSpecialisms(personId, journeyInstanceId),
             AddRoutePage.ChangeReason => RouteAddChangeReason(personId, journeyInstanceId),
+            AddRoutePage.CheckYourAnswers => RouteAddCheckYourAnswers(personId, journeyInstanceId),
+            _ => throw new ArgumentOutOfRangeException($"{nameof(AddRoutePage)}: {page.ToString()}")
+        };
+
+    public string RouteEditPage(AddRoutePage page, Guid qualificationId, JourneyInstanceId journeyInstanceId) =>
+        page switch
+        {
+            AddRoutePage.Route => RouteEditRoute(qualificationId, journeyInstanceId),
+            AddRoutePage.Status => RouteEditStatus(qualificationId, journeyInstanceId),
+            AddRoutePage.StartAndEndDate => RouteEditStartAndEndDate(qualificationId, journeyInstanceId),
+            AddRoutePage.HoldsFrom => RouteEditHoldsFrom(qualificationId, journeyInstanceId),
+            AddRoutePage.InductionExemption => RouteEditInductionExemption(qualificationId, journeyInstanceId),
+            AddRoutePage.TrainingProvider => RouteEditTrainingProvider(qualificationId, journeyInstanceId),
+            AddRoutePage.DegreeType => RouteEditDegreeType(qualificationId, journeyInstanceId),
+            AddRoutePage.Country => RouteEditCountry(qualificationId, journeyInstanceId),
+            AddRoutePage.AgeRangeSpecialism => RouteEditAgeRangeSpecialism(qualificationId, journeyInstanceId),
+            AddRoutePage.SubjectSpecialisms => RouteEditSubjectSpecialisms(qualificationId, journeyInstanceId),
+            AddRoutePage.ChangeReason => RouteEditChangeReason(qualificationId, journeyInstanceId),
+            AddRoutePage.CheckYourAnswers => RouteEditCheckYourAnswers(qualificationId, journeyInstanceId),
             _ => throw new ArgumentOutOfRangeException($"{nameof(AddRoutePage)}: {page.ToString()}")
         };
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditRouteToProfessionalStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/EditRouteToProfessionalStatusTests.cs
@@ -17,7 +17,16 @@ public class EditRouteToProfessionalStatusTests : TestBase
     public async Task EditEachField_Cya_ShowsEditedContent()
     {
         var route = (await TestData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
-            .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
+            .Where(r =>
+                r.TrainingStartDateRequired != FieldRequirement.NotApplicable
+                && r.TrainingEndDateRequired != FieldRequirement.NotApplicable
+                && r.TrainingCountryRequired != FieldRequirement.NotApplicable
+                && r.HoldsFromRequired != FieldRequirement.NotApplicable
+                && r.InductionExemptionRequired != FieldRequirement.NotApplicable
+                && r.DegreeTypeRequired != FieldRequirement.NotApplicable
+                && r.TrainingSubjectsRequired != FieldRequirement.NotApplicable
+                && r.TrainingProviderRequired != FieldRequirement.NotApplicable
+                && r.TrainingAgeSpecialismTypeRequired != FieldRequirement.NotApplicable)
             .First();
         var status = RouteToProfessionalStatusStatus.Holds;
         var startDate = new DateOnly(2021, 1, 1);
@@ -272,7 +281,12 @@ public class EditRouteToProfessionalStatusTests : TestBase
     public async Task EditEndDate_ToCya_EditEndDate_Continue()
     {
         var route = (await TestData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
-            .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
+            .Where(r =>
+                r.TrainingEndDateRequired != FieldRequirement.NotApplicable
+                && r.TrainingProviderRequired == FieldRequirement.Optional
+                && r.DegreeTypeRequired == FieldRequirement.Optional
+                && r.TrainingAgeSpecialismTypeRequired == FieldRequirement.Optional
+                && r.TrainingSubjectsRequired == FieldRequirement.Optional)
             .First();
         var status = RouteToProfessionalStatusStatus.InTraining;
         var country = await TestData.ReferenceDataCache.GetTrainingCountryByIdAsync(_countryCode);
@@ -330,7 +344,12 @@ public class EditRouteToProfessionalStatusTests : TestBase
     public async Task EditStartDate_ToCya_EditStartDate_Continue()
     {
         var route = (await TestData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
-            .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
+            .Where(r =>
+                r.TrainingEndDateRequired != FieldRequirement.NotApplicable
+                && r.TrainingProviderRequired == FieldRequirement.Optional
+                && r.DegreeTypeRequired == FieldRequirement.Optional
+                && r.TrainingAgeSpecialismTypeRequired == FieldRequirement.Optional
+                && r.TrainingSubjectsRequired == FieldRequirement.Optional)
             .First();
         var status = RouteToProfessionalStatusStatus.InTraining;
         var startDate = new DateOnly(2021, 1, 1);
@@ -390,7 +409,12 @@ public class EditRouteToProfessionalStatusTests : TestBase
     public async Task EditEndDate_BackLinks()
     {
         var route = (await TestData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
-            .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
+            .Where(r =>
+                r.TrainingEndDateRequired != FieldRequirement.NotApplicable
+                && r.TrainingProviderRequired == FieldRequirement.Optional
+                && r.DegreeTypeRequired == FieldRequirement.Optional
+                && r.TrainingAgeSpecialismTypeRequired == FieldRequirement.Optional
+                && r.TrainingSubjectsRequired == FieldRequirement.Optional)
             .First();
         var status = RouteToProfessionalStatusStatus.InTraining;
         var startDate = new DateOnly(2021, 1, 1);
@@ -453,7 +477,12 @@ public class EditRouteToProfessionalStatusTests : TestBase
     public async Task EditStartDate_BackLinks()
     {
         var route = (await TestData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
-            .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
+            .Where(r =>
+                r.TrainingEndDateRequired != FieldRequirement.NotApplicable
+                && r.TrainingProviderRequired == FieldRequirement.Optional
+                && r.DegreeTypeRequired == FieldRequirement.Optional
+                && r.TrainingAgeSpecialismTypeRequired == FieldRequirement.Optional
+                && r.TrainingSubjectsRequired == FieldRequirement.Optional)
             .First();
         var status = RouteToProfessionalStatusStatus.InTraining;
         var startDate = new DateOnly(2021, 1, 1);


### PR DESCRIPTION
### Context
Support console users need the ability to clearly see what fields are currently filled in on a route, and which ones are optional and not yet provided

https://trello.com/c/hJjqapUV/1274-routes-updates-to-row-logic-for-cya-and-summary-cards-on-routes-tab

### Changes proposed in this pull request

* Hides all fields in Edit Details and Edit/Add Check Your Answers pages which are Not Applicable to the route

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
