### PR TITLE
Implement Compare matching records page on manual merge journey

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml
@@ -9,14 +9,126 @@
     <govuk-back-link data-testid="back-link" href="@Model.BackLink" />
 }
 
+@functions {
+#pragma warning disable CS1998
+    private async Task RenderWithHighlightIfDifferent(string? value, bool different)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            value = UiDefaults.EmptyDisplayContent;
+        }
+
+        if (different)
+        {
+            <highlight>@value</highlight>
+        }
+        else
+        {
+            @value
+        }
+    }
+#pragma warning restore CS1998
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
+        <span class="govuk-caption-l">Support tasks</span>
         <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
-        <form action="@LinkGenerator.PersonMergeEnterTrn(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post" data-testid="submit-form">
+        @if (Model.CannotMergeReason is not null)
+        {
+            <govuk-warning-text icon-fallback-text="Warning" data-testid="warning-text">
+                @(Model.CannotMergeReason) Refer this to the Teaching Regulation Agency (TRA).
+            </govuk-warning-text>
+        }
+
+        <div class="trs-potential-duplicates">
+            @foreach (var (match, i) in Model.PotentialDuplicates!.Select((match, i) => (match, i)))
+            {
+                <govuk-summary-card data-testid="record-@match.Identifier.ToString().ToLower()" class="trs-potential-duplicates--item">
+                    <govuk-summary-card-title>
+                        TRN @match.Trn
+                    </govuk-summary-card-title>
+                    <govuk-summary-card-actions>
+                        <govuk-summary-card-action href="@LinkGenerator.PersonDetail(match.PersonId)" target="_blank">
+                            View record (opens in a new tab)
+                        </govuk-summary-card-action>
+                    </govuk-summary-card-actions>
+                    <govuk-summary-list>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>First name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfDifferent(match.FirstName, !match.MatchedAttributes.Contains(PersonMatchedAttribute.FirstName)); }
+                            </govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Middle name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfDifferent(match.MiddleName, !match.MatchedAttributes.Contains(PersonMatchedAttribute.MiddleName)); }
+                            </govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfDifferent(match.LastName, !match.MatchedAttributes.Contains(PersonMatchedAttribute.LastName)); }
+                            </govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfDifferent(match.DateOfBirth?.ToString(UiDefaults.DateOnlyDisplayFormat), !match.MatchedAttributes.Contains(PersonMatchedAttribute.DateOfBirth)); }
+                            </govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfDifferent(match.EmailAddress, !match.MatchedAttributes.Contains(PersonMatchedAttribute.EmailAddress)); }
+                            </govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>
+                                @{ await RenderWithHighlightIfDifferent(match.NationalInsuranceNumber, !match.MatchedAttributes.Contains(PersonMatchedAttribute.NationalInsuranceNumber)); }
+                            </govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@match.Trn</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        @if (match.ActiveAlertCount > 0)
+                        {
+                            <govuk-summary-list-row>
+                                <govuk-summary-list-row-key>Alerts</govuk-summary-list-row-key>
+                                <govuk-summary-list-row-value><a href="@LinkGenerator.PersonAlerts(match.PersonId)" target="_blank">(@match.ActiveAlertCount) open alert@(match.ActiveAlertCount == 1 ? "" : "s") (opens in a new tab)</a></govuk-summary-list-row-value>
+                            </govuk-summary-list-row>
+                        }
+                    </govuk-summary-list>
+                </govuk-summary-card>
+            }
+        </div>
+
+        <form action="@Model.GetPageLink(MergeJourneyPage.CompareMatchingRecords)" method="post" data-testid="submit-form">
+            @if (Model.CannotMergeReason is null)
+            {
+                <govuk-radios asp-for="PrimaryRecordId" data-testid="primary-record-options">
+                    <govuk-radios-fieldset>
+                        <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" />
+                        @foreach (var match in Model.PotentialDuplicates!)
+                        {
+                            <govuk-radios-item value="@match.PersonId">
+                                TRN @match.Trn
+                            </govuk-radios-item>
+                        }
+                    </govuk-radios-fieldset>
+                </govuk-radios>
+            }
+
             <div class="govuk-button-group">
-                <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.PersonMergeCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit" data-testid="cancel-button">Cancel and return to record</govuk-button>
+                @if (Model.CannotMergeReason is null)
+                {
+                    <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
+                }
+                <govuk-button formaction="@Model.CancelLink" class="govuk-button--secondary" type="submit" data-testid="cancel-button">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/CompareMatchingRecords.cshtml.cs
@@ -1,7 +1,10 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.Matches;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
 
