### PR TITLE
Add support for a secondary person ID in events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -14,7 +14,9 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.Property(e => e.Payload).IsRequired().HasColumnType("jsonb");
         builder.Property(e => e.Published);
         builder.HasKey(e => e.EventId);
+        builder.Property(e => e.PersonIds);
         builder.HasIndex(e => new { e.PersonId, e.EventName }).HasFilter("person_id is not null");
+        builder.HasIndex(e => new { e.PersonIds, e.EventName }).HasDatabaseName("ix_events_person_ids").HasMethod("gin").IsCreatedConcurrently();
         builder.HasIndex(e => new { e.EventName, e.Created }).IsCreatedConcurrently();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250801110135_EventPersonIds.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250801110135_EventPersonIds.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250801110135_EventPersonIds")]
+    partial class EventPersonIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250801110135_EventPersonIds.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250801110135_EventPersonIds.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class EventPersonIds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                CREATE EXTENSION IF NOT EXISTS pg_trgm;
+                CREATE EXTENSION IF NOT EXISTS btree_gin;
+                """);
+
+            migrationBuilder.Sql(
+                "alter table events add column if not exists person_ids uuid[] not null default '{}'::uuid[]");
+
+            migrationBuilder.Sql(
+                "create index concurrently if not exists ix_events_person_ids on events using gin (person_ids, event_name)",
+                suppressTransaction: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_events_person_ids",
+                table: "events");
+
+            migrationBuilder.DropColumn(
+                name: "person_ids",
+                table: "events");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/NpgsqlExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/NpgsqlExtensions.cs
@@ -56,6 +56,7 @@ public static class NpgsqlExtensions
             "inserted",
             "payload",
             "person_id",
+            "person_ids",
             "qualification_id",
             "alert_id"
         };
@@ -70,6 +71,7 @@ public static class NpgsqlExtensions
                 inserted TIMESTAMP WITH TIME ZONE NOT NULL,
                 payload JSONB NOT NULL,
                 person_id UUID,
+                person_ids UUID[],
                 qualification_id UUID,
                 alert_id UUID
             )
@@ -103,6 +105,7 @@ public static class NpgsqlExtensions
             writer.WriteValueOrNull(e.Inserted, NpgsqlDbType.TimestampTz);
             writer.WriteValueOrNull(e.Payload, NpgsqlDbType.Jsonb);
             writer.WriteValueOrNull(e.PersonId, NpgsqlDbType.Uuid);
+            writer.WriteValueOrNull(e.PersonIds, NpgsqlDbType.Uuid | NpgsqlDbType.Array);
             writer.WriteValueOrNull(e.QualificationId, NpgsqlDbType.Uuid);
             writer.WriteValueOrNull(e.AlertId, NpgsqlDbType.Uuid);
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithSecondaryPersonId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/IEventWithSecondaryPersonId.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public interface IEventWithSecondaryPersonId
+{
+    Guid SecondaryPersonId { get; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonsMergedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/PersonsMergedEvent.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.Core.Events.Models;
 
 namespace TeachingRecordSystem.Core.Events;
 
-public record PersonsMergedEvent : EventBase, IEventWithPersonAttributes
+public record PersonsMergedEvent : EventBase, IEventWithPersonAttributes, IEventWithSecondaryPersonId
 {
     public required Guid PersonId { get; init; }
     public required string PersonTrn { get; init; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -1386,8 +1386,6 @@ public class TrsDataSyncHelper(
 
     public async Task<int> SyncEventsAsync(IReadOnlyCollection<dfeta_TRSEvent> events, bool dryRun, CancellationToken cancellationToken = default)
     {
-        var modelTypeSyncInfo = GetModelTypeSyncInfo<EventInfo>(ModelTypes.Event);
-
         var mapped = events.Select(e => EventInfo.Deserialize(e.dfeta_Payload).Event).ToArray();
 
         await using var connection = await trsDbDataSource.OpenConnectionAsync(cancellationToken);

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -32,7 +32,7 @@ module "postgres" {
 
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_monitoring
-  azure_extensions               = ["pg_stat_statements"]
+  azure_extensions               = ["pg_stat_statements", "pg_trgm", "btree_gin", "btree_gist"]
   server_version                 = var.postgres_server_version
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_enable_high_availability = var.postgres_enable_high_availability


### PR DESCRIPTION
We have some events, notably `PersonsMergedEvent`, that relate to multiple Persons so our scalar `PersonId` event doesn't work. This adds a `PersonIds` property, an `IEventWithSecondaryPersonId` interface and updates the event mapping to populate it.

Subsequent PRs will follow to back-fill `PersonId`s, start using it, and finally to remove `PersonId`. 