### PR TITLE
Rewire reject page for name and DOB change requests to use TRS support tasks

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskCancelledEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskCancelledEvent.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record ChangeDateOfBirthRequestSupportTaskCancelledEvent : SupportTaskUpdatedEvent
+{
+    public required EventModels.ChangeDateOfBirthRequestData RequestData { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskRejectedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskRejectedEvent.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record ChangeDateOfBirthRequestSupportTaskRejectedEvent : SupportTaskUpdatedEvent
+{
+    public required EventModels.ChangeDateOfBirthRequestData RequestData { get; init; }
+    public required string? RejectionReason { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskCancelledEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskCancelledEvent.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record ChangeNameRequestSupportTaskCancelledEvent : SupportTaskUpdatedEvent
+{
+    public required EventModels.ChangeNameRequestData RequestData { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskRejectedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskRejectedEvent.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record ChangeNameRequestSupportTaskRejectedEvent : SupportTaskUpdatedEvent
+{
+    public required EventModels.ChangeNameRequestData RequestData { get; init; }
+    public required string? RejectionReason { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ChangeDateOfBirthRequestData.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ChangeDateOfBirthRequestData.cs
@@ -1,0 +1,22 @@
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record ChangeDateOfBirthRequestData
+{
+    public required DateOnly DateOfBirth { get; init; }
+    public required Guid EvidenceFileId { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required string? EmailAddress { get; init; }
+    public required SupportRequestOutcome? ChangeRequestOutcome { get; init; }
+
+    public static ChangeDateOfBirthRequestData FromModel(Core.Models.SupportTaskData.ChangeDateOfBirthRequestData model) =>
+        new()
+        {
+            DateOfBirth = model.DateOfBirth,
+            EvidenceFileId = model.EvidenceFileId,
+            EvidenceFileName = model.EvidenceFileName,
+            EmailAddress = model.EmailAddress,
+            ChangeRequestOutcome = model.ChangeRequestOutcome
+        };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ChangeNameRequestData.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/ChangeNameRequestData.cs
@@ -1,0 +1,26 @@
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+
+namespace TeachingRecordSystem.Core.Events.Models;
+
+public record ChangeNameRequestData
+{
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required Guid EvidenceFileId { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required string? EmailAddress { get; init; }
+    public required SupportRequestOutcome? ChangeRequestOutcome { get; init; }
+
+    public static ChangeNameRequestData FromModel(Core.Models.SupportTaskData.ChangeNameRequestData model) =>
+        new()
+        {
+            FirstName = model.FirstName,
+            MiddleName = model.MiddleName,
+            LastName = model.LastName,
+            EvidenceFileId = model.EvidenceFileId,
+            EvidenceFileName = model.EvidenceFileName,
+            EmailAddress = model.EmailAddress,
+            ChangeRequestOutcome = model.ChangeRequestOutcome
+        };
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestEmailConstants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestEmailConstants.cs
@@ -3,7 +3,9 @@ namespace TeachingRecordSystem.Core.Models.SupportTaskData;
 public static class ChangeRequestEmailConstants
 {
     public const string GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId = "d83d28e8-fc4c-4728-ac62-e58a0dd1622e";
+    public const string GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId = "96ed1a90-3398-4f96-bd37-eedf18297337";
     public const string GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId = "664fd278-3af8-4011-9f58-b4d44c733402";
+    public const string GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId = "bee1f8b8-fcb2-4e47-876d-509e60064bd4";
     public const string FirstNameEmailPersonalisationKey = "first name";
     public const string EmailReplyToId = "3ac9a271-449e-4fc6-8bba-2acd833d6901";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml
@@ -1,4 +1,4 @@
-@page "/change-requests/{ticketNumber}/reject"
+@page "/change-requests/{supportTaskReference}/reject"
 @using static TeachingRecordSystem.SupportUi.Pages.ChangeRequests.EditChangeRequest.RejectModel;
 @model TeachingRecordSystem.SupportUi.Pages.ChangeRequests.EditChangeRequest.RejectModel
 @{
@@ -6,15 +6,15 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.EditChangeRequest(Model.TicketNumber)" />
+    <govuk-back-link href="@LinkGenerator.EditChangeRequest(Model.SupportTaskReference)" />
 }
 
-<span class="govuk-caption-l">@Model.ChangeType - @Model.PersonName</span>
+<span class="govuk-caption-l">@(Model.ChangeType == SupportTaskType.ChangeNameRequest ? "Change of Name" : "Change of Date of Birth") - @Model.PersonName</span>
 <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">        
-        <form action="@LinkGenerator.RejectChangeRequest(Model.TicketNumber)" method="post">
+        <form action="@LinkGenerator.RejectChangeRequest(Model.SupportTaskReference)" method="post">
             <govuk-radios asp-for="RejectionReasonChoice">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -177,7 +177,7 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
 
     public string AcceptChangeRequest(string ticketNumber) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Accept", routeValues: new { ticketNumber });
 
-    public string RejectChangeRequest(string ticketNumber) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Reject", routeValues: new { ticketNumber });
+    public string RejectChangeRequest(string supportTaskReference) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Reject", routeValues: new { supportTaskReference });
 
     public string MqAdd(Guid personId) =>
         GetRequiredPathByPage("/Mqs/AddMq/Index", routeValues: new { personId });
@@ -323,13 +323,14 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
         GetRequiredPathByPage("/SupportTasks/Index", routeValues: new { category = categories, sortBy, reference, _f = filtersApplied == true ? "1" : null });
 
     public string SupportTaskDetail(string supportTaskReference, SupportTaskType supportTaskType) =>
-        supportTaskReference.StartsWith("CAS-") ? EditChangeRequest(supportTaskReference) :
         supportTaskType switch
         {
             SupportTaskType.ConnectOneLoginUser => ConnectOneLoginUserSupportTask(supportTaskReference),
             SupportTaskType.ApiTrnRequest => ApiTrnRequestMatches(supportTaskReference),
             SupportTaskType.TrnRequestManualChecksNeeded => ResolveTrnRequestManualChecksNeeded(supportTaskReference),
             SupportTaskType.NpqTrnRequest => NpqTrnRequestDetailsPage(supportTaskReference),
+            SupportTaskType.ChangeDateOfBirthRequest => EditChangeRequest(supportTaskReference),
+            SupportTaskType.ChangeNameRequest => EditChangeRequest(supportTaskReference),
             _ => throw new ArgumentException($"Unknown {nameof(SupportTaskType)}: '{supportTaskType}'.", nameof(supportTaskType))
         };
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ChangeRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ChangeRequestTests.cs
@@ -7,7 +7,7 @@ public class ChangeRequestTests : TestBase
     {
     }
 
-    [Theory(Skip = "Will re-enable once Accept page has been changed to use TRS support task")]
+    [Theory(Skip = "Will re-enable once Support Tasks Index and Accept page has been changed to use TRS support task")]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndApprove(bool isNameChange)
@@ -47,22 +47,26 @@ public class ChangeRequestTests : TestBase
         await page.AssertFlashMessageAsync("The request has been accepted");
     }
 
-    [Theory(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
+    [Theory(Skip = "Will re-enable once Support Tasks Index and Reject page has been changed to use TRS support task")]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndReject(bool isNameChange)
     {
         var createPersonResult = await TestData.CreatePersonAsync();
-        string caseReference;
+        string supportTaskReference;
         if (isNameChange)
         {
-            var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
-            caseReference = createIncidentResult.TicketNumber;
+            var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
+            supportTaskReference = supportTask.SupportTaskReference;
         }
         else
         {
-            var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
-            caseReference = createIncidentResult.TicketNumber;
+            var supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
+            supportTaskReference = supportTask.SupportTaskReference;
         }
 
         await using var context = await HostFixture.CreateBrowserContext();
@@ -72,13 +76,13 @@ public class ChangeRequestTests : TestBase
 
         await page.AssertOnSupportTasksPageAsync();
 
-        await page.ClickCaseReferenceLinkChangeRequestsPageAsync(caseReference);
+        await page.ClickCaseReferenceLinkChangeRequestsPageAsync(supportTaskReference);
 
-        await page.AssertOnChangeRequestDetailPageAsync(caseReference);
+        await page.AssertOnChangeRequestDetailPageAsync(supportTaskReference);
 
         await page.ClickRejectChangeButtonAsync();
 
-        await page.AssertOnRejectChangeRequestPageAsync(caseReference);
+        await page.AssertOnRejectChangeRequestPageAsync(supportTaskReference);
 
         await page.CheckAsync("label:text-is('Request and proof don’t match')");
 
@@ -89,22 +93,26 @@ public class ChangeRequestTests : TestBase
         await page.AssertFlashMessageAsync("The request has been rejected");
     }
 
-    [Theory(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
+    [Theory(Skip = "Will re-enable once Support Tasks Index and Reject page has been changed to use TRS support task")]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndCancel(bool isNameChange)
     {
         var createPersonResult = await TestData.CreatePersonAsync();
-        string caseReference;
+        string supportTaskReference;
         if (isNameChange)
         {
-            var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
-            caseReference = createIncidentResult.TicketNumber;
+            var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
+            supportTaskReference = supportTask.SupportTaskReference;
         }
         else
         {
-            var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
-            caseReference = createIncidentResult.TicketNumber;
+            var supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
+            supportTaskReference = supportTask.SupportTaskReference;
         }
 
         await using var context = await HostFixture.CreateBrowserContext();
@@ -112,13 +120,13 @@ public class ChangeRequestTests : TestBase
 
         await page.GotoAsync("/support-tasks");
 
-        await page.ClickCaseReferenceLinkChangeRequestsPageAsync(caseReference);
+        await page.ClickCaseReferenceLinkChangeRequestsPageAsync(supportTaskReference);
 
-        await page.AssertOnChangeRequestDetailPageAsync(caseReference);
+        await page.AssertOnChangeRequestDetailPageAsync(supportTaskReference);
 
         await page.ClickRejectChangeButtonAsync();
 
-        await page.AssertOnRejectChangeRequestPageAsync(caseReference);
+        await page.AssertOnRejectChangeRequestPageAsync(supportTaskReference);
 
         await page.CheckAsync("label:text-is('Change no longer required')");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -8,6 +8,7 @@ using TeachingRecordSystem.Core.Dqt;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.Notify;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
@@ -75,6 +76,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<ReferenceDataCache, TestReferenceDataCache>();
             services.AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>();
             services.AddTestScoped<IOptions<TrnRequestOptions>>(tss => Options.Create(tss.TrnRequestOptions));
+            services.AddSingleton<INotificationSender, NoopNotificationSender>();
         });
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/IndexTests.cs
@@ -65,7 +65,7 @@ public class IndexTests : TestBase
     }
 
     [Fact]
-    public async Task Get_WithSupportTaskReferenceForClosedSupportTask_ReturnsBadRequest()
+    public async Task Get_WithSupportTaskReferenceForClosedSupportTask_ReturnsNotFound()
     {
         // Arrange
         var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
@@ -1,3 +1,6 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ChangeRequests.EditChangeRequest;
 
 public class RejectTests : TestBase
@@ -8,15 +11,17 @@ public class RejectTests : TestBase
         SetCurrentUser(TestUsers.GetUser(UserRoles.RecordManager));
     }
 
-    [Fact(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
+    [Fact]
     public async Task Get_WhenUserHasNoRoles_ReturnsForbidden()
     {
         // Arrange
         SetCurrentUser(TestUsers.GetUser(role: null));
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{createIncidentResult.TicketNumber}/reject");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -25,16 +30,18 @@ public class RejectTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
-    [Theory(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
+    [Theory]
     [RoleNamesData(except: [UserRoles.RecordManager, UserRoles.AccessManager, UserRoles.Administrator])]
     public async Task Get_WhenUserDoesNotHaveSupportOfficerOrAccessManagerOrAdministratorRole_ReturnsForbidden(string role)
     {
         // Arrange
         SetCurrentUser(TestUsers.GetUser(role));
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{createIncidentResult.TicketNumber}/reject");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -43,13 +50,13 @@ public class RejectTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
-    [Fact(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
-    public async Task Get_WithTicketNumberForNonExistentIncident_ReturnsNotFound()
+    [Fact]
+    public async Task Get_WithSupportTaskReferenceForNonExistentSupportTask_ReturnsNotFound()
     {
         // Arrange
-        var nonExistentTicketNumber = Guid.NewGuid().ToString();
+        var nonExistentSupportTaskReference = Guid.NewGuid().ToString();
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{nonExistentTicketNumber}/reject");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{nonExistentSupportTaskReference}/reject");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -58,30 +65,34 @@ public class RejectTests : TestBase
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
     }
 
-    [Fact(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
-    public async Task Get_WithTicketNumberForInactiveIncident_ReturnsBadRequest()
+    [Fact]
+    public async Task Get_WithSupportTaskReferenceForClosedSupportTask_ReturnsNotFound()
     {
         // Arrange
         var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId).WithCanceledStatus());
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)).WithStatus(SupportTaskStatus.Closed));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{createIncidentResult.TicketNumber}/reject");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}/reject");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
     }
 
-    [Fact(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
+    [Fact]
     public async Task Post_WhenRejectionReasonChoiceHasNoSelection_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        var supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{createIncidentResult.TicketNumber}/reject")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{supportTask.SupportTaskReference}/reject")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -93,16 +104,18 @@ public class RejectTests : TestBase
         await AssertEx.HtmlResponseHasErrorAsync(response, "RejectionReasonChoice", "Select the reason for rejecting this change");
     }
 
-    [Theory(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
+    [Theory]
     [RoleNamesData(except: [UserRoles.RecordManager, UserRoles.AccessManager, UserRoles.Administrator])]
     public async Task Post_WhenUserDoesNotHaveSupportOfficerOrAccessManagerOrAdministratorRole_ReturnsForbidden(string role)
     {
         // Arrange
         SetCurrentUser(TestUsers.GetUser(role));
         var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{createIncidentResult.TicketNumber}/reject")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{supportTask.SupportTaskReference}/reject")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -117,14 +130,30 @@ public class RejectTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
-    [Fact(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
-    public async Task Post_WhenRejectionReasonChoiceIsNotChangeNoLongerRequired_RedirectsWithFlashMessage()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_WhenRejectionReasonChoiceIsNotChangeNoLongerRequired_RedirectsWithFlashMessage(bool isNameChange)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        SupportTask supportTask;
+        if (isNameChange)
+        {
+            supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
+        }
+        else
+        {
+            supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
+        }
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{createIncidentResult.TicketNumber}/reject")
+        EventPublisher.Clear();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{supportTask.SupportTaskReference}/reject")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -136,20 +165,89 @@ public class RejectTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
+        await WithDbContext(async dbContext =>
+        {
+            var supportTask = await dbContext.SupportTasks.SingleOrDefaultAsync(t => t.PersonId == createPersonResult.PersonId);
+            Assert.Equal(SupportTaskStatus.Closed, supportTask!.Status);
+
+            if (isNameChange)
+            {
+                var requestData = (ChangeNameRequestData)supportTask!.Data;
+                Assert.Equal(SupportRequestOutcome.Rejected, requestData!.ChangeRequestOutcome);
+                var email = await dbContext.Emails
+                    .Where(e => e.EmailAddress == requestData.EmailAddress)
+                    .SingleOrDefaultAsync();
+                Assert.NotNull(email);
+                Assert.NotNull(email.SentOn);
+                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId, email.TemplateId);
+            }
+            else
+            {
+                var requestData = (ChangeDateOfBirthRequestData)supportTask!.Data;
+                Assert.Equal(SupportRequestOutcome.Rejected, requestData!.ChangeRequestOutcome);
+                var email = await dbContext.Emails
+                    .Where(e => e.EmailAddress == requestData.EmailAddress)
+                    .SingleOrDefaultAsync();
+                Assert.NotNull(email);
+                Assert.NotNull(email.SentOn);
+                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId, email.TemplateId);
+            }
+        });
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            if (isNameChange)
+            {
+                var actualEvent = Assert.IsType<ChangeNameRequestSupportTaskRejectedEvent>(e);
+                Assert.Equal("Request and proof don’t match", actualEvent.RejectionReason);
+                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
+                Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
+            }
+            else
+            {
+                var actualEvent = Assert.IsType<ChangeDateOfBirthRequestSupportTaskRejectedEvent>(e);
+                Assert.Equal("Request and proof don’t match", actualEvent.RejectionReason);
+                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
+                Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
+            }
+        },
+        e2 =>
+        {
+            var emailEvent = Assert.IsType<EmailSentEvent>(e2);
+        });
+
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();
         AssertEx.HtmlDocumentHasFlashSuccess(redirectDoc, "The request has been rejected");
     }
 
-    [Fact(Skip = "Will re-enable once Reject page has been changed to use TRS support task")]
-    public async Task Post_WhenRejectionReasonChoiceIsChangeNoLongerRequired_RedirectsWithFlashMessage()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_WhenRejectionReasonChoiceIsChangeNoLongerRequired_RedirectsWithFlashMessage(bool isNameChange)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        SupportTask supportTask;
+        if (isNameChange)
+        {
+            supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
+        }
+        else
+        {
+            supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
+        }
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{createIncidentResult.TicketNumber}/reject")
+        EventPublisher.Clear();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{supportTask.SupportTaskReference}/reject")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -161,6 +259,40 @@ public class RejectTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
+        await WithDbContext(async dbContext =>
+        {
+            var supportTask = await dbContext.SupportTasks.SingleOrDefaultAsync(t => t.PersonId == createPersonResult.PersonId);
+            Assert.Equal(SupportTaskStatus.Closed, supportTask!.Status);
+
+            if (isNameChange)
+            {
+                var requestData = (ChangeNameRequestData)supportTask!.Data;
+                Assert.Equal(SupportRequestOutcome.Cancelled, requestData!.ChangeRequestOutcome);
+            }
+            else
+            {
+                var requestData = (ChangeDateOfBirthRequestData)supportTask!.Data;
+                Assert.Equal(SupportRequestOutcome.Cancelled, requestData!.ChangeRequestOutcome);
+            }
+        });
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            SupportTaskUpdatedEvent? actualEvent;
+            if (isNameChange)
+            {
+                actualEvent = Assert.IsType<ChangeNameRequestSupportTaskCancelledEvent>(e);
+            }
+            else
+            {
+                actualEvent = Assert.IsType<ChangeDateOfBirthRequestSupportTaskCancelledEvent>(e);
+            }
+
+            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
+            Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
+        });
+
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();


### PR DESCRIPTION
### Context

The TRS Console currently allows users to manage Change name and change date of birth requests which are stored as “Cases” in DQT.
These cases/requests are created when a teacher requests a change of details via AYTQ.
As part of migrating from DQT, we need to move these to be stored as support tasks in TRS.

### Changes proposed in this pull request

Re-wire the `Reject` page at `TeachingRecordSystem.SupportUi.Pages.ChangeRequests.EditChangeRequest` to reject or cancel a change name or date of birth request `SupportTask`.
Considerations:
- When the task is Rejected we need to replicate sending an email like the `CaseRejectedSendEmailPlugin` does currently.
- Use `INotificationSender` to send emails via Notify in TRS (see the API endpoints for prior art).
- Need to create a `ChangeNameRequestSupportTaskRejected` or `ChangeNameRequestSupportTaskCancelled` event.