@@ -13,10 +16,183 @@ public class CompareMatchingRecordsModel(
     IFileService fileService)
     : CommonJourneyPage(dbContext, linkGenerator, fileService)
 {
+    private static readonly InductionStatus[] _invalidInductionStatusesForMerge = [InductionStatus.InProgress, InductionStatus.Passed, InductionStatus.Failed];
+
     public string BackLink => GetPageLink(MergeJourneyPage.EnterTrn);
+
+    public string? CannotMergeReason { get; private set; }
+
+    public PotentialDuplicate[]? PotentialDuplicates { get; private set; }
+
+    [Display(Name = "Which is the primary record?")]
+    [Required(ErrorMessage = "Select primary record")]
+    [BindProperty]
+    public Guid? PrimaryRecordId { get; set; }
+
+    protected override async Task OnPageHandlerExecutingAsync(PageHandlerExecutingContext context)
+    {
+        await base.OnPageHandlerExecutingAsync(context);
+
+        if (JourneyInstance!.State.PersonAId is not Guid personAId || JourneyInstance!.State.PersonBId is not Guid personBId)
+        {
+            context.Result = Redirect(GetPageLink(MergeJourneyPage.EnterTrn));
+            return;
+        }
+
+        Guid[] personIds = [personAId, personBId];
+
+        var potentialDuplicates = (await DbContext.Persons
+            .IgnoreQueryFilters()
+            .Where(p => personIds.Contains(p.PersonId))
+            .Select(p => new PotentialDuplicate
+            {
+                Identifier = 'X', // We'll fix this below, can't do it over an IQueryable
+                MatchedAttributes = Array.Empty<PersonMatchedAttribute>(),  // ditto
+                PersonId = p.PersonId,
+                FirstName = p.FirstName,
+                MiddleName = p.MiddleName,
+                LastName = p.LastName,
+                DateOfBirth = p.DateOfBirth,
+                EmailAddress = p.EmailAddress,
+                NationalInsuranceNumber = p.NationalInsuranceNumber,
+                Trn = p.Trn!,
+                HasQts = p.QtsDate != null,
+                HasEyts = p.EytsDate != null,
+                ActiveAlertCount = p.Alerts!.Count(a => a.IsOpen),
+                InductionStatus = p.InductionStatus,
+                Status = p.Status
+            })
+            .ToArrayAsync())
+            .OrderBy(p => Array.IndexOf(personIds, p.PersonId))
+            .ToArray();
+
+        PotentialDuplicates = potentialDuplicates
+            .Select((r, i) => r with
+            {
+                Identifier = (char)('A' + i),
+                MatchedAttributes = i == 0
+                    ? [
+                        PersonMatchedAttribute.FirstName,
+                        PersonMatchedAttribute.MiddleName,
+                        PersonMatchedAttribute.LastName,
+                        PersonMatchedAttribute.DateOfBirth,
+                        PersonMatchedAttribute.EmailAddress,
+                        PersonMatchedAttribute.NationalInsuranceNumber
+                    ]
+                    : GetPersonAttributeMatches(
+                        potentialDuplicates[0],
+                        r.FirstName,
+                        r.MiddleName,
+                        r.LastName,
+                        r.DateOfBirth,
+                        r.EmailAddress,
+                        r.NationalInsuranceNumber)
+            })
+            .ToArray();
+
+        foreach (var potentialDuplicate in PotentialDuplicates)
+        {
+            var hasBeenDeactivated = potentialDuplicate.Status == PersonStatus.Deactivated;
+            var hasActiveAlerts = potentialDuplicate.ActiveAlertCount > 0;
+            var invalidStatus = _invalidInductionStatusesForMerge
+                .Cast<InductionStatus?>()
+                .FirstOrDefault(s => potentialDuplicate.InductionStatus == s);
+
+            if (hasBeenDeactivated)
+            {
+                CannotMergeReason = "One of these records has been deactivated.";
+                break;
+            }
+
+            if (hasActiveAlerts && invalidStatus is not null)
+            {
+                CannotMergeReason = $"One of these records has an alert and an induction status of {invalidStatus.GetDisplayName()}.";
+                break;
+            }
+
+            if (hasActiveAlerts)
+            {
+                CannotMergeReason = "One of these records has an alert.";
+                break;
+            }
+
+            if (invalidStatus is not null)
+            {
+                CannotMergeReason = $"The induction status of one of these records is {invalidStatus.GetDisplayName()}.";
+                break;
+            }
+        }
+    }
 
     public IActionResult OnGet()
     {
+        PrimaryRecordId = JourneyInstance!.State.PrimaryRecordId;
+
         return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (CannotMergeReason is not null)
+        {
+            return BadRequest();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        await JourneyInstance!.UpdateStateAsync(state =>
+        {
+            state.PrimaryRecordId = PrimaryRecordId;
+        });
+
+        return Redirect(GetPageLink(MergeJourneyPage.SelectDetailsToMerge));
+    }
+
+    protected IReadOnlyCollection<PersonMatchedAttribute> GetPersonAttributeMatches(
+        PotentialDuplicate recordToMatchAgainst,
+        string firstName,
+        string middleName,
+        string lastName,
+        DateOnly? dateOfBirth,
+        string? emailAddress,
+        string? nationalInsuranceNumber)
+    {
+        return Impl().AsReadOnly();
+
+        IEnumerable<PersonMatchedAttribute> Impl()
+        {
+            if (firstName == recordToMatchAgainst.FirstName)
+            {
+                yield return PersonMatchedAttribute.FirstName;
+            }
+
+            if (middleName == recordToMatchAgainst.MiddleName)
+            {
+                yield return PersonMatchedAttribute.MiddleName;
+            }
+
+            if (lastName == recordToMatchAgainst.LastName)
+            {
+                yield return PersonMatchedAttribute.LastName;
+            }
+
+            if (dateOfBirth == recordToMatchAgainst.DateOfBirth)
+            {
+                yield return PersonMatchedAttribute.DateOfBirth;
+            }
+
+            if (emailAddress == recordToMatchAgainst.EmailAddress)
+            {
+                yield return PersonMatchedAttribute.EmailAddress;
+            }
+
+            if (nationalInsuranceNumber == recordToMatchAgainst.NationalInsuranceNumber)
+            {
+                yield return PersonMatchedAttribute.NationalInsuranceNumber;
+            }
+        }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml
@@ -11,14 +11,14 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.PersonMergeEnterTrn(Model.PersonId, Model.JourneyInstance!.InstanceId)" method="post" data-testid="submit-form">
+        <form action="@Model.GetPageLink(MergeJourneyPage.EnterTrn)" method="post" data-testid="submit-form">
             <govuk-input asp-for="OtherTrn" data-testid="other-trn">
                 <govuk-input-label is-page-heading="true" class="govuk-label--l" />
                 <govuk-input-hint class="govuk-inset-text">You&rsquo;re merging into the record with the TRN <strong data-testid="this-trn">@Model.ThisTrn</strong>. You&rsquo;ll be able to review both records before completing the merge.</govuk-input-hint>
             </govuk-input>
             <div class="govuk-button-group">
-                <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.PersonMergeCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit" data-testid="cancel-button">Cancel and return to record</govuk-button>
+                <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
+                <govuk-button formaction="@Model.CancelLink" class="govuk-button--secondary" type="submit" data-testid="cancel-button">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/EnterTrn.cshtml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.Files;
@@ -15,6 +16,10 @@ public class EnterTrnModel(
     IFileService fileService)
     : CommonJourneyPage(dbContext, linkGenerator, fileService)
 {
+    private static readonly InductionStatus[] _invalidInductionStatusesForMerge = [InductionStatus.InProgress, InductionStatus.Passed, InductionStatus.Failed];
+
+    public string? ThisTrn { get; set; }
+
     [Display(Name = "Enter the TRN of the other record you want to merge")]
     [Required(ErrorMessage = "Enter a TRN")]
     [RegularExpression(@"^\d+$", ErrorMessage = "TRN must be a number")]
@@ -25,44 +30,66 @@ public class EnterTrnModel(
 
     public string BackLink => GetPageLink(null);
 
+    protected override async Task OnPageHandlerExecutingAsync(PageHandlerExecutingContext context)
+    {
+        await base.OnPageHandlerExecutingAsync(context);
+
+        ThisTrn = JourneyInstance!.State.PersonATrn;
+    }
+
     public IActionResult OnGet()
     {
+        OtherTrn = JourneyInstance!.State.PersonBTrn;
+
         return Page();
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        var personA = (await DbContext.Persons
+            .SingleOrDefaultAsync(p =>
+                p.PersonId == JourneyInstance!.State.PersonAId &&
+                !p.Alerts!.Any(a => a.IsOpen) &&
+                !_invalidInductionStatusesForMerge.Contains(p.InductionStatus)));
+
+        if (personA is null)
+        {
+            return BadRequest();
+        }
+
         if (OtherTrn == ThisTrn)
         {
             ModelState.AddModelError(nameof(OtherTrn), "TRN must be for a different record");
         }
 
-        if (ModelState.IsValid)
-        {
-            var otherPerson = await DbContext.Persons
+        var otherPerson = OtherTrn is null
+            ? null
+            : await DbContext.Persons
                 .IgnoreQueryFilters()
                 .SingleOrDefaultAsync(p => p.Trn == OtherTrn);
 
-            if (otherPerson is null)
-            {
-                ModelState.AddModelError(nameof(OtherTrn), "No record found with that TRN");
-            }
-            else if (otherPerson.Status != PersonStatus.Active)
-            {
-                ModelState.AddModelError(nameof(OtherTrn), "The TRN you entered belongs to a deactivated record");
-            }
+        if (otherPerson is null)
+        {
+            ModelState.AddModelError(nameof(OtherTrn), "No record found with that TRN");
+        }
+        else if (otherPerson.Status != PersonStatus.Active)
+        {
+            ModelState.AddModelError(nameof(OtherTrn), "The TRN you entered belongs to a deactivated record");
         }
 
-        if (!ModelState.IsValid)
+        if (!ModelState.IsValid || otherPerson is null)
         {
             return this.PageWithErrors();
         }
-
-        await JourneyInstance!.UpdateStateAsync(state =>
+        else
         {
-            state.OtherTrn = OtherTrn;
-        });
+            await JourneyInstance!.UpdateStateAsync(state =>
+            {
+                state.PersonBId = otherPerson.PersonId;
+                state.PersonBTrn = otherPerson.Trn;
+            });
 
-        return Redirect(GetPageLink(MergeJourneyPage.CompareMatchingRecords));
+            return Redirect(GetPageLink(MergeJourneyPage.CompareMatchingRecords));
+        }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeJourneyPage.cs
@@ -3,5 +3,6 @@ namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
 public enum MergeJourneyPage
 {
     EnterTrn,
-    CompareMatchingRecords
+    CompareMatchingRecords,
+    SelectDetailsToMerge
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/MergeState.cs
@@ -10,15 +10,35 @@ public class MergeState : IRegisterJourney
         appendUniqueKey: true);
 
     public bool Initialized { get; set; }
-    public string? OtherTrn { get; set; }
+    public string? PersonATrn { get; set; }
+    public string? PersonBTrn { get; set; }
+    public Guid? PersonAId { get; set; }
+    public Guid? PersonBId { get; set; }
+    public Guid? PrimaryRecordId { get; set; }
+    public bool PersonAttributeSourcesSet { get; set; }
+    public PersonAttributeSource? FirstNameSource { get; set; }
+    public PersonAttributeSource? MiddleNameSource { get; set; }
+    public PersonAttributeSource? LastNameSource { get; set; }
+    public PersonAttributeSource? DateOfBirthSource { get; set; }
+    public PersonAttributeSource? EmailAddressSource { get; set; }
+    public PersonAttributeSource? NationalInsuranceNumberSource { get; set; }
+    public string? Comments { get; set; }
 
-    public void EnsureInitialized()
+    public enum PersonAttributeSource
+    {
+        PersonA = 0,
+        PersonB = 1
+    }
+
+    public async Task EnsureInitializedAsync(Guid personAId, Func<Task<string?>> getPersonATrn)
     {
         if (Initialized)
         {
             return;
         }
 
+        PersonAId = personAId;
+        PersonATrn = await getPersonATrn();
         Initialized = true;
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/SelectDetailsToMerge.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/SelectDetailsToMerge.cshtml
@@ -1,0 +1,24 @@
+@page "/persons/{personId}/merge/select-details-to-merge"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.Merge.SelectDetailsToMergeModel
+@{
+    Layout = "_Layout";
+    ViewBag.Title = "Select the details to merge into the primary record";
+}
+
+@section BeforeContent {
+    <govuk-back-link data-testid="back-link" href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full-from-desktop">
+        <span class="govuk-caption-l">Support tasks</span>
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+        <form action="@Model.GetPageLink(MergeJourneyPage.SelectDetailsToMerge)" method="post" data-testid="submit-form">
+            <div class="govuk-button-group">
+                <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
+                <govuk-button formaction="@Model.CancelLink" class="govuk-button--secondary" type="submit" data-testid="cancel-button">Cancel and return to record</govuk-button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/SelectDetailsToMerge.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Merge/SelectDetailsToMerge.cshtml.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.Merge;
+
+[RequireFeatureEnabledFilterFactory(FeatureNames.ContactsMigrated)]
+[Journey(JourneyNames.MergePerson), RequireJourneyInstance]
+public class SelectDetailsToMergeModel(
+    TrsDbContext dbContext,
+    TrsLinkGenerator linkGenerator,
+    IFileService fileService)
+    : CommonJourneyPage(dbContext, linkGenerator, fileService)
+{
+    public string BackLink => GetPageLink(MergeJourneyPage.CompareMatchingRecords);
+
+    public IActionResult OnGet()
+    {
+        return Page();
+    }
+
+    public IActionResult OnPost()
+    {
+        return Page();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/TrsLinkGenerator.cs
@@ -98,6 +98,9 @@ public partial class TrsLinkGenerator
     public string PersonMergeCompareMatchingRecords(Guid personId, JourneyInstanceId? journeyInstanceId = null) =>
         GetRequiredPathByPage("/Persons/Merge/CompareMatchingRecords", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
+    public string PersonMergeSelectDetailsToMerge(Guid personId, JourneyInstanceId? journeyInstanceId = null) =>
+        GetRequiredPathByPage("/Persons/Merge/SelectDetailsToMerge", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+
     public string PersonMergeCancel(Guid personId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/Persons/Merge/EnterTrn", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml
@@ -100,7 +100,7 @@
                         @{
                             var tags = new List<string>();
 
-                            if (match.HasActiveAlerts)
+                            if (match.ActiveAlertCount > 0)
                             {
                                 tags.Add("Alerts");
                             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
@@ -100,7 +100,9 @@ public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : R
                     Trn = p.Trn!,
                     HasQts = p.QtsDate != null,
                     HasEyts = p.EytsDate != null,
-                    HasActiveAlerts = p.Alerts!.Any(a => a.IsOpen)
+                    ActiveAlertCount = p.Alerts!.Count(a => a.IsOpen),
+                    InductionStatus = p.InductionStatus,
+                    Status = p.Status
                 })
                 .ToArrayAsync())
             // matchedPersonIds is ordered by best match first; ensure we maintain that order
@@ -135,7 +137,9 @@ public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : R
         // TODO Gender
         public required bool HasQts { get; init; }
         public required bool HasEyts { get; init; }
-        public required bool HasActiveAlerts { get; init; }
+        public required int ActiveAlertCount { get; init; }
+        public required InductionStatus InductionStatus { get; init; }
+        public required PersonStatus Status { get; init; }
         public required IReadOnlyCollection<PersonMatchedAttribute> MatchedAttributes { get; init; }
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestState.cs
@@ -20,7 +20,8 @@ public class ResolveApiTrnRequestState : IRegisterJourney
     public PersonAttributeSource? NationalInsuranceNumberSource { get; set; }
     public string? Comments { get; set; }
 
-    public enum PersonAttributeSource
+    public enum
+        PersonAttributeSource
     {
         ExistingRecord = 0,
         TrnRequest = 1

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml
@@ -100,7 +100,7 @@
                         @{
                             var tags = new List<string>();
 
-                            if (match.HasActiveAlerts)
+                            if (match.ActiveAlertCount > 0)
                             {
                                 tags.Add("Alerts");
                             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml.cs
@@ -97,7 +97,9 @@ public class MatchesModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator
                     Trn = p.Trn!,
                     HasQts = p.QtsDate != null,
                     HasEyts = p.EytsDate != null,
-                    HasActiveAlerts = p.Alerts!.Any(a => a.IsOpen)
+                    ActiveAlertCount = p.Alerts!.Count(a => a.IsOpen),
+                    InductionStatus = p.InductionStatus,
+                    Status = p.Status
                 })
                 .ToArrayAsync())
             // matchedPersonIds is ordered by best match first; ensure we maintain that order

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/wwwroot/Styles/site.scss
@@ -323,3 +323,21 @@
     color: govuk-colour("white") !important;
   }
 }
+
+.trs-potential-duplicates {
+  @include govuk-media-query($from: desktop) {
+    display: flex;
+    flex-flow: wrap;
+  }
+
+  .trs-potential-duplicates--item {
+    @include govuk-media-query($from: desktop) {
+      box-sizing: border-box;
+      flex: 0 0 calc(50% - 15px);
+
+      &:nth-child(2n) {
+        margin-left: 30px;
+      }
+    }
+  }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/CreateReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/CreateReasonTests.cs
@@ -71,14 +71,14 @@ public class CreateReasonTests : TestBase
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
 
-        var reasonChoiceSelection = GetChildElementsOfTestId<IHtmlInputElement>(doc, "create-reason-options", "input[type='radio']")
+        var reasonChoiceSelection = doc.GetChildElementsOfTestId<IHtmlInputElement>("create-reason-options", "input[type='radio']")
             .Single(i => i.IsChecked == true).Value;
         Assert.Equal(reasonChoice.ToString(), reasonChoiceSelection);
 
         var additionalDetailTextArea = doc.GetElementByTestId("create-reason-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
         Assert.Equal(reasonDetail, additionalDetailTextArea!.Value);
 
-        var uploadEvidenceChoices = GetChildElementsOfTestId<IHtmlInputElement>(doc, "upload-evidence-options", "input[type='radio']")
+        var uploadEvidenceChoices = doc.GetChildElementsOfTestId<IHtmlInputElement>("upload-evidence-options", "input[type='radio']")
             .Single(i => i.IsChecked == true).Value;
         Assert.Equal(true.ToString(), uploadEvidenceChoices);
 
@@ -86,10 +86,10 @@ public class CreateReasonTests : TestBase
         Assert.Equal("evidence.jpg (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(doc, nameof(CreateReasonModel.EvidenceFileId)));
-        Assert.Equal("evidence.jpg", GetHiddenInputValue(doc, nameof(CreateReasonModel.EvidenceFileName)));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(doc, nameof(CreateReasonModel.EvidenceFileSizeDescription)));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(doc, nameof(CreateReasonModel.EvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileId)));
+        Assert.Equal("evidence.jpg", doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileName)));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileSizeDescription)));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileUrl)));
     }
 
     [Fact]
@@ -284,19 +284,19 @@ public class CreateReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var evidenceFileId = await FileServiceMock.AssertFileWasUploadedAsync();
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("validfile.png (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileId)));
-        Assert.Equal("validfile.png", GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileName)));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileSizeDescription)));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileId)));
+        Assert.Equal("validfile.png", doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileName)));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileSizeDescription)));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileUrl)));
     }
 
     [Fact]
