### PR TITLE
Highlight tag helper fixes and other match comparison fixes

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/CheckAnswers.cshtml.cs
@@ -112,7 +112,7 @@ public class CheckAnswersModel(
             PreviousMiddleName = state.PreviousMiddleName,
             PreviousLastName = state.PreviousLastName,
             WorkEmailAddress = state.WorkEmail,
-            Name = new[] { state.FirstName!, state.MiddleName ?? string.Empty, state.LastName! },
+            Name = GetNonEmptyValues(state.FirstName, state.MiddleName, state.LastName),
             EmailAddress = state.PersonalEmail,
             DateOfBirth = state.DateOfBirth!.Value,
             NationalInsuranceNumber = Core.NationalInsuranceNumber.Normalize(state.NationalInsuranceNumber),
@@ -166,6 +166,21 @@ public class CheckAnswersModel(
         await JourneyInstance!.UpdateStateAsync(state => state.HasPendingTrnRequest = true);
 
         return Redirect(linkGenerator.RequestTrnSubmitted(JourneyInstance!.InstanceId));
+
+        static string[] GetNonEmptyValues(params string?[] values)
+        {
+            var result = new List<string>(values.Length);
+
+            foreach (var value in values)
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    result.Add(value);
+                }
+            }
+
+            return result.ToArray();
+        }
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
@@ -126,22 +126,4 @@ public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : R
 
         await base.OnPageHandlerExecutionAsync(context, next);
     }
-
-    public record PotentialDuplicate
-    {
-        public required char Identifier { get; init; }
-        public required Guid PersonId { get; init; }
-        public required string FirstName { get; init; }
-        public required string MiddleName { get; init; }
-        public required string LastName { get; init; }
-        public required DateOnly? DateOfBirth { get; init; }
-        public required string? EmailAddress { get; init; }
-        public required string? NationalInsuranceNumber { get; init; }
-        public required string Trn { get; init; }
-        public required Gender? Gender { get; init; }
-        public required bool HasQts { get; init; }
-        public required bool HasEyts { get; init; }
-        public required bool HasActiveAlerts { get; init; }
-        public required IReadOnlyCollection<PersonMatchedAttribute> MatchedAttributes { get; init; }
-    }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestPageModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestPageModel.cs
@@ -39,7 +39,7 @@ public abstract class ResolveApiTrnRequestPageModel(TrsDbContext dbContext) : Pa
                 yield return PersonMatchedAttribute.FirstName;
             }
 
-            if (middleName == requestData.MiddleName)
+            if (middleName == requestData.MiddleName || (string.IsNullOrWhiteSpace(requestData.MiddleName) && string.IsNullOrWhiteSpace(middleName)))
             {
                 yield return PersonMatchedAttribute.MiddleName;
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Details.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Details.cshtml
@@ -51,7 +51,7 @@
                         <govuk-summary-list-row-value data-testid="evidence">
                             @if (Model.NpqEvidenceFileId is not null)
                             {
-                                <a href="@Model.NpqEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="evidence-link">@($"{Model.NpqEvidenceFileName} (opens in new tab)")</a>
+                                <a href="@Model.NpqEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="evidence-link">@($"{Model.NpqEvidenceFileName} (opens in a new tab)")</a>
                             }
                             else
                             {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml
@@ -55,7 +55,16 @@
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Evidence</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value use-empty-fallback>TO DO</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value data-testid="evidence">
+                            @if (Model.NpqEvidenceFileId is not null)
+                            {
+                                <a href="@Model.NpqEvidenceFileUrl" class="govuk-link" rel="noreferrer noopener" target="_blank" data-testid="evidence-link">@($"{Model.NpqEvidenceFileName} (opens in a new tab)")</a>
+                            }
+                            else
+                            {
+                                <span use-empty-fallback></span>
+                            }
+                        </govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                 </govuk-summary-list>
             </govuk-summary-card>
@@ -149,6 +158,7 @@
                             <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>@match.Trn</govuk-summary-list-row-value>
                         </govuk-summary-list-row>
+
                     </govuk-summary-list>
                 </govuk-summary-card>
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml.cs
@@ -3,18 +3,22 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.SupportUi;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
-using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.Matches;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve;
 
 [Journey(JourneyNames.ResolveNpqTrnRequest), RequireJourneyInstance, ActivatesJourney]
-public class MatchesModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : ResolveNpqTrnRequestPageModel(dbContext)
+public class MatchesModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IFileService fileService) : ResolveNpqTrnRequestPageModel(dbContext)
 {
     public TrnRequestMetadata? RequestData { get; set; }
 
     public PotentialDuplicate[]? PotentialDuplicates { get; set; }
+
+    public Guid? NpqEvidenceFileId { get; set; }
+    public string? NpqEvidenceFileName { get; set; }
+    public string? NpqEvidenceFileUrl { get; set; }
 
     public string SourceApplicationUserName => RequestData!.ApplicationUser!.Name;
 
@@ -115,6 +119,13 @@ public class MatchesModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator
                     r.NationalInsuranceNumber)
             })
             .ToArray();
