### PR TITLE
Add authorization for notes

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/Legacy/LegacyNotesViewAuthorizationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/Legacy/LegacyNotesViewAuthorizationHandler.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security.AuthorizationHandlers.Legacy;
+
+/// <summary>
+/// AuthorizationHandler for Legacy user roles, delete when existing users have been migrated to new user roles.
+/// </summary>
+public class LegacyNotesViewAuthorizationHandler : AuthorizationHandler<NotesViewRequirement, Guid>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, NotesViewRequirement requirement, Guid personId)
+    {
+        // If the user has been migrated to the new user roles, they may still have the legacy roles, so we need to
+        // disregard them for this user as they may be different to their new role.
+        if (context.User.HasBeenMigrated())
+        {
+            return Task.CompletedTask;
+        }
+
+        // The Notes tab was previously visible to all users, so if the user hasn't been migrated yet,
+        // they should still see the tab.
+        context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/NotesViewAuthorizationHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationHandlers/NotesViewAuthorizationHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Authorization;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security.AuthorizationHandlers;
+
+public class NotesViewAuthorizationHandler(TrsDbContext dbContext) : AuthorizationHandler<NotesViewRequirement, Guid>
+{
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, NotesViewRequirement requirement, Guid personId)
+    {
+        var hasDbsAlerts = await dbContext.Alerts
+            .Where(a => a.PersonId == personId && a.AlertTypeId == AlertType.DbsAlertTypeId)
+            .AnyAsync();
+
+        // If the person has DBS alerts, we only want users with DBS view permissions to view notes
+        if (!hasDbsAlerts || context.User.HasMinimumPermission(new(UserPermissionTypes.DbsAlerts, UserPermissionLevel.View)))
+        {
+            context.Succeed(requirement);
+        }
+
+        return;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationPolicies.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/AuthorizationPolicies.cs
@@ -17,4 +17,5 @@ public static class AuthorizationPolicies
     public const string NonPersonOrAlertDataView = nameof(NonPersonOrAlertDataView);
     public const string NonPersonOrAlertDataEdit = nameof(NonPersonOrAlertDataEdit);
     public const string PersonDataEdit = nameof(PersonDataEdit);
+    public const string NotesView = nameof(NotesView);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/NonPersonOrAlertDataAuthorization.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/NonPersonOrAlertDataAuthorization.cs
@@ -21,12 +21,22 @@ public static class NonPersonOrAlertDataAuthorization
                 .RequireAuthenticatedUser()
                 .AddRequirements(new NonPersonOrAlertDataEditRequirement()));
 
+        builder.AddPolicy(
+            AuthorizationPolicies.NotesView,
+            policy => policy
+                .RequireAuthenticatedUser()
+                .AddRequirements(new NotesViewRequirement()));
+
         builder.Services
             .AddSingleton<IAuthorizationHandler, NonPersonOrAlertDataViewAuthorizationHandler>()
             .AddSingleton<IAuthorizationHandler, NonPersonOrAlertDataEditAuthorizationHandler>()
+            // NotesViewAuthorizationHandler consumes TrsDbContext which is scoped
+            .AddScoped<IAuthorizationHandler, NotesViewAuthorizationHandler>()
             // AuthorizationHandler for Legacy user roles, delete when existing users have been migrated to new user roles.
             .AddSingleton<IAuthorizationHandler, LegacyNonPersonOrAlertDataViewAuthorizationHandler>()
-            .AddSingleton<IAuthorizationHandler, LegacyNonPersonOrAlertDataEditAuthorizationHandler>();
+            .AddSingleton<IAuthorizationHandler, LegacyNonPersonOrAlertDataEditAuthorizationHandler>()
+            .AddSingleton<IAuthorizationHandler, LegacyNotesViewAuthorizationHandler>();
+
 
         return builder;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/Requirements/NotesViewRequirement.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Security/Requirements/NotesViewRequirement.cs
@@ -1,0 +1,5 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
+
+public record NotesViewRequirement : IAuthorizationRequirement;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml
@@ -18,30 +18,43 @@
     <h2 class="govuk-heading-m">Notes</h2>
 
 </div>
-@if (Model.Notes.Count() == 0)
+
+@if (Model.NotesNotVisibleFlag)
 {
-    <p class="govuk-body" data-testid="no-dqt-notes">There are no notes associated with this record</p>
+    <govuk-notification-banner data-testid="no-notes-permission">
+        <p class="govuk-notification-banner__heading">
+            You do not have permission to view Notes on this record.
+            <a class="govuk-notification-banner__link" href="mailto:TQ.DATARECEIPT@education.gov.uk">Contact the TRA</a> for more information.
+        </p>
+    </govuk-notification-banner>
 }
 else
 {
-    foreach (var note in Model.Notes)
+    @if (Model.Notes.Count() == 0)
     {
-        var downloadUrl = await fileService.GetFileUrlAsync(note.NoteId, TimeSpan.FromMinutes(15));
+        <p class="govuk-body" data-testid="no-dqt-notes">There are no notes associated with this record</p>
+    }
+    else
+    {
+        foreach (var note in Model.Notes)
+        {
+            var downloadUrl = await fileService.GetFileUrlAsync(note.NoteId, TimeSpan.FromMinutes(15));
 
-        <div data-testid="dqtnote">
-            <h3 class="govuk-heading-s">Added by <span data-testid="@note.NoteId-dqt-note-created-by">@note.CreatedByDqtUserName</span> on <span data-testid="@note.NoteId-dqt-note-created-on">@note.CreatedOn.ToString("dd MMMM yyyy 'at' HH:mm")</span></h3>
-            <div class="govuk-details" data-testid="@note.NoteId-dqt-note">
-                <div class="govuk-details__text">
-                    <p>
-                        <span data-testid="@note.NoteId-dqt-note-text">@note.Description</span>
-                    </p>
-                    @if (note.OriginalFileName is not null)
-                    {
-                        <h2 class="govuk-heading-s">Attached file</h2>
-                        <a href=@downloadUrl target="_blank" class="govuk-link"><span data-testid="@note.NoteId-dqt-note-file-name">@note.OriginalFileName</span> (opens in a new tab)</a>
-                    }
+            <div data-testid="dqtnote">
+                <h3 class="govuk-heading-s">Added by <span data-testid="@note.NoteId-dqt-note-created-by">@note.CreatedByDqtUserName</span> on <span data-testid="@note.NoteId-dqt-note-created-on">@note.CreatedOn.ToString("dd MMMM yyyy 'at' HH:mm")</span></h3>
+                <div class="govuk-details" data-testid="@note.NoteId-dqt-note">
+                    <div class="govuk-details__text">
+                        <p>
+                            <span data-testid="@note.NoteId-dqt-note-text">@note.Description</span>
+                        </p>
+                        @if (note.OriginalFileName is not null)
+                        {
+                            <h2 class="govuk-heading-s">Attached file</h2>
+                            <a href=@downloadUrl target="_blank" class="govuk-link"><span data-testid="@note.NoteId-dqt-note-file-name">@note.OriginalFileName</span> (opens in a new tab)</a>
+                        }
+                    </div>
                 </div>
             </div>
-        </div>
+        }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml.cs
@@ -1,18 +1,24 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
-public class NotesModel(TrsDbContext dbContext) : PageModel
+public class NotesModel(TrsDbContext dbContext, IAuthorizationService authorizationService) : PageModel
 {
     [FromRoute]
     public Guid PersonId { get; set; }
 
     public List<Note> Notes { get; set; } = new List<Note>();
 
+    public bool NotesNotVisibleFlag { get; set; }
+
     public async Task OnGetAsync()
     {
+        NotesNotVisibleFlag = (await authorizationService.AuthorizeAsync(User, PersonId, AuthorizationPolicies.NotesView)) is not { Succeeded: true };
+
         var notesResult = await dbContext.Notes
             .Where(x => x.PersonId == PersonId)
             .ToArrayAsync();


### PR DESCRIPTION
### Context

We need to restrict access to the Notes section in certain scenarios where a user holds a DBS alert as the Notes may contain information that is not appropriate for all users to see.
https://trello.com/c/SL5pHmy2/1320-restrict-access-to-notes-based-on-user-permissions

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