@@ -325,18 +325,18 @@ public class CreateReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("testfile.jpg (3 KB)", link.TrimmedText());
         Assert.Equal("http://test.com/file", link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileId)));
-        Assert.Equal("testfile.jpg", GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileName)));
-        Assert.Equal("3 KB", GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileSizeDescription)));
-        Assert.Equal("http://test.com/file", GetHiddenInputValue(html, nameof(CreateReasonModel.EvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileId)));
+        Assert.Equal("testfile.jpg", doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileName)));
+        Assert.Equal("3 KB", doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileSizeDescription)));
+        Assert.Equal("http://test.com/file", doc.GetHiddenInputValue(nameof(CreateReasonModel.EvidenceFileUrl)));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/PersonalDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Create/PersonalDetailsTests.cs
@@ -63,14 +63,14 @@ public class PersonalDetailsTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var firstName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-first-name", "input");
-        var middleName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-middle-name", "input");
-        var lastName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-last-name", "input");
-        var dateOfBirth = GetChildElementsOfTestId<IHtmlInputElement>(doc, "edit-details-date-of-birth", "input");
-        var emailAddress = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-email-address", "input");
-        var mobileNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-mobile-number", "input");
-        var nationalInsuranceNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-national-insurance-number", "input");
-        var genderSelection = GetChildElementsOfTestId<IHtmlInputElement>(doc, "edit-details-gender-options", "input[type='radio']")
+        var firstName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-first-name", "input");
+        var middleName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-middle-name", "input");
+        var lastName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-last-name", "input");
+        var dateOfBirth = doc.GetChildElementsOfTestId<IHtmlInputElement>("edit-details-date-of-birth", "input");
+        var emailAddress = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-email-address", "input");
+        var mobileNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-mobile-number", "input");
+        var nationalInsuranceNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-national-insurance-number", "input");
+        var genderSelection = doc.GetChildElementsOfTestId<IHtmlInputElement>("edit-details-gender-options", "input[type='radio']")
             .Single(i => i.IsChecked == true);
 
         Assert.Equal("Alfred", firstName.Value.Trim());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CompareMatchingRecordsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CompareMatchingRecordsTests.cs
