### PR TITLE
Allow viewing deactivated person

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/AllowDeactivatedPersonAttribute.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/AllowDeactivatedPersonAttribute.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace TeachingRecordSystem.SupportUi;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class AllowDeactivatedPersonAttribute : Attribute, IPageApplicationModelConvention
+{
+    public void Apply(PageApplicationModel model)
+    {
+        model.EndpointMetadata.Add(AllowDeactivatedPersonMetadata.Instance);
+    }
+}
+
+public sealed class AllowDeactivatedPersonMetadata
+{
+    private AllowDeactivatedPersonMetadata() { }
+
+    public static AllowDeactivatedPersonMetadata Instance { get; } = new();
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -15,8 +15,7 @@ namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 /// <remarks>
 /// <para>Returns a <see cref="StatusCodes.Status400BadRequest"/> response if the request is missing the personId route value.</para>
 /// <para>
-/// Returns a <see cref="StatusCodes.Status404NotFound"/> response if no person with the specified ID exists or if
-/// <paramref name="requireQts"/> is <c>true</c> and the person does not have QTS.
+/// Returns a <see cref="StatusCodes.Status404NotFound"/> response if no person with the specified ID exists.
 /// </para>
 /// <para>Assigns the <see cref="CurrentPersonFeature"/> on success.</para>
 /// </remarks>
@@ -80,7 +79,8 @@ public class CheckPersonExistsFilter(
         await next();
 
         Task<Person?> GetPersonAsync() => dbContext.Persons
-            .FromSql($"select * from persons where person_id = {personId} and status = 0 for update")  // https://github.com/dotnet/efcore/issues/26042
+            .FromSql($"select * from persons where person_id = {personId} for update")  // https://github.com/dotnet/efcore/issues/26042
+            .IgnoreQueryFilters()
             .SingleOrDefaultAsync();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireActivePersonFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RequireActivePersonFilter.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+public class RequireActivePersonFilter : IResourceFilter, IOrderedFilter
+{
+    public void OnResourceExecuting(ResourceExecutingContext context)
+    {
+        var currentPerson = context.HttpContext.Features.Get<CurrentPersonFeature>();
+
+        if (currentPerson is null)
+        {
+            return;
+        }
+
+        if (context.ActionDescriptor.EndpointMetadata.Any(m => m is AllowDeactivatedPersonMetadata))
+        {
+            return;
+        }
+
+        if (currentPerson.Status is not PersonStatus.Active)
+        {
+            context.Result = new StatusCodeResult(StatusCodes.Status400BadRequest);
+        }
+    }
+
+    public void OnResourceExecuted(ResourceExecutedContext context)
+    {
+    }
+
+    public int Order => 100;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/PageContextFeatures.cs
@@ -16,6 +16,8 @@ public static class HttpContextExtensions
             context,
             new CurrentPersonFeature(
                 person.PersonId,
+                person.Trn,
+                person.Status,
                 person.FirstName,
                 person.MiddleName,
                 person.LastName));
@@ -45,7 +47,7 @@ public static class HttpContextExtensions
         context.Features.Set(currentAlertFeature);
 }
 
-public record CurrentPersonFeature(Guid PersonId, string FirstName, string MiddleName, string LastName)
+public record CurrentPersonFeature(Guid PersonId, string? Trn, PersonStatus Status, string FirstName, string MiddleName, string LastName)
 {
     public string Name => (FirstName + " " + MiddleName).Trim() + " " + LastName;
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml.cs
@@ -9,6 +9,7 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Security.Requirements;
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
 [Authorize(Policy = AuthorizationPolicies.AlertsView)]
+[AllowDeactivatedPerson]
 public class AlertsModel(TrsDbContext dbContext, ReferenceDataCache referenceDataCache, IAuthorizationService authorizationService) : PageModel
 {
     [FromRoute]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
@@ -10,6 +10,7 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.Timeline.Events;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
+[AllowDeactivatedPerson]
 public class ChangeHistoryModel(
     ICrmQueryDispatcher crmQueryDispatcher,
     TrsDbContext dbContext,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -6,6 +6,7 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
+[AllowDeactivatedPerson]
 public class IndexModel(
     TrsDbContext dbContext,
     ICrmQueryDispatcher crmQueryDispatcher,
@@ -40,7 +41,9 @@ public class IndexModel(
 
     private async Task<PersonProfessionalStatusInfo?> BuildPersonStatusInfoAsync()
     {
-        var person = await dbContext.Persons.SingleAsync(p => p.PersonId == PersonId);
+        var person = await dbContext.Persons
+            .IgnoreQueryFilters()
+            .SingleAsync(p => p.PersonId == PersonId);
 
         var personProfessionalStatusInfo = new PersonProfessionalStatusInfo
         {
@@ -69,6 +72,7 @@ public class IndexModel(
         if (featureProvider.IsEnabled(FeatureNames.ContactsMigrated))
         {
             var person = await dbContext.Persons
+                .IgnoreQueryFilters()
                 .SingleOrDefaultAsync(p => p.PersonId == PersonId);
 
             var previousNames = await dbContext.PreviousNames

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml.cs
@@ -8,6 +8,7 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
 [Authorize(Policy = AuthorizationPolicies.NonPersonOrAlertDataView)]
+[AllowDeactivatedPerson]
 public class InductionModel(
     TrsDbContext dbContext,
     IClock clock,
@@ -58,6 +59,7 @@ public class InductionModel(
     public async Task OnGetAsync()
     {
         var person = await dbContext.Persons
+            .IgnoreQueryFilters()
             .Include(p => p.Qualifications)
             .SingleAsync(q => q.PersonId == PersonId);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml.cs
@@ -6,6 +6,7 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
+[AllowDeactivatedPerson]
 public class NotesModel(TrsDbContext dbContext, IAuthorizationService authorizationService) : PageModel
 {
     [FromRoute]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml.cs
@@ -9,6 +9,7 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
 
 [Authorize(Policy = AuthorizationPolicies.NonPersonOrAlertDataView)]
+[AllowDeactivatedPerson]
 public class QualificationsModel(TrsDbContext dbContext, ReferenceDataCache referenceDataCache) : PageModel
 {
     [FromRoute]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -109,6 +109,7 @@ builder.Services
         options.Filters.Add(new AuthorizeFilter(policy));
         options.Filters.Add(new CheckUserExistsFilter());
         options.Filters.Add(new NoCachePageFilter());
+        options.Filters.Add(new RequireActivePersonFilter());
 
         options.ModelBinderProviders.Insert(2, new DateOnlyModelBinderProvider());
     })


### PR DESCRIPTION
This allows viewing a deactivated record on the console. All edit functions will currently return a Bad Request error. This is super crude but it'll be refined later.