+
+        NpqEvidenceFileId = RequestData.NpqEvidenceFileId;
+        NpqEvidenceFileName = RequestData.NpqEvidenceFileName;
+
+        NpqEvidenceFileUrl = NpqEvidenceFileId is not null ?
+            await fileService.GetFileUrlAsync(NpqEvidenceFileId!.Value, FileUploadDefaults.FileUrlExpiry) :
+            null;
 
         await base.OnPageHandlerExecutionAsync(context, next);
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/ResolveNpqTrnRequestPageModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/ResolveNpqTrnRequestPageModel.cs
@@ -28,8 +28,6 @@ public abstract class ResolveNpqTrnRequestPageModel(TrsDbContext dbContext) : Pa
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        var supportTaskFeature = context.HttpContext.GetCurrentSupportTaskFeature();
-
         base.OnPageHandlerExecuting(context);
     }
 
@@ -126,7 +124,7 @@ public abstract class ResolveNpqTrnRequestPageModel(TrsDbContext dbContext) : Pa
                 yield return PersonMatchedAttribute.FirstName;
             }
 
-            if (middleName == requestData.MiddleName)
+            if (middleName == requestData.MiddleName || (string.IsNullOrWhiteSpace(requestData.MiddleName) && string.IsNullOrWhiteSpace(middleName)))
             {
                 yield return PersonMatchedAttribute.MiddleName;
             }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/PotentialDuplicate.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/PotentialDuplicate.cs
@@ -1,0 +1,19 @@
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks;
+
+public record PotentialDuplicate
+{
+    public required char Identifier { get; init; }
+    public required Guid PersonId { get; init; }
+    public required string FirstName { get; init; }
+    public required string MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required DateOnly? DateOfBirth { get; init; }
+    public required string? EmailAddress { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
+    public required string Trn { get; init; }
+    public required Gender? Gender { get; init; }
+    public required bool HasQts { get; init; }
+    public required bool HasEyts { get; init; }
+    public required bool HasActiveAlerts { get; init; }
+    public required IReadOnlyCollection<PersonMatchedAttribute> MatchedAttributes { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/HighlightTagHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/TagHelpers/HighlightTagHelper.cs
@@ -1,4 +1,4 @@
-using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
@@ -15,19 +15,19 @@ public class HighlightTagHelper : TagHelper
     {
         if (Highlight)
         {
-            var content = await output.GetChildContentAsync();
+            var content = (await output.GetChildContentAsync()).GetContent();
 
             if (output.IsContentModified)
             {
-                content = output.Content;
+                content = output.Content.GetContent();
             }
 
             var mark = new TagBuilder("mark");
             mark.AddCssClass("hods-highlight");
 
             var strong = new TagBuilder("strong");
-            strong.InnerHtml.Append(content.ToHtmlString(HtmlEncoder.Default));
-            mark.InnerHtml.AppendHtml(strong);
+            strong.InnerHtml.SetHtmlContent(content);
+            mark.InnerHtml.SetHtmlContent(strong);
 
             output.Content.SetHtmlContent(mark);
         }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestTests.cs
@@ -80,7 +80,7 @@ public class NpqTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
                 t.WithMatchedPersons([matchedPerson1.PersonId, matchedPerson2.PersonId]);
                 t.WithNationalInsuranceNumber(matchedPerson1.NationalInsuranceNumber);
                 t.WithDateOfBirth(matchedPerson1.DateOfBirth);
-                t.WithEmailAddress(matchedPerson1.Email);
+                t.WithEmailAddress(matchedPerson1.Email!);
             });
         var requestData = supportTask.TrnRequestMetadata!;
         var supportTaskReference = supportTask.SupportTaskReference;
@@ -152,7 +152,7 @@ public class NpqTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
                 t.WithMatchedPersons([matchedPerson1.PersonId, matchedPerson2.PersonId]);
                 t.WithNationalInsuranceNumber(matchedPerson1.NationalInsuranceNumber);
                 t.WithDateOfBirth(matchedPerson1.DateOfBirth);
-                t.WithEmailAddress(matchedPerson1.Email);
+                t.WithEmailAddress(matchedPerson1.Email!);
             });
 
         var requestData = supportTask.TrnRequestMetadata!;
