### PR TITLE
Fixed so that evidence shows embedded in the change request page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Index.cshtml
@@ -109,14 +109,14 @@
         </govuk-details>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
-                @if (Model.Evidence!.IsPdf)
+                @if (Model.Evidence!.MimeType == "application/pdf")
                 {
-                    <object data="@Model.Evidence!.FileUrl" type="application/pdf" width="100%" height="500px" class="govuk-!-margin-bottom-2" data-testid="pdf-@Model.Evidence!.FileId">
+                    <object data="@LinkGenerator.ChangeRequestEvidence(Model.SupportTaskReference!)" type="application/pdf" width="100%" height="500px" class="govuk-!-margin-bottom-2" data-testid="pdf-@Model.Evidence!.FileId">
                     </object>
                 }
                 else
                 {
-                    <img src="@Model.Evidence!.FileUrl" alt="evidence.FileName" width="100%" height="auto" class="govuk-!-margin-bottom-2" data-testid="image-@Model.Evidence!.FileId" />
+                    <img src="@LinkGenerator.ChangeRequestEvidence(Model.SupportTaskReference!)" alt="@Model.Evidence.FileName" width="100%" height="auto" class="govuk-!-margin-bottom-2" data-testid="image-@Model.Evidence!.FileId" />
                 }
                 <a href="@Model.Evidence!.FileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" date-testid="view-larger-@Model.Evidence!.FileId">View larger (opens in new tab)</a>
             </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TrsLinkGenerator.cs
@@ -173,7 +173,7 @@ public partial class TrsLinkGenerator(LinkGenerator linkGenerator)
 
     public string EditChangeRequest(string supportTaskReference) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Index", routeValues: new { supportTaskReference });
 
-    public string ChangeRequestDocument(string ticketNumber, Guid documentId) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Index", "documents", routeValues: new { ticketNumber, id = documentId });
+    public string ChangeRequestEvidence(string supportTaskReference) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Index", "evidence", routeValues: new { supportTaskReference });
 
     public string AcceptChangeRequest(string supportTaskReference) => GetRequiredPathByPage("/ChangeRequests/EditChangeRequest/Accept", routeValues: new { supportTaskReference });
 


### PR DESCRIPTION
In the Change Name / Date of Birth page, the uploaded evidence should render embedded on the page (as well as being able to click on a link to open in a separate tab.
This PR fixes the issue
