### PR TITLE
Fix person search facet perf

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/Index.cshtml.cs
@@ -88,7 +88,8 @@ public class IndexModel(
         }
 
         var groupedByStatus = await query
-            .GroupBy(p => p.Status)
+            .Select(p => p.Status)
+            .GroupBy(p => p)
             .Select(g => new { Status = g.Key, Count = g.Count() })
             .ToArrayAsync();
 


### PR DESCRIPTION
Previously EF was pulling every matched record into memory and then doing the `group by`.