### PR TITLE
Added UI for DQT ITT / QTS events in change history

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
@@ -82,7 +82,11 @@ public class ChangeHistoryModel(
             nameof(RouteToProfessionalStatusDeletedEvent),
             nameof(RouteToProfessionalStatusMigratedEvent),
             nameof(ApiTrnRequestSupportTaskUpdatedEvent),
-            nameof(NpqTrnRequestSupportTaskUpdatedEvent)
+            nameof(NpqTrnRequestSupportTaskUpdatedEvent),
+            nameof(DqtInitialTeacherTrainingCreatedEvent),
+            nameof(DqtInitialTeacherTrainingUpdatedEvent),
+            nameof(DqtQtsRegistrationCreatedEvent),
+            nameof(DqtQtsRegistrationUpdatedEvent)
         };
 
         var alertEventTypes = eventTypes.Where(et => et.StartsWith("Alert")).ToArray();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtInitialTeacherTrainingCreatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtInitialTeacherTrainingCreatedEvent.cshtml
@@ -1,0 +1,24 @@
+@using TeachingRecordSystem.Core.Events
+@model TimelineItem<TimelineEvent<DqtInitialTeacherTrainingCreatedEvent>>
+@{
+    var dqtCreatedEvent = Model.ItemModel.Event;
+    var itt = dqtCreatedEvent.InitialTeacherTraining;
+}
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-dqt-itt-created-event">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">DQT initial teacher training created</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Result</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="itt-result" use-empty-fallback>@itt?.Result</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtInitialTeacherTrainingUpdatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtInitialTeacherTrainingUpdatedEvent.cshtml
@@ -1,0 +1,36 @@
+@using TeachingRecordSystem.Core.Events
+@model TimelineItem<TimelineEvent<DqtInitialTeacherTrainingUpdatedEvent>>
+@{
+    var dqtUpdatedEvent = Model.ItemModel.Event;
+    var itt = dqtUpdatedEvent.InitialTeacherTraining;
+    var oldItt = dqtUpdatedEvent.OldInitialTeacherTraining;
+}
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-dqt-itt-updated-event">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">DQT initial teacher training updated</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Result</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value data-testid="itt-result" use-empty-fallback>@itt?.Result</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+        <govuk-details class="govuk-!-margin-bottom-2">
+            <govuk-details-summary>Previous data</govuk-details-summary>
+            <govuk-details-text>
+                <govuk-summary-list>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Result</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value data-testid="old-itt-result" use-empty-fallback>@oldItt?.Result</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                </govuk-summary-list>
+            </govuk-details-text>
+        </govuk-details>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtQtsRegistrationCreatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtQtsRegistrationCreatedEvent.cshtml
@@ -1,0 +1,51 @@
+@using TeachingRecordSystem.Core.Events
+@model TimelineItem<TimelineEvent<DqtQtsRegistrationCreatedEvent>>
+@{
+    var dqtCreatedEvent = Model.ItemModel.Event;
+    var qts = dqtCreatedEvent.QtsRegistration;
+}
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-dqt-qts-created-event">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">DQT QTS registration created</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            @if (qts?.TeacherStatusName is not null)
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Teacher status name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="teacher-status-name" use-empty-fallback>@qts?.TeacherStatusName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+
+            @if (qts?.EarlyYearsStatusName is not null)
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Early years status name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="early-years-status-name" use-empty-fallback>@qts?.EarlyYearsStatusName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+
+            @if (qts?.QtsDate is not null)
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>QTS date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="qts-date" use-empty-fallback>@qts?.QtsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }            
+
+            @if (qts?.EytsDate is not null)
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>EYTS date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="eyts-date" use-empty-fallback>@qts?.EytsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }            
+        </govuk-summary-list>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtQtsRegistrationUpdatedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/DqtQtsRegistrationUpdatedEvent.cshtml
@@ -1,0 +1,90 @@
+@using TeachingRecordSystem.Core.Events
+@model TimelineItem<TimelineEvent<DqtQtsRegistrationUpdatedEvent>>
+@{
+    var dqtUpdatedEvent = Model.ItemModel.Event;
+    var qts = dqtUpdatedEvent.QtsRegistration;
+    var oldQts = dqtUpdatedEvent.OldQtsRegistration;
+}
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-testid="timeline-item-dqt-qts-updated-event">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">DQT QTS registration updated</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span data-testid="raised-by">By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")" data-testid="timeline-item-time">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.TeacherStatusValue))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Teacher status name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="teacher-status-name" use-empty-fallback>@qts?.TeacherStatusName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+
+            @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.EarlyYearsStatusValue))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Early years status name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="early-years-status-name" use-empty-fallback>@qts?.EarlyYearsStatusName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+
+            @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.QtsDate))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>QTS date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="qts-date" use-empty-fallback>@qts?.QtsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+
+            @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.EytsDate))
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>EYTS date</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value data-testid="eyts-date" use-empty-fallback>@qts?.EytsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            }
+        </govuk-summary-list>
+        <govuk-details class="govuk-!-margin-bottom-2">
+            <govuk-details-summary>Previous data</govuk-details-summary>
+            <govuk-details-text>
+                <govuk-summary-list>
+                    @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.TeacherStatusValue))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Teacher status name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-teacher-status-name" use-empty-fallback>@oldQts?.TeacherStatusName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+
+                    @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.EarlyYearsStatusValue))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Early years status name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-early-years-status-name" use-empty-fallback>@oldQts?.EarlyYearsStatusName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+
+                    @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.QtsDate))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>QTS date</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-qts-date" use-empty-fallback>@oldQts?.QtsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+
+                    @if (dqtUpdatedEvent.Changes.HasFlag(DqtQtsRegistrationUpdatedEventChanges.EytsDate))
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>EYTS date</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value data-testid="old-eyts-date" use-empty-fallback>@oldQts?.EytsDate?.ToString(UiDefaults.DateOnlyDisplayFormat)</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    }
+                </govuk-summary-list>
+            </govuk-details-text>
+        </govuk-details>
+    </div>
+</div>


### PR DESCRIPTION
### Context

We need build an audit trail for the TRS console to display the events created by the backfil and live sync job for the QTS Reg table so that peple can view historical changes from DQT

### Changes proposed in this pull request

Amend Change History UI to render content for the following events
- `DqtInitialTeacherTrainingCreatedEvent`
- `DqtInitialTeacherTrainingUpdatedEvent`
- `DqtQtsRegistrationCreatedEvent`
- `DqtQtsRegistrationUpdatedEvent`