### PR TITLE
Temporary API fix for semi-migrated pre-prod data

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Dtos/QtsInfo.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Dtos/QtsInfo.cs
@@ -26,14 +26,15 @@ public record QtsInfo
             .Where(r => r.RouteToProfessionalStatusType!.ProfessionalStatusType is ProfessionalStatusType.QualifiedTeacherStatus && r.Status is RouteToProfessionalStatusStatus.Holds)
             .ToArray();
 
-        var oldestRoute = holdsRoutes.OrderBy(r => r.HoldsFrom).First();
-        Debug.Assert(oldestRoute.HoldsFrom == person.QtsDate);
+        // TEMP until we get data fixed up
+        var oldestRoute = holdsRoutes.OrderBy(r => r.HoldsFrom).FirstOrDefault();
+        Debug.Assert(oldestRoute is null || oldestRoute.HoldsFrom == person.QtsDate);
 
         return new QtsInfo()
         {
-            HoldsFrom = oldestRoute.HoldsFrom.Value,
+            HoldsFrom = person.QtsDate!.Value,
             CertificateUrl = "/v3/certificates/qts",
-            StatusDescription = oldestRoute.RouteToProfessionalStatusTypeId == PostgresModels.RouteToProfessionalStatusType.QtlsAndSetMembershipId
+            StatusDescription = oldestRoute?.RouteToProfessionalStatusTypeId == PostgresModels.RouteToProfessionalStatusType.QtlsAndSetMembershipId
                 ? "Qualified Teacher Learning and Skills status"
                 : "Qualified",
             AwardedOrApprovedCount = holdsRoutes.Length,


### PR DESCRIPTION
We have some pre-prod data where the person has a non-`null` QTS date but no routes migrated (yet). This tweaks the API's logic to handle the missing routes. This will be reverted once the data is fixed up.