@@ -18,27 +18,755 @@ public class CompareMatchingRecordsTests : TestBase
     }
 
     [Fact]
-    public async Task Get_BacklinkLinksToPersonDetails()
+    public async Task Get_OtherTrnNotSelected_RedirectsToEnterTrnPage()
     {
-        var person = await TestData.CreatePersonAsync();
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
 
         var journeyInstance = await CreateJourneyInstanceAsync(
-            person.PersonId,
+            personA.PersonId,
             new MergeStateBuilder()
-                .WithInitializedState()
+                .WithInitializedState(personA)
                 .Build());
 
-        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(person, journeyInstance));
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-        var document = await response.GetDocumentAsync();
-        var backlink = document.GetElementByTestId("back-link") as IHtmlAnchorElement;
+        AssertEx.ResponseIsRedirectTo(response,
+            $"/persons/{personA.PersonId}/merge/enter-trn?{journeyInstance.GetUniqueIdQueryParameter()}");
+    }
+
+    [Fact]
+    public async Task Get_BacklinkLinksToPersonDetails()
+    {
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var backlink = doc.GetElementByTestId("back-link") as IHtmlAnchorElement;
+
         Assert.NotNull(backlink);
-        Assert.Contains($"/persons/{person.PersonId}/merge/enter-trn", backlink.Href);
+        Assert.Contains($"/persons/{personA.PersonId}/merge/enter-trn", backlink.Href);
+    }
+
+    [Fact]
+    public async Task Get_FieldsPopulatedFromPersonRecord()
+    {
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithFirstName("Alfred")
+            .WithMiddleName("The")
+            .WithLastName("Great")
+            .WithDateOfBirth(DateOnly.Parse("1 Jan 2001"))
+            .WithEmail("an@email.com")
+            .WithNationalInsuranceNumber("AB123456D"));
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithFirstName("Lily")
+            .WithMiddleName("The")
+            .WithLastName("Pink")
+            .WithDateOfBirth(DateOnly.Parse("1 Feb 2002"))
+            .WithEmail("another@email.com")
+            .WithNationalInsuranceNumber("AB987654D"));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertRow("record-a", "First name", v => Assert.Equal("Alfred", v.TrimmedText()));
+        doc.AssertRow("record-a", "Middle name", v => Assert.Equal("The", v.TrimmedText()));
+        doc.AssertRow("record-a", "Last name", v => Assert.Equal("Great", v.TrimmedText()));
+        doc.AssertRow("record-a", "Date of birth", v => Assert.Equal("1 January 2001", v.TrimmedText()));
+        doc.AssertRow("record-a", "Email", v => Assert.Equal("an@email.com", v.TrimmedText()));
+        doc.AssertRow("record-a", "National Insurance number", v => Assert.Equal("AB123456D", v.TrimmedText()));
+        doc.AssertRow("record-a", "TRN", v => Assert.Equal(personA.Trn, v.TrimmedText()));
+
+        doc.AssertRow("record-b", "First name", v => Assert.Equal("Lily", v.TrimmedText()));
+        doc.AssertRow("record-b", "Middle name", v => Assert.Equal("The", v.TrimmedText()));
+        doc.AssertRow("record-b", "Last name", v => Assert.Equal("Pink", v.TrimmedText()));
+        doc.AssertRow("record-b", "Date of birth", v => Assert.Equal("1 February 2002", v.TrimmedText()));
+        doc.AssertRow("record-b", "Email", v => Assert.Equal("another@email.com", v.TrimmedText()));
+        doc.AssertRow("record-b", "National Insurance number", v => Assert.Equal("AB987654D", v.TrimmedText()));
+        doc.AssertRow("record-b", "TRN", v => Assert.Equal(personB.Trn, v.TrimmedText()));
+    }
+
+    [Fact]
+    public async Task Get_PersonHasOpenAlert_ShowsAlertCountAndLinkToAlertsPage()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithAlert(a => a.WithEndDate(null)));
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithAlert(a => a.WithEndDate(null))
+            .WithAlert(a => a.WithEndDate(null)));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertRow("record-a", "Alerts", v =>
+        {
+            var a = v.QuerySelector("a") as IHtmlAnchorElement;
+            Assert.NotNull(a);
+            Assert.Equal("(1) open alert (opens in a new tab)", a.TrimmedText());
+            Assert.Contains($"/persons/{personA.PersonId}/alerts", a.Href);
+        });
+        doc.AssertRow("record-b", "Alerts", v =>
+        {
+            var a = v.QuerySelector("a") as IHtmlAnchorElement;
+            Assert.NotNull(a);
+            Assert.Equal("(2) open alerts (opens in a new tab)", a.TrimmedText());
+            Assert.Contains($"/persons/{personB.PersonId}/alerts", a.Href);
+        });
+    }
+
+    public static TheoryData<PersonMatchedAttribute[]> HighlightedDifferencesData { get; } = new()
+    {
+        // We could go nuts creating loads of combinations here, but checking every attribute once seems sufficient
+        new[] { PersonMatchedAttribute.FirstName },
+        new[] { PersonMatchedAttribute.MiddleName },
+        new[] { PersonMatchedAttribute.LastName },
+        new[] { PersonMatchedAttribute.DateOfBirth },
+        new[] { PersonMatchedAttribute.EmailAddress },
+        new[] { PersonMatchedAttribute.NationalInsuranceNumber }
+    };
+
+    [Theory]
+    [MemberData(nameof(HighlightedDifferencesData))]
+    public async Task Get_HighlightsDifferencesBetweenPersonAAndPersonB(IReadOnlyCollection<PersonMatchedAttribute> matchedAttributes)
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithEmail()
+            .WithNationalInsuranceNumber());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithFirstName(
+                matchedAttributes.Contains(PersonMatchedAttribute.FirstName)
+                    ? personA.FirstName
+                    : TestData.GenerateChangedFirstName(personA.FirstName))
+            .WithMiddleName(
+                matchedAttributes.Contains(PersonMatchedAttribute.MiddleName)
+                    ? personA.MiddleName
+                    : TestData.GenerateChangedMiddleName(personA.MiddleName))
+            .WithLastName(
+                matchedAttributes.Contains(PersonMatchedAttribute.LastName)
+                    ? personA.LastName
+                    : TestData.GenerateChangedLastName(personA.LastName))
+            .WithDateOfBirth(
+                matchedAttributes.Contains(PersonMatchedAttribute.DateOfBirth)
+                    ? personA.DateOfBirth
+                    : TestData.GenerateChangedDateOfBirth(personA.DateOfBirth))
+            .WithEmail(
+                matchedAttributes.Contains(PersonMatchedAttribute.EmailAddress)
+                    ? personA.Email ?? ""
+                    : TestData.GenerateUniqueEmail())
+            .WithNationalInsuranceNumber(
+                matchedAttributes.Contains(PersonMatchedAttribute.NationalInsuranceNumber)
+                    ? personA.NationalInsuranceNumber ?? ""
+                    : TestData.GenerateChangedNationalInsuranceNumber(personA.NationalInsuranceNumber!)));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertMatchRowHasExpectedHighlight("record-a", "First name", false);
+        doc.AssertMatchRowHasExpectedHighlight("record-a", "Middle name", false);
+        doc.AssertMatchRowHasExpectedHighlight("record-a", "Last name", false);
+        doc.AssertMatchRowHasExpectedHighlight("record-a", "Date of birth", false);
+        doc.AssertMatchRowHasExpectedHighlight("record-a", "Email", false);
+        doc.AssertMatchRowHasExpectedHighlight("record-a", "National Insurance number", false);
+
+        doc.AssertMatchRowHasExpectedHighlight("record-b", "First name", !matchedAttributes.Contains(PersonMatchedAttribute.FirstName));
+        doc.AssertMatchRowHasExpectedHighlight("record-b", "Middle name", !matchedAttributes.Contains(PersonMatchedAttribute.MiddleName));
+        doc.AssertMatchRowHasExpectedHighlight("record-b", "Last name", !matchedAttributes.Contains(PersonMatchedAttribute.LastName));
+        doc.AssertMatchRowHasExpectedHighlight("record-b", "Date of birth", !matchedAttributes.Contains(PersonMatchedAttribute.DateOfBirth));
+        doc.AssertMatchRowHasExpectedHighlight("record-b", "Email", !matchedAttributes.Contains(PersonMatchedAttribute.EmailAddress));
+        doc.AssertMatchRowHasExpectedHighlight("record-b", "National Insurance number", !matchedAttributes.Contains(PersonMatchedAttribute.NationalInsuranceNumber));
+    }
+
+    [Fact]
+    public async Task Post_PersonBIsDeactivated_ShowsWarningAndHidesContinueButton()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.Attach(personB.Person);
+            personB.Person.Status = PersonStatus.Deactivated;
+            await dbContext.SaveChangesAsync();
+        });
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        // Assert
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var warningText = doc.GetElementByTestId("warning-text");
+        var primaryRecordOptions = doc.GetElementByTestId("primary-record-options");
+        var continueButton = doc.GetElementByTestId("continue-button");
+
+        Assert.NotNull(warningText);
+        Assert.Contains("One of these records has been deactivated. Refer this to the Teaching Regulation Agency (TRA).", warningText.TrimmedText());
+        Assert.Null(primaryRecordOptions);
+        Assert.Null(continueButton);
+    }
+
+    [Fact]
+    public async Task Get_PersonBHasOpenAlert_ShowsWarningAndHidesContinueButton()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithAlert(a => a.WithEndDate(null)));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var warningText = doc.GetElementByTestId("warning-text");
+        var primaryRecordOptions = doc.GetElementByTestId("primary-record-options");
+        var continueButton = doc.GetElementByTestId("continue-button");
+
+        Assert.NotNull(warningText);
+        Assert.Contains("One of these records has an alert. Refer this to the Teaching Regulation Agency (TRA).", warningText.TrimmedText());
+        Assert.Null(primaryRecordOptions);
+        Assert.Null(continueButton);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.InProgress, false)]
+    [InlineData(InductionStatus.Passed, false)]
+    [InlineData(InductionStatus.Failed, false)]
+    [InlineData(InductionStatus.None, true)]
+    [InlineData(InductionStatus.Exempt, true)]
+    [InlineData(InductionStatus.FailedInWales, true)]
+    [InlineData(InductionStatus.RequiredToComplete, true)]
+    public async Task Get_PersonBWithInductionStatus_ShowsWarningAndHidesContinueButtonAsExpected(InductionStatus status, bool expectMergeToBeAllowed)
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithInductionStatus(i => i
+                .WithStatus(status)
+                .WithStartDate(new DateOnly(2024, 1, 1))
+                .WithCompletedDate(new DateOnly(2024, 1, 1))));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var warningText = doc.GetElementByTestId("warning-text");
+        var primaryRecordOptions = doc.GetElementByTestId("primary-record-options");
+        var continueButton = doc.GetElementByTestId("continue-button");
+
+        if (expectMergeToBeAllowed)
+        {
+            Assert.Null(warningText);
+            Assert.NotNull(primaryRecordOptions);
+            Assert.NotNull(continueButton);
+        }
+        else
+        {
+            Assert.NotNull(warningText);
+            Assert.Contains($"The induction status of one of these records is {status.GetDisplayName()}. Refer this to the Teaching Regulation Agency (TRA).", warningText.TrimmedText());
+            Assert.Null(primaryRecordOptions);
+            Assert.Null(continueButton);
+        }
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.Passed)]
+    [InlineData(InductionStatus.Failed)]
+    public async Task Get_PersonBHasOpenAlertAndInvalidInductionStatus_ShowsWarningAndHidesContinueButton(InductionStatus status)
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithAlert(a => a.WithEndDate(null))
+            .WithInductionStatus(i => i
+                .WithStatus(status)
+                .WithStartDate(new DateOnly(2024, 1, 1))
+                .WithCompletedDate(new DateOnly(2024, 1, 1))));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var warningText = doc.GetElementByTestId("warning-text");
+        var primaryRecordOptions = doc.GetElementByTestId("primary-record-options");
+        var continueButton = doc.GetElementByTestId("continue-button");
+
+        Assert.NotNull(warningText);
+        Assert.Contains($"One of these records has an alert and an induction status of {status.GetDisplayName()}. Refer this to the Teaching Regulation Agency (TRA).", warningText.TrimmedText());
+        Assert.Null(primaryRecordOptions);
+        Assert.Null(continueButton);
+    }
+
+    [Fact]
+    public async Task Get_PrimaryRecordAlreadySelected_SelectsChosenRecord()
+    {
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .WithPrimaryRecord(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(personA, journeyInstance));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var primaryRecordChoice = doc.GetChildElementsOfTestId<IHtmlInputElement>("primary-record-options", "input[type='radio']")
+            .Single(i => i.IsChecked == true).Value;
+        Assert.Equal(personB.PersonId.ToString(), primaryRecordChoice);
+    }
+
+    [Fact]
+    public async Task Post_PrimaryRecordNotSelected_ShowsPageError()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(null)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(CompareMatchingRecordsModel.PrimaryRecordId), "Select primary record");
+    }
+
+    [Fact]
+    public async Task Post_PersonAIsDeactivated_ReturnsBadRequest()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.Attach(personA.Person);
+            personA.Person.Status = PersonStatus.Deactivated;
+            await dbContext.SaveChangesAsync();
+        });
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(personB.PersonId)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_PersonAHasOpenAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithAlert(a => a.WithEndDate(null)));
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(personB.PersonId)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.Passed)]
+    [InlineData(InductionStatus.Failed)]
+    public async Task Post_PersonAHasInvalidInductionStatus_ReturnsBadRequest(InductionStatus status)
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithInductionStatus(i => i
+                .WithStatus(status)
+                .WithStartDate(new DateOnly(2024, 1, 1))
+                .WithCompletedDate(new DateOnly(2024, 1, 1))));
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(personB.PersonId)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_PersonBIsDeactivated_ReturnsBadRequest()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.Attach(personB.Person);
+            personB.Person.Status = PersonStatus.Deactivated;
+            await dbContext.SaveChangesAsync();
+        });
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(personA.PersonId)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_PersonBHasOpenAlert_ReturnsBadRequest()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithAlert(a => a.WithEndDate(null)));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(personA.PersonId)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(InductionStatus.InProgress)]
+    [InlineData(InductionStatus.Passed)]
+    [InlineData(InductionStatus.Failed)]
+    public async Task Post_PersonBHasInvalidInductionStatus_ReturnsBadRequest(InductionStatus status)
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn()
+            .WithInductionStatus(i => i
+                .WithStatus(status)
+                .WithStartDate(new DateOnly(2024, 1, 1))
+                .WithCompletedDate(new DateOnly(2024, 1, 1))));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(personA.PersonId)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_PersistsDetailsAndRedirectsToNextPage()
+    {
+        // Arrange
+        var personA = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var personB = await TestData.CreatePersonAsync(p => p
+            .WithPersonDataSource(TestDataPersonDataSource.Trs)
+            .WithTrn());
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personA.PersonId,
+            new MergeStateBuilder()
+                .WithInitializedState(personA)
+                .WithPersonB(personB)
+                .Build());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(personA, journeyInstance))
+        {
+            Content = new MergePostRequestContentBuilder()
+                .WithPrimaryRecordId(personB.PersonId)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        AssertEx.ResponseIsRedirectTo(response,
+            $"/persons/{personA.PersonId}/merge/select-details-to-merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        Assert.Equal(personB.PersonId, journeyInstance.State.PrimaryRecordId);
     }
 
     private string GetRequestPath(TestData.CreatePersonResult person, JourneyInstance<MergeState>? journeyInstance = null) =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergePostRequestContentBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergePostRequestContentBuilder.cs
@@ -3,10 +3,17 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.Merge;
 public class MergePostRequestContentBuilder : PostRequestContentBuilder
 {
     private string? OtherTrn { get; set; }
+    private Guid? PrimaryRecordId { get; set; }
 
     public MergePostRequestContentBuilder WithOtherTrn(string? otherTrn)
     {
         OtherTrn = otherTrn;
+        return this;
+    }
+
+    public MergePostRequestContentBuilder WithPrimaryRecordId(Guid? primaryRecordId)
+    {
+        PrimaryRecordId = primaryRecordId;
         return this;
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergeStateBuilder.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergeStateBuilder.cs
@@ -5,10 +5,32 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.Merge;
 public class MergeStateBuilder
 {
     private bool Initialized { get; set; }
+    private string? PersonATrn { get; set; }
+    private string? PersonBTrn { get; set; }
+    private Guid? PersonAId { get; set; }
+    private Guid? PersonBId { get; set; }
+    private Guid? PrimaryRecordId { get; set; }
 
-    public MergeStateBuilder WithInitializedState()
+    public MergeStateBuilder WithInitializedState(TestData.CreatePersonResult personA)
     {
         Initialized = true;
+        PersonAId = personA.PersonId;
+        PersonATrn = personA.Trn;
+
+        return this;
+    }
+
+    public MergeStateBuilder WithPersonB(TestData.CreatePersonResult personB)
+    {
+        PersonBId = personB.PersonId;
+        PersonBTrn = personB.Trn;
+
+        return this;
+    }
+
+    public MergeStateBuilder WithPrimaryRecord(TestData.CreatePersonResult person)
+    {
+        PrimaryRecordId = person.PersonId;
 
         return this;
     }
@@ -17,7 +39,12 @@ public class MergeStateBuilder
     {
         return new MergeState
         {
-            Initialized = Initialized
+            Initialized = Initialized,
+            PersonAId = PersonAId,
+            PersonATrn = PersonATrn,
+            PersonBId = PersonBId,
+            PersonBTrn = PersonBTrn,
+            PrimaryRecordId = PrimaryRecordId
         };
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/NameChangeReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/NameChangeReasonTests.cs
@@ -109,11 +109,11 @@ public class NameChangeReasonTests : TestBase
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
 
-        var reasonChoiceSelection = GetChildElementsOfTestId<IHtmlInputElement>(doc, "change-reason-options", "input[type='radio']")
+        var reasonChoiceSelection = doc.GetChildElementsOfTestId<IHtmlInputElement>("change-reason-options", "input[type='radio']")
             .Single(i => i.IsChecked == true).Value;
         Assert.Equal(reasonChoice.ToString(), reasonChoiceSelection);
 
-        var uploadEvidenceChoices = GetChildElementsOfTestId<IHtmlInputElement>(doc, "upload-evidence-options", "input[type='radio']")
+        var uploadEvidenceChoices = doc.GetChildElementsOfTestId<IHtmlInputElement>("upload-evidence-options", "input[type='radio']")
             .Single(i => i.IsChecked == true).Value;
         Assert.Equal(true.ToString(), uploadEvidenceChoices);
 
@@ -121,10 +121,10 @@ public class NameChangeReasonTests : TestBase
         Assert.Equal("evidence.jpg (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(doc, nameof(NameChangeReasonModel.NameChangeEvidenceFileId)));
-        Assert.Equal("evidence.jpg", GetHiddenInputValue(doc, nameof(NameChangeReasonModel.NameChangeEvidenceFileName)));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(doc, nameof(NameChangeReasonModel.NameChangeEvidenceFileSizeDescription)));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(doc, nameof(NameChangeReasonModel.NameChangeUploadedEvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileId)));
+        Assert.Equal("evidence.jpg", doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileName)));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileSizeDescription)));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeUploadedEvidenceFileUrl)));
     }
 
     [Fact]
