### PR TITLE
Fix TRN request matching for email and NINO matches

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.TrnRequest.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.TrnRequest.cs
@@ -309,6 +309,14 @@ public partial class PersonMatchingServiceTests
                 continue;
             }
 
+            // NINO and email matches are always potential matches
+            if (matchedAttrs.Contains("NationalInsuranceNumber") ||
+                matchedAttrs.Contains("EmploymentNationalInsuranceNumber") ||
+                matchedAttrs.Contains("EmailAddress"))
+            {
+                continue;
+            }
+
             AddCase(
                 TrnRequestMatchResultOutcome.NoMatches,
                 matchedAttrs.Contains("EmailAddress") ? EmailAddressArgumentOption.Matches : EmailAddressArgumentOption.DoesNotMatch,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.TrnRequest.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.TrnRequest.cs
@@ -230,7 +230,7 @@ public partial class PersonMatchingServiceTests
             "DateOfBirth",
             "EmailAddress",
             "NationalInsuranceNumber",
-            "EmploymentNationalInsuranceNumber"
+            "WorkforceNationalInsuranceNumber"
         ];
 
         static ISet<string> GetDistinctAttributeTypes(IEnumerable<string> attributes)
@@ -245,7 +245,7 @@ public partial class PersonMatchingServiceTests
                     continue;
                 }
 
-                if (attr == "EmploymentNationalInsuranceNumber")
+                if (attr == "WorkforceNationalInsuranceNumber")
                 {
                     attrNames.Add("NationalInsuranceNumber");
                     continue;
@@ -272,7 +272,7 @@ public partial class PersonMatchingServiceTests
 
             // Exclude definite match cases
             if (matchedAttrs.Contains("DateOfBirth") &&
-                (matchedAttrs.Contains("NationalInsuranceNumber") || matchedAttrs.Contains("EmploymentNationalInsuranceNumber")))
+                (matchedAttrs.Contains("NationalInsuranceNumber") || matchedAttrs.Contains("WorkforceNationalInsuranceNumber")))
             {
                 continue;
             }
@@ -284,7 +284,7 @@ public partial class PersonMatchingServiceTests
                 matchedAttrs.Contains("MiddleName") ? MiddleNameArgumentOption.Matches : MiddleNameArgumentOption.DoesNotMatch,
                 matchedAttrs.Contains("LastName") ? LastNameArgumentOption.Matches : LastNameArgumentOption.DoesNotMatch,
                 matchedAttrs.Contains("DateOfBirth") ? DateOfBirthArgumentOption.Matches : DateOfBirthArgumentOption.DoesNotMatch,
-                matchedAttrs.Contains("NationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesPersonNino : matchedAttrs.Contains("EmploymentNationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesEmploymentNino : NationalInsuranceNumberArgumentOption.DoesNotMatch);
+                matchedAttrs.Contains("NationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesPersonNino : matchedAttrs.Contains("WorkforceNationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesEmploymentNino : NationalInsuranceNumberArgumentOption.DoesNotMatch);
         }
 
         // Match on 2 or fewer attributes
@@ -304,14 +304,14 @@ public partial class PersonMatchingServiceTests
 
             // Exclude definite match cases
             if (matchedAttrs.Contains("DateOfBirth") &&
-                (matchedAttrs.Contains("NationalInsuranceNumber") || matchedAttrs.Contains("EmploymentNationalInsuranceNumber")))
+                (matchedAttrs.Contains("NationalInsuranceNumber") || matchedAttrs.Contains("WorkforceNationalInsuranceNumber")))
             {
                 continue;
             }
 
             // NINO and email matches are always potential matches
             if (matchedAttrs.Contains("NationalInsuranceNumber") ||
-                matchedAttrs.Contains("EmploymentNationalInsuranceNumber") ||
+                matchedAttrs.Contains("WorkforceNationalInsuranceNumber") ||
                 matchedAttrs.Contains("EmailAddress"))
             {
                 continue;
@@ -324,7 +324,7 @@ public partial class PersonMatchingServiceTests
                 matchedAttrs.Contains("MiddleName") ? MiddleNameArgumentOption.Matches : MiddleNameArgumentOption.DoesNotMatch,
                 matchedAttrs.Contains("LastName") ? LastNameArgumentOption.Matches : LastNameArgumentOption.DoesNotMatch,
                 matchedAttrs.Contains("DateOfBirth") ? DateOfBirthArgumentOption.Matches : DateOfBirthArgumentOption.DoesNotMatch,
-                matchedAttrs.Contains("NationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesPersonNino : matchedAttrs.Contains("EmploymentNationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesEmploymentNino : NationalInsuranceNumberArgumentOption.DoesNotMatch);
+                matchedAttrs.Contains("NationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesPersonNino : matchedAttrs.Contains("WorkforceNationalInsuranceNumber") ? NationalInsuranceNumberArgumentOption.MatchesEmploymentNino : NationalInsuranceNumberArgumentOption.DoesNotMatch);
         }
 
         return data;


### PR DESCRIPTION
A match on NINO or email only should be considered possible matches (and not a definite match).

Also adds `COLLATE` to ensure the index on `person_search_attributes` is being used.