@@ -231,7 +231,7 @@ public class NpqTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
                 t.WithMatchedPersons([matchedPerson1.PersonId, matchedPerson2.PersonId]);
                 t.WithNationalInsuranceNumber(matchedPerson1.NationalInsuranceNumber);
                 t.WithDateOfBirth(matchedPerson1.DateOfBirth);
-                t.WithEmailAddress(matchedPerson1.Email);
+                t.WithEmailAddress(matchedPerson1.Email!);
             });
 
         var requestData = supportTask.TrnRequestMetadata!;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestTests.cs
@@ -317,9 +317,7 @@ public class NpqTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
         var applicationUser = await TestData.CreateApplicationUserAsync(name: "NPQ");
 
         var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(applicationUser.UserId, configure =>
-        {
-            configure.WithMatches(false);
-        });
+            configure.WithMatches(false).WithMiddleName(TestData.GenerateMiddleName()));
 
         var requestData = supportTask.TrnRequestMetadata!;
         var supportTaskReference = supportTask.SupportTaskReference;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/DetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/DetailsTests.cs
@@ -11,7 +11,10 @@ public class DetailsTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
 
-        var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(applicationUser.UserId);
+        var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(applicationUser.UserId, s => s
+            .WithEmailAddress(TestData.GenerateUniqueEmail())
+            .WithMiddleName(TestData.GenerateMiddleName())
+            .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
         var metadata = supportTask.TrnRequestMetadata!;
 
         var request = new HttpRequestMessage(
@@ -25,11 +28,11 @@ public class DetailsTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         var doc = await response.GetDocumentAsync();
         doc.AssertRowContentMatches("Name", $"{metadata.FirstName} {metadata.MiddleName} {metadata.LastName}");
         doc.AssertRowContentMatches("Date of birth", metadata.DateOfBirth.ToString(UiDefaults.DateOnlyDisplayFormat));
-        doc.AssertRowContentMatches("Working in school or educational setting", metadata.NpqWorkingInEducationalSetting.HasValue ? metadata.NpqWorkingInEducationalSetting.Value ? "Yes" : "No" : "Not provided");
+        doc.AssertRowContentMatches("Working in school or educational setting", metadata.NpqWorkingInEducationalSetting.HasValue ? metadata.NpqWorkingInEducationalSetting.Value ? "Yes" : "No" : UiDefaults.EmptyDisplayContent);
         doc.AssertRowContentMatches("NPQ application ID", metadata.NpqApplicationId);
         doc.AssertRowContentMatches("NPQ name", metadata.NpqName);
         doc.AssertRowContentMatches("NPQ training provider", metadata.NpqTrainingProvider);
-        doc.AssertRowContentMatches("Evidence", metadata.NpqEvidenceFileId.HasValue ? $"{metadata.NpqEvidenceFileName} (opens in new tab)" : "not provided");
+        doc.AssertRowContentMatches("Evidence", $"{metadata.NpqEvidenceFileName} (opens in a new tab)");
     }
 
     [Fact]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/NoMatches/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/NoMatches/CheckAnswersTests.cs
@@ -54,6 +54,9 @@ public class CheckAnswersTests : NpqTrnRequestTestBase
 
         var supportTask = await new CreateNpqTrnRequestSupportTaskBuilder(applicationUser.UserId)
             .WithMatches(false)
+            .WithMiddleName(TestData.GenerateMiddleName())
+            .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber())
+            .WithEmailAddress(TestData.GenerateUniqueEmail())
             .ExecuteAsync(TestData);
 
         var requestMetadata = supportTask.TrnRequestMetadata;

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/NpqTrnRequestTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/NpqTrnRequestTestBase.cs
@@ -38,7 +38,7 @@ public abstract class NpqTrnRequestTestBase(HostFixture hostFixture) : TestBase(
                         : TestData.GenerateChangedDateOfBirth(matchedPerson.DateOfBirth))
                 .WithEmailAddress(
                     differentAttribute != PersonMatchedAttribute.EmailAddress
-                        ? matchedPerson.Email
+                        ? matchedPerson.Email!
                         : TestData.GenerateUniqueEmail())
                 .WithNationalInsuranceNumber(
                     differentAttribute != PersonMatchedAttribute.NationalInsuranceNumber

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/CheckAnswersTests.cs
@@ -552,7 +552,12 @@ public class CheckAnswersTests : NpqTrnRequestTestBase
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
 
-        var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(applicationUser.UserId);
+        var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(applicationUser.UserId, s =>
+        {
+            s.WithMiddleName(TestData.GenerateMiddleName());
+            s.WithEmailAddress(TestData.GenerateUniqueEmail());
+            s.WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber());
+        });
         var requestMetadata = supportTask.TrnRequestMetadata;
         Assert.NotNull(requestMetadata);
         var comments = Faker.Lorem.Paragraph();