@@ -287,19 +287,19 @@ public class NameChangeReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var evidenceFileId = await FileServiceMock.AssertFileWasUploadedAsync();
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("validfile.png (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeEvidenceFileId)));
-        Assert.Equal("validfile.png", GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeEvidenceFileName)));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeEvidenceFileSizeDescription)));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeUploadedEvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileId)));
+        Assert.Equal("validfile.png", doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileName)));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileSizeDescription)));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeUploadedEvidenceFileUrl)));
     }
 
     [Fact]
@@ -332,18 +332,18 @@ public class NameChangeReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("testfile.jpg (3 KB)", link.TrimmedText());
         Assert.Equal("http://test.com/file", link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeEvidenceFileId)));
-        Assert.Equal("testfile.jpg", GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeEvidenceFileName)));
-        Assert.Equal("3 KB", GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeEvidenceFileSizeDescription)));
-        Assert.Equal("http://test.com/file", GetHiddenInputValue(html, nameof(NameChangeReasonModel.NameChangeUploadedEvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileId)));
+        Assert.Equal("testfile.jpg", doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileName)));
+        Assert.Equal("3 KB", doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeEvidenceFileSizeDescription)));
+        Assert.Equal("http://test.com/file", doc.GetHiddenInputValue(nameof(NameChangeReasonModel.NameChangeUploadedEvidenceFileUrl)));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/OtherDetailsChangeReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/OtherDetailsChangeReasonTests.cs
@@ -114,14 +114,14 @@ public class OtherDetailsChangeReasonTests : TestBase
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
 
