### PR TITLE
Ensure DB transactions

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Program.cs
@@ -31,7 +31,6 @@ using TeachingRecordSystem.Core.Services.PersonMatching;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Infrastructure.FormFlow;
-using TeachingRecordSystem.WebCommon;
 using TeachingRecordSystem.WebCommon.Filters;
 using TeachingRecordSystem.WebCommon.FormFlow;
 using TeachingRecordSystem.WebCommon.Infrastructure.Logging;
@@ -269,6 +268,7 @@ if (builder.Environment.IsProduction())
 app.UseMiddleware<AddAnalyticsDataMiddleware>();
 
 app.UseRouting();
+app.UseTransactions();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/TeachingRecordSystem.AuthorizeAccess.csproj
@@ -34,7 +34,11 @@
     <ProjectReference Include="..\TeachingRecordSystem.Core\TeachingRecordSystem.Core.csproj" />
     <ProjectReference Include="..\TeachingRecordSystem.WebCommon\TeachingRecordSystem.WebCommon.csproj" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <Using Include="TeachingRecordSystem.WebCommon" />
+  </ItemGroup>
+
   <ItemGroup>
     <SassFile Include="wwwroot/Styles/site.scss" Exclude="wwwroot/lib/**/*" />
   </ItemGroup>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Extensions.cs
@@ -69,8 +69,7 @@ public static class Extensions
                 .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
                 .UseSimpleAssemblyNameTypeSerializer()
                 .UseRecommendedSerializerSettings()
