### PR TITLE
Create 'further checks needed' tasks

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
@@ -37,7 +37,7 @@ public class GetTrnRequestHandler(TrnRequestService trnRequestService, ICurrentU
             Trn = trnRequest.ResolvedPersonTrn,
             Status = metadata.Status ?? TrnRequestStatus.Pending,
             PotentialDuplicate = metadata.PotentialDuplicate ?? false,
-            AccessYourTeachingQualificationsLink = metadata.TrnToken is string trnToken ?
+            AccessYourTeachingQualificationsLink = metadata is { TrnToken: string trnToken, Status: TrnRequestStatus.Completed } ?
                 trnRequestService.GetAccessYourTeachingQualificationsLink(trnToken) :
                 null
         };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -21,12 +21,48 @@ public class SupportTask
     public Guid? PersonId { get; init; }
     public Guid? TrnRequestApplicationUserId { get; init; }
     public string? TrnRequestId { get; init; }
-    public TrnRequestMetadata? TrnRequestMetadata { get; set; }
+    public TrnRequestMetadata? TrnRequestMetadata { get; }
 
     public required object Data
     {
         get => JsonSerializer.Deserialize(_data, GetDataType(), SerializerOptions)!;
         init => _data = JsonSerializer.SerializeToDocument(value, GetDataType(), SerializerOptions);
+    }
+
+    public static SupportTask Create(
+        SupportTaskType supportTaskType,
+        object data,
+        Guid? personId,
+        string? oneLoginUserSubject,
+        Guid? trnRequestApplicationUserId,
+        string? trnRequestId,
+        EventModels.RaisedByUserInfo createdBy,
+        DateTime now,
+        out SupportTaskCreatedEvent createdEvent)
+    {
+        var task = new SupportTask
+        {
+            SupportTaskReference = GenerateSupportTaskReference(),
+            CreatedOn = now,
+            UpdatedOn = now,
+            SupportTaskType = supportTaskType,
+            Status = SupportTaskStatus.Open,
+            Data = data,
+            PersonId = personId,
+            OneLoginUserSubject = oneLoginUserSubject,
+            TrnRequestApplicationUserId = trnRequestApplicationUserId,
+            TrnRequestId = trnRequestId
+        };
+
+        createdEvent = new SupportTaskCreatedEvent
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = createdBy,
+            SupportTask = EventModels.SupportTask.FromModel(task)
+        };
+
+        return task;
     }
 
     public static string GenerateSupportTaskReference()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestOptions.cs
@@ -3,5 +3,6 @@ namespace TeachingRecordSystem.Core.Services.TrnRequests;
 public class TrnRequestOptions
 {
     public Guid[] AllowContactPiiUpdatesFromUserIds { get; set; } = [];
+    public Guid[] FlagFurtherChecksRequiredFromUserIds { get; set; } = [];
 }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
@@ -2,6 +2,7 @@ using FakeXrmEasy.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.TestCommon.Infrastructure;
 
 namespace TeachingRecordSystem.Api.UnitTests;
@@ -38,6 +39,8 @@ public abstract class OperationTestBase
     public CaptureEventObserver EventObserver => _testServices.EventObserver;
 
     public TestableFeatureProvider FeatureProvider => _testServices.FeatureProvider;
+
+    public TrnRequestOptions TrnRequestOptions => _testServices.TrnRequestOptions;
 
     public T AssertSuccess<T>(ApiResult<T> result) where T : notnull
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Startup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Startup.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Npgsql;
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Implementation.Operations;
@@ -62,7 +63,8 @@ public class Startup
                     .AddTransient<GetPersonHelper>()
                     .AddPersonMatching()
                     .AddTrnRequestService(context.Configuration)
-                    .AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>();
+                    .AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>()
+                    .AddTestScoped<IOptions<TrnRequestOptions>>(tss => Options.Create(tss.TrnRequestOptions));
             });
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.TestCommon.Infrastructure;
 
 namespace TeachingRecordSystem.Api.UnitTests;
@@ -16,6 +17,7 @@ public class TestScopedServices
         GetAnIdentityApiClient = new();
         EventObserver = new();
         FeatureProvider = ActivatorUtilities.CreateInstance<TestableFeatureProvider>(serviceProvider);
+        TrnRequestOptions = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -52,4 +54,6 @@ public class TestScopedServices
     public CaptureEventObserver EventObserver { get; }
 
     public TestableFeatureProvider FeatureProvider { get; }
