### PR TITLE
Don't deploy to dev environment for PR builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,24 @@ jobs:
     uses: ./.github/workflows/package.yml
     secrets: inherit
 
+  deploy_dev:
+    name: Deploy dev environment
+    runs-on: ubuntu-latest
+    needs: [package]
+    environment: dev
+    concurrency: deploy_dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/workflows/actions/deploy-aks-environment
+        id: deploy
+        with:
+          environment_name: dev
+          docker_image: ${{ needs.package.outputs.docker_image }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+
   check_environments:
     name: Check environment deployments
     runs-on: ubuntu-latest
@@ -53,7 +71,7 @@ jobs:
   deploy_test:
     name: Deploy test environment
     runs-on: ubuntu-latest
-    needs: [package]
+    needs: [deploy_dev, package]
     environment: test
     concurrency: deploy_test
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -211,22 +211,3 @@ jobs:
     name: Package application
     uses: ./.github/workflows/package.yml
     secrets: inherit
-
-  deploy_dev:
-    name: Deploy dev environment
-    runs-on: ubuntu-latest
-    needs: [lint, validate_terraform, tests, package]
-    if: always() && (needs.tests.result == 'success' || needs.tests.result == 'skipped')
-    environment: dev
-    concurrency: deploy_dev
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/workflows/actions/deploy-aks-environment
-        id: deploy
-        with:
-          environment_name: dev
-          docker_image: ${{ needs.package.outputs.docker_image }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
We don't need to deploy to dev for every PR build indeed that sometimes causes problems when migrations in PRs get changed.