### PR TITLE
Don't recalculate more than we need to when routes change

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -506,13 +506,11 @@ public class Person
         return (CpdInductionModifiedOn is not null && (InductionCompletedDate is null || InductionCompletedDate > sevenYearsAgo));
     }
 
-    public (EventModels.Induction NewInduction, EventModels.Induction OldInduction, bool Changed) RefreshInductionStatusForQtsProfessionalStatusChanged(
+    public bool RefreshInductionStatusForQtsProfessionalStatusChanged(
         DateTime now,
         IReadOnlyCollection<RouteToProfessionalStatusType> allRouteTypes,
         IEnumerable<RouteToProfessionalStatus>? routesHint = null)
     {
-        var oldInduction = EventModels.Induction.FromModel(this);
-
         var currentStatus = InductionStatus;
         var currentStatusWithoutExemption = InductionStatusWithoutExemption;
 
@@ -562,9 +560,7 @@ public class Person
             InductionModifiedOn = now;
         }
 
-        var newInduction = EventModels.Induction.FromModel(this);
-
-        return (newInduction, oldInduction, changed);
+        return changed;
     }
 
     public bool RefreshProfessionalStatusAttributes(


### PR DESCRIPTION
When routes are added/updated/removed, it potentially affects the person's induction status, QTLS status and the various professional status fields (e.g. `QtsDate`). Previously we were recalculating everything whenever any route was changed. This change amends that to only recalculate what we need to.

This is more about ensuring we don't clobber potentially invalid data at unexpected times e.g. if a person's `QtsDate` is 'wrong' according to their routes then amending an EYTS route shouldn't be affecting that.