### PR TITLE
Added UI for route migrated event

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
@@ -79,6 +79,7 @@ public class ChangeHistoryModel(
             nameof(RouteToProfessionalStatusCreatedEvent),
             nameof(RouteToProfessionalStatusUpdatedEvent),
             nameof(RouteToProfessionalStatusDeletedEvent),
+            nameof(RouteToProfessionalStatusMigratedEvent),
             nameof(ApiTrnRequestSupportTaskUpdatedEvent)
         };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusMigratedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusMigratedEvent.cshtml
@@ -1,0 +1,228 @@
+@using TeachingRecordSystem.Core.Events
+@using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus
+@using TeachingRecordSystem.Core.Services.Files
+@inject ReferenceDataCache ReferenceDataCache
+@inject IFileService FileService
+@model TimelineItem<TimelineEvent<RouteToProfessionalStatusMigratedEvent>>
+@{
+    var migratedEvent = Model.ItemModel.Event;
+    var professionalStatus = migratedEvent.RouteToProfessionalStatus;
+    var routeType = await ReferenceDataCache.GetRouteToProfessionalStatusTypeByIdAsync(professionalStatus.RouteToProfessionalStatusTypeId);
+    var trainingProvider = professionalStatus.TrainingProviderId.HasValue ? await ReferenceDataCache.GetTrainingProviderByIdAsync(professionalStatus.TrainingProviderId.Value) : null;
+    var country = !string.IsNullOrEmpty(professionalStatus.TrainingCountryId) ? await ReferenceDataCache.GetTrainingCountryByIdAsync(professionalStatus.TrainingCountryId) : null;
+    var degreeType = professionalStatus.DegreeTypeId.HasValue ? await ReferenceDataCache.GetDegreeTypeByIdAsync(professionalStatus.DegreeTypeId.Value) : null;
+    var ageRangeType = professionalStatus.TrainingAgeSpecialismType;
+    var ageRangeFromTo = (professionalStatus.TrainingAgeSpecialismRangeFrom is not null && professionalStatus.TrainingAgeSpecialismRangeTo is not null) ?
+        $"From {professionalStatus.TrainingAgeSpecialismRangeFrom} to {professionalStatus.TrainingAgeSpecialismRangeTo}" : null;
+    var subjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(professionalStatus.TrainingSubjectIds, ReferenceDataCache);
+    var dqtQtsRegistration = migratedEvent.DqtQtsRegistration;
+    var dqtInitialTeacherTraining = migratedEvent.DqtInitialTeacherTraining;
+    var dqtIttSubjectList = new List<string>();
+    if (dqtInitialTeacherTraining?.Subject1Value is not null)
+    {
+        dqtIttSubjectList.Add($"{dqtInitialTeacherTraining.Subject1Value} - {dqtInitialTeacherTraining.Subject1Name}");
+    }
+    if (dqtInitialTeacherTraining?.Subject2Value is not null)
+    {
+        dqtIttSubjectList.Add($"{dqtInitialTeacherTraining.Subject2Value} - {dqtInitialTeacherTraining.Subject2Name}");
+    }
+    if (dqtInitialTeacherTraining?.Subject3Value is not null)
+    {
+        dqtIttSubjectList.Add($"{dqtInitialTeacherTraining.Subject3Value} - {dqtInitialTeacherTraining.Subject3Name}");
+    }
+    var dqtIttSubjects = dqtIttSubjectList.ToArray();
+}
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-route-migrated-event">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">Route migrated</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Route</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="route" use-empty-fallback>@routeType.Name</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Status</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="status" use-empty-fallback>@professionalStatus.Status.GetDisplayName()</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="start-date" use-empty-fallback>@professionalStatus.TrainingStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="end-date" use-empty-fallback>@professionalStatus.TrainingEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Professional Status date</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="award-date" use-empty-fallback>@professionalStatus.HoldsFrom?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Induction exemption</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="exemption" use-empty-fallback>@(professionalStatus.ExemptFromInduction.HasValue? professionalStatus.ExemptFromInduction.Value ? "Yes" : "No" : null)</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Training provider</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="training-provider" use-empty-fallback>@trainingProvider?.Name</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Degree type</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="degree-type" use-empty-fallback>@degreeType?.Name</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Country</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="country" use-empty-fallback>@country?.Name</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Age range</govuk-summary-list-row-key>
+                @if (ageRangeFromTo is not null)
+                {
+                    <govuk-summary-list-row-value data-testid="age-range">@ageRangeFromTo</govuk-summary-list-row-value>
+                }
+                else
+                {
+                    <govuk-summary-list-row-value data-testid="age-range" use-empty-fallback>@ageRangeType?.GetDisplayName()</govuk-summary-list-row-value>
+                }
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>
+                    @if (subjects is not null && subjects.Length > 0)
+                    {
+                        <list-text-items text-items="@subjects" data-testid="subjects" />
+                    }
+                    else
+                    {
+                        <span use-empty-fallback data-testid="subjects"></span>
+                    }
+                </govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Source application reference</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testId="source-application-reference" use-empty-fallback>@professionalStatus.SourceApplicationReference</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        </govuk-summary-list>        
+        <govuk-details class="govuk-!-margin-bottom-2">
+            <govuk-details-summary>Migrated data</govuk-details-summary>
+            <govuk-details-text>
+                 <govuk-summary-list>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>QTS registration ID</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="qts-registration-id" use-empty-fallback>@dqtQtsRegistration?.QtsRegistrationId</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Teacher status name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="teacher-status-name" use-empty-fallback>@dqtQtsRegistration?.TeacherStatusName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Teacher status value</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="teacher-status-value" use-empty-fallback>@dqtQtsRegistration?.TeacherStatusValue</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Early years status name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="early-years-status-name" use-empty-fallback>@dqtQtsRegistration?.EarlyYearsStatusName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Early years status value</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="early-years-status-value" use-empty-fallback>@dqtQtsRegistration?.EarlyYearsStatusValue</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>QTS date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="qts-date" use-empty-fallback>@dqtQtsRegistration?.QtsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>EYTS date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="eyts-date" use-empty-fallback>@dqtQtsRegistration?.EytsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Partial QTS date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="pqts-date" use-empty-fallback>@dqtQtsRegistration?.PartialRecognitionDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>QTLS date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="qtls-date" use-empty-fallback>@migratedEvent?.DqtQtlsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>ITT ID</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="itt-id" use-empty-fallback>@dqtInitialTeacherTraining?.InitialTeacherTrainingId</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Slug ID</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="slug-id" use-empty-fallback>@dqtInitialTeacherTraining?.SlugId</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Programme type</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="programme-type" use-empty-fallback>@dqtInitialTeacherTraining?.ProgrammeType</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Start date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="programme-start-date" use-empty-fallback>@dqtInitialTeacherTraining?.ProgrammeStartDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>End date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="programme-end-date" use-empty-fallback>@dqtInitialTeacherTraining?.ProgrammeEndDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Result</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="itt-result" use-empty-fallback>@dqtInitialTeacherTraining?.Result</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Qualification name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="qualification-name" use-empty-fallback>@dqtInitialTeacherTraining?.QualificationName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Qualification value</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="qualification-value" use-empty-fallback>@dqtInitialTeacherTraining?.QualificationValue</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Provider ID</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="provider-id" use-empty-fallback>@dqtInitialTeacherTraining?.ProviderId</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Provider name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="provider-name" use-empty-fallback>@dqtInitialTeacherTraining?.ProviderName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Provider UKPRN</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="provider-ukprn" use-empty-fallback>@dqtInitialTeacherTraining?.ProviderUkprn</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Country name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="country-name" use-empty-fallback>@dqtInitialTeacherTraining?.CountryName</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Country value</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="country-value" use-empty-fallback>@dqtInitialTeacherTraining?.CountryValue</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Age range from</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="dqt-age-range-from" use-empty-fallback>@dqtInitialTeacherTraining?.AgeRangeFrom</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Age range to</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="dqt-age-range-to" use-empty-fallback>@dqtInitialTeacherTraining?.AgeRangeTo</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Subjects</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>
+                            @if (dqtIttSubjects.Length > 0)
+                            {
+                                <list-text-items text-items="@dqtIttSubjects" data-testid="dqt-subjects" />
+                            }
+                            else
+                            {
+                                <span use-empty-fallback data-testid="dqt-subjects"></span>
+                            }
+                        </govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                </govuk-summary-list>
+            </govuk-details-text>
+        </govuk-details>
+    </div>
+</div>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Dqt.Models;
 using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 using TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus;
 using ProfessionalStatusType = TeachingRecordSystem.Core.Models.ProfessionalStatusType;
