### PR TITLE
Added code to move induction exemptions from person to routes during migration where appropriate

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -330,6 +330,22 @@ public class Person
         return true;
     }
 
+    public bool UnsafeRemoveInductionExemptionReason(
+        Guid exemptionReasonId,
+        EventModels.RaisedByUserInfo updatedBy,
+        DateTime now)
+    {
+        if (!InductionExemptionReasonIds.Contains(exemptionReasonId))
+        {
+            return false;
+        }
+
+        InductionExemptionReasonIds = InductionExemptionReasonIds.Except([exemptionReasonId]).ToArray();
+        InductionModifiedOn = now;
+
+        return true;
+    }
+
     public bool RemoveInductionExemptionReason(
         Guid exemptionReasonId,
         EventModels.RaisedByUserInfo updatedBy,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/RouteToProfessionalStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/RouteToProfessionalStatus.cs
@@ -28,7 +28,7 @@ public class RouteToProfessionalStatus : Qualification
     public required Guid? TrainingProviderId { get; set; }
     public TrainingProvider? TrainingProvider { get; }
     public required bool? ExemptFromInduction { get; set; }
-    public bool? ExemptFromInductionDueToQtsDate { get; private set; }
+    public bool? ExemptFromInductionDueToQtsDate { get; set; }
     public required Guid? DegreeTypeId { get; set; }
     public DegreeType? DegreeType { get; }
     public string? DqtTeacherStatusName { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.Extensions.DependencyInjection;
@@ -211,6 +212,15 @@ public class TrsDbContext : DbContext
         ConfigureOptions(optionsBuilder, connectionString: null, commandTimeout);
         var dbContext = new TrsDbContext(optionsBuilder.Options);
         dbContext.Database.SetDbConnection(dataSource.CreateConnection(), contextOwnsConnection: true);
+        return dbContext;
+    }
+
+    public static TrsDbContext Create(DbConnection connection, int? commandTimeout = null)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<TrsDbContext>();
+        ConfigureOptions(optionsBuilder, connectionString: null, commandTimeout);
+        var dbContext = new TrsDbContext(optionsBuilder.Options);
+        dbContext.Database.SetDbConnection(connection, contextOwnsConnection: false);
         return dbContext;
     }
 }


### PR DESCRIPTION
### Context

TRS supports route-level induction exemptions whereas DQT does not. As part of migration, we need to move person-level induction exemptions onto the route where possible.

### Changes proposed in this pull request

When mapping a route, if the route’s RouteToProfessionalStatusType has a non-null InductionExemptionReasonId and the Person has that same InductionExemptionReasonId in their InductionExemptionReasonIds set ExemptFromInduction to true on the route and remove the reason from the Person’s InductionExemptionReasonIds. Generate a PersonInductionUpdatedEvent too with Changes == InductionExemptionReasons.

If the route’s RouteToProfessionalStatusType has a non-null InductionExemptionReasonId and the Person does NOT have that same InductionExemptionReasonId in their InductionExemptionReasonIds set ExemptFromInduction to false (see N.B. below).

If the route’s Status is Holds and the HoldsFrom date is before 7th May 2000 and the ProfessionalStatusType of the route’s RouteToProfessionalStatusType is QualifiedTeacherStatus and the Person’s InductionExemptionReasonIds contains QualifiedBefore7May2000Id, set ExemptFromInductionDueToQtsDate to true on the mapped route and remove the reason from the Person’s InductionExemptionReasonIds. Generate a PersonInductionUpdatedEvent too with Changes == InductionExemptionReasons.

N.B. it may be possible that a single person-level induction exemption maps to a route-level exemption for multiple routes.
