### PR TITLE
Added event when route is migrated

### DIFF
--- a/TeachingRecordSystem/src/RoutesMapper/Program.cs
+++ b/TeachingRecordSystem/src/RoutesMapper/Program.cs
@@ -75,7 +75,9 @@ async IAsyncEnumerable<TrsDataSyncHelper.ContactIttQtsMapResult[]> MapAsync()
 {
     const int pageSize = 1000;
 
-    var columns = new ColumnSet(Contact.Fields.dfeta_qtlsdate);
+    var columns = new ColumnSet(
+        Contact.Fields.dfeta_qtlsdate,
+        Contact.Fields.dfeta_QtlsDateHasBeenSet);
 
     var query = new QueryExpression(Contact.EntityLogicalName)
     {
@@ -180,6 +182,7 @@ async Task WriteResultsAsync(IAsyncEnumerable<TrsDataSyncHelper.ContactIttQtsMap
     csvWriter.WriteField("Success");
     csvWriter.WriteField("Failed reason");
     csvWriter.WriteField("ITT ID");
+    csvWriter.WriteField("Slug ID");
     csvWriter.WriteField("QTS ID");
     csvWriter.WriteField("Route ID");
     csvWriter.WriteField("Route Name");
@@ -188,6 +191,8 @@ async Task WriteResultsAsync(IAsyncEnumerable<TrsDataSyncHelper.ContactIttQtsMap
     csvWriter.WriteField("Age Specialism Range To");
     csvWriter.WriteField("Status");
     csvWriter.WriteField("Holds From");
+    csvWriter.WriteField("Training Start Date");
+    csvWriter.WriteField("Training End Date");
     csvWriter.WriteField("Degree Type");
     csvWriter.WriteField("Training Provider Name");
     csvWriter.WriteField("Training Country");
@@ -204,7 +209,10 @@ async Task WriteResultsAsync(IAsyncEnumerable<TrsDataSyncHelper.ContactIttQtsMap
     csvWriter.WriteField("EYTS Date");
     csvWriter.WriteField("Partial Recognition Date");
     csvWriter.WriteField("QTLS Date");
+    csvWriter.WriteField("QTLS Date Has Been Set");
     csvWriter.WriteField("Programme Type");
+    csvWriter.WriteField("Programme Start Date");
+    csvWriter.WriteField("Programme End Date");
     csvWriter.WriteField("DQT Age Range From");
     csvWriter.WriteField("DQT Age Range To");
     csvWriter.WriteField("ITT Result");
@@ -237,6 +245,7 @@ async Task WriteResultsAsync(IAsyncEnumerable<TrsDataSyncHelper.ContactIttQtsMap
                 csvWriter.WriteField(r.Success);
                 csvWriter.WriteField(r.FailedReason);
                 csvWriter.WriteField(r.IttId);
+                csvWriter.WriteField(r.IttSlugId);
                 csvWriter.WriteField(r.QtsRegistrationId);
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.RouteToProfessionalStatusType?.RouteToProfessionalStatusTypeId);
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.RouteToProfessionalStatusType?.Name);
@@ -245,6 +254,8 @@ async Task WriteResultsAsync(IAsyncEnumerable<TrsDataSyncHelper.ContactIttQtsMap
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.ProfessionalStatus?.TrainingAgeSpecialismRangeTo);
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.ProfessionalStatus?.Status.ToString());
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.ProfessionalStatus?.HoldsFrom?.ToString("dd/MM/yyyy"));
+                csvWriter.WriteField(r.ProfessionalStatusInfo?.ProfessionalStatus?.TrainingStartDate?.ToString("dd/MM/yyyy"));
+                csvWriter.WriteField(r.ProfessionalStatusInfo?.ProfessionalStatus?.TrainingEndDate?.ToString("dd/MM/yyyy"));
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.DegreeType?.Name);
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.TrainingProvider?.Name);
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.TrainingCountry?.CountryId);
@@ -261,6 +272,7 @@ async Task WriteResultsAsync(IAsyncEnumerable<TrsDataSyncHelper.ContactIttQtsMap
                 csvWriter.WriteField(r.EytsDate?.ToString("dd/MM/yyyy"));
                 csvWriter.WriteField(r.PartialRecognitionDate?.ToString("dd/MM/yyyy"));
                 csvWriter.WriteField(r.QtlsDate?.ToString("dd/MM/yyyy"));
+                csvWriter.WriteField(r.QtlsDateHasBeenSet);
                 csvWriter.WriteField(r.ProgrammeType);
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.ProfessionalStatus?.DqtAgeRangeFrom);
                 csvWriter.WriteField(r.ProfessionalStatusInfo?.ProfessionalStatus?.DqtAgeRangeTo);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/DqtInitialTeacherTraining.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/DqtInitialTeacherTraining.cs