@@ -641,5 +642,205 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         Assert.NotNull(timelineItem);
         Assert.Equal("No", timelineItem.GetElementByTestId("has-eyps")?.TrimmedText());
         Assert.Equal("Yes", timelineItem.GetElementByTestId("old-has-eyps")?.TrimmedText());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ProfessionalStatusMigratedEvent_RendersExpectedContent(bool populateOptional)
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var startDate = Clock.Today.AddYears(-1);
+        var endDate = Clock.Today.AddDays(-1);
+        var awardDate = endDate.AddDays(1);
+        var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
+        var status = populateOptional ? RouteToProfessionalStatusStatus.Holds : RouteToProfessionalStatusStatus.InTraining;
+        var subjects = (await ReferenceDataCache.GetTrainingSubjectsAsync()).Where(s => s.Name.IndexOf('\'') == -1).Take(1);
+        var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).RandomOne();
+        var degreeType = (await ReferenceDataCache.GetDegreeTypesAsync()).RandomOne();
+        var country = (await ReferenceDataCache.GetTrainingCountriesAsync()).RandomOne();
+        var ageRangeType = TrainingAgeSpecialismType.Range;
+        var ageRangeFrom = 10;
+        var ageRangeTo = 16;
+        var createdByUser = await TestData.CreateUserAsync();
+        var sourceApplicationUserId = Guid.NewGuid();
+        var sourceApplicationReference = "source-application-reference";
+        var qualifiedTeacherStatus = await ReferenceDataCache.GetTeacherStatusByValueAsync("71");
+        var earlyYearsTeacherStatus = await ReferenceDataCache.GetEarlyYearsStatusByValueAsync("221");
+        var qtsDate = awardDate;
+        var eytsDate = awardDate.AddDays(1);
+        var pqtsDate = awardDate.AddDays(2);
+        var qtlsDate = awardDate.AddDays(3);
+        var ittQualification = await ReferenceDataCache.GetIttQualificationByValueAsync("008");
+        var ittProvider = await ReferenceDataCache.GetIttProviderByUkPrnAsync("10007799");
+        var ittSubject1 = await ReferenceDataCache.GetIttSubjectBySubjectCodeAsync("100078");
+        var ittSubject2 = await ReferenceDataCache.GetIttSubjectBySubjectCodeAsync("100079");
+        var ittSubject3 = await ReferenceDataCache.GetIttSubjectBySubjectCodeAsync("100343");
+        var dqtAgeRangeFrom = dfeta_AgeRange._10;
+        var dqtAgeRangeTo = dfeta_AgeRange._16;
+        var programmeType = dfeta_ITTProgrammeType.AssessmentOnlyRoute;
+        var ittResult = dfeta_ITTResult.Pass;
+        var dqtCountry = await ReferenceDataCache.GetCountryByCountryCodeAsync("XK");
+
+        // Use populateOptional to deliberately populate OR not populate ALL optional fields to test rendering.
+        // (even though in reality not all combinations of these fields would happen).
+        EventModels.RouteToProfessionalStatus routeToProfessionalStatus;
+        EventModels.DqtQtsRegistration? dqtQtsRegistration = null;
+        EventModels.DqtInitialTeacherTraining? dqtInitialTeacherTraining = null;
+
+        if (populateOptional)
+        {
+            routeToProfessionalStatus = new EventModels.RouteToProfessionalStatus()
+            {
+                QualificationId = Guid.NewGuid(),
+                RouteToProfessionalStatusTypeId = route.RouteToProfessionalStatusTypeId,
+                Status = status,
+                TrainingStartDate = startDate,
+                TrainingEndDate = endDate,
+                HoldsFrom = awardDate,
+                TrainingProviderId = trainingProvider.TrainingProviderId,
+                TrainingCountryId = country.CountryId,
+                TrainingSubjectIds = subjects.Select(s => s.TrainingSubjectId).ToArray(),
+                TrainingAgeSpecialismType = ageRangeType,
+                TrainingAgeSpecialismRangeFrom = ageRangeFrom,
+                TrainingAgeSpecialismRangeTo = ageRangeTo,
+                DegreeTypeId = degreeType.DegreeTypeId,
+                SourceApplicationUserId = sourceApplicationUserId,
+                SourceApplicationReference = sourceApplicationReference,
+                ExemptFromInduction = true,
+                ExemptFromInductionDueToQtsDate = true
+            };
+
+            dqtQtsRegistration = new EventModels.DqtQtsRegistration()
+            {
+                QtsRegistrationId = Guid.NewGuid(),
+                TeacherStatusName = qualifiedTeacherStatus.dfeta_name,
+                TeacherStatusValue = qualifiedTeacherStatus.dfeta_Value,
+                EarlyYearsStatusName = earlyYearsTeacherStatus.dfeta_name,
+                EarlyYearsStatusValue = earlyYearsTeacherStatus.dfeta_Value,
+                QtsDate = qtsDate,
+                EytsDate = eytsDate,
+                PartialRecognitionDate = pqtsDate
+            };
+
+            dqtInitialTeacherTraining = new EventModels.DqtInitialTeacherTraining()
+            {
+                InitialTeacherTrainingId = Guid.NewGuid(),
+                SlugId = sourceApplicationReference,
+                ProgrammeType = programmeType.ToString(),
+                ProgrammeStartDate = startDate,
+                ProgrammeEndDate = endDate,
+                Result = ittResult.ToString(),
+                QualificationName = ittQualification.dfeta_name,
+                QualificationValue = ittQualification.dfeta_Value,
+                ProviderId = ittProvider!.Id,
+                ProviderName = ittProvider.Name,
+                ProviderUkprn = ittProvider.dfeta_UKPRN,
+                CountryName = dqtCountry!.dfeta_name,
+                CountryValue = dqtCountry.dfeta_Value,
+                Subject1Name = ittSubject1!.dfeta_name,
+                Subject1Value = ittSubject1.dfeta_Value,
+                Subject2Name = ittSubject2!.dfeta_name,
+                Subject2Value = ittSubject2.dfeta_Value,
+                Subject3Name = ittSubject3!.dfeta_name,
+                Subject3Value = ittSubject3.dfeta_Value,
+                AgeRangeFrom = dqtAgeRangeFrom.ToString(),
+                AgeRangeTo = dqtAgeRangeTo.ToString()
+            };
+        }
+        else
+        {
+            routeToProfessionalStatus = new EventModels.RouteToProfessionalStatus()
+            {
+                QualificationId = Guid.NewGuid(),
+                RouteToProfessionalStatusTypeId = route.RouteToProfessionalStatusTypeId,
+                Status = status,
+                TrainingStartDate = null,
+                TrainingEndDate = null,
+                HoldsFrom = null,
+                TrainingProviderId = null,
+                TrainingCountryId = null,
+                TrainingSubjectIds = [],
+                TrainingAgeSpecialismType = null,
+                TrainingAgeSpecialismRangeFrom = null,
+                TrainingAgeSpecialismRangeTo = null,
+                DegreeTypeId = null,
+                SourceApplicationUserId = null,
+                SourceApplicationReference = null,
+                ExemptFromInduction = null,
+                ExemptFromInductionDueToQtsDate = null
+            };
+        }
+
+        var migratedEvent = new RouteToProfessionalStatusMigratedEvent()
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = Clock.UtcNow,
+            RaisedBy = createdByUser.UserId,
+            PersonId = person.PersonId,
+            RouteToProfessionalStatus = routeToProfessionalStatus,
+            DqtQtsRegistration = dqtQtsRegistration,
+            DqtInitialTeacherTraining = dqtInitialTeacherTraining,
+            DqtQtlsDate = populateOptional ? qtlsDate : null,
+            DqtQtlsDateHasBeenSet = populateOptional ? true : null,
+            PersonAttributes = EventModels.ProfessionalStatusPersonAttributes.FromModel(person.Person),
+            OldPersonAttributes = EventModels.ProfessionalStatusPersonAttributes.FromModel(person.Person)
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.AddEventWithoutBroadcast(migratedEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var timelineItem = doc.GetElementByTestId("timeline-item-route-migrated-event");
+        Assert.NotNull(timelineItem);
+        Assert.Equal($"By {createdByUser.Name} on", timelineItem.GetElementByTestId("raised-by")?.TrimmedText());
+        Assert.Equal(populateOptional ? awardDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("award-date")?.TrimmedText());
+        Assert.Equal(status.GetDisplayName(), timelineItem.GetElementByTestId("status")?.TrimmedText());
+        Assert.Equal(route.Name, timelineItem.GetElementByTestId("route")?.TrimmedText());
+        Assert.Equal(populateOptional ? startDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("start-date")!.TrimmedText());
+        Assert.Equal(populateOptional ? endDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("end-date")!.TrimmedText());
+        Assert.Equal(populateOptional ? "Yes" : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("exemption")?.TrimmedText());
+        Assert.Equal(populateOptional ? trainingProvider.Name : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("training-provider")?.TrimmedText());
+        Assert.Equal(populateOptional ? degreeType.Name : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("degree-type")?.TrimmedText());
+        Assert.Equal(populateOptional ? country.Name : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("country")?.TrimmedText());
+        Assert.Equal(populateOptional ? $"From {ageRangeFrom} to {ageRangeTo}" : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("age-range")?.TrimmedText());
+        Assert.Equal(populateOptional ? $"{subjects.Single().Reference} - {subjects.Single().Name}" : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("subjects")?.TrimmedText());
+        Assert.Equal(populateOptional ? sourceApplicationReference : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("source-application-reference")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtQtsRegistration!.QtsRegistrationId.ToString() : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("qts-registration-id")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtQtsRegistration!.TeacherStatusName : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("teacher-status-name")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtQtsRegistration!.TeacherStatusValue : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("teacher-status-value")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtQtsRegistration!.EarlyYearsStatusName : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("early-years-status-name")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtQtsRegistration!.EarlyYearsStatusValue : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("early-years-status-value")?.TrimmedText());
+        Assert.Equal(populateOptional ? qtsDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("qts-date")?.TrimmedText());
+        Assert.Equal(populateOptional ? eytsDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("eyts-date")?.TrimmedText());
+        Assert.Equal(populateOptional ? pqtsDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("pqts-date")?.TrimmedText());
+        Assert.Equal(populateOptional ? qtlsDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("qtls-date")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtInitialTeacherTraining!.InitialTeacherTrainingId.ToString() : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("itt-id")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtInitialTeacherTraining?.SlugId : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("slug-id")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtInitialTeacherTraining?.ProgrammeType : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("programme-type")?.TrimmedText());
+        Assert.Equal(populateOptional ? startDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("programme-start-date")?.TrimmedText());
+        Assert.Equal(populateOptional ? endDate.ToString(UiDefaults.DateOnlyDisplayFormat) : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("programme-end-date")?.TrimmedText());
+        Assert.Equal(populateOptional ? ittResult.ToString() : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("itt-result")?.TrimmedText());
+        Assert.Equal(populateOptional ? ittQualification.dfeta_name : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("qualification-name")?.TrimmedText());
+        Assert.Equal(populateOptional ? ittQualification.dfeta_Value : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("qualification-value")?.TrimmedText());
+        Assert.Equal(populateOptional ? ittProvider!.Id.ToString() : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("provider-id")?.TrimmedText());
+        Assert.Equal(populateOptional ? ittProvider!.Name : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("provider-name")?.TrimmedText());
+        Assert.Equal(populateOptional ? ittProvider!.dfeta_UKPRN : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("provider-ukprn")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtCountry!.dfeta_name : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("country-name")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtCountry!.dfeta_Value : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("country-value")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtAgeRangeFrom.ToString() : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("dqt-age-range-from")?.TrimmedText());
+        Assert.Equal(populateOptional ? dqtAgeRangeTo.ToString() : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("dqt-age-range-to")?.TrimmedText());
+        Assert.Equal(populateOptional ? $"{ittSubject1!.dfeta_Value} - {ittSubject1!.dfeta_name}{ittSubject2!.dfeta_Value} - {ittSubject2!.dfeta_name}{ittSubject3!.dfeta_Value} - {ittSubject3!.dfeta_name}" : UiDefaults.EmptyDisplayContent, timelineItem.GetElementByTestId("dqt-subjects")?.TrimmedText());
     }
 }


### PR DESCRIPTION
### Context

The background job which migrated ITT / QTS data from DQT into the TRS data structure generated a RouteToProfessionalStatusMigratedEvent for each migrated route.

This change allows details of this event to be displayed this in the Change History section for a person.

