### PR TITLE
Replace CRM gender with model gender in tests

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetPiiTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetPiiTests.cs
@@ -153,7 +153,7 @@ public class SetPiiTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
-            .WithGender(Contact_GenderCode.Male));
+            .WithGender(Core.Models.Gender.Male));
 
         var updatedFirstName = Faker.Name.First();
         var updatedMiddleName = Faker.Name.Middle();
@@ -199,7 +199,7 @@ public class SetPiiTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
             .WithTrn()
-            .WithGender(Contact_GenderCode.Male)
+            .WithGender(Core.Models.Gender.Male)
             .WithEmail(Faker.Internet.Email())
             .WithNationalInsuranceNumber(Faker.Identification.UkNationalInsuranceNumber()));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateContactPiiTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Dqt.CrmIntegrationTests/QueryTests/UpdateContactPiiTests.cs
@@ -22,7 +22,7 @@ public class UpdateContactPiiTests : IAsyncLifetime
         var person = await _dataScope.TestData.CreatePersonAsync(x =>
         {
             x.WithNationalInsuranceNumber();
-            x.WithGender(Contact_GenderCode.Male);
+            x.WithGender(Gender.Male);
         });
 
         var newFirstName = _dataScope.TestData.GenerateChangedFirstName(person.FirstName);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CheckAnswersTests.cs
@@ -366,7 +366,7 @@ public class CheckAnswersTests : TestBase
             .WithEmail("test@test.com")
             .WithMobileNumber("447891234567")
             .WithNationalInsuranceNumber("AB123456C")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Other));
+            .WithGender(Gender.Other));
 
         var firstName = changes.HasFlag(PersonDetailsUpdatedEventChanges.FirstName) ? "Jim" : person.FirstName;
         var middleName = changes.HasFlag(PersonDetailsUpdatedEventChanges.MiddleName) ? "A" : person.MiddleName;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CommonPageTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CommonPageTests.cs
@@ -92,7 +92,7 @@ public class CommonPageTests : TestBase
             .WithEmail("some@email-address.com")
             .WithMobileNumber("07891234567")
             .WithNationalInsuranceNumber("AB123456D")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Other));
+            .WithGender(Gender.Other));
 
         var firstName = changes.HasFlag(PersonDetailsUpdatedEventChanges.FirstName) ? "Megan" : person.FirstName;
         var middleName = changes.HasFlag(PersonDetailsUpdatedEventChanges.MiddleName) ? "Thee" : person.MiddleName;
@@ -161,7 +161,7 @@ public class CommonPageTests : TestBase
             .WithEmail("some@email-address.com")
             .WithMobileNumber("07891234567")
             .WithNationalInsuranceNumber("AB123456D")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Male));
+            .WithGender(Gender.Male));
 
         var firstName = changes.HasFlag(PersonDetailsUpdatedEventChanges.FirstName) ? "Megan" : person.FirstName;
         var middleName = changes.HasFlag(PersonDetailsUpdatedEventChanges.MiddleName) ? "Thee" : person.MiddleName;
@@ -263,7 +263,7 @@ public class CommonPageTests : TestBase
             .WithEmail("some@email-address.com")
             .WithMobileNumber("07891234567")
             .WithNationalInsuranceNumber("AB123456D")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Other));
+            .WithGender(Gender.Other));
 
         var firstName = changes.HasFlag(PersonDetailsUpdatedEventChanges.FirstName) ? "Megan" : person.FirstName;
         var middleName = changes.HasFlag(PersonDetailsUpdatedEventChanges.MiddleName) ? "Thee" : person.MiddleName;
@@ -433,7 +433,7 @@ public class CommonPageTests : TestBase
             .WithEmail("some@email-address.com")
             .WithMobileNumber("07891234567")
             .WithNationalInsuranceNumber("AB123456D")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Female));
+            .WithGender(Gender.Female));
 
         var firstName = changes.HasFlag(PersonDetailsUpdatedEventChanges.FirstName) ? "Megan" : person.FirstName;
         var middleName = changes.HasFlag(PersonDetailsUpdatedEventChanges.MiddleName) ? "Thee" : person.MiddleName;
@@ -513,7 +513,7 @@ public class CommonPageTests : TestBase
             .WithEmail("some@email-address.com")
             .WithMobileNumber("07891234567")
             .WithNationalInsuranceNumber("AB123456D")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Female));
+            .WithGender(Gender.Female));
 
         var originalFirstName = originalChanges.HasFlag(PersonDetailsUpdatedEventChanges.FirstName) ? "Megan" : person.FirstName;
         var originalMiddleName = originalChanges.HasFlag(PersonDetailsUpdatedEventChanges.MiddleName) ? "Thee" : person.MiddleName;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
