### PR TITLE
Amended DOB change to create support task in TRS (behind feature flag)

### DIFF
--- a/.github/workflows/actions/test/action.yml
+++ b/.github/workflows/actions/test/action.yml
@@ -25,7 +25,7 @@ runs:
           exit 1
         fi
 
-        cd $PROJECT_PATH && dotnet test --configuration Release --logger trx ${{ inputs.dotnet_test_args }}
+        cd $PROJECT_PATH && dotnet test --blame-hang-timeout 10m --configuration Release --logger trx ${{ inputs.dotnet_test_args }}
       shell: bash
       env:
         PROJECT_PATH: ${{ inputs.test_project_path }}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/FeatureNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/FeatureNames.cs
@@ -3,4 +3,5 @@ namespace TeachingRecordSystem.Api;
 public static class FeatureNames
 {
     public const string ApiTrnRequestsInTrs = nameof(ApiTrnRequestsInTrs);
+    public const string ChangeRequestsInTrs = nameof(ChangeRequestsInTrs);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -30,6 +30,7 @@ using TeachingRecordSystem.Core.Services.DqtOutbox;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.NameSynonyms;
+using TeachingRecordSystem.Core.Services.Notify;
 using TeachingRecordSystem.Core.Services.PersonMatching;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrnRequests;
@@ -196,7 +197,8 @@ public class Program
             .AddDqtOutboxMessageSerializer()
             .AddWebhookOptions()
             .AddTrsSyncHelper()
-            .AddTrnRequestService();
+            .AddTrnRequestService()
+            .AddEmail();
 
         services
             .AddTrsBaseServices()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
@@ -1,6 +1,12 @@
+using System.Transactions;
 using Microsoft.AspNetCore.StaticFiles;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Dqt;
-using TeachingRecordSystem.Core.Dqt.Queries;
+using TeachingRecordSystem.Core.Jobs;
+using TeachingRecordSystem.Core.Jobs.Scheduling;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+using TeachingRecordSystem.Core.Services.Files;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
@@ -15,16 +21,30 @@ public record CreateDateOfBirthChangeRequestCommand
 
 public record CreateDateOfBirthChangeRequestResult(string CaseNumber);
 
-public class CreateDateOfBirthChangeRequestHandler(ICrmQueryDispatcher crmQueryDispatcher, IHttpClientFactory httpClientFactory)
+public partial class CreateDateOfBirthChangeRequestHandler(
+    IConfiguration configuration,
+    IBackgroundJobScheduler backgroundJobScheduler,
+    IHttpClientFactory httpClientFactory,
+    TrsDbContext dbContext,
+    IFileService fileService,
+    IClock clock,
+    ICrmQueryDispatcher crmQueryDispatcher,
+    IFeatureProvider featureProvider)
 {
     private readonly HttpClient _downloadEvidenceFileHttpClient = httpClientFactory.CreateClient("EvidenceFiles");
 
     public async Task<ApiResult<CreateDateOfBirthChangeRequestResult>> HandleAsync(CreateDateOfBirthChangeRequestCommand command)
     {
-        var contact = await crmQueryDispatcher.ExecuteQueryAsync(
-            new GetActiveContactByTrnQuery(command.Trn, new Microsoft.Xrm.Sdk.Query.ColumnSet()));
+        if (!featureProvider.IsEnabled(FeatureNames.ChangeRequestsInTrs))
+        {
+            return await HandleOverDqtAsync(command);
+        }
 
-        if (contact is null)
+        var person = await dbContext.Persons
+            .Where(p => p.Trn == command.Trn)
+            .SingleOrDefaultAsync();
+
+        if (person is null)
         {
             return ApiError.PersonNotFound(command.Trn);
         }
@@ -44,17 +64,57 @@ public class CreateDateOfBirthChangeRequestHandler(ICrmQueryDispatcher crmQueryD
             evidenceFileMimeType = "application/octet-stream";
         }
 
-        var (_, ticketNumber) = await crmQueryDispatcher.ExecuteQueryAsync(new CreateDateOfBirthChangeIncidentQuery()
-        {
-            ContactId = contact.Id,
-            DateOfBirth = command.DateOfBirth,
-            EvidenceFileName = command.EvidenceFileName,
-            EvidenceFileContent = await evidenceFileResponse.Content.ReadAsStreamAsync(),
-            EvidenceFileMimeType = evidenceFileMimeType,
-            FromIdentity = true,
-            EmailAddress = command.EmailAddress,
-        });
+        using var stream = await evidenceFileResponse.Content.ReadAsStreamAsync();
+        var evidenceFileId = await fileService.UploadFileAsync(stream, evidenceFileMimeType);
 
-        return new CreateDateOfBirthChangeRequestResult(ticketNumber);
+        var changeRequestData = new ChangeDateOfBirthRequestData()
+        {
+            DateOfBirth = command.DateOfBirth,
+            EvidenceFileId = evidenceFileId,
+            EvidenceFileName = command.EvidenceFileName,
+            EmailAddress = command.EmailAddress,
+            ChangeRequestOutcome = null
+        };
+
+        var getAnIdentityApplicationUserId = configuration.GetValue<Guid>("GetAnIdentityApplicationUserId");
+
+        // Ensure enqueued Hangfire jobs are run in the same transaction as the database changes
+        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+        var supportTask = PostgresModels.SupportTask.Create(
+            SupportTaskType.ChangeDateOfBirthRequest,
+            changeRequestData,
+            person.PersonId,
+            oneLoginUserSubject: null,
+            trnRequestApplicationUserId: null,
+            trnRequestId: null,
+            createdBy: getAnIdentityApplicationUserId,
+            clock.UtcNow,
+            out var supportTaskCreatedEvent);
+
+        dbContext.SupportTasks.Add(supportTask);
+        await dbContext.AddEventAndBroadcastAsync(supportTaskCreatedEvent);
+
+        var emailAddress = string.IsNullOrEmpty(command.EmailAddress) ? person.EmailAddress : command.EmailAddress;
+
+        if (!string.IsNullOrEmpty(emailAddress))
+        {
+            var email = new Email
+            {
+                EmailId = Guid.NewGuid(),
+                TemplateId = ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId,
+                EmailAddress = emailAddress!,
+                Personalization = new Dictionary<string, string>() { { ChangeRequestEmailConstants.FirstNameEmailPersonalisationKey, person.FirstName } },
+                EmailReplyToId = ChangeRequestEmailConstants.EmailReplyToId
+            };
+
+            dbContext.Emails.Add(email);
+            await backgroundJobScheduler.EnqueueAsync<SendEmailJob>(j => j.ExecuteAsync(email.EmailId));
+        }
+
+        await dbContext.SaveChangesAsync();
+        transaction.Complete();
+
+        return new CreateDateOfBirthChangeRequestResult(supportTask.SupportTaskReference);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequestHandler_Dqt.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequestHandler_Dqt.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.StaticFiles;
+using TeachingRecordSystem.Core.Dqt.Queries;
+
+namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
+
+public partial class CreateDateOfBirthChangeRequestHandler
+{
+    public async Task<ApiResult<CreateDateOfBirthChangeRequestResult>> HandleOverDqtAsync(CreateDateOfBirthChangeRequestCommand command)
+    {
+        var contact = await crmQueryDispatcher.ExecuteQueryAsync(
+            new GetActiveContactByTrnQuery(command.Trn, new Microsoft.Xrm.Sdk.Query.ColumnSet()));
+
+        if (contact is null)
+        {
+            return ApiError.PersonNotFound(command.Trn);
+        }
+
+        using var evidenceFileResponse = await _downloadEvidenceFileHttpClient.GetAsync(
+            command.EvidenceFileUrl,
+            HttpCompletionOption.ResponseHeadersRead);
+
+        if (!evidenceFileResponse.IsSuccessStatusCode)
+        {
+            return ApiError.SpecifiedResourceUrlDoesNotExist(command.EvidenceFileUrl);
+        }
+
+        var fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
+        if (!fileExtensionContentTypeProvider.TryGetContentType(command.EvidenceFileName, out var evidenceFileMimeType))
+        {
+            evidenceFileMimeType = "application/octet-stream";
+        }
+
+        var (_, ticketNumber) = await crmQueryDispatcher.ExecuteQueryAsync(new CreateDateOfBirthChangeIncidentQuery()
+        {
+            ContactId = contact.Id,
+            DateOfBirth = command.DateOfBirth,
+            EvidenceFileName = command.EvidenceFileName,
+            EvidenceFileContent = await evidenceFileResponse.Content.ReadAsStreamAsync(),
+            EvidenceFileMimeType = evidenceFileMimeType,
+            FromIdentity = true,
+            EmailAddress = command.EmailAddress,
+        });
+
+        return new CreateDateOfBirthChangeRequestResult(ticketNumber);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.Development.json
@@ -3,5 +3,5 @@
   "AuthorizeAccessIssuer": "https://localhost:7236",
   "DetailedErrors": true,
   "StorageConnectionString": "UseDevelopmentStorage=true",
-  "EnabledFeatures": [ "RoutesToProfessionalStatus", "ApiTrnRequestsInTrs" ]
+  "EnabledFeatures": [ "RoutesToProfessionalStatus", "ApiTrnRequestsInTrs", "ChangeRequestsInTrs" ]
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EmailMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EmailMapping.cs
@@ -12,5 +12,6 @@ public class EmailMapping : IEntityTypeConfiguration<Email>
         builder.Property(e => e.EmailAddress).HasMaxLength(200);
         builder.Property(e => e.Personalization).HasJsonConversion().IsRequired().HasColumnType("jsonb");
         builder.Property(e => e.Metadata).HasJsonConversion().IsRequired().HasColumnType("jsonb");
+        builder.Property(e => e.EmailReplyToId).HasMaxLength(Guid.Empty.ToString().Length);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250804124340_AddEmailReplyToIdToEmail.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250804124340_AddEmailReplyToIdToEmail.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250804124340_AddEmailReplyToIdToEmail")]
+    partial class AddEmailReplyToIdToEmail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250804124340_AddEmailReplyToIdToEmail.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250804124340_AddEmailReplyToIdToEmail.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailReplyToIdToEmail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "email_reply_to_id",
+                table: "emails",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "email_reply_to_id",
+                table: "emails");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/TrsDbContextModelSnapshot.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/TrsDbContextModelSnapshot.cs
@@ -19988,7 +19988,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .IsRequired()
                         .HasConstraintName("fk_trn_request_metadata_application_users_application_user_id");
 
-                    b.OwnsOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMatches", "Matches", b1 =>
+                    b.OwnsOne("TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMetadata.Matches#TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMatches", "Matches", b1 =>
                         {
                             b1.Property<Guid>("TrnRequestMetadataApplicationUserId")
                                 .HasColumnType("uuid");
@@ -19998,7 +19998,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 
                             b1.HasKey("TrnRequestMetadataApplicationUserId", "TrnRequestMetadataRequestId");
 
-                            b1.ToTable("trn_request_metadata");
+                            b1.ToTable("trn_request_metadata", (string)null);
 
                             b1.ToJson("matches");
 
@@ -20006,7 +20006,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                                 .HasForeignKey("TrnRequestMetadataApplicationUserId", "TrnRequestMetadataRequestId")
                                 .HasConstraintName("fk_trn_request_metadata_trn_request_metadata_application_user_");
 
-                            b1.OwnsMany("TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMatchedPerson", "MatchedPersons", b2 =>
+                            b1.OwnsMany("TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMetadata.Matches#TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMatches.MatchedPersons#TeachingRecordSystem.Core.DataStore.Postgres.Models.TrnRequestMatchedPerson", "MatchedPersons", b2 =>
                                 {
                                     b2.Property<Guid>("TrnRequestMatchesTrnRequestMetadataApplicationUserId")
                                         .HasColumnType("uuid");
@@ -20023,7 +20023,7 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 
                                     b2.HasKey("TrnRequestMatchesTrnRequestMetadataApplicationUserId", "TrnRequestMatchesTrnRequestMetadataRequestId", "Id");
 
-                                    b2.ToTable("trn_request_metadata");
+                                    b2.ToTable("trn_request_metadata", (string)null);
 
                                     b2.ToJson("matches");
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Email.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Email.cs
@@ -8,4 +8,5 @@ public class Email
     public required IDictionary<string, string> Personalization { get; init; }
     public IDictionary<string, object> Metadata { get; init; } = new Dictionary<string, object>();
     public DateTime? SentOn { get; set; }
+    public string? EmailReplyToId { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -127,6 +127,7 @@ public class SupportTask
     internal static Type GetDataType(SupportTaskType supportTaskType) => supportTaskType switch
     {
         SupportTaskType.ConnectOneLoginUser => typeof(ConnectOneLoginUserData),
+        SupportTaskType.ChangeDateOfBirthRequest => typeof(ChangeDateOfBirthRequestData),
         SupportTaskType.ApiTrnRequest => typeof(ApiTrnRequestData),
         SupportTaskType.NpqTrnRequest => typeof(NpqTrnRequestData),
         SupportTaskType.TrnRequestManualChecksNeeded => typeof(TrnRequestManualChecksNeededData),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeDateOfBirthRequestData.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeDateOfBirthRequestData.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.Core.Models.SupportTaskData;
+
+public record ChangeDateOfBirthRequestData
+{
+    public required DateOnly DateOfBirth { get; init; }
+    public required Guid EvidenceFileId { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required string? EmailAddress { get; init; }
+    public required ChangeRequestOutcome? ChangeRequestOutcome { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestEmailConstants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestEmailConstants.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Core.Models.SupportTaskData;
+
+public static class ChangeRequestEmailConstants
+{
+    public const string GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId = "d83d28e8-fc4c-4728-ac62-e58a0dd1622e";
+    public const string FirstNameEmailPersonalisationKey = "first name";
+    public const string EmailReplyToId = "3ac9a271-449e-4fc6-8bba-2acd833d6901";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestOutcome.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestOutcome.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Models.SupportTaskData;
+
+public enum ChangeRequestOutcome
+{
+    Approved = 1,
+    Rejected = 2
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/HostFixture.cs
@@ -38,6 +38,8 @@ public class HostFixture : WebApplicationFactory<Program>
 
     public static Guid DefaultApplicationUserId { get; } = new("c0c8c511-e8e4-4b8e-96e3-55085dafc05d");
 
+    public static Guid GetAnIdentityApplicationUserId { get; } = new("873f0cb0-7174-4256-921a-e8a8aaa06361");
+
     public HttpClientInterceptorOptions EvidenceFilesHttpClientInterceptorOptions { get; } = new();
 
     public SigningCredentials JwtSigningCredentials { get; }
@@ -136,6 +138,13 @@ public class HostFixture : WebApplicationFactory<Program>
                     UserId = DefaultApplicationUserId,
                     Name = "Tests",
                     ApiRoles = ApiRoles.All.ToArray()
+                });
+
+                dbContext.ApplicationUsers.Add(new Core.DataStore.Postgres.Models.ApplicationUser()
+                {
+                    UserId = GetAnIdentityApplicationUserId,
+                    Name = "Get an identity",
+                    ApiRoles = [ApiRoles.UpdatePerson]
                 });
 
                 await dbContext.SaveChangesAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/Startup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/Startup.cs
@@ -4,10 +4,16 @@ public class Startup
 {
     public void ConfigureHost(IHostBuilder hostBuilder)
     {
+        var settings = new Dictionary<string, string>
+        {
+            { "GetAnIdentityApplicationUserId", HostFixture.GetAnIdentityApplicationUserId.ToString() }
+        };
+
         hostBuilder
             .ConfigureHostConfiguration(builder => builder
                 .AddUserSecrets<HostFixture>(optional: true)
-                .AddEnvironmentVariables())
+                .AddEnvironmentVariables()
+                .AddInMemoryCollection(settings!))
             .ConfigureServices(services =>
             {
                 services.AddSingleton<HostFixture>();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/TestBase.cs
@@ -101,6 +101,7 @@ public abstract class TestBase
         });
 
         var jwtHandler = new JwtSecurityTokenHandler();
+        jwtHandler.MapInboundClaims = false;
 
         var signingCredentials = HostFixture.JwtSigningCredentials;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
@@ -1,6 +1,7 @@
 using FakeXrmEasy.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using TeachingRecordSystem.Api.Infrastructure.Security;
+using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.TestCommon.Infrastructure;
@@ -41,6 +42,8 @@ public abstract class OperationTestBase
     public TestableFeatureProvider FeatureProvider => _testServices.FeatureProvider;
 
     public TrnRequestOptions TrnRequestOptions => _testServices.TrnRequestOptions;
+
+    public IFileService FileService => _testServices.BlobStorageFileService.Object;
 
     public T AssertSuccess<T>(ApiResult<T> result) where T : notnull
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TeachingRecordSystem.Api.UnitTests.csproj
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TeachingRecordSystem.Api.UnitTests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
+using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.TestCommon.Infrastructure;
@@ -18,6 +19,7 @@ public class TestScopedServices
         EventObserver = new();
         FeatureProvider = ActivatorUtilities.CreateInstance<TestableFeatureProvider>(serviceProvider);
         TrnRequestOptions = new();
+        BlobStorageFileService = new();
     }
 
     public static TestScopedServices GetCurrent() =>
@@ -56,4 +58,6 @@ public class TestScopedServices
     public TestableFeatureProvider FeatureProvider { get; }
 
     public TrnRequestOptions TrnRequestOptions { get; }
+
+    public Mock<IFileService> BlobStorageFileService { get; }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
@@ -1,0 +1,94 @@
+using TeachingRecordSystem.Api.V3.Implementation.Operations;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+
+namespace TeachingRecordSystem.Api.UnitTests.V3;
+
+[Collection(nameof(DisableParallelization))]
+public class CreateDateOfBirthChangeTests : OperationTestBase
+{
+    public CreateDateOfBirthChangeTests(OperationTestFixture operationTestFixture) : base(operationTestFixture)
+    {
+        FeatureProvider.Features.Add(FeatureNames.ChangeRequestsInTrs);
+    }
+
+    [Fact]
+    public Task HandleAsync_PersonDoesNotExist_ReturnsError() =>
+        WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
+        {
+            // Arrange
+            var command = await CreateCommand();
+
+            // Act
+            var result = await handler.HandleAsync(command);
+
+            // Assert
+            AssertError(result, ApiError.ErrorCodes.PersonNotFound);
+        });
+
+    [Fact]
+    public Task HandleAsync_EvidenceFileDoesNotExist_ReturnsError() =>
+        WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
+        {
+            // Arrange
+            var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var command = await CreateCommand() with
+            {
+                Trn = createPersonResult!.Trn!,
+                EvidenceFileUrl = "https://nonexistenturl.com"
+            };
+
+            // Act
+            var result = await handler.HandleAsync(command);
+
+            // Assert
+            AssertError(result, ApiError.ErrorCodes.SpecifiedResourceUrlDoesNotExist);
+        });
+
+    [Fact]
+    public Task HandleAsync_ValidRequest_CreatesSupportTaskAndSendsEmailAndReturnsTicketNumber() =>
+        WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
+        {
+            // Arrange
+            var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var command = await CreateCommand() with
+            {
+                Trn = createPersonResult!.Trn!
+            };
+
+            // Act
+            var result = await handler.HandleAsync(command);
+
+            // Assert
+            var success = AssertSuccess(result);
+            Assert.NotEmpty(success.CaseNumber);
+
+            await DbFixture.WithDbContextAsync(async dbContext =>
+            {
+                var supportTask = await dbContext.SupportTasks.SingleOrDefaultAsync(t => t.PersonId == createPersonResult.PersonId);
+                Assert.NotNull(supportTask);
+                Assert.Equal(SupportTaskType.ChangeDateOfBirthRequest, supportTask.SupportTaskType);
+                var requestData = supportTask.Data as ChangeDateOfBirthRequestData;
+                Assert.NotNull(requestData);
+                Assert.Equal(command.DateOfBirth, requestData.DateOfBirth);
+                Assert.Equal(command.EvidenceFileName, requestData.EvidenceFileName);
+
+                var email = await dbContext.Emails
+                    .Where(e => e.EmailAddress == command.EmailAddress)
+                    .SingleOrDefaultAsync();
+                Assert.NotNull(email);
+                Assert.NotNull(email.SentOn);
+            });
+        });
+
+    private async Task<CreateDateOfBirthChangeRequestCommand> CreateCommand()
+    {
+        return new CreateDateOfBirthChangeRequestCommand()
+        {
+            Trn = await TestData.GenerateTrnAsync(),
+            DateOfBirth = TestData.GenerateDateOfBirth(),
+            EmailAddress = TestData.GenerateUniqueEmail(),
+            EvidenceFileName = "evidence.txt",
+            EvidenceFileUrl = Startup.EvidenceFileUrl
+        };
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
@@ -2,6 +2,16 @@
   "version": 2,
   "dependencies": {
     "net8.0": {
+      "JustEat.HttpClientInterception": {
+        "type": "Direct",
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "wlP4slFg5MzuixNXs2meao6ZzSLMCL3wN/SQk0ss51hog1hC9FhskCWIxfrht4nNTv5waCT+nArOkW9lHa5Nyg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.WebUtilities": "2.2.0",
+          "System.Text.Json": "4.7.2"
+        }
+      },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -305,6 +315,15 @@
         "type": "Transitive",
         "resolved": "3.1.32",
         "contentHash": "MPL4iVyiaRxnOUY5VATHjvhDWaAEFb77KFiUxVRklv3Z3v+STofUr1UG/aCt1O9cgN7FVTDaC5A7U+zsLub8Xg=="
+      },
+      "Microsoft.AspNetCore.WebUtilities": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "9ErxAAKaDzxXASB/b5uLEkLgUWv1QbeVxyJYEHQwMaxXOeFFVkQxiq8RyfVcifLU7NR0QY0p3acqx4ZpYfhHDg==",
+        "dependencies": {
+          "Microsoft.Net.Http.Headers": "2.2.0",
+          "System.Text.Encodings.Web": "4.5.0"
+        }
       },
       "Microsoft.Azure.Services.AppAuthentication": {
         "type": "Transitive",
@@ -718,6 +737,15 @@
         "dependencies": {
           "System.Collections.Immutable": "1.5.0",
           "System.Memory": "4.5.5"
+        }
+      },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "2.2.0",
+        "contentHash": "iZNkjYqlo8sIOI0bQfpsSoMTmB/kyvmV2h225ihyZT33aTp48ZpF6qYnXxzSXmHt8DpBAwBTX+1s1UFLbYfZKg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "2.2.0",
+          "System.Buffers": "4.5.0"
         }
       },
       "Microsoft.NETCore.Platforms": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/ExecuteImmediatelyJobScheduler.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/ExecuteImmediatelyJobScheduler.cs
@@ -9,7 +9,7 @@ public class ExecuteImmediatelyJobScheduler(IServiceProvider serviceProvider) : 
     public async Task<string> EnqueueAsync<T>(Expression<Func<T, Task>> expression) where T : notnull
     {
         using var scope = serviceProvider.CreateScope();
-        var service = scope.ServiceProvider.GetRequiredService<T>();
+        var service = ActivatorUtilities.CreateInstance<T>(scope.ServiceProvider);
         var task = expression.Compile()(service);
         await task;
         return Guid.NewGuid().ToString();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/ExecuteOnCommitBackgroundJobScheduler.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/Infrastructure/ExecuteOnCommitBackgroundJobScheduler.cs
@@ -27,7 +27,7 @@ public class ExecuteOnCommitBackgroundJobScheduler(IServiceProvider serviceProvi
             await transactionCompleted.Task;
 
             using var scope = serviceProvider.CreateScope();
-            var service = scope.ServiceProvider.GetRequiredService<T>();
+            var service = ActivatorUtilities.CreateInstance<T>(scope.ServiceProvider);
             var task = expression.Compile()(service);
             await task;
         }


### PR DESCRIPTION
### Context

The TRS Console currently allows users to manage Change name and change date of birth requests which are stored as “Cases” in DQT.
As part of migrating from DQT, we need to move these to be stored as support tasks in TRS.

### Changes proposed in this pull request

Create a new record `ChangeDateOfBirthRequestData` in the `TeachingRecordSystem.Core.Models.SupportTaskData` namespace based on existing fields in `CreateDateOfBirthChangeRequestCommand` replacing `EvidenceFileUrl` with `EvidenceFileId`.

 Amend `CreateDateOfBirthChangeRequestHandler` to create a `SupportTask` of type `ChangeDateOfBirthRequest` populating the `Data` field with a `ChangeDateOfBirthRequestData` record populated from the incoming request (when the feature flag is enabled otherwise call the existing code which creates cases in DQT).

Considerations:
- The incoming request populates the `EvidenceFileUrl` with an expiring link to download uploaded evidence.
We need to use this URL to download the evidence and then re-upload it to the `uploads` container in Azure Blob Storage for TRS, storing the file ID returned from blob storage in the `ChangeDateOfBirthRequestData.EvidenceFileId` field.
- We need to replicate the call to send an email from the CRM plugin `CaseCreatedSendEmailPlugin` (using `INotificationSender` to send emails via Notify in TRS).
- This should be kept behind a feature flag.
