### PR TITLE
Rewired Accept/Approved page for change requests to use TRS support tasks

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskApprovedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskApprovedEvent.cs
@@ -1,0 +1,17 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record ChangeDateOfBirthRequestSupportTaskApprovedEvent : SupportTaskUpdatedEvent, IEventWithPersonAttributes
+{
+    public required Guid PersonId { get; init; }
+    public required EventModels.ChangeDateOfBirthRequestData RequestData { get; init; }
+    public required ChangeDateOfBirthRequestSupportTaskApprovedEventChanges Changes { get; init; }
+    public required EventModels.PersonAttributes PersonAttributes { get; init; }
+    public required EventModels.PersonAttributes? OldPersonAttributes { get; init; }
+}
+
+[Flags]
+public enum ChangeDateOfBirthRequestSupportTaskApprovedEventChanges
+{
+    None = 0,
+    DateOfBirth = PersonAttributesChanges.DateOfBirth
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskCancelledEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskCancelledEvent.cs
@@ -1,6 +1,7 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record ChangeDateOfBirthRequestSupportTaskCancelledEvent : SupportTaskUpdatedEvent
+public record ChangeDateOfBirthRequestSupportTaskCancelledEvent : SupportTaskUpdatedEvent, IEventWithPersonId
 {
+    public required Guid PersonId { get; init; }
     public required EventModels.ChangeDateOfBirthRequestData RequestData { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskRejectedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeDateOfBirthRequestSupportTaskRejectedEvent.cs
@@ -1,7 +1,8 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record ChangeDateOfBirthRequestSupportTaskRejectedEvent : SupportTaskUpdatedEvent
+public record ChangeDateOfBirthRequestSupportTaskRejectedEvent : SupportTaskUpdatedEvent, IEventWithPersonId
 {
+    public required Guid PersonId { get; init; }
     public required EventModels.ChangeDateOfBirthRequestData RequestData { get; init; }
     public required string? RejectionReason { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskApprovedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskApprovedEvent.cs
@@ -1,0 +1,20 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record ChangeNameRequestSupportTaskApprovedEvent : SupportTaskUpdatedEvent, IEventWithPersonAttributes
+{
+    public required Guid PersonId { get; init; }
+    public required EventModels.ChangeNameRequestData RequestData { get; init; }
+    public required ChangeNameRequestSupportTaskApprovedEventChanges Changes { get; init; }
+    public required EventModels.PersonAttributes PersonAttributes { get; init; }
+    public required EventModels.PersonAttributes? OldPersonAttributes { get; init; }
+}
+
+[Flags]
+public enum ChangeNameRequestSupportTaskApprovedEventChanges
+{
+    None = 0,
+    FirstName = PersonAttributesChanges.FirstName,
+    MiddleName = PersonAttributesChanges.MiddleName,
+    LastName = PersonAttributesChanges.LastName,
+    NameChange = FirstName | MiddleName | LastName,
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskCancelledEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskCancelledEvent.cs
@@ -1,6 +1,7 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record ChangeNameRequestSupportTaskCancelledEvent : SupportTaskUpdatedEvent
+public record ChangeNameRequestSupportTaskCancelledEvent : SupportTaskUpdatedEvent, IEventWithPersonId
 {
+    public required Guid PersonId { get; init; }
     public required EventModels.ChangeNameRequestData RequestData { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskRejectedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/ChangeNameRequestSupportTaskRejectedEvent.cs
@@ -1,7 +1,8 @@
 namespace TeachingRecordSystem.Core.Events;
 
-public record ChangeNameRequestSupportTaskRejectedEvent : SupportTaskUpdatedEvent
+public record ChangeNameRequestSupportTaskRejectedEvent : SupportTaskUpdatedEvent, IEventWithPersonId
 {
+    public required Guid PersonId { get; init; }
     public required EventModels.ChangeNameRequestData RequestData { get; init; }
     public required string? RejectionReason { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestEmailConstants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskData/ChangeRequestEmailConstants.cs
@@ -3,8 +3,10 @@ namespace TeachingRecordSystem.Core.Models.SupportTaskData;
 public static class ChangeRequestEmailConstants
 {
     public const string GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId = "d83d28e8-fc4c-4728-ac62-e58a0dd1622e";
+    public const string GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId = "214c838c-0f8e-44da-8b97-3041d2bfec91";
     public const string GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId = "96ed1a90-3398-4f96-bd37-eedf18297337";
     public const string GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId = "664fd278-3af8-4011-9f58-b4d44c733402";
+    public const string GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId = "7b0a2a7f-4e6c-4c75-a6b8-61f69ea273eb";
     public const string GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId = "bee1f8b8-fcb2-4e47-876d-509e60064bd4";
     public const string FirstNameEmailPersonalisationKey = "first name";
     public const string EmailReplyToId = "3ac9a271-449e-4fc6-8bba-2acd833d6901";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml
@@ -1,19 +1,19 @@
-@page "/change-requests/{ticketNumber}/accept"
+@page "/change-requests/{supportTaskReference}/accept"
 @model TeachingRecordSystem.SupportUi.Pages.ChangeRequests.EditChangeRequest.AcceptModel
 @{
     ViewBag.Title = "Confirm the change";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.EditChangeRequest(Model.TicketNumber)" />
+    <govuk-back-link href="@LinkGenerator.EditChangeRequest(Model.SupportTaskReference)" />
 }
 
-<span class="govuk-caption-l">@Model.CaseType - @Model.PersonName</span>
+<span class="govuk-caption-l">@(Model.ChangeType == SupportTaskType.ChangeNameRequest ? "Change of Name" : "Change of Date of Birth") - @Model.PersonName</span>
 <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">        
-        <form action="@LinkGenerator.AcceptChangeRequest(Model.TicketNumber)" method="post">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AcceptChangeRequest(Model.SupportTaskReference)" method="post">
             <table class="govuk-table">                
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
@@ -22,7 +22,7 @@
                         <th scope="col" class="govuk-table__header">New</th>
                     </tr>
                 </thead>
-                @if (Model.CaseType == DqtConstants.NameChangeSubjectTitle)
+                @if (Model.ChangeType == SupportTaskType.ChangeNameRequest)
                 {
                     <tbody class="govuk-table__body">
                         @if (Model.NameChangeRequest!.CurrentFirstName != Model.NameChangeRequest!.NewFirstName)
@@ -51,7 +51,7 @@
                         }
                     </tbody>
                 }
-                @if (Model.CaseType == DqtConstants.DateOfBirthChangeSubjectTitle)
+                @if (Model.ChangeType == SupportTaskType.ChangeDateOfBirthRequest)
                 {
                     <tbody class="govuk-table__body">
                         <tr class="govuk-table__row" data-testid="date-of-birth">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
@@ -70,6 +70,7 @@ public class RejectModel(
 
                 cancelledEvent = new ChangeNameRequestSupportTaskCancelledEvent()
                 {
+                    PersonId = Person!.PersonId,
                     RequestData = changeNameRequestData!,
                     SupportTask = EventModels.SupportTask.FromModel(SupportTask!),
                     OldSupportTask = oldSupportTask,
@@ -87,6 +88,7 @@ public class RejectModel(
 
                 cancelledEvent = new ChangeDateOfBirthRequestSupportTaskCancelledEvent()
                 {
+                    PersonId = Person!.PersonId,
                     RequestData = changeDateOfBirthRequestData!,
                     SupportTask = EventModels.SupportTask.FromModel(SupportTask!),
                     OldSupportTask = oldSupportTask,
@@ -111,6 +113,7 @@ public class RejectModel(
                 });
                 rejectedEvent = new ChangeNameRequestSupportTaskRejectedEvent()
                 {
+                    PersonId = Person!.PersonId,
                     RequestData = changeNameRequestData!,
                     SupportTask = EventModels.SupportTask.FromModel(SupportTask!),
                     OldSupportTask = oldSupportTask,
@@ -132,6 +135,7 @@ public class RejectModel(
 
                 rejectedEvent = new ChangeDateOfBirthRequestSupportTaskRejectedEvent()
                 {
+                    PersonId = Person!.PersonId,
                     RequestData = changeDateOfBirthRequestData!,
                     SupportTask = EventModels.SupportTask.FromModel(SupportTask!),
                     OldSupportTask = oldSupportTask,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -175,7 +175,7 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
 
     public string ChangeRequestDocument(string ticketNumber, Guid documentId) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Index", "documents", routeValues: new { ticketNumber, id = documentId });
 
-    public string AcceptChangeRequest(string ticketNumber) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Accept", routeValues: new { ticketNumber });
+    public string AcceptChangeRequest(string supportTaskReference) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Accept", routeValues: new { supportTaskReference });
 
     public string RejectChangeRequest(string supportTaskReference) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Reject", routeValues: new { supportTaskReference });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ChangeRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ChangeRequestTests.cs
@@ -7,22 +7,26 @@ public class ChangeRequestTests : TestBase
     {
     }
 
-    [Theory(Skip = "Will re-enable once Support Tasks Index and Accept page has been changed to use TRS support task")]
+    [Theory(Skip = "Will re-enable once Support Tasks Index page has been changed to use TRS support task")]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndApprove(bool isNameChange)
     {
         var createPersonResult = await TestData.CreatePersonAsync();
-        string caseReference;
+        string supportTaskReference;
         if (isNameChange)
         {
-            var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
-            caseReference = createIncidentResult.TicketNumber;
+            var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
+            supportTaskReference = supportTask.SupportTaskReference;
         }
         else
         {
-            var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
-            caseReference = createIncidentResult.TicketNumber;
+            var supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
+            supportTaskReference = supportTask.SupportTaskReference;
         }
 
         await using var context = await HostFixture.CreateBrowserContext();
@@ -32,13 +36,13 @@ public class ChangeRequestTests : TestBase
 
         await page.AssertOnSupportTasksPageAsync();
 
-        await page.ClickCaseReferenceLinkChangeRequestsPageAsync(caseReference);
+        await page.ClickCaseReferenceLinkChangeRequestsPageAsync(supportTaskReference);
 
-        await page.AssertOnChangeRequestDetailPageAsync(caseReference);
+        await page.AssertOnChangeRequestDetailPageAsync(supportTaskReference);
 
         await page.ClickAcceptChangeButtonAsync();
 
-        await page.AssertOnAcceptChangeRequestPageAsync(caseReference);
+        await page.AssertOnAcceptChangeRequestPageAsync(supportTaskReference);
 
         await page.ClickConfirmButtonAsync();
 
@@ -47,7 +51,7 @@ public class ChangeRequestTests : TestBase
         await page.AssertFlashMessageAsync("The request has been accepted");
     }
 
-    [Theory(Skip = "Will re-enable once Support Tasks Index and Reject page has been changed to use TRS support task")]
+    [Theory(Skip = "Will re-enable once Support Tasks Index page has been changed to use TRS support task")]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndReject(bool isNameChange)
@@ -93,7 +97,7 @@ public class ChangeRequestTests : TestBase
         await page.AssertFlashMessageAsync("The request has been rejected");
     }
 
-    [Theory(Skip = "Will re-enable once Support Tasks Index and Reject page has been changed to use TRS support task")]
+    [Theory(Skip = "Will re-enable once Support Tasks Index page has been changed to use TRS support task")]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndCancel(bool isNameChange)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/AcceptTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/AcceptTests.cs
@@ -1,3 +1,6 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTaskData;
+
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ChangeRequests.EditChangeRequest;
 
 public class AcceptTests : TestBase
@@ -8,15 +11,17 @@ public class AcceptTests : TestBase
         SetCurrentUser(TestUsers.GetUser(UserRoles.RecordManager));
     }
 
-    [Fact(Skip = "Will re-enable once Accept page has been changed to use TRS support task")]
+    [Fact]
     public async Task Get_WhenUserHasNoRoles_ReturnsForbidden()
     {
         // Arrange
         SetCurrentUser(TestUsers.GetUser(role: null));
         var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{createIncidentResult.TicketNumber}/accept");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}/accept");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -25,16 +30,18 @@ public class AcceptTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
-    [Theory(Skip = "Will re-enable once Accept page has been changed to use TRS support task")]
+    [Theory]
     [RoleNamesData(except: [UserRoles.RecordManager, UserRoles.AccessManager, UserRoles.Administrator])]
     public async Task Get_WhenUserDoesNotHaveSupportOfficerOrAccessManagerOrAdministratorRole_ReturnsForbidden(string role)
     {
         // Arrange
         SetCurrentUser(TestUsers.GetUser(role));
         var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{createIncidentResult.TicketNumber}/accept");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}/accept");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -43,13 +50,13 @@ public class AcceptTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
-    [Fact(Skip = "Will re-enable once Accept page has been changed to use TRS support task")]
-    public async Task Get_WithTicketNumberForNonExistentIncident_ReturnsNotFound()
+    [Fact]
+    public async Task Get_WithSupportTaskReferenceForNonExistentSupportTask_ReturnsNotFound()
     {
         // Arrange
-        var nonExistentTicketNumber = Guid.NewGuid().ToString();
+        var nonExistentSupportTaskReference = Guid.NewGuid().ToString();
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{nonExistentTicketNumber}/accept");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{nonExistentSupportTaskReference}/accept");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -58,32 +65,36 @@ public class AcceptTests : TestBase
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
     }
 
-    [Fact(Skip = "Will re-enable once Accept page has been changed to use TRS support task")]
-    public async Task Get_WithTicketNumberForInactiveIncident_ReturnsBadRequest()
+    [Fact]
+    public async Task Get_WithSupportTaskReferenceForClosedSupportTask_ReturnsNotFound()
     {
         // Arrange
         var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateNameChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId).WithCanceledStatus());
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)).WithStatus(SupportTaskStatus.Closed));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{createIncidentResult.TicketNumber}/accept");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}/accept");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
     }
 
-    [Theory(Skip = "Will re-enable once Accept page has been changed to use TRS support task")]
+    [Theory]
     [RoleNamesData(except: [UserRoles.RecordManager, UserRoles.AccessManager, UserRoles.Administrator])]
     public async Task Post_WhenUserDoesNotHaveSupportOfficerOrAccessManagerOrAdministratorRole_ReturnsForbidden(string role)
     {
         // Arrange
         SetCurrentUser(TestUsers.GetUser(role));
         var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            createPersonResult.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{createIncidentResult.TicketNumber}/accept")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{supportTask.SupportTaskReference}/accept")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -95,14 +106,33 @@ public class AcceptTests : TestBase
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 
-    [Fact(Skip = "Will re-enable once Accept page has been changed to use TRS support task")]
-    public async Task Post_ValidRequest_RedirectsWithFlashMessage()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidRequest_RedirectsWithFlashMessage(bool isNameChange)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var createIncidentResult = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(createPersonResult.ContactId));
+        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        SupportTask supportTask;
+        if (isNameChange)
+        {
+            supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b
+                    .WithFirstName(TestData.GenerateChangedFirstName(createPersonResult.FirstName))
+                    .WithMiddleName(TestData.GenerateChangedMiddleName(createPersonResult.MiddleName))
+                    .WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
+        }
+        else
+        {
+            supportTask = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+                createPersonResult.PersonId,
+                b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(createPersonResult.DateOfBirth)));
+        }
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{createIncidentResult.TicketNumber}/accept")
+        EventPublisher.Clear();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/change-requests/{supportTask.SupportTaskReference}/accept")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -111,6 +141,74 @@ public class AcceptTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
+        await WithDbContext(async dbContext =>
+        {
+            var supportTask = await dbContext.SupportTasks.SingleOrDefaultAsync(t => t.PersonId == createPersonResult.PersonId);
+            Assert.Equal(SupportTaskStatus.Closed, supportTask!.Status);
+
+            if (isNameChange)
+            {
+                var requestData = (ChangeNameRequestData)supportTask!.Data;
+                Assert.Equal(SupportRequestOutcome.Approved, requestData!.ChangeRequestOutcome);
+                var email = await dbContext.Emails
+                    .Where(e => e.EmailAddress == requestData.EmailAddress)
+                    .SingleOrDefaultAsync();
+                Assert.NotNull(email);
+                Assert.NotNull(email.SentOn);
+                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId, email.TemplateId);
+
+                var updatedPerson = await dbContext.Persons
+                    .SingleAsync(p => p.PersonId == createPersonResult.PersonId);
+                Assert.Equal(requestData.FirstName, updatedPerson.FirstName);
+                Assert.Equal(requestData.MiddleName, updatedPerson.MiddleName);
+                Assert.Equal(requestData.LastName, updatedPerson.LastName);
+                Assert.Equal(Clock.UtcNow, updatedPerson.UpdatedOn);
+
+                var previousName = await dbContext.PreviousNames
+                    .SingleOrDefaultAsync(pn => pn.PersonId == createPersonResult.PersonId);
+                Assert.NotNull(previousName);
+                Assert.Equal(createPersonResult.FirstName, previousName!.FirstName);
+                Assert.Equal(createPersonResult.MiddleName, previousName.MiddleName);
+                Assert.Equal(createPersonResult.LastName, previousName.LastName);
+            }
+            else
+            {
+                var requestData = (ChangeDateOfBirthRequestData)supportTask!.Data;
+                Assert.Equal(SupportRequestOutcome.Approved, requestData!.ChangeRequestOutcome);
+                var email = await dbContext.Emails
+                    .Where(e => e.EmailAddress == requestData.EmailAddress)
+                    .SingleOrDefaultAsync();
+                Assert.NotNull(email);
+                Assert.NotNull(email.SentOn);
+                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId, email.TemplateId);
+            }
+        });
+
+        EventPublisher.AssertEventsSaved(e =>
+        {
+            if (isNameChange)
+            {
+                var actualEvent = Assert.IsType<ChangeNameRequestSupportTaskApprovedEvent>(e);
+                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
+                Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
+                Assert.Equal(createPersonResult.PersonId, actualEvent.PersonId);
+                Assert.Equal(ChangeNameRequestSupportTaskApprovedEventChanges.NameChange, actualEvent.Changes);
+            }
+            else
+            {
+                var actualEvent = Assert.IsType<ChangeDateOfBirthRequestSupportTaskApprovedEvent>(e);
+                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
+                Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
+                Assert.Equal(ChangeDateOfBirthRequestSupportTaskApprovedEventChanges.DateOfBirth, actualEvent.Changes);
+            }
+        },
+        e2 =>
+        {
+            var emailEvent = Assert.IsType<EmailSentEvent>(e2);
+        });
+
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);
         var redirectDoc = await redirectResponse.GetDocumentAsync();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
@@ -21,7 +21,7 @@ public class RejectTests : TestBase
             createPersonResult.PersonId,
             b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}/reject");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -41,7 +41,7 @@ public class RejectTests : TestBase
             createPersonResult.PersonId,
             b => b.WithLastName(TestData.GenerateChangedLastName(createPersonResult.LastName)));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/change-requests/{supportTask.SupportTaskReference}/reject");
 
         // Act
         var response = await HttpClient.SendAsync(request);


### PR DESCRIPTION
### Context

The TRS Console currently allows users to manage Change name and change date of birth requests which are stored as “Cases” in DQT.
These cases/requests are created when a teacher requests a change of details via AYTQ.
As part of migrating from DQT, we need to move these to be stored as support tasks in TRS.

### Changes proposed in this pull request

Re-wire the `Accept` page at `TeachingRecordSystem.SupportUi.Pages.ChangeRequests.EditChangeRequest` to approve a change name or date of birth request `SupportTask` in TRS and update `Person` and `PreviousName` tables as appropriate + raise events + send emails.