### PR TITLE
Allow querying for deactivated records

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByIdQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetActiveContactDetailByIdQuery.cs
@@ -1,5 +1,0 @@
-using Microsoft.Xrm.Sdk.Query;
-
-namespace TeachingRecordSystem.Core.Dqt.Queries;
-
-public record GetActiveContactDetailByIdQuery(Guid ContactId, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByIdQuery.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/Queries/GetContactDetailByIdQuery.cs
@@ -1,0 +1,5 @@
+using Microsoft.Xrm.Sdk.Query;
+
+namespace TeachingRecordSystem.Core.Dqt.Queries;
+
+public record GetContactDetailByIdQuery(Guid ContactId, ColumnSet ColumnSet) : ICrmQuery<ContactDetail?>;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Dqt/QueryHandlers/GetContactDetailByIdHandler.cs
@@ -5,13 +5,12 @@ using TeachingRecordSystem.Core.Dqt.Queries;
 
 namespace TeachingRecordSystem.Core.Dqt.QueryHandlers;
 
-public class GetActiveContactDetailByIdHandler : ICrmQueryHandler<GetActiveContactDetailByIdQuery, ContactDetail?>
+public class GetContactDetailByIdHandler : ICrmQueryHandler<GetContactDetailByIdQuery, ContactDetail?>
 {
-    public async Task<ContactDetail?> ExecuteAsync(GetActiveContactDetailByIdQuery query, IOrganizationServiceAsync organizationService)
+    public async Task<ContactDetail?> ExecuteAsync(GetContactDetailByIdQuery query, IOrganizationServiceAsync organizationService)
     {
         var contactFilter = new FilterExpression();
         contactFilter.AddCondition(Contact.PrimaryIdAttribute, ConditionOperator.Equal, query.ContactId);
-        contactFilter.AddCondition(Contact.Fields.StateCode, ConditionOperator.Equal, (int)ContactState.Active);
         var contactQueryExpression = new QueryExpression(Contact.EntityLogicalName)
         {
             ColumnSet = query.ColumnSet,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckPersonExistsFilter.cs
@@ -42,7 +42,7 @@ public class CheckPersonExistsFilter(
         {
             // If person isn't in the TRS DB it may be because we haven't synced it yet..
 
-            var dqtContact = await crmQueryDispatcher.ExecuteQueryAsync(new GetActiveContactDetailByIdQuery(personId, new ColumnSet()));
+            var dqtContact = await crmQueryDispatcher.ExecuteQueryAsync(new GetContactDetailByIdQuery(personId, new ColumnSet()));
 
             if (dqtContact is not null)
             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml.cs
@@ -136,7 +136,7 @@ public class IndexModel(
         else
         {
             var contactDetail = await crmQueryDispatcher.ExecuteQueryAsync(
-                new GetActiveContactDetailByIdQuery(
+                new GetContactDetailByIdQuery(
                     PersonId,
                     new ColumnSet(
                         Contact.Fields.dfeta_TRN,


### PR DESCRIPTION
Now that we're showing deactivated records our DQT fallback queries need the 'is active' predicate removing.