@@ -596,7 +601,6 @@ public class CheckAnswersTests : NpqTrnRequestTestBase
             Assert.Equal(person.DateOfBirth, requestMetadata.DateOfBirth);
             Assert.Equal(person.EmailAddress, requestMetadata.EmailAddress);
             Assert.Equal(person.NationalInsuranceNumber, requestMetadata.NationalInsuranceNumber);
-            Assert.Equal(person.Gender, requestMetadata.Gender);
         });
 
         // support task is updated

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
@@ -44,7 +44,7 @@ public partial class TestData
         private Option<string> _requestId;
         private Option<string?> _emailAddress;
         private Option<string> _firstName;
-        private Option<string> _middleName;
+        private Option<string?> _middleName;
         private Option<string> _lastName;
         private Option<DateOnly> _dateOfBirth;
         private Option<string?> _nationalInsuranceNumber;
@@ -63,7 +63,7 @@ public partial class TestData
 
         public CreateApiTrnRequestSupportTaskBuilder WithMiddleName(string? middleName)
         {
-            _middleName = Option.Some(middleName ?? string.Empty);
+            _middleName = Option.Some(middleName);
             return this;
         }
 
@@ -132,7 +132,7 @@ public partial class TestData
             var trnRequestId = _requestId.ValueOr(Guid.NewGuid().ToString);
             var emailAddress = _emailAddress.ValueOr(testData.GenerateUniqueEmail);
             var firstName = _firstName.ValueOr(testData.GenerateFirstName);
-            var middleName = _middleName.ValueOr(testData.GenerateMiddleName);
+            var middleName = _middleName.ValueOrDefault();
             var lastName = _lastName.ValueOr(testData.GenerateLastName);
             var dateOfBirth = _dateOfBirth.ValueOr(testData.GenerateDateOfBirth);
             var nationalInsuranceNumber = _nationalInsuranceNumber.ValueOr(testData.GenerateNationalInsuranceNumber);
