### PR TITLE
Amended job to derive environment from ConnectedOrgFriendlyName property

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BackfillDqtIttQtsBusinessEventAuditsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BackfillDqtIttQtsBusinessEventAuditsJob.cs
@@ -100,11 +100,11 @@ public class BackfillDqtIttQtsBusinessEventAuditsJob(
             var result = await resiliencePipeline.ExecuteAsync(async _ => await QueryAsync());
 
             // For some reason the date format in dfeta_businesseventaudit changes over the years from dd/MM/yyyy to M/d/yyyy in BUILD and PROD but not PRE-PROD!
-            if (serviceClient.ConnectedOrgUniqueName == "ent-dqt-prod")
+            if (serviceClient.ConnectedOrgFriendlyName == "Ent DQT Prod")
             {
                 crmDateFormatChangeDate = new DateTime(2021, 01, 30);
             }
-            else if (serviceClient.ConnectedOrgUniqueName == "ent-dqt-build")
+            else if (serviceClient.ConnectedOrgFriendlyName == "Ent DQT Build")
             {
                 crmDateFormatChangeDate = new DateTime(2019, 04, 04);
             }


### PR DESCRIPTION
### Context

Background job to migrate ITT / QTS events needs to cater for different date formats on different environments and Service Client `ConnectedOrgUniqueName` was not as expected for prod so changed to using `ConnectedOrgFriendlyName`.
