### PR TITLE
put induction exemption changes for routes behind the routes feature flag

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/ExemptionReason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/ExemptionReason.cshtml.cs
@@ -146,7 +146,9 @@ public class ExemptionReasonModel(
             return;
         }
 
-        var exemptionReasons = await referenceDataCache.GetPersonLevelInductionExemptionReasonsAsync(activeOnly: true);
+        var exemptionReasons = featureProvider.IsEnabled(FeatureNames.RoutesToProfessionalStatus)
+            ? await referenceDataCache.GetPersonLevelInductionExemptionReasonsAsync(activeOnly: true)
+            : await referenceDataCache.GetInductionExemptionReasonsAsync(activeOnly: true);
 
         if (featureProvider.IsEnabled(FeatureNames.RoutesToProfessionalStatus))
         {
@@ -165,6 +167,7 @@ public class ExemptionReasonModel(
                     RouteToProfessionalStatusName = r.RouteToProfessionalStatusType.Name
                 });
         }
+        // note: RoutesWithInductionExemptions is null if the Feature RoutesToProfessionalStatus isn't enabled
         if (RoutesWithInductionExemptions is not null && RoutesWithInductionExemptions.Any()) // exclude some exemptions from the choices if they apply because of a route
         {
             var exemptionReasonIdsToExclude = ExemptionReasonCategories.ExemptionsToBeExcludedIfRouteQualificationIsHeld
@@ -173,7 +176,7 @@ public class ExemptionReasonModel(
                     r => r.InductionExemptionReasonId,
                     (guid, route) => route.InductionExemptionReasonId);
 
-            var exemptionReasonsToDisplay = ExemptionReasonCategories.ExemptionReasonIds
+            var exemptionReasonsToDisplay = ExemptionReasonCategories.RouteFeatureExemptionReasonIds
                 .Where(id => !exemptionReasonIdsToExclude.Contains(id))
                 .Join(exemptionReasons,
                     guid => guid,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/ExemptionReasonCategory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditInduction/ExemptionReasonCategory.cs
@@ -20,6 +20,30 @@ public static class ExemptionReasonCategories
         { ExemptionReasonCategory.Miscellaneous, new List<Guid> {
             InductionExemptionReason.QualifiedThroughFurtherEducationRouteBetween1Sep2001And1Sep2004Id,
             InductionExemptionReason.ExemptDataLossOrErrorCriteriaId,
+            InductionExemptionReason.QtlsId,
+            InductionExemptionReason.OverseasTrainedTeacherId,
+            InductionExemptionReason.ExemptId,
+            InductionExemptionReason.QualifiedThroughEEAMutualRecognitionRouteId} },
+        { ExemptionReasonCategory.HistoricalQualificationRoute, new List<Guid> {
+            InductionExemptionReason.QualifiedBetween7May1999And1April2003FirstPostInWalesId,
+            InductionExemptionReason.RegisteredTeacherWithAtLeast2YearsFullTimeTeachingExperienceId,
+            InductionExemptionReason.QualifiedBefore7May2000Id} },
+        { ExemptionReasonCategory.InductionCompletedOutsideEngland, new List<Guid> {
+            InductionExemptionReason.HasOrIsEligibleForFullRegistrationInScotlandId,
+            InductionExemptionReason.PassedInductionInJerseyId,
+            InductionExemptionReason.PassedInductionInNorthernIrelandId,
+            InductionExemptionReason.PassedInWalesId,
+            InductionExemptionReason.PassedInductionInServiceChildrensEducationSchoolsInGermanyOrCyprusId,
+            InductionExemptionReason.PassedProbationaryPeriodInGibraltarId,
+            InductionExemptionReason.PassedInductionInIsleOfManId,
+            InductionExemptionReason.PassedInductionInGuernseyId} }
+    };
+
+    private static Dictionary<ExemptionReasonCategory, IEnumerable<Guid>> RoutesFeatureExemptionReasonCategoryMap => new()
+    {
+        { ExemptionReasonCategory.Miscellaneous, new List<Guid> {
+            InductionExemptionReason.QualifiedThroughFurtherEducationRouteBetween1Sep2001And1Sep2004Id,
+            InductionExemptionReason.ExemptDataLossOrErrorCriteriaId,
             InductionExemptionReason.ExemptId,
             InductionExemptionReason.QualifiedThroughEEAMutualRecognitionRouteId} },
         { ExemptionReasonCategory.HistoricalQualificationRoute, new List<Guid> {
@@ -58,10 +82,6 @@ public static class ExemptionReasonCategories
     public static IEnumerable<Guid> ExemptionReasonIds =>
         ExemptionReasonCategoryMap.Values.SelectMany(g => g);
 
-    public static IEnumerable<Guid> GetExemptionReasonIdsForCategory(ExemptionReasonCategory category)
-    {
-        return ExemptionReasonCategoryMap.ContainsKey(category) ? ExemptionReasonCategoryMap[category] : new List<Guid>();
-    }
-
-    public static IEnumerable<ExemptionReasonCategory> All => Enum.GetValues(typeof(ExemptionReasonCategory)).Cast<ExemptionReasonCategory>();
+    public static IEnumerable<Guid> RouteFeatureExemptionReasonIds =>
+        RoutesFeatureExemptionReasonCategoryMap.Values.SelectMany(g => g);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
@@ -65,8 +65,9 @@ public class InductionModel(
         StartDate = person.InductionStartDate;
         CompletedDate = person.InductionCompletedDate;
         ExemptionReasonIdsHeldOnPerson = person.InductionExemptionReasonIds;
-        ExemptionReasonNames = (await referenceDataCache
-            .GetPersonLevelInductionExemptionReasonsAsync())
+        ExemptionReasonNames = (featureProvider.IsEnabled(FeatureNames.RoutesToProfessionalStatus)
+            ? (await referenceDataCache.GetPersonLevelInductionExemptionReasonsAsync())
+            : (await referenceDataCache.GetInductionExemptionReasonsAsync()))
             .Where(i => ExemptionReasonIdsHeldOnPerson.Contains(i.InductionExemptionReasonId))
             .Select(i => i.Name)
             .OrderDescending();


### PR DESCRIPTION
### Context
Route-only induction exemption reasons should be removed from the inductions exemptions reason tab, only when the route feature flag is enabled