+
+    public TrnRequestOptions TrnRequestOptions { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -3,11 +3,13 @@ using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
+using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure.Security;
@@ -72,6 +74,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.RemoveAll<ReferenceDataCache>();
             services.AddSingleton<ReferenceDataCache, TestReferenceDataCache>();
             services.AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>();
+            services.AddTestScoped<IOptions<TrnRequestOptions>>(tss => Options.Create(tss.TrnRequestOptions));
         });
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
@@ -24,13 +24,22 @@ public abstract class ResolveApiTrnRequestTestBase(HostFixture hostFixture) : Te
 
     protected async Task<(SupportTask SupportTask, TestData.CreatePersonResult MatchedPerson)> CreateSupportTaskWithSingleDifferenceToMatch(
         Guid applicationUserId,
-        PersonMatchedAttribute differentAttribute)
+        PersonMatchedAttribute differentAttribute,
+        bool matchedPersonHasFlags = false)
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn()
-            .WithNationalInsuranceNumber()
-            .WithEmail(TestData.GenerateUniqueEmail()));
+        var matchedPerson = await TestData.CreatePersonAsync(p =>
+        {
+            p
+                .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
+                .WithTrn()
+                .WithNationalInsuranceNumber()
+                .WithEmail(TestData.GenerateUniqueEmail());
+
+            if (matchedPersonHasFlags)
+            {
+                p.WithQts().WithEyts().WithAlert();
+            }
+        });
 
         var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
             applicationUserId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -9,6 +9,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure.Security;
 using TeachingRecordSystem.TestCommon.Infrastructure;
@@ -69,6 +70,8 @@ public abstract class TestBase : IDisposable
     public Mock<IFileService> FileServiceMock => _testServices.BlobStorageFileServiceMock;
 
     public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock => _testServices.GetAnIdentityApiClientMock;
+
+    public TrnRequestOptions TrnRequestOptions => _testServices.TrnRequestOptions;
 
     public async Task<JourneyInstance<TState>> CreateJourneyInstance<TState>(
             string journeyName,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
@@ -1,6 +1,7 @@
 using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 using TeachingRecordSystem.TestCommon.Infrastructure;
 
@@ -27,6 +28,7 @@ public class TestScopedServices
             .Setup(s => s.GetFileUrlAsync(It.IsAny<Guid>(), It.IsAny<TimeSpan>()))
             .ReturnsAsync((Guid id, TimeSpan time) => $"{FakeBlobStorageFileUrlBase}{id}");
         GetAnIdentityApiClientMock = new();
+        TrnRequestOptions = new TrnRequestOptions();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -55,4 +57,6 @@ public class TestScopedServices
     public Mock<IFileService> BlobStorageFileServiceMock { get; }
 
     public Mock<IGetAnIdentityApiClient> GetAnIdentityApiClientMock { get; }
+
+    public TrnRequestOptions TrnRequestOptions { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/DbFixture.cs
@@ -40,6 +40,7 @@ public class DbFixture(DbHelper dbHelper, IServiceProvider serviceProvider)
         WithDbContextAsync(dbContext =>
             dbContext.Database.ExecuteSqlAsync(
                 $"""
+                 delete from support_tasks where person_id is not null;
                  update persons set merged_with_person_id = null;
                  delete from persons;
                  """));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
@@ -200,27 +200,30 @@ public partial class TestData
 
             var status = _status.ValueOr(() => SupportTaskStatus.Open);
 
-            var task = new SupportTask
-            {
-                SupportTaskReference = SupportTask.GenerateSupportTaskReference(),
-                CreatedOn = createdOn,
-                UpdatedOn = createdOn,
-                SupportTaskType = SupportTaskType.ApiTrnRequest,
-                Status = status,
-                Data = new ApiTrnRequestData(),
-                TrnRequestApplicationUserId = applicationUserId,
-                TrnRequestId = trnRequestId,
-                TrnRequestMetadata = metadata
-            };
+            var task = SupportTask.Create(
+                SupportTaskType.ApiTrnRequest,
+                new ApiTrnRequestData(),
+                personId: null,
+                oneLoginUserSubject: null,
+                applicationUserId,
+                trnRequestId,
+                SystemUser.SystemUserId,
+                createdOn,
+                out var createdEvent);
+            task.Status = status;
 
-            await testData.WithDbContextAsync(async dbContext =>
+            return await testData.WithDbContextAsync(async dbContext =>
             {
                 dbContext.TrnRequestMetadata.Add(metadata);
                 dbContext.SupportTasks.Add(task);
+                dbContext.AddEventWithoutBroadcast(createdEvent);
                 await dbContext.SaveChangesAsync();
-            });
 
-            return task;
+                // Re-query what we've just added so we return a SupportTask with TrnRequestMetadata populated
+                return await dbContext.SupportTasks
+                    .Include(t => t.TrnRequestMetadata)
+                    .SingleAsync(t => t.SupportTaskReference == task.SupportTaskReference);
+            });
         }
     }
 }


### PR DESCRIPTION
This creates a 'further checks needed' support task once the TRN request resolves to a known person and that person has an open alert, QTS or EYTS *and* the request came from Register or AYTQ.