-                .UsePostgreSqlStorage(o => o.UseConnectionFactory(
-                    new DbDataSourceConnectionFactory(sp.GetRequiredService<NpgsqlDataSource>())),
+                .UsePostgreSqlStorage(o => o.UseConnectionFactory(new DbDataSourceConnectionFactory(sp.GetRequiredService<NpgsqlDataSource>())),
                     new PostgreSqlStorageOptions()
                     {
                         PrepareSchemaIfNecessary = prepareSchemaIfNecessary,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
@@ -29,12 +29,14 @@ public class CheckAlertExistsFilter(Permissions.Alerts requiredPermissionType, T
             return;
         }
 
+        await context.HttpContext.EnsureDbTransactionAsync();
+
         var query = dbContext.Alerts
             .FromSql($"select * from alerts where alert_id = {alertId} for update")  // https://github.com/dotnet/efcore/issues/26042
             .Include(a => a.Person);
 
         // Query without query filters first - query filters will filter out deactivated Person
-        // meaning the entire Alert is not found, but if Person is deactivated we
+        // meaning the entire Alert is not found, but if Person is deactivated
         // we need to return a BadRequest instead of a NotFound result
         var currentAlertWithPotentiallyDeactivatedPerson = await query
             .IgnoreQueryFilters()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckMandatoryQualificationExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckMandatoryQualificationExistsFilter.cs
@@ -24,6 +24,8 @@ public class CheckMandatoryQualificationExistsFilter(TrsDbContext dbContext) : I
             return;
         }
 
+        await context.HttpContext.EnsureDbTransactionAsync();
+
         var query = dbContext.MandatoryQualifications
             .FromSql($"select * from qualifications where qualification_id = {qualificationId} for update")  // https://github.com/dotnet/efcore/issues/26042
             .Include(mq => mq.Person);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -32,6 +32,8 @@ public class CheckPersonExistsFilter(
             return;
         }
 
+        await context.HttpContext.EnsureDbTransactionAsync();
+
         var person = await GetPersonAsync();
 
         if (person is not null)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckRouteToProfessionalStatusExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckRouteToProfessionalStatusExistsFilter.cs
@@ -24,6 +24,8 @@ public class CheckRouteToProfessionalStatusExistsFilter(TrsDbContext dbContext) 
             return;
         }
 
+        await context.HttpContext.EnsureDbTransactionAsync();
+
         var query = dbContext.RouteToProfessionalStatuses
             .FromSql($"select * from qualifications where qualification_id = {qualificationId} for update") // https://github.com/dotnet/efcore/issues/26042
             .Include(ps => ps.Person)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckSupportTaskExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckSupportTaskExistsFilter.cs
@@ -14,6 +14,8 @@ public class CheckSupportTaskExistsFilter(TrsDbContext dbContext, bool openOnly,
             return;
         }
 
+        await context.HttpContext.EnsureDbTransactionAsync();
+
         var currentSupportTaskQuery = dbContext.SupportTasks
             .FromSql($"select * from support_tasks where support_task_reference = {supportTaskReference} for update");  // https://github.com/dotnet/efcore/issues/26042
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -7,12 +7,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTaskData;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrnRequests;
-using TeachingRecordSystem.WebCommon;
 using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.ResolveApiTrnRequestState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
 
-[Journey(JourneyNames.ResolveApiTrnRequest), RequireJourneyInstance, TransactionScope]
+[Journey(JourneyNames.ResolveApiTrnRequest), RequireJourneyInstance]
 public class CheckAnswers(
     TrsDbContext dbContext,
     TrnRequestService trnRequestService,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -31,7 +31,6 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 using TeachingRecordSystem.SupportUi.Pages;
 using TeachingRecordSystem.SupportUi.Services;
 using TeachingRecordSystem.SupportUi.TagHelpers;
-using TeachingRecordSystem.WebCommon;
 using TeachingRecordSystem.WebCommon.Filters;
 using TeachingRecordSystem.WebCommon.Infrastructure;
 using TeachingRecordSystem.WebCommon.Infrastructure.Logging;
@@ -227,11 +226,10 @@ app.UseMiddleware<AppendSecurityResponseHeadersMiddleware>();
 app.UseStaticFiles();
 
 app.UseRouting();
+app.UseTransactions();
 
 app.UseAuthentication();
 app.UseAuthorization();
-
-app.UseMiddleware<TransactionScopeMiddleware>();
 
 app.MapRazorPages();
 app.MapControllers();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TeachingRecordSystem.SupportUi.csproj
@@ -30,6 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="TeachingRecordSystem.WebCommon" />
+  </ItemGroup>
+
+  <ItemGroup>
     <SassFile Include="wwwroot/Styles/site.scss" Exclude="wwwroot/lib/**/*" />
   </ItemGroup>
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/HttpContextExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/HttpContextExtensions.cs
@@ -1,0 +1,21 @@
+using System.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.WebCommon.Infrastructure;
+
+namespace TeachingRecordSystem.WebCommon;
+
+public static class HttpContextExtensions
+{
+    public static async Task EnsureDbTransactionAsync(this HttpContext context)
+    {
+        var dbContext = context.RequestServices.GetRequiredService<TrsDbContext>();
+
+        if (dbContext.Database.CurrentTransaction is null && System.Transactions.Transaction.Current is null)
+        {
+            await dbContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+            context.Items.Add(typeof(DbTransactionCreatedMarker), DbTransactionCreatedMarker.Instance);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Infrastructure/DbTransactionCreatedMarker.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Infrastructure/DbTransactionCreatedMarker.cs
@@ -1,0 +1,10 @@
+namespace TeachingRecordSystem.WebCommon.Infrastructure;
+
+internal sealed class DbTransactionCreatedMarker
+{
+    private DbTransactionCreatedMarker()
+    {
+    }
+
+    public static DbTransactionCreatedMarker Instance { get; } = new();
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Infrastructure/RequireTransactionScopeBackgroundJobScheduler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Infrastructure/RequireTransactionScopeBackgroundJobScheduler.cs
@@ -1,0 +1,30 @@
+using System.Linq.Expressions;
+using TeachingRecordSystem.Core.Jobs.Scheduling;
+
+namespace TeachingRecordSystem.WebCommon.Infrastructure;
+
+public class RequireTransactionScopeBackgroundJobScheduler(IBackgroundJobScheduler innerScheduler) : IBackgroundJobScheduler
+{
+    public Task<string> EnqueueAsync<T>(Expression<Func<T, Task>> expression) where T : notnull
+    {
+        RequireTransactionScope();
+        return innerScheduler.EnqueueAsync(expression);
+    }
+
+    public Task<string> ContinueJobWithAsync<T>(string parentId, Expression<Func<T, Task>> expression) where T : notnull
+    {
+        RequireTransactionScope();
+        return innerScheduler.ContinueJobWithAsync(parentId, expression);
+    }
+
+    public Task WaitForJobToCompleteAsync(string jobId, CancellationToken cancellationToken) =>
+        innerScheduler.WaitForJobToCompleteAsync(jobId, cancellationToken);
+
+    private void RequireTransactionScope()
+    {
+        if (System.Transactions.Transaction.Current is null)
+        {
+            throw new InvalidOperationException("A transaction scope is required.");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Middleware/CommitDbTransactionMiddleware.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Middleware/CommitDbTransactionMiddleware.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.WebCommon.Infrastructure;
+
+namespace TeachingRecordSystem.WebCommon.Middleware;
+
+public class CommitDbTransactionMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        await next(context);
+
+        if (context.Items.ContainsKey(typeof(DbTransactionCreatedMarker)))
+        {
+            var dbContext = context.RequestServices.GetRequiredService<TrsDbContext>();
+            Debug.Assert(dbContext.Database.CurrentTransaction is not null);
+            await dbContext.Database.CurrentTransaction.CommitAsync();
+        }
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/HostFixture.cs
@@ -17,6 +17,7 @@ using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
 using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.Core.Services.Webhooks;
+using TeachingRecordSystem.WebCommon.Infrastructure;
 
 namespace TeachingRecordSystem.Api.IntegrationTests;
 
@@ -95,6 +96,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.AddSingleton<OutboxMessageHandler>();
             services.AddSingleton<MessageSerializer>();
             services.AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>();
+            services.Decorate<IBackgroundJobScheduler, RequireTransactionScopeBackgroundJobScheduler>();
 
             services.Configure<GetAnIdentityOptions>(options =>
             {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Startup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Startup.cs
@@ -19,6 +19,7 @@ using TeachingRecordSystem.Core.Services.TrnGeneration;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.Core.Services.Webhooks;
 using TeachingRecordSystem.TestCommon.Infrastructure;
+using TeachingRecordSystem.WebCommon.Infrastructure;
 
 namespace TeachingRecordSystem.Api.UnitTests;
 
@@ -81,6 +82,7 @@ public class Startup
                     .AddPersonMatching()
                     .AddTrnRequestService(context.Configuration)
                     .AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>()
+                    .Decorate<IBackgroundJobScheduler, RequireTransactionScopeBackgroundJobScheduler>()
                     .AddTestScoped<IOptions<TrnRequestOptions>>(tss => Options.Create(tss.TrnRequestOptions))
                     .AddSingleton<INotificationSender, NoopNotificationSender>();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/HostFixture.cs
@@ -13,7 +13,7 @@ using TeachingRecordSystem.Core.Services.TrsDataSync;
 using TeachingRecordSystem.SupportUi.EndToEndTests.Infrastructure.Security;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 using TeachingRecordSystem.TestCommon.Infrastructure;
-using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
+using TeachingRecordSystem.WebCommon.Infrastructure;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests;
 
@@ -92,6 +92,7 @@ public sealed class HostFixture : IAsyncDisposable
                     services.AddSingleton(GetMockGetAnIdentityApiClient());
                     services.AddStartupTask<SeedLookupData>();
                     services.AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>();
+                    services.Decorate<IBackgroundJobScheduler, RequireTransactionScopeBackgroundJobScheduler>();
 
                     IFileService GetMockFileService()
                     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -16,6 +16,7 @@ using TeachingRecordSystem.SupportUi.Tests.Infrastructure.Security;
 using TeachingRecordSystem.TestCommon.Infrastructure;
 using TeachingRecordSystem.UiTestCommon.Infrastructure.FormFlow;
 using TeachingRecordSystem.WebCommon.FormFlow.State;
+using TeachingRecordSystem.WebCommon.Infrastructure;
 
 namespace TeachingRecordSystem.SupportUi.Tests;
 
@@ -73,6 +74,7 @@ public class HostFixture : WebApplicationFactory<Program>
             services.RemoveAll<ReferenceDataCache>();
             services.AddSingleton<ReferenceDataCache, TestReferenceDataCache>();
             services.AddSingleton<IBackgroundJobScheduler, TestBackgroundJobScheduler>();
+            services.Decorate<IBackgroundJobScheduler, RequireTransactionScopeBackgroundJobScheduler>();
             services.AddTestScoped<IOptions<TrnRequestOptions>>(tss => Options.Create(tss.TrnRequestOptions));
             services.AddSingleton<INotificationSender, NoopNotificationSender>();
         });


### PR DESCRIPTION
We have a few places where we take locks `select ... for update` and where we schedule jobs where we require a transaction. This fixes both of those places with two different approaches:

An extension method is added on `HttpContext` - `EnsureDbTransactionAsync` - that checks the current request's `TrsDbContext` and starts a transaction if required. A middleware will commit that transaction when the request is done. This ensures that the `select ... for update`s we do in filters keep the row locked for the duration of the request.

For enqueueing Hangfire jobs, we need an ambient `TransactionScope` instead. This adds a decorator to `IBackgroundJobScheduler` that checks if there is a current `Transaction`, and throws if there is not. Our existing `TransactionScopeAttribute` will deal with creating the `TransactionScope`.