@@ -82,7 +82,7 @@ public class PersonalDetailsTests : TestBase
             .WithEmail("test@test.com")
             .WithMobileNumber("07891234567")
             .WithNationalInsuranceNumber("AB123456C")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Female));
+            .WithGender(Gender.Female));
 
         var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person));
 
@@ -746,7 +746,7 @@ public class PersonalDetailsTests : TestBase
             .WithEmail("test@test.com")
             .WithMobileNumber("447891234567")
             .WithNationalInsuranceNumber("AB123456C")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Male));
+            .WithGender(Gender.Male));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -787,7 +787,7 @@ public class PersonalDetailsTests : TestBase
             .WithEmail("test@test.com")
             .WithMobileNumber("447891234567")
             .WithNationalInsuranceNumber("AB123456C")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Notavailable));
+            .WithGender(Gender.NotAvailable));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -828,7 +828,7 @@ public class PersonalDetailsTests : TestBase
             .WithEmail("test@test.com")
             .WithMobileNumber("447891234567")
             .WithNationalInsuranceNumber("AB123456C")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Male));
+            .WithGender(Gender.Male));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -915,7 +915,7 @@ public class PersonalDetailsTests : TestBase
             .WithEmail("original@email.com")
             .WithMobileNumber("447891234567")
             .WithNationalInsuranceNumber("AB123456C")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Female));
+            .WithGender(Gender.Female));
 
         var nameEvidenceFileId = Guid.NewGuid();
         var otherEvidenceFileId = Guid.NewGuid();
@@ -989,7 +989,7 @@ public class PersonalDetailsTests : TestBase
             .WithEmail("original@email.com")
             .WithMobileNumber("447891234567")
             .WithNationalInsuranceNumber("AB123456C")
-            .WithGender(Core.Dqt.Models.Contact_GenderCode.Other));
+            .WithGender(Gender.Other));
 
         var nameEvidenceFileId = Guid.NewGuid();
         var otherEvidenceFileId = Guid.NewGuid();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -49,7 +49,7 @@ public partial class TestData
         private bool? _hasNationalInsuranceNumber;
         private string? _nationalInsuranceNumber;
         private bool? _hasGender;
-        private Contact_GenderCode? _gender;
+        private Gender? _gender;
         private readonly List<Qualification> _qualifications = new();
         private readonly List<QtsRegistration> _qtsRegistrations = new();
         private readonly List<CreatePersonAlertBuilder> _alertBuilders = [];
@@ -269,7 +269,7 @@ public partial class TestData
             return this;
         }
 
-        public CreatePersonBuilder WithGender(Contact_GenderCode gender)
+        public CreatePersonBuilder WithGender(Gender gender)
         {
             _hasGender = true;
             _gender = gender;
@@ -458,6 +458,7 @@ public partial class TestData
             var middleName = string.Join(" ", firstAndMiddleNames.Skip(1));
             var lastName = _lastName ?? testData.GenerateLastName();
             var dateOfBirth = _dateOfBirth ?? testData.GenerateDateOfBirth();
+            var gender = _gender ?? testData.GenerateGender();
 
             var events = new List<EventBase>();
 
@@ -501,7 +502,7 @@ public partial class TestData
 
             if (_hasGender ?? false)
             {
-                contact.GenderCode = _gender ?? testData.GenerateGender();
+                contact.GenderCode = gender.ToContact_GenderCode();
             }
 
             if (_qtlsDate is not null)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using TeachingRecordSystem.Core.DataStore.Postgres;
-using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 
 namespace TeachingRecordSystem.TestCommon;
@@ -262,21 +261,7 @@ public partial class TestData
 
     public Task<string> GenerateTrnAsync() => _generateTrn();
 
-    public Contact_GenderCode GenerateGender()
-    {
-        Contact_GenderCode gender;
-
-        lock (_gate)
-        {
-            do
-            {
-                gender = Faker.Enum.Random<Contact_GenderCode>();
-            }
-            while (gender == Contact_GenderCode.Notprovided);
-        }
-
-        return gender;
-    }
+    public Gender GenerateGender() => Faker.Enum.Random<Gender>();
 
     public DateOnly GenerateDate() => GenerateDate(min: new DateOnly(1990, 1, 1), max: new DateOnly(2030, 1, 1));
 


### PR DESCRIPTION
We want to be using the model Gender enum in the tests rather than the CRM enum - so when contacts are migrated the tests won't need updating