### PR TITLE
Add UI to add a note

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/NoteMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/NoteMapping.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Mappings;
 
-public class DqtNoteMapping : IEntityTypeConfiguration<Note>
+public class NoteMapping : IEntityTypeConfiguration<Note>
 {
     public void Configure(EntityTypeBuilder<Note> builder)
     {
@@ -14,6 +14,7 @@ public class DqtNoteMapping : IEntityTypeConfiguration<Note>
         builder.Property(x => x.CreatedByDqtUserId).IsRequired(false);
         builder.Property(x => x.CreatedByDqtUserName).IsRequired(false);
         builder.Property(x => x.CreatedOn).IsRequired();
+        builder.HasOne(x => x.CreatedBy).WithMany().HasForeignKey(x => x.CreatedByUserId);
         builder.HasOne<Person>().WithMany().HasForeignKey(q => q.PersonId);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805162823_NoteCreatedBy.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805162823_NoteCreatedBy.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250805162823_NoteCreatedBy")]
+    partial class NoteCreatedBy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -3803,10 +3806,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("uuid")
                         .HasColumnName("note_id");
 
-                    b.Property<string>("Content")
-                        .HasColumnType("text")
-                        .HasColumnName("content");
-
                     b.Property<string>("ContentHtml")
                         .HasColumnType("text")
                         .HasColumnName("content_html");
@@ -3827,9 +3826,9 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("created_on");
 
-                    b.Property<Guid?>("FileId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("file_id");
+                    b.Property<string>("FileName")
+                        .HasColumnType("text")
+                        .HasColumnName("file_name");
 
                     b.Property<string>("OriginalFileName")
                         .HasColumnType("text")

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805162823_NoteCreatedBy.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805162823_NoteCreatedBy.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class NoteCreatedBy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "created_by_user_id",
+                table: "notes",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_notes_users_created_by_user_id",
+                table: "notes",
+                column: "created_by_user_id",
+                principalTable: "users",
+                principalColumn: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_notes_users_created_by_user_id",
+                table: "notes");
+
+            migrationBuilder.DropColumn(
+                name: "created_by_user_id",
+                table: "notes");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805165316_NoteFileId.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805165316_NoteFileId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250805165316_NoteFileId")]
+    partial class NoteFileId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -3803,10 +3806,6 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("uuid")
                         .HasColumnName("note_id");
 
-                    b.Property<string>("Content")
-                        .HasColumnType("text")
-                        .HasColumnName("content");
-
                     b.Property<string>("ContentHtml")
                         .HasColumnType("text")
                         .HasColumnName("content_html");
@@ -3827,9 +3826,9 @@ namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("created_on");
 
-                    b.Property<Guid?>("FileId")
+                    b.Property<Guid?>("FileName")
                         .HasColumnType("uuid")
-                        .HasColumnName("file_id");
+                        .HasColumnName("file_name");
 
                     b.Property<string>("OriginalFileName")
                         .HasColumnType("text")

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805165316_NoteFileId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250805165316_NoteFileId.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class NoteFileId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("alter table notes alter column file_name type uuid using file_name::uuid;");
+
+            migrationBuilder.RenameColumn(
+                name: "file_name",
+                table: "notes",
+                newName: "file_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "file_id",
+                table: "notes",
+                newName: "file_name");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "file_name",
+                table: "notes",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250806074708_NoteContent.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250806074708_NoteContent.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250806074708_NoteContent")]
+    partial class NoteContent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250806074708_NoteContent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250806074708_NoteContent.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class NoteContent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "content",
+                table: "notes",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "content",
+                table: "notes");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Note.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/Note.cs
@@ -1,0 +1,24 @@
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record Note
+{
+    public required Guid NoteId { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string Content { get; init; }
+    public required File? File { get; init; }
+
+    public static Note FromModel(Core.DataStore.Postgres.Models.Note model) =>
+        new()
+        {
+            NoteId = model.NoteId,
+            PersonId = model.PersonId,
+            Content = model.Content!,
+            File = model.FileId is not null ?
+                new File
+                {
+                    FileId = model.FileId!.Value,
+                    Name = model.OriginalFileName!
+                } :
+                null
+        };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/NoteCreatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/NoteCreatedEvent.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record NoteCreatedEvent : EventBase, IEventWithPersonId
+{
+    public required EventModels.Note Note { get; init; }
+    public Guid PersonId => Note.PersonId;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrsDataSync/TrsDataSyncHelper.cs
@@ -647,7 +647,7 @@ public class TrsDataSyncHelper(
             CreatedOn = annotation.CreatedOn!.Value,
             UpdatedByDqtUserId = annotation.ModifiedBy?.Id,
             UpdatedByDqtUserName = annotation.ModifiedBy?.Name,
-            FileName = null,
+            FileId = null,
             AttachmentBytes = string.IsNullOrEmpty(annotation.FileName) ? null : Convert.FromBase64String(annotation.DocumentBody),
             OriginalFileName = annotation.FileName,
             MimeType = annotation.MimeType,
@@ -1011,7 +1011,7 @@ public class TrsDataSyncHelper(
             {
                 //not interested if file exists or not
                 await fileService.DeleteFileAsync(fileId!.Value);
-                noteAttachment.FileName = null;
+                noteAttachment.FileId = null;
                 noteAttachment.OriginalFileName = null;
             }
 
@@ -1024,7 +1024,7 @@ public class TrsDataSyncHelper(
                 {
                     await fileService.UploadFileAsync(stream, noteAttachment.MimeType, noteAttachment.Id);
                     noteAttachment.OriginalFileName = noteAttachment.OriginalFileName;
-                    noteAttachment.FileName = fileId.ToString();
+                    noteAttachment.FileId = fileId;
                 }
             }
         }
@@ -2251,7 +2251,7 @@ public class TrsDataSyncHelper(
             "content_html",
             "created_on",
             "created_by_dqt_user_id",
-            "file_name",
+            "file_id",
             "original_file_name",
             "created_by_dqt_user_name",
             "updated_by_dqt_user_id",
@@ -2261,7 +2261,7 @@ public class TrsDataSyncHelper(
 
         var columnsToUpdate = new[] {
             "content_html",
-            "file_name",
+            "file_id",
             "original_file_name",
             "updated_on",
             "updated_by_dqt_user_id",
@@ -2279,7 +2279,7 @@ public class TrsDataSyncHelper(
                 content_html TEXT NULL,
                 created_on timestamp with time zone,
                 created_by_dqt_user_id uuid NOT NULL,
-                file_name TEXT NULL,
+                file_id UUID NULL,
                 original_file_name TEXT NULL,
                 created_by_dqt_user_name TEXT,
                 updated_by_dqt_user_name text NULL,
@@ -2325,7 +2325,7 @@ public class TrsDataSyncHelper(
             writer.WriteValueOrNull(note.ContentHtml, NpgsqlDbType.Text);
             writer.WriteValueOrNull(note.CreatedOn, NpgsqlDbType.TimestampTz);
             writer.WriteValueOrNull(note.CreatedByDqtUserId, NpgsqlDbType.Uuid);
-            writer.WriteValueOrNull(note.FileName, NpgsqlDbType.Text);
+            writer.WriteValueOrNull(note.FileId, NpgsqlDbType.Uuid);
             writer.WriteValueOrNull(note.OriginalFileName, NpgsqlDbType.Text);
             writer.WriteValueOrNull(note.CreatedByDqtUserName, NpgsqlDbType.Text);
             writer.WriteValueOrNull(note.UpdatedByDqtUserId, NpgsqlDbType.Uuid);
@@ -4673,7 +4673,7 @@ public class TrsDataSyncHelper(
         public required DateTime? UpdatedOn { get; set; }
         public required Guid? UpdatedByDqtUserId { get; set; }
         public required string? UpdatedByDqtUserName { get; set; }
-        public required string? FileName { get; set; }
+        public required Guid? FileId { get; set; }
         public required byte[]? AttachmentBytes { get; set; }
         public required string? OriginalFileName { get; set; }
         public required string? MimeType { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/HtmlHelperExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/HtmlHelperExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace TeachingRecordSystem.SupportUi;
+
+public static class HtmlHelperExtensions
+{
+    public static IHtmlContent ConvertNewlinesToLineBreaks(this IHtmlHelper htmlHelper, string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return HtmlString.Empty;
+        }
+
+        var htmlContent = text.Trim().Replace("\r", "").Replace("\n", "<br>");
+        return new HtmlString(htmlContent);
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/AddNote.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/AddNote.cshtml
@@ -1,0 +1,24 @@
+@page "/persons/{personId}/notes/add"
+@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.AddNote
+@{
+    ViewBag.Title = $"Add a note for {Model.PersonName}";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AddNote(Model.PersonId)" method="post">
+            <govuk-textarea for="Text" data-testid="text">
+                <govuk-textarea-label class="govuk-label--l" is-page-heading="true">@ViewBag.Title</govuk-textarea-label>
+            </govuk-textarea>
+
+            <govuk-file-upload for="File" input-accept=".bmp, .csv, .doc, .docx, .eml, .jpeg, .jpg, .mbox, .msg, .ods, .odt, .pdf, .png, .tif, .txt, .xls, .xlsx">
+                <govuk-file-upload-label>Upload a file (optional)</govuk-file-upload-label>
+            </govuk-file-upload>
+
+            <div class="govuk-button-group">
+                <govuk-button type="submit">Continue</govuk-button>
+                <govuk-button-link href="@LinkGenerator.PersonNotes(Model.PersonId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button-link>
+            </div>
+        </form>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/AddNote.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/AddNote.cshtml.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.SupportUi.Infrastructure.DataAnnotations;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail;
+
+[Authorize(Policy = AuthorizationPolicies.PersonDataEdit)]
+public class AddNote(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IFileService fileService, IClock clock) : PageModel
+{
+    [FromRoute]
+    public Guid PersonId { get; set; }
+
+    public string? PersonName { get; set; }
+
+    [BindProperty]
+    [Required(ErrorMessage = "Enter text for the note")]
+    public string? Text { get; set; }
+
+    [BindProperty]
+    [EvidenceFile]
+    [FileSize(FileUploadDefaults.MaxFileUploadSizeMb * 1024 * 1024, ErrorMessage = $"The selected file {FileUploadDefaults.MaxFileUploadSizeErrorMessage}")]
+    public new IFormFile? File { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        Guid? fileId = null;
+        if (File is not null)
+        {
+            await using var stream = File.OpenReadStream();
+            fileId = await fileService.UploadFileAsync(stream, File.ContentType);
+        }
+
+        var now = clock.UtcNow;
+
+        var note = new Core.DataStore.Postgres.Models.Note
+        {
+            NoteId = Guid.NewGuid(),
+            PersonId = PersonId,
+            Content = Text!,
+            UpdatedOn = now,
+            CreatedOn = now,
+            CreatedByUserId = User.GetUserId(),
+            FileId = fileId,
+            OriginalFileName = File?.FileName
+        };
+
+        var noteCreatedEvent = new NoteCreatedEvent
+        {
+            Note = EventModels.Note.FromModel(note),
+            EventId = Guid.NewGuid(),
+            CreatedUtc = now,
+            RaisedBy = User.GetUserId()
+        };
+
+        dbContext.Notes.Add(note);
+        await dbContext.AddEventAndBroadcastAsync(noteCreatedEvent);
+
+        await dbContext.SaveChangesAsync();
+
+        return Redirect(linkGenerator.PersonNotes(PersonId));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var currentPerson = HttpContext.GetCurrentPersonFeature();
+        PersonName = currentPerson.Name;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Notes.cshtml
@@ -2,7 +2,7 @@
 @using TeachingRecordSystem.Core.Dqt.Models
 @using TeachingRecordSystem.SupportUi.Pages.Common;
 @using TeachingRecordSystem.Core.Services.Files;
-@inject IFileService fileService;
+@inject IFileService FileService;
 @model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.NotesModel
 @{
     Layout = "Layout";
@@ -14,12 +14,9 @@
     <govuk-back-link href="@LinkGenerator.PersonDetail(person.PersonId)">Back to record</govuk-back-link>
 }
 
-<div>
-    <h2 class="govuk-heading-m">Notes</h2>
+<h2 class="govuk-heading-m">Notes</h2>
 
-</div>
-
-@if (Model.NotesNotVisibleFlag)
+@if (!Model.CanViewNotes)
 {
     <govuk-notification-banner data-testid="no-notes-permission">
         <p class="govuk-notification-banner__heading">
@@ -30,27 +27,33 @@
 }
 else
 {
-    @if (Model.Notes.Count() == 0)
+    <govuk-button-link href="@LinkGenerator.AddNote(person.PersonId)" data-testid="add-note-button">Add a note</govuk-button-link>
+
+    @if (Model.Notes!.Count == 0)
     {
-        <p class="govuk-body" data-testid="no-dqt-notes">There are no notes associated with this record</p>
+        <p class="govuk-body" data-testid="no-notes">There are no notes associated with this record</p>
     }
     else
     {
         foreach (var note in Model.Notes)
         {
-            var downloadUrl = await fileService.GetFileUrlAsync(note.NoteId, TimeSpan.FromMinutes(15));
-
-            <div data-testid="dqtnote">
-                <h3 class="govuk-heading-s">Added by <span data-testid="@note.NoteId-dqt-note-created-by">@note.CreatedByDqtUserName</span> on <span data-testid="@note.NoteId-dqt-note-created-on">@note.CreatedOn.ToString("dd MMMM yyyy 'at' HH:mm")</span></h3>
-                <div class="govuk-details" data-testid="@note.NoteId-dqt-note">
+            <div data-testid="note" class="govuk-!-margin-bottom-3">
+                <div class="govuk-heading-s">
+                    Added by <span data-testid="@note.NoteId-note-created-by">@note.CreatedBy</span>
+                    on <span data-testid="@note.NoteId-note-created-on">@note.CreatedOn.ToString($"{UiDefaults.DateOnlyDisplayFormat} 'at' HH:mm")</span>
+                </div>
+                <div class="govuk-details">
                     <div class="govuk-details__text">
-                        <p>
-                            <span data-testid="@note.NoteId-dqt-note-text">@note.Description</span>
+                        <p data-testid="@note.NoteId-note-text">
+                            @(Html.ConvertNewlinesToLineBreaks(note.Content))
                         </p>
-                        @if (note.OriginalFileName is not null)
+                        @if (note.FileId is Guid fileId)
                         {
-                            <h2 class="govuk-heading-s">Attached file</h2>
-                            <a href=@downloadUrl target="_blank" class="govuk-link"><span data-testid="@note.NoteId-dqt-note-file-name">@note.OriginalFileName</span> (opens in a new tab)</a>
+                            var downloadUrl = await FileService.GetFileUrlAsync(fileId, TimeSpan.FromMinutes(15));
+                            <div class="govuk-heading-s govuk-!-margin-bottom-0">Attached file</div>
+                            <a href=@downloadUrl target="_blank" class="govuk-link">
+                                <span data-testid="@note.NoteId-note-file-name">@note.OriginalFileName</span> (opens in a new tab)
+                            </a>
                         }
                     </div>
                 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -414,6 +414,9 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
     public string ResolveTrnRequestManualChecksNeededConfirm(string supportTaskReference) =>
         GetRequiredPathByPage("/SupportTasks/TrnRequestManualChecksNeeded/Resolve/Confirm", routeValues: new { supportTaskReference });
 
+    public string AddNote(Guid personId) =>
+        GetRequiredPathByPage("/Persons/PersonDetail/AddNote", routeValues: new { personId });
+
     private string GetRequiredPathByPage(string page, string? handler = null, object? routeValues = null, JourneyInstanceId? journeyInstanceId = null)
     {
         var url = linkGenerator.GetPathByPage(page, handler, values: routeValues) ?? throw new InvalidOperationException("Page was not found.");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.DqtNote.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/TrsDataSync/TrsDataSyncHelperTests.DqtNote.cs
@@ -43,7 +43,7 @@ public partial class TrsDataSyncHelperTests
         {
             var dqtNote = await dbContext.Notes.SingleOrDefaultAsync(p => p.NoteId == note.Id);
             Assert.NotNull(dqtNote);
-            Assert.Null(dqtNote.FileName);
+            Assert.Null(dqtNote.FileId);
             Assert.Equal(createPersonResult.PersonId, dqtNote.PersonId);
             Assert.Equal(noteText, dqtNote.ContentHtml);
             Assert.Equal(createdOn, dqtNote.CreatedOn);
@@ -102,7 +102,7 @@ public partial class TrsDataSyncHelperTests
         {
             var dqtNote = await dbContext.Notes.SingleOrDefaultAsync(p => p.NoteId == note.Id);
             Assert.NotNull(dqtNote);
-            Assert.Null(dqtNote.FileName);
+            Assert.Null(dqtNote.FileId);
             Assert.Equal(createPersonResult.PersonId, dqtNote.PersonId);
             Assert.Equal(updatedNoteText, dqtNote.ContentHtml);
             Assert.Equal(updatedDate, dqtNote.UpdatedOn);
@@ -154,7 +154,7 @@ public partial class TrsDataSyncHelperTests
         {
             var dqtNote = await dbContext.Notes.SingleOrDefaultAsync(p => p.NoteId == note.Id);
             Assert.NotNull(dqtNote);
-            Assert.Null(dqtNote.FileName);
+            Assert.Null(dqtNote.FileId);
             Assert.Equal(createPersonResult.PersonId, dqtNote.PersonId);
             Assert.Equal(createdOn, dqtNote.CreatedOn);
             Assert.Equal(noteText, dqtNote.ContentHtml);
@@ -245,7 +245,7 @@ public partial class TrsDataSyncHelperTests
         {
             var dqtNote = await dbContext.Notes.SingleOrDefaultAsync(p => p.NoteId == note.Id);
             Assert.NotNull(dqtNote);
-            Assert.NotNull(dqtNote.FileName);
+            Assert.NotNull(dqtNote.FileId);
             Assert.Equal(createPersonResult.PersonId, dqtNote.PersonId);
             Assert.Equal(noteText, dqtNote.ContentHtml);
             //updatedon defaults to createdon
@@ -313,7 +313,7 @@ public partial class TrsDataSyncHelperTests
             Assert.Equal(note.CreatedBy.Id, dqtNote.CreatedByDqtUserId);
             Assert.Equal(note.ModifiedBy!.Id, dqtNote.UpdatedByDqtUserId);
             Assert.Null(dqtNote.OriginalFileName);
-            Assert.Null(dqtNote.FileName);
+            Assert.Null(dqtNote.FileId);
             Assert.Equal(createdByDqtUserName, dqtNote.CreatedByDqtUserName);
             Assert.Equal(updatedByDqtUserName, dqtNote.UpdatedByDqtUserName);
             BlobStorageFileService.Verify(x => x.UploadFileAsync(It.IsAny<Stream>(), It.IsAny<string>(), note.Id), Times.Once());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AddNoteTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AddNoteTests.cs
@@ -1,0 +1,103 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
+
+public class AddNoteTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Post_ContentIsEmpty_ReturnsError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/notes/add")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Text", "" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, "Text", "Enter text for the note");
+    }
+
+    [Fact]
+    public async Task Post_ContentWithoutFile_CreatesNoteAndEventAndRedirects()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var text = Faker.Lorem.Paragraph();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/notes/add")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Text", text }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/notes", response.Headers.Location?.OriginalString);
+
+        var note = await WithDbContext(dbContext => dbContext.Notes.SingleOrDefaultAsync(n => n.PersonId == person.PersonId));
+        Assert.NotNull(note);
+        Assert.Equal(text, note.Content);
+        Assert.Null(note.FileId);
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var noteCreatedEvent = Assert.IsType<NoteCreatedEvent>(e);
+            Assert.Equal(note.NoteId, noteCreatedEvent.Note.NoteId);
+            Assert.Equal(person.PersonId, noteCreatedEvent.Note.PersonId);
+            Assert.Equal(GetCurrentUserId(), noteCreatedEvent.RaisedBy);
+            Assert.Equal(text, noteCreatedEvent.Note.Content);
+        });
+    }
+
+    [Fact]
+    public async Task Post_ContentWithFile_CreatesNoteAndEventAndRedirects()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+
+        var text = Faker.Lorem.Paragraph();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/notes/add")
+        {
+            Content = new MultipartFormDataContentBuilder
+            {
+                { "Text", text },
+                { "File", CreateEvidenceFileBinaryContent(), "Attachment.jpeg" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/notes", response.Headers.Location?.OriginalString);
+
+        var note = await WithDbContext(dbContext => dbContext.Notes.SingleOrDefaultAsync(n => n.PersonId == person.PersonId));
+        Assert.NotNull(note);
+        Assert.Equal(text, note.Content);
+        Assert.NotNull(note.FileId);
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            var noteCreatedEvent = Assert.IsType<NoteCreatedEvent>(e);
+            Assert.Equal(note.NoteId, noteCreatedEvent.Note.NoteId);
+            Assert.Equal(person.PersonId, noteCreatedEvent.Note.PersonId);
+            Assert.Equal(GetCurrentUserId(), noteCreatedEvent.RaisedBy);
+            Assert.Equal(text, noteCreatedEvent.Note.Content);
+            Assert.NotNull(noteCreatedEvent.Note.File);
+        });
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/NotesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/NotesTests.cs
@@ -2,13 +2,8 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
 
-public class NotesTests : TestBase
+public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    public NotesTests(HostFixture hostFixture)
-        : base(hostFixture)
-    {
-    }
-
     [Fact]
     public async Task Get_PersonDoesNotExist_ReturnsNotFound()
     {
@@ -37,7 +32,7 @@ public class NotesTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var noNotesMessage = doc.GetElementByTestId("no-dqt-notes");
+        var noNotesMessage = doc.GetElementByTestId("no-notes");
         Assert.NotNull(noNotesMessage);
         Assert.Equal("There are no notes associated with this record", noNotesMessage.TrimmedText());
     }
@@ -56,8 +51,8 @@ public class NotesTests : TestBase
         var expectedNoteText = "Note without attachment";
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
-        var note1 = await TestData.CreateNoteAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
-        var note2 = await TestData.CreateNoteAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
+        var note1 = await TestData.CreateNoteFromDqtAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
+        var note2 = await TestData.CreateNoteFromDqtAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/notes");
 
@@ -66,11 +61,11 @@ public class NotesTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var notes = doc.GetAllElementsByTestId("dqtnote");
+        var notes = doc.GetAllElementsByTestId("note");
         Assert.Collection(notes,
-            n => Assert.Equal(expectedNoteText, n.GetElementByTestId($"{note1.NoteId}-dqt-note-text")?.TrimmedText()),
-            n => Assert.Equal(expectedNoteText, n.GetElementByTestId($"{note2.NoteId}-dqt-note-text")?.TrimmedText()));
-        var note2Text = doc.GetElementByTestId($"{note2.NoteId}-dqt-note-text");
+            n => Assert.Equal(expectedNoteText, n.GetElementByTestId($"{note1.NoteId}-note-text")?.TrimmedText()),
+            n => Assert.Equal(expectedNoteText, n.GetElementByTestId($"{note2.NoteId}-note-text")?.TrimmedText()));
+        var note2Text = doc.GetElementByTestId($"{note2.NoteId}-note-text");
     }
 
     [Fact]
@@ -89,8 +84,8 @@ public class NotesTests : TestBase
         var expectedNoteText = "Note without attachment";
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
-        var note1 = await TestData.CreateNoteAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
-        var note2 = await TestData.CreateNoteAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
+        var note1 = await TestData.CreateNoteFromDqtAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
+        var note2 = await TestData.CreateNoteFromDqtAsync(person.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/notes");
 
@@ -100,7 +95,7 @@ public class NotesTests : TestBase
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
         var flag = doc.GetElementByTestId("no-notes-permission");
-        var notes = doc.GetAllElementsByTestId("dqtnote");
+        var notes = doc.GetAllElementsByTestId("note");
         Assert.NotNull(flag);
         Assert.Empty(notes);
     }
@@ -113,7 +108,7 @@ public class NotesTests : TestBase
         var expectedNoteText = "Note without attachment";
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
-        var note = await TestData.CreateNoteAsync(createPersonResult.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
+        var note = await TestData.CreateNoteFromDqtAsync(createPersonResult.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}/notes");
 
@@ -122,18 +117,18 @@ public class NotesTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var noNotesMessage = doc.GetElementByTestId("no-dqt-notes");
+        var noNotesMessage = doc.GetElementByTestId("no-notes");
         Assert.Null(noNotesMessage);
-        var createdby = doc.GetElementByTestId($"{note.NoteId}-dqt-note-created-by");
-        Assert.NotNull(createdby);
-        Assert.Equal(expectedCreatedBy, createdby.TrimmedText());
-        var createddate = doc.GetElementByTestId($"{note.NoteId}-dqt-note-created-on");
-        Assert.NotNull(createddate);
-        Assert.Equal(note.CreatedOn.ToString("dd MMMM yyyy 'at' HH:mm"), createddate.TrimmedText());
-        var noteText = doc.GetElementByTestId($"{note.NoteId}-dqt-note-text");
+        var createdBy = doc.GetElementByTestId($"{note.NoteId}-note-created-by");
+        Assert.NotNull(createdBy);
+        Assert.Equal(expectedCreatedBy, createdBy.TrimmedText());
+        var createdDate = doc.GetElementByTestId($"{note.NoteId}-note-created-on");
+        Assert.NotNull(createdDate);
+        Assert.Equal(note.CreatedOn.ToString($"{UiDefaults.DateOnlyDisplayFormat} 'at' HH:mm"), createdDate.TrimmedText());
+        var noteText = doc.GetElementByTestId($"{note.NoteId}-note-text");
         Assert.NotNull(noteText);
         Assert.Equal(expectedNoteText, noteText.TrimmedText());
-        var originalFileName = doc.GetElementByTestId($"{note.NoteId}-dqt-note-file-name");
+        var originalFileName = doc.GetElementByTestId($"{note.NoteId}-note-file-name");
         Assert.Null(originalFileName);
     }
 
@@ -146,7 +141,7 @@ public class NotesTests : TestBase
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
         var expectedOriginalFileName = "file.png";
-        var note = await TestData.CreateNoteAsync(createPersonResult.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, expectedOriginalFileName, Guid.NewGuid());
+        var note = await TestData.CreateNoteFromDqtAsync(createPersonResult.ContactId, expectedNoteText, createdByUserId, expectedCreatedBy, expectedOriginalFileName, Guid.NewGuid());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}/notes");
 
@@ -155,18 +150,18 @@ public class NotesTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var noNotesMessage = doc.GetElementByTestId("no-dqt-notes");
+        var noNotesMessage = doc.GetElementByTestId("no-notes");
         Assert.Null(noNotesMessage);
-        var createdby = doc.GetElementByTestId($"{note.NoteId}-dqt-note-created-by");
-        Assert.NotNull(createdby);
-        Assert.Equal(expectedCreatedBy, createdby.TrimmedText());
-        var createddate = doc.GetElementByTestId($"{note.NoteId}-dqt-note-created-on");
-        Assert.NotNull(createddate);
-        Assert.Equal(note.CreatedOn.ToString("dd MMMM yyyy 'at' HH:mm"), createddate.TrimmedText());
-        var noteText = doc.GetElementByTestId($"{note.NoteId}-dqt-note-text");
+        var createdBy = doc.GetElementByTestId($"{note.NoteId}-note-created-by");
+        Assert.NotNull(createdBy);
+        Assert.Equal(expectedCreatedBy, createdBy.TrimmedText());
+        var createdDate = doc.GetElementByTestId($"{note.NoteId}-note-created-on");
+        Assert.NotNull(createdDate);
+        Assert.Equal(note.CreatedOn.ToString($"{UiDefaults.DateOnlyDisplayFormat} 'at' HH:mm"), createdDate.TrimmedText());
+        var noteText = doc.GetElementByTestId($"{note.NoteId}-note-text");
         Assert.NotNull(noteText);
         Assert.Equal(expectedNoteText, noteText.TrimmedText());
-        var originalFileName = doc.GetElementByTestId($"{note.NoteId}-dqt-note-file-name");
+        var originalFileName = doc.GetElementByTestId($"{note.NoteId}-note-file-name");
         Assert.NotNull(originalFileName);
         Assert.Equal(expectedOriginalFileName, originalFileName.TrimmedText());
     }
@@ -181,7 +176,7 @@ public class NotesTests : TestBase
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
         var expectedOriginalFileName = "file.png";
-        var note = await TestData.CreateNoteAsync(createPersonResult.ContactId, htmlNote, createdByUserId, expectedCreatedBy, expectedOriginalFileName, null);
+        var note = await TestData.CreateNoteFromDqtAsync(createPersonResult.ContactId, htmlNote, createdByUserId, expectedCreatedBy, expectedOriginalFileName, null);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}/notes");
 
@@ -190,7 +185,7 @@ public class NotesTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var noteText = doc.GetElementByTestId($"{note.NoteId}-dqt-note-text");
+        var noteText = doc.GetElementByTestId($"{note.NoteId}-note-text");
         Assert.NotNull(noteText);
         Assert.Equal(expectedNoteText, noteText.TrimmedText());
     }
@@ -210,8 +205,8 @@ public class NotesTests : TestBase
         var createdByUserId2 = Guid.NewGuid();
         var expectedOriginalFileName2 = "file2.png";
         var expectedCreatedDate2 = Clock.UtcNow;
-        var note1 = await TestData.CreateNoteAsync(createPersonResult.ContactId, expectedNoteText1, createdByUserId1, expectedCreatedBy1, expectedOriginalFileName1, Guid.NewGuid(), expectedCreatedDate1);
-        var note2 = await TestData.CreateNoteAsync(createPersonResult.ContactId, expectedNoteText2, createdByUserId2, expectedCreatedBy2, expectedOriginalFileName2, Guid.NewGuid(), expectedCreatedDate2);
+        var note1 = await TestData.CreateNoteFromDqtAsync(createPersonResult.ContactId, expectedNoteText1, createdByUserId1, expectedCreatedBy1, expectedOriginalFileName1, Guid.NewGuid(), expectedCreatedDate1);
+        var note2 = await TestData.CreateNoteFromDqtAsync(createPersonResult.ContactId, expectedNoteText2, createdByUserId2, expectedCreatedBy2, expectedOriginalFileName2, Guid.NewGuid(), expectedCreatedDate2);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}/notes");
 
         // Act
@@ -219,35 +214,35 @@ public class NotesTests : TestBase
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var notes = doc.GetAllElementsByTestId("dqtnote");
+        var notes = doc.GetAllElementsByTestId("note");
         Assert.Collection(notes,
             item1 =>
             {
-                var createdby = item1.GetElementByTestId($"{note2.NoteId}-dqt-note-created-by");
-                Assert.NotNull(createdby);
-                Assert.Equal(expectedCreatedBy2, createdby.TrimmedText());
-                var createddate = item1.GetElementByTestId($"{note2.NoteId}-dqt-note-created-on");
-                Assert.NotNull(createddate);
-                Assert.Equal(note2.CreatedOn.ToString("dd MMMM yyyy 'at' HH:mm"), createddate.TrimmedText());
-                var noteText = item1.GetElementByTestId($"{note2.NoteId}-dqt-note-text");
+                var createdBy = item1.GetElementByTestId($"{note2.NoteId}-note-created-by");
+                Assert.NotNull(createdBy);
+                Assert.Equal(expectedCreatedBy2, createdBy.TrimmedText());
+                var createdDate = item1.GetElementByTestId($"{note2.NoteId}-note-created-on");
+                Assert.NotNull(createdDate);
+                Assert.Equal(note2.CreatedOn.ToString($"{UiDefaults.DateOnlyDisplayFormat} 'at' HH:mm"), createdDate.TrimmedText());
+                var noteText = item1.GetElementByTestId($"{note2.NoteId}-note-text");
                 Assert.NotNull(noteText);
                 Assert.Equal(expectedNoteText2, noteText.TrimmedText());
-                var originalFileName = item1.GetElementByTestId($"{note2.NoteId}-dqt-note-file-name");
+                var originalFileName = item1.GetElementByTestId($"{note2.NoteId}-note-file-name");
                 Assert.NotNull(originalFileName);
                 Assert.Equal(expectedOriginalFileName2, originalFileName.TrimmedText());
             },
             item2 =>
             {
-                var createdby = item2.GetElementByTestId($"{note1.NoteId}-dqt-note-created-by");
-                Assert.NotNull(createdby);
-                Assert.Equal(expectedCreatedBy1, createdby.TrimmedText());
-                var createddate = item2.GetElementByTestId($"{note1.NoteId}-dqt-note-created-on");
-                Assert.NotNull(createddate);
-                Assert.Equal(note1.CreatedOn.ToString("dd MMMM yyyy 'at' HH:mm"), createddate.TrimmedText());
-                var noteText = item2.GetElementByTestId($"{note1.NoteId}-dqt-note-text");
+                var createdBy = item2.GetElementByTestId($"{note1.NoteId}-note-created-by");
+                Assert.NotNull(createdBy);
+                Assert.Equal(expectedCreatedBy1, createdBy.TrimmedText());
+                var createdDate = item2.GetElementByTestId($"{note1.NoteId}-note-created-on");
+                Assert.NotNull(createdDate);
+                Assert.Equal(note1.CreatedOn.ToString($"{UiDefaults.DateOnlyDisplayFormat} 'at' HH:mm"), createdDate.TrimmedText());
+                var noteText = item2.GetElementByTestId($"{note1.NoteId}-note-text");
                 Assert.NotNull(noteText);
                 Assert.Equal(expectedNoteText1, noteText.TrimmedText());
-                var originalFileName = item2.GetElementByTestId($"{note1.NoteId}-dqt-note-file-name");
+                var originalFileName = item2.GetElementByTestId($"{note1.NoteId}-note-file-name");
                 Assert.NotNull(originalFileName);
                 Assert.Equal(expectedOriginalFileName1, originalFileName.TrimmedText());
             });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
@@ -10,7 +10,12 @@ public class ConfirmTests : TestBase, IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        await WithDbContext(async dbContext =>
+        {
+            await dbContext.Notes.ExecuteDeleteAsync();
+            await dbContext.Users.ExecuteDeleteAsync();
+        });
+
         TestUsers.ClearCache();
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/IndexTests.cs
@@ -10,7 +10,12 @@ public class IndexTests : TestBase, IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        await WithDbContext(async dbContext =>
+        {
+            await dbContext.Notes.ExecuteDeleteAsync();
+            await dbContext.Users.ExecuteDeleteAsync();
+        });
+
         TestUsers.ClearCache();
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
@@ -13,7 +13,12 @@ public class DeactivateTests : TestBase, IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        await WithDbContext(async dbContext =>
+        {
+            await dbContext.Notes.ExecuteDeleteAsync();
+            await dbContext.Users.ExecuteDeleteAsync();
+        });
+
         TestUsers.ClearCache();
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/IndexTests.cs
@@ -10,7 +10,12 @@ public class IndexTests : TestBase, IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        await WithDbContext(async dbContext =>
+        {
+            await dbContext.Notes.ExecuteDeleteAsync();
+            await dbContext.Users.ExecuteDeleteAsync();
+        });
+
         TestUsers.ClearCache();
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/UsersTests.cs
@@ -14,7 +14,12 @@ public class UsersTests : TestBase, IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        await WithDbContext(dbContext => dbContext.Users.ExecuteDeleteAsync());
+        await WithDbContext(async dbContext =>
+        {
+            await dbContext.Notes.ExecuteDeleteAsync();
+            await dbContext.Users.ExecuteDeleteAsync();
+        });
+
         TestUsers.ClearCache();
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateDqtNote.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateDqtNote.cs
@@ -4,21 +4,35 @@ namespace TeachingRecordSystem.TestCommon;
 
 public partial class TestData
 {
-    public Task<Note> CreateNoteAsync(Guid personId, string noteText, Guid createdByUserId, string? createdByUserName, string? originalFileName, Guid? fileName, DateTime? createDate = null) => WithDbContextAsync(async dbContext =>
+    public Task<Note> CreateNoteFromDqtAsync(
+            Guid personId,
+            string contentHtml,
+            Guid createdByUserId,
+            string? createdByUserName,
+            string? originalFileName,
+            Guid? fileName,
+            DateTime? createdDate = null) =>
+        WithDbContextAsync(async dbContext =>
     {
-        var note = new Note()
+        var noteId = Guid.NewGuid();
+
+        var note = new Note
         {
-            NoteId = Guid.NewGuid(),
+            NoteId = noteId,
             PersonId = personId,
-            ContentHtml = noteText,
+            ContentHtml = contentHtml,
             CreatedByDqtUserName = createdByUserName ?? GenerateName(),
             CreatedByDqtUserId = createdByUserId,
-            CreatedOn = createDate ?? Clock.UtcNow,
+            CreatedOn = createdDate ?? Clock.UtcNow,
             UpdatedByDqtUserId = null,
             UpdatedOn = null,
             UpdatedByDqtUserName = null,
             OriginalFileName = originalFileName,
-            FileName = fileName?.ToString()
+            FileId = originalFileName is not null
+                ? noteId
+                : null,
+            Content = null,
+            CreatedByUserId = null
         };
 
         dbContext.Notes.Add(note);


### PR DESCRIPTION
This also amends the notes view to preserve line breaks when rendering out notes. I'm not 100% sure all the HTML content we have from DQT will render correctly but we can tweak things later on.

For now I've added a separate column for plaintext content; notes from DQT will have HTML and notes created via this process will have plaintext content. We can look at consolidating those two columns later.

https://trello.com/c/7sEBSPDF/1407-create-functionality-to-add-new-notes-through-the-trs-console