### PR TITLE
Add tile for change requests and amend support tasks index to get change requests from TRS

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureNames.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/FeatureNames.cs
@@ -7,4 +7,5 @@ public static class FeatureNames
     public const string DqtNotes = "DqtNotes";
     public const string ContactsMigrated = "ContactsMigrated";
     public const string ApiTrnRequestsInTrs = nameof(ApiTrnRequestsInTrs);
+    public const string ChangeRequestsInTrs = nameof(ChangeRequestsInTrs);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
@@ -147,7 +147,7 @@ public class AcceptModel(
             $"The request has been accepted",
             "The user’s record has been changed and they have been notified.");
 
-        return Redirect(linkGenerator.SupportTasks());
+        return Redirect(linkGenerator.SupportTasks(categories: [SupportTaskCategory.ChangeRequests], sortBy: SupportTasks.IndexModel.SortByOption.DateRequested, filtersApplied: true));
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks()" />
+    <govuk-back-link href="@LinkGenerator.SupportTasks(categories: [SupportTaskCategory.ChangeRequests], sortBy: SupportTasks.IndexModel.SortByOption.DateRequested, filtersApplied: true)" />
 }
 
 <span class="govuk-caption-l" data-testid="heading-caption">@(Model.ChangeType == SupportTaskType.ChangeNameRequest ? "Change of Name" : "Change of Date of Birth") - @Model.PersonName</span>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
@@ -174,7 +174,7 @@ public class RejectModel(
             $"The request has been {requestStatus}",
             flashMessage);
 
-        return Redirect(linkGenerator.SupportTasks());
+        return Redirect(linkGenerator.SupportTasks(categories: [SupportTaskCategory.ChangeRequests], sortBy: SupportTasks.IndexModel.SortByOption.DateRequested, filtersApplied: true));
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
@@ -53,6 +53,20 @@
         </div>
     }
 
+    @if (FeatureProvider.IsEnabled(FeatureNames.ChangeRequestsInTrs) && (await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.SupportTasksEdit)).Succeeded)
+    {
+        <div class="trs-tile-section">
+            <h2 class="govuk-heading-m">Change requests</h2>
+            <div class="trs-tile-row">
+                <a href="@LinkGenerator.SupportTasks(categories: [SupportTaskCategory.ChangeRequests], sortBy: SupportTasks.IndexModel.SortByOption.DateRequested, filtersApplied: true)" class="trs-tile">
+                    <span class="trs-tile__count">@(Model.SupportTaskCounts!.GetValueOrDefault(SupportTaskType.ChangeNameRequest) + Model.SupportTaskCounts!.GetValueOrDefault(SupportTaskType.ChangeDateOfBirthRequest))</span>
+                    <span class="trs-tile__title">Name and date of birth change requests</span>
+                </a>
+            </div>
+        </div>
+    }
+)
+
     <div class="trs-tile-section">
         <h2 class="govuk-heading-m">Third-party tasks</h2>
         <div class="trs-tile-row">

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
@@ -1,4 +1,4 @@
 {
   "DetailedErrors": true,
-  "EnabledFeatures": [ "SwitchRoles", "RoutesToProfessionalStatus", "NewUserRoles", "DqtNotes", "ContactsMigrated", "ApiTrnRequestsInTrs" ]
+  "EnabledFeatures": [ "SwitchRoles", "RoutesToProfessionalStatus", "NewUserRoles", "DqtNotes", "ContactsMigrated", "ApiTrnRequestsInTrs", "ChangeRequestsInTrs" ]
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
@@ -7,5 +7,5 @@
       }
     }
   },
-  "EnabledFeatures": [ "RoutesToProfessionalStatus", "NewUserRoles", "ContactsMigrated" ]
+  "EnabledFeatures": [ "RoutesToProfessionalStatus", "NewUserRoles", "ContactsMigrated", "ChangeRequestsInTrs" ]
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ChangeRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/ChangeRequestTests.cs
@@ -7,7 +7,7 @@ public class ChangeRequestTests : TestBase
     {
     }
 
-    [Theory(Skip = "Will re-enable once Support Tasks Index page has been changed to use TRS support task")]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndApprove(bool isNameChange)
@@ -51,7 +51,7 @@ public class ChangeRequestTests : TestBase
         await page.AssertFlashMessageAsync("The request has been accepted");
     }
 
-    [Theory(Skip = "Will re-enable once Support Tasks Index page has been changed to use TRS support task")]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndReject(bool isNameChange)
@@ -97,7 +97,7 @@ public class ChangeRequestTests : TestBase
         await page.AssertFlashMessageAsync("The request has been rejected");
     }
 
