### PR TITLE
Relax NINO validation to allow for legacy TPS workforce data

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumber.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/NationalInsuranceNumber.cs
@@ -16,7 +16,8 @@ public sealed partial class NationalInsuranceNumber : IEquatable<NationalInsuran
     // A NINO is made up of 2 letters, 6 numbers and a final letter, which is always A, B, C, or D
     // The characters D, F, I, Q, U, and V are not used as either the first or second letter of a NINO prefix.
     // The letter O is not used as the second letter of a prefix.
-    private const string ValidNinoRegexPattern = "^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-D]{1}$";
+    // 2025-07-03: Added QQ as a valid prefix and F|M|U as valid postfixes as apparently TPS workforce data uses these
+    private const string ValidNinoRegexPattern = "^[A-CEGHJ-PQR-TW-Z]{1}[A-CEGHJ-NPQR-TW-Z]{1}[0-9]{6}[A-DFMU]{1}$";
     // Prefixes BG, GB, KN, NK, NT, TN and ZZ are not to be used
     private static readonly string[] _invalidPrefixes = ["BG", "GB", "KN", "NK", "NT", "TN", "ZZ"];
     // It is sometimes necessary to use a Temporary Reference Number (TRN) for Individuals. The format of a TRN is 11 a1 11 11

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/PersonalDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/PersonalDetailsTests.cs
@@ -457,17 +457,22 @@ public class PersonalDetailsTests : TestBase
     [InlineData("AB 12 34 56 D", true)]
     [InlineData("AB 12 34 56 E", false)]
     [InlineData("AB 12 34 56 X", false)]
-    // The characters D, F, I, Q, U, and V are not used as either the first or second letter of a NINO prefix.
+    // 2025-07-03: F|M|U are allowed as postfixes to accomodate legacy data
+    [InlineData("AB 12 34 56 F", true)]
+    [InlineData("AB 12 34 56 M", true)]
+    [InlineData("AB 12 34 56 U", true)]
+    // The characters D, F, I, (Q), U, and V are not used as either the first or second letter of a NINO prefix.
+    // 2025-07-03: Q is allowed as a prefix to accomodate legacy data
     [InlineData("DA 12 34 56 A", false)]
     [InlineData("FA 12 34 56 A", false)]
     [InlineData("IA 12 34 56 A", false)]
-    [InlineData("QA 12 34 56 A", false)]
+    [InlineData("QA 12 34 56 A", true)]
     [InlineData("UA 12 34 56 A", false)]
     [InlineData("VA 12 34 56 A", false)]
     [InlineData("AD 12 34 56 A", false)]
     [InlineData("AF 12 34 56 A", false)]
     [InlineData("AI 12 34 56 A", false)]
-    [InlineData("AQ 12 34 56 A", false)]
+    [InlineData("AQ 12 34 56 A", true)]
     [InlineData("AU 12 34 56 A", false)]
     [InlineData("AV 12 34 56 A", false)]
     // The letter O is not used as the second letter of a prefix.

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
@@ -628,17 +628,22 @@ public class PersonalDetailsTests : TestBase
     [InlineData("AB 12 34 56 D", true)]
     [InlineData("AB 12 34 56 E", false)]
     [InlineData("AB 12 34 56 X", false)]
-    // The characters D, F, I, Q, U, and V are not used as either the first or second letter of a NINO prefix.
+    // 2025-07-03: F|M|U are allowed as postfixes to accomodate legacy data
+    [InlineData("AB 12 34 56 F", true)]
+    [InlineData("AB 12 34 56 M", true)]
+    [InlineData("AB 12 34 56 U", true)]
+    // The characters D, F, I, (Q), U, and V are not used as either the first or second letter of a NINO prefix.
+    // 2025-07-03: Q is allowed as a prefix to accomodate legacy data
     [InlineData("DA 12 34 56 A", false)]
     [InlineData("FA 12 34 56 A", false)]
     [InlineData("IA 12 34 56 A", false)]
-    [InlineData("QA 12 34 56 A", false)]
+    [InlineData("QA 12 34 56 A", true)]
     [InlineData("UA 12 34 56 A", false)]
     [InlineData("VA 12 34 56 A", false)]
     [InlineData("AD 12 34 56 A", false)]
     [InlineData("AF 12 34 56 A", false)]
     [InlineData("AI 12 34 56 A", false)]
-    [InlineData("AQ 12 34 56 A", false)]
+    [InlineData("AQ 12 34 56 A", true)]
     [InlineData("AU 12 34 56 A", false)]
     [InlineData("AV 12 34 56 A", false)]
     // The letter O is not used as the second letter of a prefix.


### PR DESCRIPTION
TPS workforce data currently has NINOs in the form `QQ 12 34 56 A` | `AB 12 34 56 F` | `AB 12 34 56 M` | `AB 12 34 56 U` which are technically invalid NINOs. Relaxing validation to accommodate existing data