### PR TITLE
Handle TRN requests in both DQT and TRS

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
@@ -1,6 +1,5 @@
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Implementation.Dtos;
-using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
@@ -19,7 +18,7 @@ public class GetTrnRequestHandler(TrnRequestService trnRequestService, ICurrentU
             return ApiError.TrnRequestDoesNotExist(command.RequestId);
         }
 
-        var contact = trnRequest.Contact;
+        var metadata = trnRequest.Metadata;
 
         return new TrnRequestInfo()
         {
@@ -28,19 +27,18 @@ public class GetTrnRequestHandler(TrnRequestService trnRequestService, ICurrentU
             Person = new TrnRequestInfoPerson()
 #pragma warning restore TRS0001
             {
-                // FUTURE - these values should be what was submitted in the original request
-                FirstName = contact.FirstName,
-                LastName = contact.LastName,
-                MiddleName = contact.MiddleName,
-                EmailAddress = contact.EMailAddress1,
-                NationalInsuranceNumber = contact.dfeta_NINumber,
-                DateOfBirth = contact.BirthDate!.Value.ToDateOnlyWithDqtBstFix(isLocalTime: false)
+                FirstName = metadata.FirstName!,
+                LastName = metadata.LastName!,
+                MiddleName = metadata.MiddleName,
+                EmailAddress = metadata.EmailAddress,
+                NationalInsuranceNumber = metadata.NationalInsuranceNumber,
+                DateOfBirth = metadata.DateOfBirth
             },
-            Trn = trnRequest.Trn,
-            Status = trnRequest.IsCompleted ? TrnRequestStatus.Completed : TrnRequestStatus.Pending,
-            PotentialDuplicate = trnRequest.PotentialDuplicate,
-            AccessYourTeachingQualificationsLink = trnRequest.TrnToken is not null ?
-                trnRequestService.GetAccessYourTeachingQualificationsLink(trnRequest.TrnToken) :
+            Trn = trnRequest.ResolvedPersonTrn,
+            Status = metadata.Status ?? TrnRequestStatus.Pending,
+            PotentialDuplicate = metadata.PotentialDuplicate ?? false,
+            AccessYourTeachingQualificationsLink = metadata.TrnToken is string trnToken ?
+                trnRequestService.GetAccessYourTeachingQualificationsLink(trnToken) :
                 null
         };
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyHelper.cs
@@ -363,10 +363,12 @@ public class SignInJourneyHelper(
             return null;
         }
 
-        if (!trnRequest.IsCompleted)
+        if (trnRequest.Metadata.Status is not TrnRequestStatus.Completed)
         {
             return null;
         }
+        Debug.Assert(trnRequest.Metadata.ResolvedPersonId.HasValue);
+        Debug.Assert(trnRequest.ResolvedPersonTrn is not null);
 
         oneLoginUser.SetVerified(
             verifiedOn: trnRequestMetadata.CreatedOn,
@@ -376,11 +378,11 @@ public class SignInJourneyHelper(
             verifiedDatesOfBirth: [trnRequestMetadata.DateOfBirth]);
 
         oneLoginUser.SetMatched(
-            trnRequest.Contact.Id,
+            trnRequest.Metadata.ResolvedPersonId!.Value,
             route: OneLoginUserMatchRoute.TrnRequest,
             matchedAttributes: null);
 
-        return new(trnRequest.Contact.dfeta_TRN);
+        return new(trnRequest.ResolvedPersonTrn!);
     }
 
     public void Complete(SignInJourneyState state, string trn)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250721161658_TrnRequestMetadataStatusOptional.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250721161658_TrnRequestMetadataStatusOptional.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250721161658_TrnRequestMetadataStatusOptional")]
+    partial class TrnRequestMetadataStatusOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -19967,6 +19970,11 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .IsRequired()
                         .HasConstraintName("fk_trn_request_metadata_application_users_application_user_id");
 
+                    b.HasOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.Person", "ResolvedPerson")
+                        .WithMany()
+                        .HasForeignKey("ResolvedPersonId")
+                        .HasConstraintName("fk_trn_request_metadata_persons_resolved_person_id");
+
                     b.OwnsOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMatches", "Matches", b1 =>
                         {
                             b1.Property<Guid>("TrnRequestMetadataApplicationUserId")
@@ -20017,6 +20025,8 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                     b.Navigation("ApplicationUser");
 
                     b.Navigation("Matches");
+
+                    b.Navigation("ResolvedPerson");
                 });
 
             modelBuilder.Entity("TeachingRecordSystem.Core.DataStore.Postgres.Models.WebhookEndpoint", b =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250721161658_TrnRequestMetadataStatusOptional.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250721161658_TrnRequestMetadataStatusOptional.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnRequestMetadataStatusOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "status",
+                table: "trn_request_metadata",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.Sql("update trn_request_metadata set status = null where resolved_person_id is null");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "status",
+                table: "trn_request_metadata",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/TrnRequestMetadata.cs
@@ -1,3 +1,5 @@
+using TeachingRecordSystem.Core.Services.DqtOutbox.Messages;
+
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class TrnRequestMetadata
@@ -27,7 +29,7 @@ public class TrnRequestMetadata
     public string? Country { get; init; }
     public string? TrnToken { get; set; }
     public Guid? ResolvedPersonId { get; private set; }
-    public TrnRequestStatus Status { get; private set; } = TrnRequestStatus.Pending;
+    public TrnRequestStatus? Status { get; private set; } = TrnRequestStatus.Pending;
     public TrnRequestMatches? Matches { get; set; }
 
     public void SetResolvedPerson(Guid personId, TrnRequestStatus requestStatus = TrnRequestStatus.Completed)
@@ -35,6 +37,35 @@ public class TrnRequestMetadata
         ResolvedPersonId = personId;
         Status = requestStatus;
     }
