### PR TITLE
Re-add induction importer service for ewc wales

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -55,6 +55,7 @@ public static class HostApplicationBuilderExtensions
             builder.Services.AddHttpClient<PopulateNameSynonymsJob>();
 
             builder.Services.AddTransient<QtsImporter>();
+            builder.Services.AddTransient<InductionImporter>();
 
             builder.Services.AddStartupTask(sp =>
             {


### PR DESCRIPTION
The ewc induction importer service got accidentally removed, which causes the ewc job to fail. This re-adds the service.