### PR TITLE
Don't sync QtsDate, EytsDate or QtlsStatus

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.SyncPerson.cs
@@ -41,7 +41,7 @@ public partial class Commands
                 var crmQueryDispatcher = services.GetRequiredKeyedService<ICrmQueryDispatcher>(TrsDataSyncService.CrmClientName);
                 var syncHelper = services.GetRequiredService<TrsDataSyncHelper>();
 
-                var entityInfo = TrsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person);
+                var entityInfo = syncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person);
                 var contact = await crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactByTrnQuery(trn, new Microsoft.Xrm.Sdk.Query.ColumnSet(entityInfo.AttributeNames)));
 
                 if (contact is null)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/MigrateInductionsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/MigrateInductionsFromCrmJob.cs
@@ -20,7 +20,7 @@ public class MigrateInductionsFromCrmJob(
         const int pageSize = 1000;
 
         var serviceClient = crmServiceClientProvider.GetClient(TrsDataSyncService.CrmClientName);
-        var columns = new ColumnSet(TrsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person).AttributeNames);
+        var columns = new ColumnSet(trsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person).AttributeNames);
 
         var query = new QueryExpression(Contact.EntityLogicalName)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SyncAllPersonsFromCrmJob.cs
@@ -30,7 +30,7 @@ public class SyncAllPersonsFromCrmJob
         const int pageSize = 1000;
 
         var serviceClient = _crmServiceClientProvider.GetClient(TrsDataSyncService.CrmClientName);
-        var columns = new ColumnSet(TrsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person).AttributeNames);
+        var columns = new ColumnSet(_trsDataSyncHelper.GetEntityInfoForModelType(TrsDataSyncHelper.ModelTypes.Person).AttributeNames);
 
         // Ensure this is kept in sync with the predicate in TrsDataSyncHelper.SyncContacts
         var filter = new FilterExpression(LogicalOperator.And);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncService.cs
@@ -97,7 +97,7 @@ public class TrsDataSyncService(
             _ => $"{ChangesKeyPrefix}:{modelType}"
         };
 
-        var (entityLogicalName, attributeNames) = TrsDataSyncHelper.GetEntityInfoForModelType(modelType);
+        var (entityLogicalName, attributeNames) = trsDataSyncHelper.GetEntityInfoForModelType(modelType);
         var columns = new ColumnSet(attributeNames);
 
         var modifiedSince = await trsDataSyncHelper.GetLastModifiedOnForModelTypeAsync(modelType);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestFixture.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Api.Infrastructure.Security;
@@ -17,7 +18,8 @@ public class OperationTestFixture
         DbFixture dbFixture,
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
-        ICurrentUserProvider currentUserProvider)
+        ICurrentUserProvider currentUserProvider,
+        IConfiguration configuration)
     {
         _currentUserProvider = currentUserProvider;
         Clock = new TestableClock();
@@ -31,7 +33,8 @@ public class OperationTestFixture
             Clock,
             new TestableAuditRepository(),
             new NullLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new(
             DbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/CrmClientFixture.cs
@@ -72,7 +72,7 @@ public sealed class CrmClientFixture : IDisposable
                 _referenceDataCache,
                 Clock,
                 () => _trnGenerationApiClient.GenerateTrnAsync(),
-                withSync ? TestDataSyncConfiguration.Sync(new(DbFixture.GetDataSource(), orgService, _referenceDataCache, Clock, new TestableAuditRepository(), _loggerFactory.CreateLogger<TrsDataSyncHelper>(), BlobStorageFileServiceMock.Object)) : TestDataSyncConfiguration.NoSync()),
+                withSync ? TestDataSyncConfiguration.Sync(new(DbFixture.GetDataSource(), orgService, _referenceDataCache, Clock, new TestableAuditRepository(), _loggerFactory.CreateLogger<TrsDataSyncHelper>(), BlobStorageFileServiceMock.Object, Configuration)) : TestDataSyncConfiguration.NoSync()),
             _memoryCache,
             onAsyncDispose);
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/EventMapperTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/EventMapperTestBase.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -33,7 +34,8 @@ public class EventMapperFixture
         ICrmQueryDispatcher crmQueryDispatcher,
         FakeTrnGenerator trnGenerator,
         IServiceProvider serviceProvider,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         Clock = new TestableClock();
         DbFixture = dbFixture;
@@ -46,7 +48,8 @@ public class EventMapperFixture
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -912,7 +913,8 @@ public class EwcWalesImportJobFixture : IAsyncLifetime
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
         IServiceProvider provider,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         OrganizationService = provider.GetService<IOrganizationServiceAsync2>()!;
         DbFixture = dbFixture;
@@ -924,7 +926,8 @@ public class EwcWalesImportJobFixture : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         var blobServiceClient = new Mock<BlobServiceClient>();
         var qtsImporter = ActivatorUtilities.CreateInstance<QtsImporter>(provider);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
@@ -1,4 +1,5 @@
 using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -17,7 +18,8 @@ public class InductionImporterTests : IAsyncLifetime
       ReferenceDataCache referenceDataCache,
       FakeTrnGenerator trnGenerator,
       IServiceProvider provider,
