### PR TITLE
Amended to allow embedded content to render if it's from the same origin

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Middleware/AppendSecurityResponseHeadersMiddleware.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/Middleware/AppendSecurityResponseHeadersMiddleware.cs
@@ -8,7 +8,7 @@ public class AppendSecurityResponseHeadersMiddleware(RequestDelegate next)
     {
         var response = context.Response;
 
-        response.Headers["X-Frame-Options"] = "DENY";
+        response.Headers["X-Frame-Options"] = "SAMEORIGIN";
         response.Headers["X-Xss-Protection"] = "0";
         response.Headers["X-Content-Type-Options"] = "nosniff";
         response.Headers["X-Permitted-Cross-Domain-Policies"] = "none";


### PR DESCRIPTION
PDFs were not rendering embedded in the change name / date of birth chang request page.
This fix amends the response headers to allow content from the same origina (i.e. from the same website)