-    [Theory(Skip = "Will re-enable once Support Tasks Index page has been changed to use TRS support task")]
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task SelectChangeRequestAndCancel(bool isNameChange)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IndexTests.cs
@@ -19,9 +19,10 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
     public async Task Get_NoSortByQueryParam_ShowsTasksSortedByDateRequested()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var dobChangeRequest = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(person.ContactId));
-        Clock.UtcNow = dobChangeRequest.CreatedOn.ToUniversalTime().AddMinutes(1);  // CRM entity creations don't use IClock
+        var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        var dobChangeRequest = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            person.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(person.DateOfBirth)));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync();
         var connectOneLoginUser = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -32,16 +33,17 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        AssertResults(doc, dobChangeRequest.TicketNumber, connectOneLoginUser.SupportTaskReference);
+        AssertResults(doc, dobChangeRequest.SupportTaskReference, connectOneLoginUser.SupportTaskReference);
     }
 
     [Fact]
     public async Task Get_DateRequestedSortByQueryParam_ShowsTasksSortedByDateRequested()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var dobChangeRequest = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(person.ContactId));
-        Clock.UtcNow = dobChangeRequest.CreatedOn.ToUniversalTime().AddMinutes(1);  // CRM entity creations don't use IClock
+        var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.Trs));
+        var dobChangeRequest = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            person.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(person.DateOfBirth)));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync();
         var connectOneLoginUser = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -52,7 +54,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        AssertResults(doc, dobChangeRequest.TicketNumber, connectOneLoginUser.SupportTaskReference);
+        AssertResults(doc, dobChangeRequest.SupportTaskReference, connectOneLoginUser.SupportTaskReference);
     }
 
     [Fact]
@@ -60,8 +62,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var dobChangeRequest = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(person.ContactId));
-        Clock.UtcNow = dobChangeRequest.CreatedOn.ToUniversalTime().AddMinutes(1);  // CRM entity creations don't use IClock
+        var dobChangeRequest = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            person.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(person.DateOfBirth)));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync();
         var connectOneLoginUser = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -72,7 +75,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        AssertResults(doc, dobChangeRequest.TicketNumber, connectOneLoginUser.SupportTaskReference);
+        AssertResults(doc, dobChangeRequest.SupportTaskReference, connectOneLoginUser.SupportTaskReference);
     }
 
     [Fact]
@@ -80,7 +83,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var dobChangeRequest = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(person.ContactId));
+        var dobChangeRequest = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            person.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(person.DateOfBirth)));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync();
         var connectOneLoginUser = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -92,7 +97,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
         var references = GetTaskReferences(doc);
-        Assert.Contains(dobChangeRequest.TicketNumber, references);
+        Assert.Contains(dobChangeRequest.SupportTaskReference, references);
         Assert.Contains(connectOneLoginUser.SupportTaskReference, references);
     }
 
@@ -121,7 +126,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var dobChangeRequest = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(person.ContactId));
+        var dobChangeRequest = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            person.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(person.DateOfBirth)));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync();
         var connectOneLoginUser = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -133,7 +140,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
         var references = GetTaskReferences(doc);
-        Assert.Contains(dobChangeRequest.TicketNumber, references);
+        Assert.Contains(dobChangeRequest.SupportTaskReference, references);
         Assert.DoesNotContain(connectOneLoginUser.SupportTaskReference, references);
     }
 
@@ -142,7 +149,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
-        var dobChangeRequest = await TestData.CreateDateOfBirthChangeIncidentAsync(b => b.WithCustomerId(person.ContactId));
+        var dobChangeRequest = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(
+            person.PersonId,
+            b => b.WithDateOfBirth(TestData.GenerateChangedDateOfBirth(person.DateOfBirth)));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync();
         var connectOneLoginUser = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -154,7 +163,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
         var references = GetTaskReferences(doc);
-        Assert.DoesNotContain(dobChangeRequest.TicketNumber, references);
+        Assert.DoesNotContain(dobChangeRequest.SupportTaskReference, references);
         Assert.Contains(connectOneLoginUser.SupportTaskReference, references);
     }
 


### PR DESCRIPTION
### Context

The TRS Console currently allows users to manage Change name and change date of birth requests which are stored as “Cases” in DQT.
These cases/requests are created when a teacher requests a change of details via AYTQ.
As part of migrating from DQT, we need to move these to be stored as support tasks in TRS.

### Changes proposed in this pull request

Amend the `Pages/SupportTasks/Index` page to get change date of birth and name requests from TRS instead of DQT i.e. `SupportTask` with `SupportTaskType` of `SupportTaskType.ChangeNameRequest` or `SupportTaskType.ChangeDateOfBirthRequest` with Status `SupportTaskStatus.Open`
Amend the `Pages/Index` page to add a tile for change requests which links to the above page (i.e.  `/support-tasks`).