### PR TITLE
Temporarily ignore postgres DB version changes in deploys

### DIFF
--- a/global_config/dev.sh
+++ b/global_config/dev.sh
@@ -2,4 +2,4 @@ CONFIG=dev
 CONFIG_SHORT=dv
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test
 AZURE_RESOURCE_PREFIX=s189t01
-TERRAFORM_MODULES_TAG=main
+TERRAFORM_MODULES_TAG=skip-postgres-version-changes

--- a/global_config/dv_review.sh
+++ b/global_config/dv_review.sh
@@ -2,4 +2,4 @@ CONFIG=dv_review
 CONFIG_SHORT=rv
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-development
 AZURE_RESOURCE_PREFIX=s189d01
-TERRAFORM_MODULES_TAG=main
+TERRAFORM_MODULES_TAG=skip-postgres-version-changes

--- a/global_config/pre-production.sh
+++ b/global_config/pre-production.sh
@@ -2,4 +2,4 @@ CONFIG=pre-production
 CONFIG_SHORT=pp
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test
 AZURE_RESOURCE_PREFIX=s189t01
-TERRAFORM_MODULES_TAG=testing
+TERRAFORM_MODULES_TAG=skip-postgres-version-changes

--- a/global_config/production.sh
+++ b/global_config/production.sh
@@ -2,4 +2,4 @@ CONFIG=production
 CONFIG_SHORT=pd
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
 AZURE_RESOURCE_PREFIX=s189p01
-TERRAFORM_MODULES_TAG=stable
+TERRAFORM_MODULES_TAG=skip-postgres-version-changes

--- a/global_config/test.sh
+++ b/global_config/test.sh
@@ -2,4 +2,4 @@ CONFIG=test
 CONFIG_SHORT=ts
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test
 AZURE_RESOURCE_PREFIX=s189t01
-TERRAFORM_MODULES_TAG=testing
+TERRAFORM_MODULES_TAG=skip-postgres-version-changes


### PR DESCRIPTION
Terraform doesn't support Postgres 17 yet (but we've already upgraded). For now, reference a version of the `aks` module that ignores version changes on the Postgres DB.