-        var reasonChoiceSelection = GetChildElementsOfTestId<IHtmlInputElement>(doc, "change-reason-options", "input[type='radio']")
+        var reasonChoiceSelection = doc.GetChildElementsOfTestId<IHtmlInputElement>("change-reason-options", "input[type='radio']")
             .Single(i => i.IsChecked == true).Value;
         Assert.Equal(reasonChoice.ToString(), reasonChoiceSelection);
 
         var additionalDetailTextArea = doc.GetElementByTestId("change-reason-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
         Assert.Equal(reasonDetail, additionalDetailTextArea!.Value);
 
-        var uploadEvidenceChoices = GetChildElementsOfTestId<IHtmlInputElement>(doc, "upload-evidence-options", "input[type='radio']")
+        var uploadEvidenceChoices = doc.GetChildElementsOfTestId<IHtmlInputElement>("upload-evidence-options", "input[type='radio']")
             .Single(i => i.IsChecked == true).Value;
         Assert.Equal(true.ToString(), uploadEvidenceChoices);
 
@@ -129,10 +129,10 @@ public class OtherDetailsChangeReasonTests : TestBase
         Assert.Equal("evidence.jpg (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(doc, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileId)));
-        Assert.Equal("evidence.jpg", GetHiddenInputValue(doc, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileName)));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(doc, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileSizeDescription)));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(doc, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeUploadedEvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileId)));
+        Assert.Equal("evidence.jpg", doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileName)));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileSizeDescription)));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeUploadedEvidenceFileUrl)));
     }
 
     [Fact]
@@ -403,19 +403,19 @@ public class OtherDetailsChangeReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var evidenceFileId = await FileServiceMock.AssertFileWasUploadedAsync();
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("validfile.png (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileId)));
-        Assert.Equal("validfile.png", GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileName)));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileSizeDescription)));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeUploadedEvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileId)));
+        Assert.Equal("validfile.png", doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileName)));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileSizeDescription)));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeUploadedEvidenceFileUrl)));
     }
 
     [Fact]
@@ -450,18 +450,18 @@ public class OtherDetailsChangeReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("testfile.jpg (3 KB)", link.TrimmedText());
         Assert.Equal("http://test.com/file", link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileId)));
