### PR TITLE
Fix out of range dates on reporting DB sync

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/DqtReportingService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/DqtReportingService.cs
@@ -581,8 +581,20 @@ public partial class DqtReportingService : BackgroundService
                 }
             }
 
+            if (value is null)
+            {
+                value = DBNull.Value;
+            }
+
             var parameterName = $"@p{parameters.Count + 1}";
-            parameters.Add(new SqlParameter(parameterName, value ?? DBNull.Value));
+            var parameter = new SqlParameter(parameterName, value);
+
+            if (value is DateTime)
+            {
+                parameter.SqlDbType = SqlDbType.DateTime2;
+            }
+
+            parameters.Add(parameter);
             columnNames.Add(columnName);
         }
 


### PR DESCRIPTION
We have some bad data in prod, dates before 1753. Since our reporting DB sync uses `SqlDateTime` as the exchange type and pre-1753 isn't valid for that type things are blowing up. This changes to using `SqlDateTime2`.