### PR TITLE
Altered status length in RouteMigrationReportItem from 20 to 25

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/RouteMigrationReportItemMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/RouteMigrationReportItemMapping.cs
@@ -38,7 +38,7 @@ public class RouteMigrationReportItemMapping : IEntityTypeConfiguration<RouteMig
         builder.Property(r => r.RouteToProfessionalStatusTypeName).HasMaxLength(100);
         builder.Property(r => r.SourceApplicationReference).HasMaxLength(200);
         builder.Property(r => r.SourceApplicationUserShortName).HasMaxLength(25);
-        builder.Property(r => r.Status).HasMaxLength(20);
+        builder.Property(r => r.Status).HasMaxLength(25);
         builder.Property(r => r.TrainingSubject1Name).HasColumnName("training_subject1_name").HasMaxLength(200);
         builder.Property(r => r.TrainingSubject1Reference).HasColumnName("training_subject1_reference").HasMaxLength(10);
         builder.Property(r => r.TrainingSubject2Name).HasColumnName("training_subject2_name").HasMaxLength(200);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250709231243_RouteMigrationReportItemStatusLength.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250709231243_RouteMigrationReportItemStatusLength.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250709231243_RouteMigrationReportItemStatusLength")]
+    partial class RouteMigrationReportItemStatusLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250709231243_RouteMigrationReportItemStatusLength.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250709231243_RouteMigrationReportItemStatusLength.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class RouteMigrationReportItemStatusLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "status",
+                table: "route_migration_report_items",
+                type: "character varying(25)",
+                maxLength: 25,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(20)",
+                oldMaxLength: 20,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "status",
+                table: "route_migration_report_items",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(25)",
+                oldMaxLength: 25,
+                oldNullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0075_TrsRouteMigrationReportItemStatusLength.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0075_TrsRouteMigrationReportItemStatusLength.sql
@@ -1,0 +1,1 @@
+ALTER TABLE trs_route_migration_report_items ALTER COLUMN [status] varchar(25) NULL;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -108,6 +108,7 @@
     <None Remove="Services\DqtReporting\Migrations\0072_TrsQualificationsDqtAgeRange.sql" />
     <None Remove="Services\DqtReporting\Migrations\0073_TrsPersonsGender.sql" />
     <None Remove="Services\DqtReporting\Migrations\0074_TrsRouteMigrationReportItem.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0075_TrsRouteMigrationReportItemStatusLength.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -214,6 +215,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0072_TrsQualificationsDqtAgeRange.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0073_TrsPersonsGender.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0074_TrsRouteMigrationReportItem.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0075_TrsRouteMigrationReportItemStatusLength.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed issue found during dry run of route migration job (status field in routemigration report table was too small)