-        Assert.Equal("testfile.jpg", GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileName)));
-        Assert.Equal("3 KB", GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileSizeDescription)));
-        Assert.Equal("http://test.com/file", GetHiddenInputValue(html, nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeUploadedEvidenceFileUrl)));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileId)));
+        Assert.Equal("testfile.jpg", doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileName)));
+        Assert.Equal("3 KB", doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeEvidenceFileSizeDescription)));
+        Assert.Equal("http://test.com/file", doc.GetHiddenInputValue(nameof(OtherDetailsChangeReasonModel.OtherDetailsChangeUploadedEvidenceFileUrl)));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
@@ -98,14 +98,14 @@ public class PersonalDetailsTests : TestBase
         Assert.Equal(StatusCodes.Status200OK, (int)redirectResponse.StatusCode);
 
         var doc = await AssertEx.HtmlResponseAsync(redirectResponse);
-        var firstName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-first-name", "input");
-        var middleName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-middle-name", "input");
-        var lastName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-last-name", "input");
-        var dateOfBirth = GetChildElementsOfTestId<IHtmlInputElement>(doc, "edit-details-date-of-birth", "input");
-        var emailAddress = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-email-address", "input");
-        var mobileNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-mobile-number", "input");
-        var nationalInsuranceNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-national-insurance-number", "input");
-        var genderSelection = GetChildElementsOfTestId<IHtmlInputElement>(doc, "edit-details-gender-options", "input[type='radio']")
+        var firstName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-first-name", "input");
+        var middleName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-middle-name", "input");
+        var lastName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-last-name", "input");
+        var dateOfBirth = doc.GetChildElementsOfTestId<IHtmlInputElement>("edit-details-date-of-birth", "input");
+        var emailAddress = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-email-address", "input");
+        var mobileNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-mobile-number", "input");
+        var nationalInsuranceNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-national-insurance-number", "input");
+        var genderSelection = doc.GetChildElementsOfTestId<IHtmlInputElement>("edit-details-gender-options", "input[type='radio']")
             .Single(i => i.IsChecked == true);
 
         Assert.Equal("Alfred", firstName.Value.Trim());
@@ -144,9 +144,9 @@ public class PersonalDetailsTests : TestBase
         Assert.Equal(StatusCodes.Status200OK, (int)redirectResponse.StatusCode);
 
         var doc = await AssertEx.HtmlResponseAsync(redirectResponse);
-        var mobileNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-mobile-number", "input");
-        var emailAddress = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-email-address", "input");
-        var nationalInsuranceNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-national-insurance-number", "input");
+        var mobileNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-mobile-number", "input");
+        var emailAddress = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-email-address", "input");
+        var nationalInsuranceNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-national-insurance-number", "input");
 
         // Mobile number is normalized during TRS Sync process so invalid numbers are converted to null
         Assert.Equal("", mobileNumber.Value.Trim());
@@ -178,14 +178,14 @@ public class PersonalDetailsTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var firstName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-first-name", "input");
-        var middleName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-middle-name", "input");
-        var lastName = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-last-name", "input");
-        var dateOfBirth = GetChildElementsOfTestId<IHtmlInputElement>(doc, "edit-details-date-of-birth", "input");
-        var emailAddress = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-email-address", "input");
-        var mobileNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-mobile-number", "input");
-        var nationalInsuranceNumber = GetChildElementOfTestId<IHtmlInputElement>(doc, "edit-details-national-insurance-number", "input");
-        var genderSelection = GetChildElementsOfTestId<IHtmlInputElement>(doc, "edit-details-gender-options", "input[type='radio']")
+        var firstName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-first-name", "input");
+        var middleName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-middle-name", "input");
+        var lastName = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-last-name", "input");
+        var dateOfBirth = doc.GetChildElementsOfTestId<IHtmlInputElement>("edit-details-date-of-birth", "input");
+        var emailAddress = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-email-address", "input");
+        var mobileNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-mobile-number", "input");
+        var nationalInsuranceNumber = doc.GetChildElementOfTestId<IHtmlInputElement>("edit-details-national-insurance-number", "input");
+        var genderSelection = doc.GetChildElementsOfTestId<IHtmlInputElement>("edit-details-gender-options", "input[type='radio']")
             .Single(i => i.IsChecked == true);
 
         Assert.Equal("Alfred", firstName.Value.Trim());
@@ -225,7 +225,7 @@ public class PersonalDetailsTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var genderOptions = GetChildElementsOfTestId<IHtmlInputElement>(doc, "edit-details-gender-options", "input[type='radio']");
+        var genderOptions = doc.GetChildElementsOfTestId<IHtmlInputElement>("edit-details-gender-options", "input[type='radio']");
 
         Action<IHtmlInputElement> AssertRadioButtonValue(string expectedValue) =>
             radio => Assert.Equal(expectedValue, radio.Value);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/ChangeReasonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/ChangeReasonTests.cs
@@ -240,19 +240,19 @@ public class ChangeReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var evidenceFileId = await FileServiceMock.AssertFileWasUploadedAsync();
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("validfile.png (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, "EvidenceFileId"));
-        Assert.Equal("validfile.png", GetHiddenInputValue(html, "EvidenceFileName"));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(html, "EvidenceFileSizeDescription"));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(html, "UploadedEvidenceFileUrl"));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue("EvidenceFileId"));
+        Assert.Equal("validfile.png", doc.GetHiddenInputValue("EvidenceFileName"));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue("EvidenceFileSizeDescription"));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue("UploadedEvidenceFileUrl"));
     }
 
     [Fact]
@@ -282,18 +282,18 @@ public class ChangeReasonTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("testfile.jpg (3 KB)", link.TrimmedText());
         Assert.Equal("http://test.com/file", link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, "EvidenceFileId"));
-        Assert.Equal("testfile.jpg", GetHiddenInputValue(html, "EvidenceFileName"));
-        Assert.Equal("3 KB", GetHiddenInputValue(html, "EvidenceFileSizeDescription"));
-        Assert.Equal("http://test.com/file", GetHiddenInputValue(html, "UploadedEvidenceFileUrl"));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue("EvidenceFileId"));
+        Assert.Equal("testfile.jpg", doc.GetHiddenInputValue("EvidenceFileName"));
+        Assert.Equal("3 KB", doc.GetHiddenInputValue("EvidenceFileSizeDescription"));
+        Assert.Equal("http://test.com/file", doc.GetHiddenInputValue("UploadedEvidenceFileUrl"));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
@@ -399,19 +399,19 @@ public class DeactivateTests : TestBase, IAsyncLifetime
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var evidenceFileId = await FileServiceMock.AssertFileWasUploadedAsync();
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("validfile.png (1.2 KB)", link.TrimmedText());
         Assert.Equal(expectedFileUrl, link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, "EvidenceFileId"));
-        Assert.Equal("validfile.png", GetHiddenInputValue(html, "EvidenceFileName"));
-        Assert.Equal("1.2 KB", GetHiddenInputValue(html, "EvidenceFileSizeDescription"));
-        Assert.Equal(expectedFileUrl, GetHiddenInputValue(html, "UploadedEvidenceFileUrl"));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue("EvidenceFileId"));
+        Assert.Equal("validfile.png", doc.GetHiddenInputValue("EvidenceFileName"));
+        Assert.Equal("1.2 KB", doc.GetHiddenInputValue("EvidenceFileSizeDescription"));
+        Assert.Equal(expectedFileUrl, doc.GetHiddenInputValue("UploadedEvidenceFileUrl"));
     }
 
     [Fact]
@@ -442,18 +442,18 @@ public class DeactivateTests : TestBase, IAsyncLifetime
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-        var html = await AssertEx.HtmlResponseAsync(response, 400);
+        var doc = await AssertEx.HtmlResponseAsync(response, 400);
 
         var expectedFileUrl = $"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}";
 
-        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(html.GetElementByTestId("uploaded-evidence-file-link"));
+        var link = Assert.IsAssignableFrom<IHtmlAnchorElement>(doc.GetElementByTestId("uploaded-evidence-file-link"));
         Assert.Equal("testfile.jpg (3 KB)", link.TrimmedText());
         Assert.Equal("http://test.com/file", link.Href);
 