+
+    public static TrnRequestMetadata FromOutboxMessage(TrnRequestMetadataMessage message) =>
+        new()
+        {
+            ApplicationUserId = message.ApplicationUserId,
+            RequestId = message.RequestId,
+            CreatedOn = message.CreatedOn,
+            IdentityVerified = message.IdentityVerified,
+            OneLoginUserSubject = message.OneLoginUserSubject,
+            EmailAddress = message.EmailAddress,
+            Name = message.Name,
+            FirstName = message.FirstName,
+            MiddleName = message.MiddleName,
+            LastName = message.LastName,
+            PreviousFirstName = message.PreviousFirstName,
+            PreviousLastName = message.PreviousLastName,
+            DateOfBirth = message.DateOfBirth,
+            PotentialDuplicate = message.PotentialDuplicate,
+            NationalInsuranceNumber = message.NationalInsuranceNumber,
+            Gender = message.Gender,
+            AddressLine1 = message.AddressLine1,
+            AddressLine2 = message.AddressLine2,
+            AddressLine3 = message.AddressLine3,
+            City = message.City,
+            Postcode = message.Postcode,
+            Country = message.Country,
+            TrnToken = message.TrnToken,
+            Status = null  // Requests resolved in DQT have their status deduced later
+        };
 }
 
 public record TrnRequestMatches

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtOutbox/Handlers/TrnRequestMetadataMessageHandler.cs
@@ -9,32 +9,7 @@ public class TrnRequestMetadataMessageHandler(TrsDbContext dbContext) : IMessage
     {
         if (!await dbContext.TrnRequestMetadata.AnyAsync(m => m.ApplicationUserId == message.ApplicationUserId && m.RequestId == message.RequestId))
         {
-            var trnRequestMetadata = new DataStore.Postgres.Models.TrnRequestMetadata
-            {
-                ApplicationUserId = message.ApplicationUserId,
-                RequestId = message.RequestId,
-                CreatedOn = message.CreatedOn,
-                IdentityVerified = message.IdentityVerified,
-                OneLoginUserSubject = message.OneLoginUserSubject,
-                EmailAddress = message.EmailAddress,
-                Name = message.Name,
-                FirstName = message.FirstName,
-                MiddleName = message.MiddleName,
-                LastName = message.LastName,
-                PreviousFirstName = message.PreviousFirstName,
-                PreviousLastName = message.PreviousLastName,
-                DateOfBirth = message.DateOfBirth,
-                PotentialDuplicate = message.PotentialDuplicate,
-                NationalInsuranceNumber = message.NationalInsuranceNumber,
-                Gender = message.Gender,
-                AddressLine1 = message.AddressLine1,
-                AddressLine2 = message.AddressLine2,
-                AddressLine3 = message.AddressLine3,
-                City = message.City,
-                Postcode = message.Postcode,
-                Country = message.Country,
-                TrnToken = message.TrnToken
-            };
+            var trnRequestMetadata = DataStore.Postgres.Models.TrnRequestMetadata.FromOutboxMessage(message);
 
             if (message.ResolvedPersonId is Guid personId)
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/GetTrnRequestResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/GetTrnRequestResult.cs
@@ -1,13 +1,5 @@
-using System.Diagnostics.CodeAnalysis;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.Core.Services.TrnRequests;
 
-public record GetTrnRequestResult(Contact Contact, TrnRequestMetadata Metadata)
-{
-    public string? Trn => Contact.dfeta_TRN;
-    public bool PotentialDuplicate => Metadata.PotentialDuplicate == true;
-    public string? TrnToken => Metadata.TrnToken;
-    [MemberNotNullWhen(true, nameof(Trn))]
-    public bool IsCompleted => Trn is not null;
-}
+public record GetTrnRequestResult(TrnRequestMetadata Metadata, string? ResolvedPersonTrn);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -623,9 +623,10 @@ public partial class TestData
                         EmailAddress = _email,
                         Name = [firstName, lastName],
                         FirstName = firstName,
-                        MiddleName = "",
+                        MiddleName = middleName,
                         LastName = lastName,
                         DateOfBirth = dateOfBirth,
+                        NationalInsuranceNumber = _nationalInsuranceNumber,
                         TrnToken = _trnToken,
                         PotentialDuplicate = trnRequest.PotentialDuplicate ?? _hasTrn != true
                     });


### PR DESCRIPTION
This updates `TrnRequestService.GetTrnRequestInfoAsync` to handle TRN requests that are resolved both in DQT and TRS. For tasks resolved in DQT we need to figure out the `TrnRequestStatus` ourselves; for the TRS ones the various task resolution journeys will sort that out.