### PR TITLE
Add indexes to trn column on email job item tables

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EytsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EytsAwardedEmailsJobItemMapping.cs
@@ -17,5 +17,6 @@ public class EytsAwardedEmailsJobItemMapping : IEntityTypeConfiguration<EytsAwar
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.EytsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.EytsAwardedEmailsJobId);
+        builder.HasIndex(i => i.Trn);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionCompletedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InductionCompletedEmailsJobItemMapping.cs
@@ -17,5 +17,6 @@ public class InductionCompletedEmailsJobItemMapping : IEntityTypeConfiguration<I
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.InductionCompletedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.InductionCompletedEmailsJobId);
+        builder.HasIndex(i => i.Trn);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InternationalQtsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/InternationalQtsAwardedEmailsJobItemMapping.cs
@@ -17,5 +17,6 @@ public class InternationalQtsAwardedEmailsJobItemMapping : IEntityTypeConfigurat
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.InternationalQtsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.InternationalQtsAwardedEmailsJobId);
+        builder.HasIndex(i => i.Trn);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QtsAwardedEmailsJobItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QtsAwardedEmailsJobItemMapping.cs
@@ -17,5 +17,6 @@ public class QtsAwardedEmailsJobItemMapping : IEntityTypeConfiguration<QtsAwarde
         builder.Property(i => i.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.HasIndex(i => i.Personalization).HasMethod("gin");
         builder.HasOne(i => i.QtsAwardedEmailsJob).WithMany(j => j.JobItems).HasForeignKey(i => i.QtsAwardedEmailsJobId);
+        builder.HasIndex(i => i.Trn);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250704081507_EmailJobItemsTrnIndex.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250704081507_EmailJobItemsTrnIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250704081507_EmailJobItemsTrnIndex")]
+    partial class EmailJobItemsTrnIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250704081507_EmailJobItemsTrnIndex.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250704081507_EmailJobItemsTrnIndex.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EmailJobItemsTrnIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_qts_awarded_emails_job_items_trn",
+                table: "qts_awarded_emails_job_items",
+                column: "trn");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_international_qts_awarded_emails_job_items_trn",
+                table: "international_qts_awarded_emails_job_items",
+                column: "trn");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_induction_completed_emails_job_items_trn",
+                table: "induction_completed_emails_job_items",
+                column: "trn");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_eyts_awarded_emails_job_items_trn",
+                table: "eyts_awarded_emails_job_items",
+                column: "trn");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_qts_awarded_emails_job_items_trn",
+                table: "qts_awarded_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_international_qts_awarded_emails_job_items_trn",
+                table: "international_qts_awarded_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_induction_completed_emails_job_items_trn",
+                table: "induction_completed_emails_job_items");
+
+            migrationBuilder.DropIndex(
+                name: "ix_eyts_awarded_emails_job_items_trn",
+                table: "eyts_awarded_emails_job_items");
+        }
+    }
+}


### PR DESCRIPTION
The email jobs that email when someone is awarded QTS/EYTS/iQTS or completes induction check we haven't already sent an email for the given TRN. This adds an index to the `trn` column to speed up that check.