-      ILoggerFactory loggerFactory)
+      ILoggerFactory loggerFactory,
+      IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -28,7 +30,8 @@ public class InductionImporterTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionStatusUpdatedSupportJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionStatusUpdatedSupportJobTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -21,7 +22,8 @@ public class InductionStatusUpdatedSupportJobTests : IAsyncLifetime
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
         IServiceProvider provider,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         OrganizationService = provider.GetService<IOrganizationServiceAsync2>()!;
         DbFixture = dbFixture!;
@@ -33,7 +35,8 @@ public class InductionStatusUpdatedSupportJobTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/NightlyEmailJobFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/NightlyEmailJobFixture.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Dqt;
@@ -18,7 +19,8 @@ public class NightlyEmailJobFixture : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         LoggerFactory = loggerFactory;
@@ -32,7 +34,8 @@ public class NightlyEmailJobFixture : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/QTSImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/QTSImporterTests.cs
@@ -1,4 +1,5 @@
 using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -17,7 +18,8 @@ public class QtsImporterTests : IAsyncLifetime
       ReferenceDataCache referenceDataCache,
       FakeTrnGenerator trnGenerator,
       IServiceProvider provider,
-      ILoggerFactory loggerFactory)
+      ILoggerFactory loggerFactory,
+      IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -28,7 +30,8 @@ public class QtsImporterTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncFromCrmJobFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SyncFromCrmJobFixture.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Dqt;
@@ -13,7 +14,8 @@ public class SyncFromCrmJobFixture : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         LoggerFactory = loggerFactory;
@@ -27,7 +29,8 @@ public class SyncFromCrmJobFixture : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/DqtOutbox/OutboxMessageHandlerTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/DqtOutbox/OutboxMessageHandlerTests.cs
@@ -228,7 +228,8 @@ public class OutboxMessageHandlerFixture
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            new Mock<IFileService>().Object);
+            new Mock<IFileService>().Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Gias/EstablishmentRefresherTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Services.Establishments.Gias;
@@ -14,7 +15,8 @@ public class EstablishmentRefresherTests
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -26,7 +28,8 @@ public class EstablishmentRefresherTests
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            new Mock<IFileService>().Object);
+            new Mock<IFileService>().Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/Establishments/Tps/TpsEstablishmentRefresherTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
@@ -31,7 +32,8 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -43,7 +45,8 @@ public class TpsEstablishmentRefresherTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            new Mock<IFileService>().Object);
+            new Mock<IFileService>().Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.Services.Files;
@@ -14,7 +15,8 @@ public partial class PersonMatchingServiceTests : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -26,7 +28,8 @@ public partial class PersonMatchingServiceTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            Mock.Of<IFileService>());
+            Mock.Of<IFileService>(),
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.cs
@@ -1,5 +1,6 @@
 using FakeXrmEasy.Extensions;
 using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
@@ -17,7 +18,8 @@ public partial class TrsDataSyncHelperTests : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -29,7 +31,8 @@ public partial class TrsDataSyncHelperTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncServiceFixture.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -15,7 +16,8 @@ public class TrsDataSyncServiceFixture : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -28,7 +30,8 @@ public class TrsDataSyncServiceFixture : IAsyncLifetime
             Clock,
             AuditRepository,
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            BlobStorageFileService.Object);
+            BlobStorageFileService.Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),
@@ -53,7 +56,7 @@ public class TrsDataSyncServiceFixture : IAsyncLifetime
 
     public Task PublishChangedItemAndConsumeAsync(string modelType, IChangedItem changedItem)
     {
-        var (entityLogicalname, _) = TrsDataSyncHelper.GetEntityInfoForModelType(modelType);
+        var (entityLogicalname, _) = Helper.GetEntityInfoForModelType(modelType);
 
         return WithServiceAsync(entityLogicalname, async (service, changesObserver) =>
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
@@ -15,7 +16,8 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -27,7 +29,8 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            new Mock<IFileService>().Object);
+            new Mock<IFileService>().Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -1,5 +1,6 @@
 using Google.Apis.Upload;
 using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -19,7 +20,8 @@ public class WorkforceDataExporterTests : IAsyncLifetime
         IOrganizationServiceAsync2 organizationService,
         ReferenceDataCache referenceDataCache,
         FakeTrnGenerator trnGenerator,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IConfiguration configuration)
     {
         DbFixture = dbFixture;
         Clock = new();
@@ -31,7 +33,8 @@ public class WorkforceDataExporterTests : IAsyncLifetime
             Clock,
             new TestableAuditRepository(),
             loggerFactory.CreateLogger<TrsDataSyncHelper>(),
-            new Mock<IFileService>().Object);
+            new Mock<IFileService>().Object,
+            configuration);
 
         TestData = new TestData(
             dbFixture.GetDbContextFactory(),


### PR DESCRIPTION
This is controlled by the `SkipQtsSync` configuration value so we can control it per environment.