-        Assert.Equal(evidenceFileId.ToString(), GetHiddenInputValue(html, "EvidenceFileId"));
-        Assert.Equal("testfile.jpg", GetHiddenInputValue(html, "EvidenceFileName"));
-        Assert.Equal("3 KB", GetHiddenInputValue(html, "EvidenceFileSizeDescription"));
-        Assert.Equal("http://test.com/file", GetHiddenInputValue(html, "UploadedEvidenceFileUrl"));
+        Assert.Equal(evidenceFileId.ToString(), doc.GetHiddenInputValue("EvidenceFileId"));
+        Assert.Equal("testfile.jpg", doc.GetHiddenInputValue("EvidenceFileName"));
+        Assert.Equal("3 KB", doc.GetHiddenInputValue("EvidenceFileSizeDescription"));
+        Assert.Equal("http://test.com/file", doc.GetHiddenInputValue("UploadedEvidenceFileUrl"));
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -1,6 +1,4 @@
 using System.Reactive.Linq;
-using AngleSharp.Dom;
-using AngleSharp.Html.Dom;
 using FakeXrmEasy.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -172,32 +170,5 @@ public abstract class TestBase : IDisposable
         var byteArrayContent = new ByteArrayContent(content ?? []);
         byteArrayContent.Headers.Add("Content-Type", "application/octet-stream");
         return byteArrayContent;
-    }
-
-    protected T GetChildElementOfTestId<T>(IHtmlDocument doc, string testId, string childSelector) where T : IElement
-    {
-        var parent = doc.GetElementByTestId(testId);
-        Assert.NotNull(parent);
-        var child = parent.QuerySelector(childSelector);
-        Assert.NotNull(child);
-        Assert.IsAssignableFrom<T>(child);
-        return (T)child;
-    }
-
-    protected IEnumerable<T> GetChildElementsOfTestId<T>(IHtmlDocument doc, string testId, string childSelector) where T : IElement
-    {
-        var parent = doc.GetElementByTestId(testId);
-        Assert.NotNull(parent);
-        var children = parent.QuerySelectorAll(childSelector);
-        Assert.All(children, c => Assert.IsAssignableFrom<T>(c));
-        return children.Cast<T>();
-    }
-
-    protected string GetHiddenInputValue(IHtmlDocument html, string name)
-    {
-        var element = html.QuerySelector($@"input[type=""hidden""][name=""{name}""]");
-        var input = Assert.IsAssignableFrom<IHtmlInputElement>(element);
-
-        return input.Value;
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -40,7 +40,9 @@ public partial class TestData
         private string? _firstName;
         private string? _middleName;
         private string? _lastName;
+        private bool? _hasEmail;
         private string? _email;
+        private bool? _hasMobileNumber;
         private string? _mobileNumber;
         private bool? _hasNationalInsuranceNumber;
         private string? _nationalInsuranceNumber;
@@ -90,14 +92,40 @@ public partial class TestData
             return this;
         }
 
+        public CreatePersonBuilder WithEmail(bool hasEmail = true)
+        {
+            _hasEmail = hasEmail;
+
+            if (_hasEmail is false)
+            {
+                _email = null;
+            }
+
+            return this;
+        }
+
         public CreatePersonBuilder WithEmail(string? email)
         {
+            _hasEmail = email != null;
             _email = email;
+            return this;
+        }
+
+        public CreatePersonBuilder WithMobileNumber(bool hasMobileNumber = true)
+        {
+            _hasMobileNumber = hasMobileNumber;
+
+            if (_hasMobileNumber is false)
+            {
+                _mobileNumber = null;
+            }
+
             return this;
         }
 
         public CreatePersonBuilder WithMobileNumber(string? mobileNumber)
         {
+            _hasMobileNumber = mobileNumber != null;
             _mobileNumber = mobileNumber;
             return this;
         }
@@ -436,14 +464,14 @@ public partial class TestData
                 contact.dfeta_TRN = trn;
             }
 
-            if (_email is not null)
+            if (_hasEmail ?? false)
             {
-                contact.EMailAddress1 = _email;
+                contact.EMailAddress1 = _email ?? testData.GenerateUniqueEmail();
             }
 
-            if (_mobileNumber is not null)
+            if (_hasMobileNumber ?? false)
             {
-                contact.MobilePhone = _mobileNumber;
+                contact.MobilePhone = _mobileNumber ?? testData.GenerateUniqueMobileNumber();
             }
 
             if (_hasNationalInsuranceNumber ?? false)
@@ -664,8 +692,8 @@ public partial class TestData
                 StatedFirstName = statedFirstName,
                 StatedMiddleName = statedMiddleName,
                 StatedLastName = lastName,
-                Email = _email,
-                MobileNumber = _mobileNumber,
+                Email = contact.EMailAddress1,
+                MobileNumber = contact.MobilePhone,
                 NationalInsuranceNumber = contact.dfeta_NINumber,
                 Gender = contact.GenderCode.ToGender(),
                 QtsDate = person?.QtsDate,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AngleSharpExtensions.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using Xunit;
 
 namespace TeachingRecordSystem.UiTestCommon;
 
@@ -101,4 +102,31 @@ public static class AngleSharpExtensions
     }
 
     public static string TrimmedText(this INode node) => node.Text().Trim();
+
+    public static T GetChildElementOfTestId<T>(this IHtmlDocument doc, string testId, string childSelector) where T : IElement
+    {
+        var parent = doc.GetElementByTestId(testId);
+        Assert.NotNull(parent);
+        var child = parent.QuerySelector(childSelector);
+        Assert.NotNull(child);
+        Assert.IsAssignableFrom<T>(child);
+        return (T)child;
+    }
+
+    public static IEnumerable<T> GetChildElementsOfTestId<T>(this IHtmlDocument doc, string testId, string childSelector) where T : IElement
+    {
+        var parent = doc.GetElementByTestId(testId);
+        Assert.NotNull(parent);
+        var children = parent.QuerySelectorAll(childSelector);
+        Assert.All(children, c => Assert.IsAssignableFrom<T>(c));
+        return children.Cast<T>();
+    }
+
+    public static string GetHiddenInputValue(this IHtmlDocument doc, string name)
+    {
+        var element = doc.QuerySelector($@"input[type=""hidden""][name=""{name}""]");
+        var input = Assert.IsAssignableFrom<IHtmlInputElement>(element);
+
+        return input.Value;
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AssertEx.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.UiTestCommon/AssertEx.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using TeachingRecordSystem.Core.Services.Files;
 using Xunit;
@@ -9,6 +10,13 @@ namespace TeachingRecordSystem.UiTestCommon;
 
 public static partial class AssertEx
 {
+    public static void ResponseIsRedirectTo(HttpResponseMessage response, string expectedUrl)
+    {
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        var location = response.Headers.Location?.OriginalString;
+        Assert.Equal(expectedUrl, location);
+    }
+
     public static async Task<IHtmlDocument> HtmlResponseAsync(HttpResponseMessage response, int expectedStatusCode = 200)
     {
         Assert.Equal(expectedStatusCode, (int)response.StatusCode);
@@ -173,6 +181,23 @@ public static partial class AssertEx
     public static void AssertRowDoesNotExist(this IHtmlDocument doc, string containerTestId, string keyContent)
     {
         doc.AssertRowDoesNotExistCore(containerTestId, keyContent);
+    }
+
+    public static void AssertMatchRowHasExpectedHighlight(this IHtmlDocument doc, string detailsId, string summaryListKey, bool expectHighlight)
+    {
+        var details = doc.GetAllElementsByTestId(detailsId).First();
+        var valueElement = details.GetSummaryListValueElementForKey(summaryListKey);
+        Assert.NotNull(valueElement);
+        var highlightElement = valueElement.GetElementsByClassName("hods-highlight").SingleOrDefault();
+
+        if (expectHighlight)
+        {
+            Assert.NotNull(highlightElement);
+        }
+        else
+        {
+            Assert.Null(highlightElement);
+        }
     }
 
     public static void AssertChangeLinkExists(this IHtmlDocument doc, string keyContent)


### PR DESCRIPTION
### Context

We need to enable support users to be able to manually merge two records within the support console if they determine that they are a duplicate of each other.

https://trello.com/c/bxcQgwpp/1344-build-the-compare-matching-records-page
https://trello.com/c/npCNEW7B/1343-build-primary-record-selection-page

### Changes proposed in this pull request

* Implement Compare matching records page
* Implement Select primary record page
* Refactor test helper methods

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