@@ -154,7 +154,7 @@ public partial class TestData
                             p
                                 .WithTrn()
                                 .WithFirstName(firstName)
-                                .WithMiddleName(middleName)
+                                .WithMiddleName(middleName ?? string.Empty)
                                 .WithLastName(lastName)
                                 .WithDateOfBirth(dateOfBirth)
                                 .WithEmail(emailAddress);
@@ -192,7 +192,7 @@ public partial class TestData
                 LastName = lastName,
                 PreviousFirstName = null,
                 PreviousLastName = null,
-                Name = [firstName, middleName, lastName],
+                Name = (new List<string?> { firstName, middleName, lastName }).OfType<string>().ToArray(),
                 DateOfBirth = dateOfBirth,
                 PotentialDuplicate = potentialDuplicate,
                 NationalInsuranceNumber = nationalInsuranceNumber,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateNpqTrnRequestSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateNpqTrnRequestSupportTask.cs
@@ -19,9 +19,9 @@ public partial class TestData
     public class CreateNpqTrnRequestSupportTaskBuilder(Guid applicationUserId)
     {
         private Option<string> _requestId;
-        private Option<string?> _emailAddress;
+        private Option<string> _emailAddress;
         private Option<string> _firstName;
-        private Option<string> _middleName;
+        private Option<string?> _middleName;
         private Option<string> _lastName;
         private Option<DateOnly> _dateOfBirth;
         private Option<string?> _nationalInsuranceNumber;
@@ -86,7 +86,7 @@ public partial class TestData
 
         public CreateNpqTrnRequestSupportTaskBuilder WithMiddleName(string? middleName)
         {
-            _middleName = Option.Some(middleName ?? string.Empty);
+            _middleName = Option.Some(middleName);
             return this;
         }
 
@@ -102,7 +102,7 @@ public partial class TestData
             return this;
         }
 
-        public CreateNpqTrnRequestSupportTaskBuilder WithEmailAddress(string? emailAddress)
+        public CreateNpqTrnRequestSupportTaskBuilder WithEmailAddress(string emailAddress)
         {
             _emailAddress = Option.Some(emailAddress);
             return this;
@@ -143,10 +143,10 @@ public partial class TestData
             var trnRequestId = _requestId.ValueOr(Guid.NewGuid().ToString);
             var emailAddress = _emailAddress.ValueOr(testData.GenerateUniqueEmail);
             var firstName = _firstName.ValueOr(testData.GenerateFirstName);
-            var middleName = _middleName.ValueOr(testData.GenerateMiddleName);
+            var middleName = _middleName.ValueOrDefault();
             var lastName = _lastName.ValueOr(testData.GenerateLastName);
             var dateOfBirth = _dateOfBirth.ValueOr(testData.GenerateDateOfBirth);
-            var nationalInsuranceNumber = _nationalInsuranceNumber.ValueOr(testData.GenerateNationalInsuranceNumber);
+            var nationalInsuranceNumber = _nationalInsuranceNumber.ValueOrDefault();
             var createdOn = _createdOn.ValueOr(testData.Clock.UtcNow);
             var npqApplicationId = _npqApplicationId.ValueOr(testData.GenerateNpqApplicationId());
             var npqIsInEducationalSetting = _npqIsInEducationalSetting.ValueOr(Faker.Boolean.Random);
@@ -203,7 +203,7 @@ public partial class TestData
                 LastName = lastName,
                 PreviousFirstName = null,
                 PreviousLastName = null,
-                Name = [firstName, middleName, lastName],
+                Name = (new List<string?> { firstName, middleName, lastName }).OfType<string>().ToArray(),
                 DateOfBirth = dateOfBirth,
                 PotentialDuplicate = potentialDuplicate,
                 NationalInsuranceNumber = nationalInsuranceNumber,


### PR DESCRIPTION
### Changes proposed in this pull request

Changes to highlight tag helper to fix double html-encoding.
Fix comparison of Person::MiddleName to support task request when it's empty
Add the file evidence to matches page