@@ -1,0 +1,26 @@
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record DqtInitialTeacherTraining
+{
+    public Guid? InitialTeacherTrainingId { get; init; }
+    public string? SlugId { get; init; }
+    public string? ProgrammeType { get; init; }
+    public DateOnly? ProgrammeStartDate { get; init; }
+    public DateOnly? ProgrammeEndDate { get; init; }
+    public string? Result { get; init; }
+    public string? QualificationName { get; init; }
+    public string? QualificationValue { get; init; }
+    public Guid? ProviderId { get; init; }
+    public string? ProviderName { get; init; }
+    public string? ProviderUkprn { get; init; }
+    public string? CountryName { get; init; }
+    public string? CountryValue { get; init; }
+    public string? Subject1Name { get; init; }
+    public string? Subject1Value { get; init; }
+    public string? Subject2Name { get; init; }
+    public string? Subject2Value { get; init; }
+    public string? Subject3Name { get; init; }
+    public string? Subject3Value { get; init; }
+    public string? AgeRangeFrom { get; init; }
+    public string? AgeRangeTo { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/DqtQtsRegistration.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/DqtQtsRegistration.cs
@@ -1,0 +1,13 @@
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record DqtQtsRegistration
+{
+    public Guid? QtsRegistrationId { get; init; }
+    public string? TeacherStatusName { get; init; }
+    public string? TeacherStatusValue { get; init; }
+    public string? EarlyYearsStatusName { get; init; }
+    public string? EarlyYearsStatusValue { get; init; }
+    public DateOnly? QtsDate { get; init; }
+    public DateOnly? EytsDate { get; init; }
+    public DateOnly? PartialRecognitionDate { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/RouteToProfessionalStatusMigratedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/RouteToProfessionalStatusMigratedEvent.cs
@@ -1,0 +1,12 @@
+using TeachingRecordSystem.Core.Events.Models;
+
+namespace TeachingRecordSystem.Core.Events;
+public record RouteToProfessionalStatusMigratedEvent : EventBase, IEventWithPersonId
+{
+    public required Guid PersonId { get; init; }
+    public required RouteToProfessionalStatus RouteToProfessionalStatus { get; init; }
+    public required DqtInitialTeacherTraining? DqtInitialTeacherTraining { get; init; }
+    public required DqtQtsRegistration? DqtQtsRegistration { get; init; }
+    public required DateOnly? DqtQtlsDate { get; init; }
+    public required bool? DqtQtlsDateHasBeenSet { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/MigrateRoutesFromCrmJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/MigrateRoutesFromCrmJob.cs
@@ -30,7 +30,9 @@ public class MigrateRoutesFromCrmJob(
 
         const int pageSize = 1000;
 
-        var columns = new ColumnSet(Contact.Fields.dfeta_qtlsdate);
+        var columns = new ColumnSet(
+            Contact.Fields.dfeta_qtlsdate,
+            Contact.Fields.dfeta_QtlsDateHasBeenSet);
 
         var query = new QueryExpression(Contact.EntityLogicalName)
         {


### PR DESCRIPTION
# Context
ITT/QTS are moving into TRS as ‘route to professional status’.
A background job has been implemented which writes data to the qualifications table in TRS.
We also need to output an event in TRS for each route so the audit history shows how they were mapped from DQT to TRS.

# Details
Create a new RouteToProfessionalStatusMigratedEvent which contains all of the values from ITT / QTS used to derive the route info in TRS along with the TRS route values.
Amend the code so that the events are written to the db as part of the migration.