### PR TITLE
Add merge button and Enter TRN page to manual merge journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonMapping.cs
@@ -13,7 +13,7 @@ public class PersonMapping : IEntityTypeConfiguration<Person>
         builder.HasIndex(p => p.DqtContactId).HasFilter("dqt_contact_id is not null").IsUnique();
         builder.HasIndex(p => p.MergedWithPersonId).HasFilter("merged_with_person_id is not null");
         builder.HasIndex(p => p.Trn).HasFilter("trn is not null").IsUnique();
-        builder.Property(p => p.Trn).HasMaxLength(7).IsFixedLength();
+        builder.Property(p => p.Trn).HasMaxLength(Person.TrnExactLength).IsFixedLength();
         builder.Property(p => p.FirstName).HasMaxLength(Person.FirstNameMaxLength).UseCollation("case_insensitive");
         builder.Property(p => p.MiddleName).HasMaxLength(Person.MiddleNameMaxLength).UseCollation("case_insensitive");
         builder.Property(p => p.LastName).HasMaxLength(Person.LastNameMaxLength).UseCollation("case_insensitive");

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -5,6 +5,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 public class Person
 {
+    public const int TrnExactLength = 7;
     public const int FirstNameMaxLength = 100;
     public const int MiddleNameMaxLength = 100;
     public const int LastNameMaxLength = 100;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
@@ -11,8 +11,6 @@ public class ReferenceDataCache(
     ICrmQueryDispatcher crmQueryDispatcher,
     IDbContextFactory<TrsDbContext> dbContextFactory) : IStartupTask
 {
-    private object _routeTypesSyncObj = new();
-
     // CRM
     private Task<dfeta_mqestablishment[]>? _mqEstablishmentsTask;
     private Task<dfeta_sanctioncode[]>? _getSanctionCodesTask;
@@ -477,7 +475,6 @@ public class ReferenceDataCache(
     private Task<RouteToProfessionalStatusType[]> EnsureRouteToProfessionalStatusTypesAsync() =>
         LazyInitializer.EnsureInitialized(
             ref _routesTypesTask,
-            ref _routeTypesSyncObj,
             InitializeRouteToProfessionalStatusTypesAsync);
 
     protected async virtual Task<RouteToProfessionalStatusType[]> InitializeRouteToProfessionalStatusTypesAsync()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/JourneyNames.cs
@@ -23,4 +23,5 @@ public static class JourneyNames
     public const string ResolveApiTrnRequest = nameof(ResolveApiTrnRequest);
     public const string EditDetails = nameof(EditDetails);
     public const string CreatePerson = nameof(CreatePerson);
+    public const string MergePerson = nameof(MergePerson);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CommonJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CommonJourneyPage.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+public abstract class CommonJourneyPage(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService) : PageModel
+{
+    public JourneyInstance<MergeState>? JourneyInstance { get; set; }
+
+    protected TrsDbContext DbContext { get; } = dbContext;
+    protected TrsLinkGenerator LinkGenerator { get; } = linkGenerator;
+    protected IFileService FileService { get; } = fileService;
+
+    [FromRoute]
+    public Guid PersonId { get; set; }
+
+    public string? ThisTrn { get; set; }
+
+    [FromQuery]
+    public bool FromCheckAnswers { get; set; }
+
+    protected string GetPageLink(MergeJourneyPage? pageName)
+    {
+        return pageName switch
+        {
+            MergeJourneyPage.EnterTrn => LinkGenerator.PersonMergeEnterTrn(PersonId, JourneyInstance!.InstanceId),
+            MergeJourneyPage.CompareMatchingRecords => LinkGenerator.PersonMergeCompareMatchingRecords(PersonId, JourneyInstance!.InstanceId),
+            _ => LinkGenerator.PersonDetail(PersonId)
+        };
+    }
+
+    public async Task<IActionResult> OnPostCancelAsync()
+    {
+        await JourneyInstance!.DeleteAsync();
+        return Redirect(GetPageLink(null));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        JourneyInstance!.State.EnsureInitialized();
+
+        var person = await DbContext.Persons.SingleAsync(q => q.PersonId == PersonId);
+        ThisTrn = person.Trn;
+
+        OnPageHandlerExecuting(context);
+        await OnPageHandlerExecutingAsync(context);
+        if (context.Result == null)
+        {
+            var executedContext = await next();
+            OnPageHandlerExecuted(executedContext);
+            await OnPageHandlerExecutedAsync(executedContext);
+        }
+    }
+
+    protected virtual Task OnPageHandlerExecutingAsync(PageHandlerExecutingContext context)
+        => Task.CompletedTask;
+
+    protected virtual Task OnPageHandlerExecutedAsync(PageHandlerExecutedContext context)
+        => Task.CompletedTask;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml
@@ -1,0 +1,23 @@
+@page "/persons/{personId}/merge/compare-matching-records"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.Merge.CompareMatchingRecordsModel
+@{
+    Layout = "_Layout";
+    ViewBag.Title = "Compare matching records";
+}
+
+@section BeforeContent {
+    <govuk-back-link data-testid="back-link" href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-from-desktop">
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+        <form action="@LinkGenerator.PersonMergeEnterTrn(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post" data-testid="submit-form">
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.PersonMergeCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit" data-testid="cancel-button">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+[RequireFeatureEnabledFilterFactory(FeatureNames.ContactsMigrated)]
+[Journey(JourneyNames.MergePerson), RequireJourneyInstance]
+public class CompareMatchingRecordsModel(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService)
+    : CommonJourneyPage(dbContext, linkGenerator, fileService)
+{
+    public string BackLink => GetPageLink(MergeJourneyPage.EnterTrn);
+
+    public IActionResult OnGet()
+    {
+        return Page();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/Conventions.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+public class Conventions : IConfigureFolderConventions
+{
+    public void Configure(RazorPagesOptions options)
+    {
+        options.Conventions.AddFolderApplicationModelConvention(
+            this.GetFolderPathFromNamespace(),
+            model =>
+            {
+                model.EndpointMetadata.Add(new AuthorizeAttribute()
+                {
+                    Policy = AuthorizationPolicies.PersonDataEdit
+                });
+            });
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml
@@ -1,0 +1,25 @@
+@page "/persons/{personId}/merge/enter-trn"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.Merge.EnterTrnModel
+@{
+    Layout = "_Layout";
+    ViewBag.Title = Html.DisplayNameFor(m => m.OtherTrn);
+}
+
+@section BeforeContent {
+    <govuk-back-link data-testid="back-link" href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.PersonMergeEnterTrn(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post" data-testid="submit-form">
+            <govuk-input asp-for="OtherTrn" data-testid="other-trn">
+                <govuk-input-label is-page-heading="true" class="govuk-label--l" />
+                <govuk-input-hint class="govuk-inset-text">You&rsquo;re merging into the record with the TRN <strong data-testid="this-trn">@Model.ThisTrn</strong>. You&rsquo;ll be able to review both records before completing the merge.</govuk-input-hint>
+            </govuk-input>
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button formaction="@LinkGenerator.PersonMergeCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit" data-testid="cancel-button">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+[RequireFeatureEnabledFilterFactory(FeatureNames.ContactsMigrated)]
+[Journey(JourneyNames.MergePerson), ActivatesJourney, RequireJourneyInstance]
+public class EnterTrnModel(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService)
+    : CommonJourneyPage(dbContext, linkGenerator, fileService)
+{
+    [Display(Name = "Enter the TRN of the other record you want to merge")]
+    [Required(ErrorMessage = "Enter a TRN")]
+    [RegularExpression(@"^\d+$", ErrorMessage = "TRN must be a number")]
+    [MaxLength(Person.TrnExactLength, ErrorMessage = "TRN must be 7 digits long")]
+    [MinLength(Person.TrnExactLength, ErrorMessage = "TRN must be 7 digits long")]
+    [BindProperty]
+    public string? OtherTrn { get; set; }
+
+    public string BackLink => GetPageLink(null);
+
+    public IActionResult OnGet()
+    {
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (OtherTrn == ThisTrn)
+        {
+            ModelState.AddModelError(nameof(OtherTrn), "TRN must be for a different record");
+        }
+
+        if (ModelState.IsValid)
+        {
+            var otherPerson = await DbContext.Persons
+                .IgnoreQueryFilters()
+                .SingleOrDefaultAsync(p => p.Trn == OtherTrn);
+
+            if (otherPerson is null)
+            {
+                ModelState.AddModelError(nameof(OtherTrn), "No record found with that TRN");
+            }
+            else if (otherPerson.Status != PersonStatus.Active)
+            {
+                ModelState.AddModelError(nameof(OtherTrn), "The TRN you entered belongs to a deactivated record");
+            }
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.OtherTrn = OtherTrn;
+        });
+
+        return Redirect(GetPageLink(MergeJourneyPage.CompareMatchingRecords));
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeJourneyPage.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+public enum MergeJourneyPage
+{
+    EnterTrn,
+    CompareMatchingRecords
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeState.cs
@@ -1,0 +1,24 @@
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+public class MergeState : IRegisterJourney
+{
+    public static JourneyDescriptor Journey => new(
+        JourneyNames.MergePerson,
+        typeof(MergeState),
+        requestDataKeys: ["personId"],
+        appendUniqueKey: true);
+
+    public bool Initialized { get; set; }
+    public string? OtherTrn { get; set; }
+
+    public void EnsureInitialized()
+    {
+        if (Initialized)
+        {
+            return;
+        }
+
+        Initialized = true;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -9,7 +9,7 @@
 
 @if (Model.HasOpenAlert)
 {
-    <govuk-notification-banner data-testid="OpenAlertNotification">
+    <govuk-notification-banner data-testid="open-alert-notification">
         <p class="govuk-notification-banner__heading">
             Alert on record.
             <a class="govuk-notification-banner__link" href="@LinkGenerator.PersonAlerts(Model.PersonId)">View alerts.</a>
@@ -89,4 +89,9 @@
             }
         </govuk-summary-list>
     </govuk-summary-card>
+}
+
+@if (FeatureProvider.IsEnabled(FeatureNames.ContactsMigrated) && Model.ShowMergeButton)
+{
+    <govuk-button-link data-testid="merge-button" href="@LinkGenerator.PersonMergeEnterTrn(Model.PersonId)" class="govuk-button--secondary">Merge with another record</govuk-button-link>
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/TrsLinkGenerator.cs
@@ -91,4 +91,13 @@ public partial class TrsLinkGenerator
 
     public string PersonNotes(Guid personId) =>
         GetRequiredPathByPage("/Persons/PersonDetail/Notes", routeValues: new { personId });
+
+    public string PersonMergeEnterTrn(Guid personId, JourneyInstanceId? journeyInstanceId = null) =>
+        GetRequiredPathByPage("/Persons/Merge/EnterTrn", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+
+    public string PersonMergeCompareMatchingRecords(Guid personId, JourneyInstanceId? journeyInstanceId = null) =>
+        GetRequiredPathByPage("/Persons/Merge/CompareMatchingRecords", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+
+    public string PersonMergeCancel(Guid personId, JourneyInstanceId? journeyInstanceId) =>
+        GetRequiredPathByPage("/Persons/Merge/EnterTrn", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <Target Name="CopyGovUkJavaScriptToWwwroot" BeforeTargets="Build">
-    <Copy SourceFiles="wwwroot/lib/govuk-frontend/govuk-frontend.min.js"
-          DestinationFolder="wwwroot"
-          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="wwwroot/lib/govuk-frontend/govuk-frontend.min.js" DestinationFolder="wwwroot" SkipUnchangedFiles="true" />
   </Target>
 
   <ItemGroup>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/CommonPageTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/CommonPageTests.cs
@@ -28,8 +28,16 @@ public class CommonPageTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            new CreateStateBuilder()
+                .WithInitializedState()
+                .WithName("Alfred", "The", "Great")
+                .WithDateOfBirth(DateOnly.Parse("1 Feb 1980"))
+                .Build());
+
         // Act
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/create/{page}");
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"/persons/create/{page}?{journeyInstance.GetUniqueIdQueryParameter()}");
         var response = await HttpClient.SendAsync(request);
 
         // Assert

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CommonPageTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CommonPageTests.cs
@@ -1,0 +1,147 @@
+using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+using Xunit.DependencyInjection;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.Merge;
+
+[Collection(nameof(DisableParallelization))]
+public class CommonPageTests : TestBase
+{
+    public CommonPageTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.ContactsMigrated);
+    }
+
+    public override void Dispose()
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.ContactsMigrated);
+        base.Dispose();
+    }
+
+    [Theory]
+    [InlineData("enter-trn")]
+    [InlineData("compare-matching-records")]
+    public async Task Get_FeatureFlagDisabled_ReturnsNotFound(string page)
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.ContactsMigrated);
+
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person, page, journeyInstance));
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.ContactsMigrated);
+    }
+
+    [Theory]
+    [InlineData("enter-trn", null)]
+    [InlineData("compare-matching-records", "enter-trn")]
+    public async Task Get_BacklinkLinksToExpected(string page, string? expectedPage)
+    {
+        var person = await TestData.CreatePersonAsync();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person, page, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+        var document = await response.GetDocumentAsync();
+        var backlink = document.GetElementByTestId("back-link") as IHtmlAnchorElement;
+        Assert.NotNull(backlink);
+        var expectedBackLink = $"/persons/{person.PersonId}";
+        if (expectedPage is not null)
+        {
+            expectedBackLink += "/merge/" + expectedPage;
+        }
+        Assert.Contains(expectedBackLink, backlink.Href);
+    }
+
+    [Theory]
+    [InlineData("enter-trn")]
+    [InlineData("compare-matching-records")]
+    public async Task Get_ContinueAndCancelButtons_ExistOnPage(string page)
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person, page, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var form = doc.GetElementByTestId("submit-form") as IHtmlFormElement;
+        Assert.NotNull(form);
+        var buttons = form.GetElementsByTagName("button").OfType<IHtmlButtonElement>();
+        Assert.Collection(buttons,
+            b => Assert.Equal("Continue", b.TrimmedText()),
+            b => Assert.Equal("Cancel and return to record", b.TrimmedText()));
+    }
+
+    [Theory]
+    [InlineData("enter-trn")]
+    [InlineData("compare-matching-records")]
+    public async Task Post_Cancel_RedirectsToPersonDetailPage(string page)
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person, page, journeyInstance));
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var cancelButton = doc.GetElementByTestId("cancel-button") as IHtmlButtonElement;
+
+        // Act
+        var redirectRequest = new HttpRequestMessage(HttpMethod.Post, cancelButton!.FormAction);
+        var redirectResponse = await HttpClient.SendAsync(redirectRequest);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)redirectResponse.StatusCode);
+        var location = redirectResponse.Headers.Location?.OriginalString;
+        Assert.Equal($"/persons/{person.PersonId}", location);
+    }
+
+    private string GetRequestPath(TestData.CreatePersonResult person, string page, JourneyInstance<MergeState>? journeyInstance = null) =>
+        $"/persons/{person.PersonId}/merge/{page}?{journeyInstance?.GetUniqueIdQueryParameter()}";
+
+    private Task<JourneyInstance<MergeState>> CreateJourneyInstanceAsync(Guid personId, MergeState? state = null) =>
+        CreateJourneyInstance(
+            JourneyNames.MergePerson,
+            state ?? new MergeState(),
+            new KeyValuePair<string, object>("personId", personId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CompareMatchingRecordsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CompareMatchingRecordsTests.cs
@@ -1,0 +1,53 @@
+using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+using Xunit.DependencyInjection;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.Merge;
+
+[Collection(nameof(DisableParallelization))]
+public class CompareMatchingRecordsTests : TestBase
+{
+    public CompareMatchingRecordsTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.ContactsMigrated);
+    }
+
+    public override void Dispose()
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.ContactsMigrated);
+        base.Dispose();
+    }
+
+    [Fact]
+    public async Task Get_BacklinkLinksToPersonDetails()
+    {
+        var person = await TestData.CreatePersonAsync();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+        var document = await response.GetDocumentAsync();
+        var backlink = document.GetElementByTestId("back-link") as IHtmlAnchorElement;
+        Assert.NotNull(backlink);
+        Assert.Contains($"/persons/{person.PersonId}/merge/enter-trn", backlink.Href);
+    }
+
+    private string GetRequestPath(TestData.CreatePersonResult person, JourneyInstance<MergeState>? journeyInstance = null) =>
+        $"/persons/{person.PersonId}/merge/compare-matching-records?{journeyInstance?.GetUniqueIdQueryParameter()}";
+
+    private Task<JourneyInstance<MergeState>> CreateJourneyInstanceAsync(Guid personId, MergeState? state = null) =>
+        CreateJourneyInstance(
+            JourneyNames.MergePerson,
+            state ?? new MergeState(),
+            new KeyValuePair<string, object>("personId", personId));
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CreatePostRequestContentBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CreatePostRequestContentBuilder.cs
@@ -1,0 +1,12 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.Merge;
+
+public class MergePostRequestContentBuilder : PostRequestContentBuilder
+{
+    private string? OtherTrn { get; set; }
+
+    public MergePostRequestContentBuilder WithOtherTrn(string? otherTrn)
+    {
+        OtherTrn = otherTrn;
+        return this;
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/EnterTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/EnterTrnTests.cs
@@ -1,0 +1,256 @@
+using TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+using Xunit.DependencyInjection;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.Merge;
+
+[Collection(nameof(DisableParallelization))]
+public class EnterTrnTests : TestBase
+{
+    public EnterTrnTests(HostFixture hostFixture) : base(hostFixture)
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Add(FeatureNames.ContactsMigrated);
+    }
+
+    public override void Dispose()
+    {
+        TestScopedServices.GetCurrent().FeatureProvider.Features.Remove(FeatureNames.ContactsMigrated);
+        base.Dispose();
+    }
+
+    [Fact]
+    public async Task Get_PopulatesThisTrnFromPersonRecord()
+    {
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var thisTrn = doc.GetElementByTestId("this-trn");
+
+        Assert.NotNull(thisTrn);
+        Assert.Equal(person.Trn, thisTrn.TrimmedText());
+    }
+
+    [Fact]
+    public async Task Post_OtherTrnMissing_ShowsPageError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithOtherTrn(null)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(EnterTrnModel.OtherTrn), "Enter a TRN");
+    }
+
+    [Theory]
+    [InlineData("A234567")]
+    [InlineData("XYZ")]
+    public async Task Post_OtherTrnNotNumeric_ShowsPageError(string trn)
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithOtherTrn(trn)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(EnterTrnModel.OtherTrn), "TRN must be a number");
+    }
+
+    [Theory]
+    [InlineData("12345678")]
+    [InlineData("123456")]
+    public async Task Post_OtherTrnNot7DigitsLong_ShowsPageError(string trn)
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithOtherTrn(trn)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(EnterTrnModel.OtherTrn), "TRN must be 7 digits long");
+    }
+
+    [Fact]
+    public async Task Post_OtherTrnSameAsThisTrn_ShowsPageError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithOtherTrn(person.Trn)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(EnterTrnModel.OtherTrn), "TRN must be for a different record");
+    }
+
+    [Fact]
+    public async Task Post_OtherTrnDoesNotBelongToPerson_ShowsPageError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var newTrn = await TestData.GenerateTrnAsync();
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithOtherTrn(newTrn)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(EnterTrnModel.OtherTrn), "No record found with that TRN");
+    }
+
+    [Fact]
+    public async Task Post_OtherTrnBelongsToDeactivatedPerson_ShowsPageError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var otherPerson = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.Attach(otherPerson.Person);
+            otherPerson.Person.Status = PersonStatus.Deactivated;
+            await dbContext.SaveChangesAsync();
+        });
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithOtherTrn(otherPerson.Trn)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(EnterTrnModel.OtherTrn), "The TRN you entered belongs to a deactivated record");
+    }
+
+    [Fact]
+    public async Task Post_PersistsDetailsAndRedirectsToNextPage()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var otherPerson = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState()
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithOtherTrn(otherPerson.Trn)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(otherPerson.Trn, journeyInstance.State.OtherTrn);
+
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        var location = response.Headers.Location?.OriginalString;
+        var expectedUrl = $"/persons/{person.PersonId}/merge/compare-matching-records?{journeyInstance.GetUniqueIdQueryParameter()}";
+        Assert.Equal(expectedUrl, location);
+    }
+
+    private string GetRequestPath(TestData.CreatePersonResult person, JourneyInstance<MergeState>? journeyInstance = null) =>
+        $"/persons/{person.PersonId}/merge/enter-trn?{journeyInstance?.GetUniqueIdQueryParameter()}";
+
+    private Task<JourneyInstance<MergeState>> CreateJourneyInstanceAsync(Guid personId, MergeState? state = null) =>
+        CreateJourneyInstance(
+            JourneyNames.MergePerson,
+            state ?? new MergeState(),
+            new KeyValuePair<string, object>("personId", personId));
+
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergeStateBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergeStateBuilder.cs
@@ -1,0 +1,23 @@
+using TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.Merge;
+
+public class MergeStateBuilder
+{
+    private bool Initialized { get; set; }
+
+    public MergeStateBuilder WithInitializedState()
+    {
+        Initialized = true;
+
+        return this;
+    }
+
+    public MergeState Build()
+    {
+        return new MergeState
+        {
+            Initialized = Initialized
+        };
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -427,7 +427,7 @@ public partial class TestData
                 dfeta_TrnRequestID = _trnRequest is { } trnRequest ? TrnRequestService.GetCrmTrnRequestId(trnRequest.ApplicationUserId, trnRequest.RequestId) : null,
                 dfeta_TrnToken = _trnToken,
                 dfeta_SlugId = _slugId,
-                dfeta_loginfailedcounter = _loginFailedCounter
+                dfeta_loginfailedcounter = _loginFailedCounter,
             };
 
             // The conditional is to work around issue in CRM where an explicit `null` TRN breaks a plugin


### PR DESCRIPTION
### Context

We need to enable support users to be able to manually merge two records within the support console if they determine that they are a duplicate of each other.

https://trello.com/c/AYw5HTmP/1345-update-record-page-and-create-trn-search-for-matching-records

### Changes proposed in this pull request

* Adds `Merge with another record` button to person details page
* Creates Merge Person journey implementing Enter TRN page including validation

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
