### PR TITLE
Add PersonId to route reference index

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetRouteToProfessionalStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetRouteToProfessionalStatus.cs
@@ -153,8 +153,10 @@ public partial class SetRouteToProfessionalStatusHandler(
 
         var (currentUserId, _) = currentUserProvider.GetCurrentApplicationUser();
 
-        var route = await dbContext.RouteToProfessionalStatuses
-            .SingleOrDefaultAsync(r => r.SourceApplicationReference == command.SourceApplicationReference && r.SourceApplicationUserId == currentUserId);
+        var route = await dbContext.RouteToProfessionalStatuses.SingleOrDefaultAsync(r =>
+            r.PersonId == person.PersonId &&
+            r.SourceApplicationReference == command.SourceApplicationReference &&
+            r.SourceApplicationUserId == currentUserId);
 
         if (route is not null)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/RouteToProfessionalStatusMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/RouteToProfessionalStatusMapping.cs
@@ -19,7 +19,7 @@ public class RouteToProfessionalStatusMapping : IEntityTypeConfiguration<RouteTo
         builder
             .Property(q => q.SourceApplicationReference)
             .HasMaxLength(RouteToProfessionalStatus.SourceApplicationReferenceMaxLength);
-        builder.HasIndex(q => new { q.SourceApplicationUserId, q.SourceApplicationReference })
+        builder.HasIndex(q => new { q.PersonId, q.SourceApplicationUserId, q.SourceApplicationReference })
             .IsUnique()
             .HasFilter("source_application_user_id is not null and source_application_reference is not null");
         builder.Property(q => q.ExemptFromInductionDueToQtsDate);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250703080330_RoutePersonReference.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250703080330_RoutePersonReference.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250703080330_RoutePersonReference")]
+    partial class RoutePersonReference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250703080330_RoutePersonReference.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250703080330_RoutePersonReference.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class RoutePersonReference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_qualifications_source_application_user_id_source_applicatio",
+                table: "qualifications");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_qualifications_person_id_source_application_user_id_source_",
+                table: "qualifications",
+                columns: new[] { "person_id", "source_application_user_id", "source_application_reference" },
+                unique: true,
+                filter: "source_application_user_id is not null and source_application_reference is not null");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_qualifications_person_id_source_application_user_id_source_",
+                table: "qualifications");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_qualifications_source_application_user_id_source_applicatio",
+                table: "qualifications",
+                columns: new[] { "source_application_user_id", "source_application_reference" },
+                unique: true,
+                filter: "source_application_user_id is not null and source_application_reference is not null");
+        }
+    }
+}


### PR DESCRIPTION
It's possible (and indeed definitely-happening in testing) that we get the same `SourceApplicationReference` for multiple people. This amends our unique index to include `PersonId` so we can have the same `SourceApplicationReference` for multiple people.