### PR TITLE
Fix NpqTrnRequestSupportTaskResolvedEvent title in Change history

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/NpqTrnRequestSupportTaskResolvedEvent.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/NpqTrnRequestSupportTaskResolvedEvent.cshtml
@@ -5,11 +5,18 @@
 @{
     var applicationUser = Model.ItemModel.ApplicationUser;
 
-    var title = applicationUser is ApplicationUserInfo userInfo
-        ? $"Record updated from {userInfo.Name} TRN request"
-        : $"Record updated from TRN request of unknown source";
-
     var updatedEvent = Model.ItemModel.Event;
+
+    var verb = updatedEvent.ChangeReason == NpqTrnRequestResolvedReason.RecordCreated
+        ? "created"
+        : "updated";
+
+    var source = applicationUser is ApplicationUserInfo userInfo
+        ? $"{userInfo.Name} TRN request"
+        : "TRN request of unknown source";
+
+    var title = $"Record {verb} from {source}";
+
     var requestData = updatedEvent.RequestData;
     var attributes = updatedEvent.PersonAttributes;
     var oldAttributes = updatedEvent.OldPersonAttributes;


### PR DESCRIPTION
### Context

@CathLass made some [changes](https://github.com/DFE-Digital/teaching-record-system/commit/83613116adef5ca505661a67dd707c978dfa74ab)
I [overwrote some of them](https://github.com/DFE-Digital/teaching-record-system/commit/f2dd7f093038a64b6eb78090fa28e56e93111e98)

This PR reinstates Cath's change and merges it with mine

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
