### PR TITLE
Job to fix incorrect OTT route mappings during migration

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/RouteToProfessionalStatusType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/RouteToProfessionalStatusType.cs
@@ -12,6 +12,7 @@ public class RouteToProfessionalStatusType
     public static Guid SchoolDirectTrainingProgrammeId { get; } = new("D9490E58-ACDC-4A38-B13E-5A5C21417737");
     public static Guid InternationalQualifiedTeacherStatusId { get; } = new("D0B60864-AB1C-4D49-A5C2-FF4BD9872EE1");
     public static Guid NiRId { get; } = new("3604EF30-8F11-4494-8B52-A2F9C5371E03");
+    public static Guid OverseasTrainedTeacherProgrammeId { get; } = new("51756384-CFEA-4F63-80E5-F193686E0F71");
     public static Guid OverseasTrainedTeacherRecognitionId { get; } = new("CE61056E-E681-471E-AF48-5FFBF2653500");
     public static Guid QtlsAndSetMembershipId { get; } = new("BE6EAF8C-92DD-4EFF-AAD3-1C89C4BEC18C");
     public static Guid ScotlandRId { get; } = new("52835B1F-1F2E-4665-ABC6-7FB1EF0A80BB");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/FixIncorrectOttRouteMigrationMappingsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/FixIncorrectOttRouteMigrationMappingsJob.cs
@@ -1,0 +1,46 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class FixIncorrectOttRouteMigrationMappingsJob(
+    IDbContextFactory<TrsDbContext> dbContextFactory,
+    ReferenceDataCache referenceDataCache,
+    IClock clock)
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var allRoutes = await referenceDataCache.GetRouteToProfessionalStatusTypesAsync(activeOnly: false);
+
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+        dbContext.Database.SetCommandTimeout(0);
+
+        var professionalStatusToFix = dbContext
+            .RouteToProfessionalStatuses
+            .Include(r => r.Person)
+            .Where(r => r.RouteToProfessionalStatusTypeId == RouteToProfessionalStatusType.OverseasTrainedTeacherProgrammeId && r.DqtTeacherStatusValue == "103")
+            .ToListAsync();
+
+        foreach (var professionalStatus in await professionalStatusToFix)
+        {
+            professionalStatus.Update(
+                allRoutes,
+                r =>
+                {
+                    r.RouteToProfessionalStatusTypeId = RouteToProfessionalStatusType.OverseasTrainedTeacherRecognitionId;
+                },
+                changeReason: "AnotherReason",
+                changeReasonDetail: "Route type incorrectly mapped during migration",
+                evidenceFile: null,
+                updatedBy: DataStore.Postgres.Models.SystemUser.SystemUserId,
+                clock.UtcNow,
+                out var updatedEvent);
+
+            if (updatedEvent is not null)
+            {
+                await dbContext.AddEventAndBroadcastAsync(updatedEvent);
+                await dbContext.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -147,6 +147,9 @@ public static class HostApplicationBuilderExtensions
                 recurringJobManager.RemoveIfExists("SyncAllInductionsFromCrmJob & (dry-run)");
                 recurringJobManager.RemoveIfExists("SyncAllInductionsFromCrmJob & migrate");
 
+                recurringJobManager.RemoveIfExists("MigrateRoutesFromCrmJob");
+                recurringJobManager.RemoveIfExists("MigrateRoutesFromCrmJob (dry-run)");
+
                 recurringJobManager.AddOrUpdate<CpdInductionImporterJob>(
                     nameof(CpdInductionImporterJob),
                     job => job.ExecuteAsync(CancellationToken.None),
@@ -213,14 +216,9 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(new DateTime(2025, 6, 6, 0, 0, 0, DateTimeKind.Utc), CancellationToken.None),
                     Cron.Never);
 
-                recurringJobManager.AddOrUpdate<MigrateRoutesFromCrmJob>(
-                    nameof(MigrateRoutesFromCrmJob),
-                    job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None),
-                    Cron.Never);
-
-                recurringJobManager.AddOrUpdate<MigrateRoutesFromCrmJob>(
-                    $"{nameof(MigrateRoutesFromCrmJob)} (dry-run)",
-                    job => job.ExecuteAsync(/*dryRun: */true, CancellationToken.None),
+                recurringJobManager.AddOrUpdate<FixIncorrectOttRouteMigrationMappingsJob>(
+                    nameof(FixIncorrectOttRouteMigrationMappingsJob),
+                    job => job.ExecuteAsync(CancellationToken.None),
                     Cron.Never);
 
                 return Task.CompletedTask;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -90,7 +90,7 @@ public class TrsDataSyncHelper(
         { "211", null },
         { "77", new("ABCB0A14-0C21-4598-A42C-A007D4B048AC") },
         { "79", new("88867B43-897B-49B5-97CC-F4F81A1D5D44") },
-        { "103", new("51756384-CFEA-4F63-80E5-F193686E0F71") },
+        { "103", new("CE61056E-E681-471E-AF48-5FFBF2653500") },
         { "100", new("57B86CEF-98E2-4962-A74A-D47C7A34B838") },
         { "222", new("8F5C0431-D006-4EDA-9336-16DFC6A26A78") },
         { "80", new("700EC96F-6BBF-4080-87BD-94EF65A6A879") },


### PR DESCRIPTION
### Context

The background job which migrated ITT / QTS data from DQT into the TRS database structure has now been executed.

As part of Post route migration sanity check around 16K records where teacher status was 103 - Qualified Teacher: By virtue of overseas qualifications were mapped incorrectly to route type Overseas Trained Teacher Programme when they should have been mapped to Overseas Trained Teacher Recognition

### Changes proposed in this pull request

Write a one-off background job to amend the `RouteToProfessionalStatusTypeId` for all `RouteToProfessionalStatus` records with `QualificationType.RouteToProfessionalStatus` and `DqtTeacherStatusValue` of `103` and `RouteToProfessionalStatusTypeId` for Overseas Trained Teacher Programme to Overseas Trained Teacher Programme 

This should create a `RouteToProfessionalStatusUpdatedEvent`.
