### PR TITLE
Always create records with a TRN in tests

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V1/Operations/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V1/Operations/GetTeacherTests.cs
@@ -67,7 +67,7 @@ public class GetTeacherTests : TestBase
         // Arrange
         var birthDate = new DateOnly(1990, 4, 1);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithDateOfBirth(birthDate));
+        var person = await TestData.CreatePersonAsync(p => p.WithDateOfBirth(birthDate));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v1/teachers/{person.Trn}?birthdate={birthDate:yyyy-MM-dd}");
 
@@ -84,9 +84,9 @@ public class GetTeacherTests : TestBase
         // Arrange
         var birthDate = new DateOnly(1990, 4, 1);
 
-        var personWithMatchingTrn = await TestData.CreatePersonAsync(p => p.WithTrn().WithDateOfBirth(birthDate));
+        var personWithMatchingTrn = await TestData.CreatePersonAsync(p => p.WithDateOfBirth(birthDate));
 
-        var personWithMatchingNino = await TestData.CreatePersonAsync(p => p.WithTrn().WithDateOfBirth(birthDate).WithNationalInsuranceNumber());
+        var personWithMatchingNino = await TestData.CreatePersonAsync(p => p.WithDateOfBirth(birthDate).WithNationalInsuranceNumber());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v1/teachers/{personWithMatchingTrn.Trn}?birthdate={birthDate:yyyy-MM-dd}&nino={personWithMatchingNino.NationalInsuranceNumber}");
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/CreateDateOfBirthChangeTests.cs
@@ -73,7 +73,7 @@ public class CreateDateOfBirthChangeTests : TestBase
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
 
@@ -145,7 +145,7 @@ public class CreateDateOfBirthChangeTests : TestBase
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";
@@ -173,7 +173,7 @@ public class CreateDateOfBirthChangeTests : TestBase
     public async Task Post_ValidRequest_CreatesIncident()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/CreateNameChangeTests.cs
@@ -80,7 +80,7 @@ public class CreateNameChangeTests : TestBase
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/v3/teachers/name-changes")
         {
@@ -156,7 +156,7 @@ public class CreateNameChangeTests : TestBase
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();
@@ -188,7 +188,7 @@ public class CreateNameChangeTests : TestBase
     public async Task Post_ValidRequest_CreatesIncident()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
@@ -24,8 +24,8 @@ public class FindTeachersTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePersonAsync(b => b.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person2 = await TestData.CreatePersonAsync(b => b.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person1 = await TestData.CreatePersonAsync(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person2 = await TestData.CreatePersonAsync(b => b.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -91,13 +91,13 @@ public class FindTeachersTests : TestBase
         var alertType = alertTypes.Where(at => Api.V3.Constants.LegacyExposableSanctionCodes.Contains(at.DqtSanctionCode)).RandomOne();
 
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
+
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null)));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
+
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null)));
@@ -169,9 +169,9 @@ public class FindTeachersTests : TestBase
         var lastName = TestData.GenerateLastName();
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person2 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person3 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
+        var person1 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person2 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person3 = await TestData.CreatePersonAsync(p => p.WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
         var updatedLastName = TestData.GenerateChangedLastName(lastName);
         await TestData.UpdatePersonAsync(b => b.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
 
@@ -241,7 +241,6 @@ public class FindTeachersTests : TestBase
         var alertType = await TestData.ReferenceDataCache.GetAlertTypeByDqtSanctionCodeAsync(sanctionCode);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherByTrnTests.cs
@@ -115,7 +115,7 @@
 //     public async Task Get_ValidRequestWithInductionAndPersonHasNullDqtStatus_ReturnsNullInductionContent()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         // Arrange
 //         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}?include=Induction");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/GetTeacherTests.cs
@@ -199,7 +199,7 @@
 //     public async Task Get_ValidRequestWithInductionAndPersonHasNullDqtStatus_ReturnsNullInductionContent()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         // Arrange
 //         var request = new HttpRequestMessage(HttpMethod.Get, "/v3/teacher?include=Induction");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/CreateDateOfBirthChangeTests.cs
@@ -19,7 +19,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
 
@@ -90,7 +90,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";
@@ -117,7 +117,7 @@ public class CreateDateOfBirthChangeTests(HostFixture hostFixture) : TestBase(ho
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/CreateNameChangeTests.cs
@@ -21,7 +21,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/v3/teacher/name-changes")
         {
@@ -46,7 +46,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();
@@ -77,7 +77,7 @@ public class CreateNameChangeTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/GetTeacherByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/GetTeacherByTrnTests.cs
@@ -11,7 +11,7 @@ public class GetTeacherByTrnTests : TestBase
     public async Task Get_DateOfBirthDoesNotMatchTeachingRecord_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var dateOfBirth = person.DateOfBirth.AddDays(1);
 
         var httpClient = GetHttpClientWithApiKey();
@@ -28,7 +28,7 @@ public class GetTeacherByTrnTests : TestBase
     public async Task Get_DateOfBirthMatchesTeachingRecord_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var httpClient = GetHttpClientWithApiKey();
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}");
@@ -44,7 +44,7 @@ public class GetTeacherByTrnTests : TestBase
     public async Task Get_DateOfBirthNotProvided_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var httpClient = GetHttpClientWithApiKey();
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/teachers/{person.Trn}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateDateOfBirthChangeTests.cs
@@ -23,7 +23,7 @@ public class CreateDateOfBirthChangeTests : TestBase
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
 
@@ -94,7 +94,7 @@ public class CreateDateOfBirthChangeTests : TestBase
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";
@@ -121,7 +121,7 @@ public class CreateDateOfBirthChangeTests : TestBase
     public async Task Post_ValidRequest_CreatesSupportTaskAndSendsEmailAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var emailAddress = Faker.Internet.Email();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateDateOfBirthChangeTests_Dqt.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateDateOfBirthChangeTests_Dqt.cs
@@ -19,7 +19,7 @@ public class CreateDateOfBirthChangeTests_Dqt(HostFixture hostFixture) : TestBas
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var newDateOfBirth = newDateOfBirthString is not null ? DateOnly.ParseExact(newDateOfBirthString, "yyyy-MM-dd") : (DateOnly?)null;
 
@@ -90,7 +90,7 @@ public class CreateDateOfBirthChangeTests_Dqt(HostFixture hostFixture) : TestBas
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";
@@ -117,7 +117,7 @@ public class CreateDateOfBirthChangeTests_Dqt(HostFixture hostFixture) : TestBas
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newDateOfBirth = TestData.GenerateChangedDateOfBirth(currentDateOfBirth: createPersonResult.DateOfBirth);
 
         var evidenceFileName = "evidence.txt";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateNameChangeTests.cs
@@ -25,7 +25,7 @@ public class CreateNameChangeTests : TestBase
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/name-changes")
         {
@@ -50,7 +50,7 @@ public class CreateNameChangeTests : TestBase
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();
@@ -81,7 +81,7 @@ public class CreateNameChangeTests : TestBase
     public async Task Post_ValidRequest_CreatesSupportTaskAndSendsEmailAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateNameChangeTests_Dqt.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateNameChangeTests_Dqt.cs
@@ -21,7 +21,7 @@ public class CreateNameChangeTests_Dqt(HostFixture hostFixture) : TestBase(hostF
         string? evidenceFileUrl)
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/v3/person/name-changes")
         {
@@ -46,7 +46,7 @@ public class CreateNameChangeTests_Dqt(HostFixture hostFixture) : TestBase(hostF
     public async Task Post_EvidenceFileDoesNotExist_ReturnsError()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();
@@ -77,7 +77,7 @@ public class CreateNameChangeTests_Dqt(HostFixture hostFixture) : TestBase(hostF
     public async Task Post_ValidRequest_CreatesIncidentAndReturnsTicketNumber()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var newFirstName = TestData.GenerateFirstName();
         var newMiddleName = TestData.GenerateMiddleName();
         var newLastName = TestData.GenerateLastName();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -21,8 +21,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = "Smith";
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person2 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person1 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person2 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -88,13 +88,11 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var alertType = alertTypes.Where(at => Api.V3.Constants.LegacyExposableSanctionCodes.Contains(at.DqtSanctionCode)).RandomOne();
 
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null)));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null)));
@@ -166,9 +164,9 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var lastName = TestData.GenerateLastName();
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
-        var person1 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person2 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person3 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
+        var person1 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person2 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        var person3 = await TestData.CreatePersonAsync(p => p.WithLastName(TestData.GenerateChangedLastName(lastName)).WithDateOfBirth(dateOfBirth));
         var updatedLastName = TestData.GenerateChangedLastName(lastName);
         await TestData.UpdatePersonAsync(p => p.WithPersonId(person2.PersonId).WithUpdatedName(person2.FirstName, person2.MiddleName, updatedLastName));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonByTrnTests.cs
@@ -114,7 +114,7 @@
 //     public async Task Get_ValidRequestWithInductionAndPersonHasNullDqtStatus_ReturnsNullInductionContent()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         // Arrange
 //         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=Induction");
@@ -279,7 +279,7 @@
 //     public async Task Get_DateOfBirthDoesNotMatchTeachingRecord_ReturnsNotFound()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //         var dateOfBirth = person.DateOfBirth.AddDays(1);
 //
 //         var httpClient = GetHttpClientWithApiKey();
@@ -296,7 +296,7 @@
 //     public async Task Get_DateOfBirthMatchesTeachingRecord_ReturnsOk()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         var httpClient = GetHttpClientWithApiKey();
 //         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?dateOfBirth={person.DateOfBirth:yyyy-MM-dd}");
@@ -312,7 +312,7 @@
 //     public async Task Get_DateOfBirthNotProvided_ReturnsOk()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         var httpClient = GetHttpClientWithApiKey();
 //         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/GetPersonTests.cs
@@ -194,7 +194,7 @@
 //     public async Task Get_ValidRequestWithInductionAndPersonHasNullDqtStatus_ReturnsNullInductionContent()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         // Arrange
 //         var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person?include=Induction");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/GetQtlsDateRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/GetQtlsDateRequestTests.cs
@@ -15,8 +15,7 @@ public class GetQtlsDateRequestTests : TestBase
     {
         // Arrange
         SetCurrentApiClient(roles);
-        var existingContact = await TestData.CreatePersonAsync(p => p
-            .WithTrn());
+        var existingContact = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"v3/persons/{existingContact.Trn}/qtls");
 
@@ -46,7 +45,7 @@ public class GetQtlsDateRequestTests : TestBase
     public async Task Get_NoQtls_ReturnsExpectedResult()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Get, $"v3/persons/{person.Trn}/qtls");
 
         // Act
@@ -59,7 +58,6 @@ public class GetQtlsDateRequestTests : TestBase
             {
                 person.Trn,
                 qtsDate = (DateOnly?)null
-
             },
             expectedStatusCode: 200);
     }
@@ -69,9 +67,8 @@ public class GetQtlsDateRequestTests : TestBase
     {
         // Arrange
         var qtlsDate = new DateOnly(2020, 01, 01);
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQtls(qtlsDate));
+        var person = await TestData.CreatePersonAsync(p => p.WithQtls(qtlsDate));
+
         var request = new HttpRequestMessage(HttpMethod.Get, $"v3/persons/{person.Trn}/qtls");
 
         // Act

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/SetQtlsDateRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/SetQtlsDateRequestTests.cs
@@ -17,7 +17,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         SetCurrentApiClient(roles);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var requestBody = CreateJsonContent(new { qtsDate = new DateOnly(1990, 01, 01) });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
@@ -36,7 +36,7 @@ public class SetQtlsDateRequestTests : TestBase
     public async Task Put_QtlsDateInFuture_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var futureDate = Clock.Today.AddDays(1);
 
@@ -77,7 +77,7 @@ public class SetQtlsDateRequestTests : TestBase
     public async Task Put_ValidQtsDateWithNoExistingQtsDate_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var qtlsDate = new DateOnly(2020, 01, 01);
 
@@ -104,9 +104,7 @@ public class SetQtlsDateRequestTests : TestBase
     public async Task Put_NullQtlsDateWithExistingQtlsDate_ReturnsOk()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQtls(new DateOnly(2020, 01, 01)));
+        var person = await TestData.CreatePersonAsync(p => p.WithQtls(new DateOnly(2020, 01, 01)));
 
         DateOnly? qtlsDate = null;
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -21,7 +21,6 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var alertType = alertTypes.Where(at => !at.InternalOnly).RandomOne();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null)));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -20,7 +20,6 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var alertType = alertTypes.Where(at => !at.InternalOnly).RandomOne();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null)));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/GetPersonTests.cs
@@ -10,7 +10,6 @@ public class GetPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var alertType = alertTypes.Where(at => !at.InternalOnly).RandomOne();
 
         var person = await TestData.CreatePersonAsync(x => x
-            .WithTrn()
             .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId).WithEndDate(null)));
 
         var alert = person.Alerts.Single();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/SetDeceasedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/SetDeceasedTests.cs
@@ -18,7 +18,7 @@ public class SetDeceasedTests : TestBase
     {
         // Arrange
         SetCurrentApiClient(roles);
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestBody = CreateJsonContent(new { DateOfDeath = new DateOnly(1990, 01, 01) });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {
@@ -37,7 +37,7 @@ public class SetDeceasedTests : TestBase
     {
         // Arrange
         var futureDate = Clock.UtcNow.AddYears(1).ToDateOnlyWithDqtBstFix(isLocalTime: false);
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestBody = CreateJsonContent(new { DateOfDeath = futureDate });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {
@@ -59,7 +59,7 @@ public class SetDeceasedTests : TestBase
     {
         // Arrange
         var futureDate = Clock.UtcNow.AddYears(1).ToDateOnlyWithDqtBstFix(isLocalTime: false);
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestBody = CreateJsonContent(new { DateOfDeath = default(DateOnly?) });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {
@@ -95,7 +95,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_ExistingDateOfDeath_ReturnsNoContent()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestBody1 = CreateJsonContent(new { DateOfDeath = new DateOnly(1990, 01, 01) });
         var requestBody2 = CreateJsonContent(new { DateOfDeath = new DateOnly(1980, 01, 01) });
         var request1 = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
@@ -120,7 +120,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_ValidDateOfDeath_ReturnsNoContent()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestBody = CreateJsonContent(new { DateOfDeath = new DateOnly(1990, 01, 01) });
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -20,7 +20,6 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth));
 
@@ -48,7 +47,6 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var inductionCompletedDate = new DateOnly(1996, 6, 7);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithInductionStatus(i => i
@@ -77,7 +75,6 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithQtlsStatus(Core.Models.QtlsStatus.Expired));
@@ -104,7 +101,6 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var qtlsDate = new DateOnly(2020, 01, 01);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithQtls(qtlsDate));
@@ -130,7 +126,6 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth));
 
@@ -159,7 +154,6 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithQts(qtsDate)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonsByTrnAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/FindPersonsByTrnAndDateOfBirthTests.cs
@@ -19,7 +19,6 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth));
 
@@ -58,7 +57,6 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var inductionCompletedDate = new DateOnly(1996, 6, 7);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithInductionStatus(i => i
@@ -99,7 +97,6 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var qtlsDate = new DateOnly(2020, 01, 01);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithQtls(qtlsDate));
@@ -136,7 +133,6 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth));
 
@@ -172,7 +168,6 @@ public class FindPersonsByTrnAndDateOfBirthTests : TestBase
         var dateOfBirth = new DateOnly(1990, 1, 1);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithLastName(lastName)
             .WithDateOfBirth(dateOfBirth)
             .WithQtlsStatus(Core.Models.QtlsStatus.Expired));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonByTrnTests.cs
@@ -194,7 +194,7 @@
 //     public async Task Get_WithoutQtlsDate_ReturnsNoneQtlsStatus()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         // Arrange
 //         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=Induction");
@@ -212,7 +212,7 @@
 //     public async Task Get_WithNullDqtInductionStatus_ReturnsNoneInductionStatus()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         // Arrange
 //         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=Induction");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/GetPersonTests.cs
@@ -43,7 +43,7 @@
 //     public async Task Get_WithNullDqtInductionStatus_ReturnsNoneInductionStatus()
 //     {
 //         // Arrange
-//         var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+//         var person = await TestData.CreatePersonAsync();
 //
 //         // Arrange
 //         var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person?include=Induction");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetCpdInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetCpdInductionStatusTests.cs
@@ -25,9 +25,7 @@ public class SetCpdInductionStatusTests : TestBase
         // Arrange
         SetCurrentApiClient(roles: []);
 
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"/v3/persons/{person.Trn}/cpd-induction")
         {
@@ -71,8 +69,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_PersonDoesNotHaveQts_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"/v3/persons/{person.Trn}/cpd-induction")
         {
@@ -97,9 +94,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_StatusIsInvalid_ReturnsError(InductionStatus status)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"/v3/persons/{person.Trn}/cpd-induction")
         {
@@ -121,9 +116,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_TimestampIsBeforePreviousUpdate_ReturnsConflict()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
 
@@ -167,9 +160,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_RequiredToCompleteWithStartDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
 
@@ -194,9 +185,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_RequiredToCompleteWithCompletedDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
         var completedDate = startDate.AddMonths(12);
@@ -222,9 +211,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_InProgressWithoutStartDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"/v3/persons/{person.Trn}/cpd-induction")
         {
@@ -246,9 +233,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_InProgressWithCompletedDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
         var completedDate = startDate.AddMonths(12);
@@ -275,9 +260,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_FailedWithoutStartDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
         var completedDate = startDate.AddMonths(12);
@@ -303,9 +286,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_FailedWithoutCompletedDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
         var completedDate = startDate.AddMonths(12);
@@ -331,9 +312,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_PassedWithoutStartDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
         var completedDate = startDate.AddMonths(12);
@@ -359,9 +338,7 @@ public class SetCpdInductionStatusTests : TestBase
     public async Task Put_PassedWithoutCompletedDate_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
 
@@ -388,7 +365,6 @@ public class SetCpdInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(currentStatus));
 
@@ -414,7 +390,6 @@ public class SetCpdInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(currentStatus));
 
@@ -443,7 +418,6 @@ public class SetCpdInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(currentStatus));
 
@@ -474,7 +448,6 @@ public class SetCpdInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(currentStatus));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
@@ -13,7 +13,6 @@ public class GetPersonByTrnTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithQtls(Clock.Today));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/CreateTrnRequestTests.cs
@@ -184,7 +184,6 @@ public class CreateTrnRequestTests : TestBase
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var existingContact = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithTrnRequest(ApplicationUserId, requestId)
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
@@ -244,7 +243,6 @@ public class CreateTrnRequestTests : TestBase
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         var existingContact = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)
@@ -292,7 +290,6 @@ public class CreateTrnRequestTests : TestBase
         var invalidNino = "IvalidNi";
 
         var existingContact = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)
@@ -445,7 +442,6 @@ public class CreateTrnRequestTests : TestBase
         var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
         await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithFirstName(firstName)
             .WithMiddleName(middleName)
             .WithLastName(lastName)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetPiiTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetPiiTests.cs
@@ -17,8 +17,7 @@ public class SetPiiTests : TestBase
         // Arrange
         SetCurrentApiClient(roles);
 
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"/v3/persons/{person.Trn}")
         {
@@ -67,8 +66,7 @@ public class SetPiiTests : TestBase
     public async Task Put_PiiUpdatesNotPermitted_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         XrmFakedContext.UpdateEntity(new Contact()
         {
@@ -98,9 +96,7 @@ public class SetPiiTests : TestBase
     public async Task Put_PersonHasQts_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var content = CreateJsonContent(new
         {
@@ -124,9 +120,7 @@ public class SetPiiTests : TestBase
     public async Task Put_PersonHasEyts_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithEyts(new DateOnly(2000, 01, 10)));
+        var person = await TestData.CreatePersonAsync(p => p.WithEyts(new DateOnly(2000, 01, 10)));
 
         var content = CreateJsonContent(new
         {
@@ -150,9 +144,7 @@ public class SetPiiTests : TestBase
     public async Task Put_ValidRequest_ReturnsNoContent()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithGender(Core.Models.Gender.Male));
+        var person = await TestData.CreatePersonAsync(p => p.WithGender(Core.Models.Gender.Male));
 
         var updatedFirstName = Faker.Name.First();
         var updatedMiddleName = Faker.Name.Middle();
@@ -197,7 +189,6 @@ public class SetPiiTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithGender(Core.Models.Gender.Male)
             .WithEmail(Faker.Internet.Email())
             .WithNationalInsuranceNumber(Faker.Identification.UkNationalInsuranceNumber()));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetProfessionalStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetProfessionalStatusTests.cs
@@ -19,7 +19,7 @@ public class SetProfessionalStatusTests : TestBase
         // Arrange
         SetCurrentApiClient(roles);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(CreateRequest());
@@ -58,7 +58,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsOverseasAndStatusIsNotApproved_ReturnsBadRequest(ProfessionalStatusStatus status)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -79,7 +79,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNotOverseasAndStatusIsApproved_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -100,7 +100,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsAssessmentOnlyRouteAndStatusIsInTraining_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -121,7 +121,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNotAssessmentOnlyRouteAndStatusIsUnderAssessment_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -144,7 +144,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_StatusIsApprovedAndAwardedDateIsNotSpecified_ReturnsBadRequest(bool isOverseasRouteType)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var status = isOverseasRouteType ? ProfessionalStatusStatus.Approved : ProfessionalStatusStatus.Awarded;
@@ -172,7 +172,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_StatusIsNotApprovedAndAwardedDateIsSpecified_ReturnsBadRequest(ProfessionalStatusStatus status)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -194,7 +194,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_AwardedDateIsInTheFuture_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -216,7 +216,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_WithoutTrainingStartDate_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -238,7 +238,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_WithoutTrainingEndDate_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -260,7 +260,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_WithTrainingEndDateBeforeTrainingStartDate_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -283,7 +283,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_WithMoreThanThreeTrainingSubjectReferences_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -305,7 +305,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_TrainingAgeSpecialismTypeIsRangeWithoutFromAge_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -332,7 +332,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_TrainingAgeSpecialismTypeIsRangeWithoutToAge_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -359,7 +359,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_TrainingAgeSpecialismTypeIsRangeWithToAgeLessThanFromAge_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -386,7 +386,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_TrainingAgeSpecialismTypeIsRangeWithToOrFromAgeNotBetween0And19_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -419,7 +419,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNotOverseasOrInternationalQualifiedTeacherStatusWithNonGBTrainingCountryReference_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -442,7 +442,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsOverseasWithoutTrainingCountryReference_ReturnsBadRequest(Guid routeTypeId)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -465,7 +465,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsInternationalQualifiedTeacherStatusWithoutTrainingCountryReference_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
         var routeTypeId = RouteToProfessionalStatusType.InternationalQualifiedTeacherStatusId;
 
@@ -489,7 +489,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsOverseasWithGBTrainingCountryReference_ReturnsBadRequest(Guid routeTypeId)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -512,7 +512,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsScotlandWithNonScotlandTrainingCountryReference_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -535,7 +535,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNotScotlandWithScotlandTrainingCountryReference_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -558,7 +558,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNorthernIrelandWithNonNorthernIrelandTrainingCountryReference_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -581,7 +581,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNotNorthernIrelandWithNorthernIrelandTrainingCountryReference_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -604,7 +604,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsWalesWithNonWalesTrainingCountryReference_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -629,7 +629,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNotWalesWithWalesTrainingCountryReference_ReturnsBadRequest(string trainingCountryReference)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -651,7 +651,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsNotOverseasWithoutTrainingProviderUkprn_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -674,7 +674,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeIsOverseasWithTrainingProviderUkprn_ReturnsBadRequest(Guid routeTypeId)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -698,7 +698,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeWhichCanHaveInductionExemptionWithoutIsExemptFromInduction_ReturnsBadRequest(Guid routeTypeId, string? trainingCountryReference)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -722,7 +722,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeWhichCannotHaveInductionExemptionWithIsExemptFromInduction_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -743,7 +743,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_RouteTypeDoesNotMapToIttProgrammeType_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
         var legacyIttRouteTypeId = Guid.Parse("4514EC65-20B0-4465-B66F-4718963C5B80");
 
@@ -767,7 +767,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_TrainingSubjectReferenceDoesNotMapToIttSubject_ReturnsBadRequest(string subject1, string subject2, string subject3)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -788,7 +788,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_TrainingCountryReferenceDoesNotMapToDqtCountry_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -813,7 +813,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_TrainingProviderUkprnDoesNotMapToIttProvider_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(
@@ -835,7 +835,7 @@ public class SetProfessionalStatusTests : TestBase
     public async Task Put_DegreeTypeDoesNotMapToIttQualification_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var requestId = Guid.NewGuid().ToString();
 
         var request = CreateJsonContent(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/GetTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/GetTrnTests.cs
@@ -23,7 +23,7 @@ public class GetTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task HandleAsync_PersonExistsButIsNotActive_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         await WithDbContextAsync(dbContext =>
             dbContext.Persons
@@ -43,8 +43,8 @@ public class GetTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task HandleAsync_PersonIsMerged_ReturnsRedirect()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
-        var anotherPerson = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
+        var anotherPerson = await TestData.CreatePersonAsync();
 
         await WithDbContextAsync(dbContext =>
             dbContext.Persons
@@ -67,7 +67,7 @@ public class GetTrnTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task HandleAsync_PersonExistsAndIsActive_ReturnsNoContent()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         Debug.Assert(person.Person.Status is PersonStatus.Active);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/trns/{person.Trn}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetWelshInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetWelshInductionStatusTests.cs
@@ -13,9 +13,7 @@ public class SetWelshInductionStatusTests : TestBase
         // Arrange
         SetCurrentApiClient(roles: []);
 
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
-            .WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         var startDate = person.QtsDate!.Value.AddDays(6);
         var completedDate = startDate.AddMonths(12);
@@ -67,8 +65,7 @@ public class SetWelshInductionStatusTests : TestBase
     public async Task Put_PersonDoesNotHaveQts_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var startDate = new DateOnly(2022, 1, 1);
         var completedDate = startDate.AddMonths(12);
@@ -95,7 +92,6 @@ public class SetWelshInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(InductionStatus.RequiredToComplete));
 
@@ -130,7 +126,6 @@ public class SetWelshInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(InductionStatus.RequiredToComplete));
 
@@ -165,7 +160,6 @@ public class SetWelshInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(InductionStatus.Passed));
 
@@ -200,7 +194,6 @@ public class SetWelshInductionStatusTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithInductionStatus(InductionStatus.Passed));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
@@ -30,7 +30,7 @@ public class CreateDateOfBirthChangeTests : OperationTestBase
         WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
         {
             // Arrange
-            var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var createPersonResult = await TestData.CreatePersonAsync();
             var command = await CreateCommand() with
             {
                 Trn = createPersonResult!.Trn!,
@@ -49,7 +49,7 @@ public class CreateDateOfBirthChangeTests : OperationTestBase
         WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
         {
             // Arrange
-            var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var createPersonResult = await TestData.CreatePersonAsync();
             var command = await CreateCommand() with
             {
                 Trn = createPersonResult!.Trn!

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateNameChangeTests.cs
@@ -30,7 +30,7 @@ public class CreateNameChangeTests : OperationTestBase
         WithHandler<CreateNameChangeRequestHandler>(async handler =>
         {
             // Arrange
-            var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var createPersonResult = await TestData.CreatePersonAsync();
             var command = await CreateCommand() with
             {
                 Trn = createPersonResult!.Trn!,
@@ -49,7 +49,7 @@ public class CreateNameChangeTests : OperationTestBase
         WithHandler<CreateNameChangeRequestHandler>(async handler =>
         {
             // Arrange
-            var createPersonResult = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var createPersonResult = await TestData.CreatePersonAsync();
             var command = await CreateCommand() with
             {
                 Trn = createPersonResult!.Trn!

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
@@ -26,7 +26,6 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var applicationUserId = CurrentUserProvider.GetCurrentApplicationUser().UserId;
 
             await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithFirstName(command.FirstName)
                 .WithMiddleName(command.MiddleName)
                 .WithLastName(command.LastName)
@@ -112,7 +111,6 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var nino = TestData.GenerateNationalInsuranceNumber();
 
             var matchedPerson = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithFirstName(matchedFields.Contains(MatchedField.FirstName) ? firstName : TestData.GenerateChangedFirstName(firstName))
                 .WithMiddleName(matchedFields.Contains(MatchedField.MiddleName) ? middleName : TestData.GenerateChangedMiddleName(middleName))
                 .WithLastName(matchedFields.Contains(MatchedField.LastName) ? lastName : TestData.GenerateChangedLastName(lastName))
@@ -174,7 +172,6 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
             var matchedPerson = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithDateOfBirth(dateOfBirth)
                 .WithNationalInsuranceNumber(nationalInsuranceNumber));
 
@@ -213,7 +210,6 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
             var matchedPerson = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithDateOfBirth(TestData.GenerateChangedDateOfBirth(dateOfBirth))
                 .WithNationalInsuranceNumber(nationalInsuranceNumber));
 
@@ -251,9 +247,7 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             // Arrange
             var emailAddress = TestData.GenerateUniqueEmail();
 
-            var matchedPerson = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
-                .WithEmail(emailAddress));
+            var matchedPerson = await TestData.CreatePersonAsync(p => p.WithEmail(emailAddress));
 
             var command = CreateCommand() with
             {
@@ -290,12 +284,10 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
             var matchedPerson1 = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithDateOfBirth(dateOfBirth)
                 .WithNationalInsuranceNumber(nationalInsuranceNumber));
 
             var matchedPerson2 = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithDateOfBirth(dateOfBirth)
                 .WithNationalInsuranceNumber(nationalInsuranceNumber));
 
@@ -335,7 +327,6 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
             var matchedPerson = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithDateOfBirth(dateOfBirth));
             Debug.Assert(matchedPerson.NationalInsuranceNumber is null);
 
@@ -388,7 +379,6 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
             var matchedPerson = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithDateOfBirth(dateOfBirth)
                 .WithNationalInsuranceNumber(nationalInsuranceNumber));
             Debug.Assert(matchedPerson.Alerts.Count == 0 && matchedPerson.QtsDate is null && matchedPerson.EytsDate is null);
@@ -440,7 +430,6 @@ public class CreateTrnRequestTests : OperationTestBase, IAsyncLifetime
             var nationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber();
 
             var matchedPerson = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithDateOfBirth(dateOfBirth)
                 .WithNationalInsuranceNumber(nationalInsuranceNumber)
                 .WithAlert());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests.cs
@@ -24,7 +24,7 @@ public partial class GetQtlsTests(OperationTestFixture operationTestFixture) : O
         WithHandler<GetQtlsHandler>(async handler =>
         {
             // Arrange
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
 
             var command = new GetQtlsCommand(person.Trn!);
 
@@ -45,7 +45,6 @@ public partial class GetQtlsTests(OperationTestFixture operationTestFixture) : O
             var qtlsDate = new DateOnly(2025, 5, 1);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithRouteToProfessionalStatus(s => s
                     .WithRouteType(RouteToProfessionalStatusType.QtlsAndSetMembershipId)
                     .WithStatus(RouteToProfessionalStatusStatus.Holds)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnRequestTests.cs
@@ -56,7 +56,6 @@ public class GetTrnRequestTests(OperationTestFixture operationTestFixture) : Ope
             var (applicationUserId, _) = CurrentUserProvider.GetCurrentApplicationUser();
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithTrnRequest(applicationUserId, requestId)
                 .WithEmail(TestData.GenerateUniqueEmail()));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnTests.cs
@@ -25,7 +25,7 @@ public class GetTrnTests(OperationTestFixture operationTestFixture) : OperationT
         WithHandler<GetTrnHandler>(async handler =>
         {
             // Arrange
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
 
             await DbFixture.WithDbContextAsync(dbContext =>
                 dbContext.Persons
@@ -46,8 +46,8 @@ public class GetTrnTests(OperationTestFixture operationTestFixture) : OperationT
         WithHandler<GetTrnHandler>(async handler =>
         {
             // Arrange
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
-            var anotherPerson = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
+            var anotherPerson = await TestData.CreatePersonAsync();
 
             await DbFixture.WithDbContextAsync(dbContext =>
                 dbContext.Persons
@@ -77,7 +77,7 @@ public class GetTrnTests(OperationTestFixture operationTestFixture) : OperationT
         WithHandler<GetTrnHandler>(async handler =>
         {
             // Arrange
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             Debug.Assert(person.Person.Status is PersonStatus.Active);
             var command = new GetTrnCommand(person.Trn!);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
@@ -24,7 +24,7 @@ public partial class SetQtlsTests(OperationTestFixture operationTestFixture) : O
         WithHandler<SetQtlsHandler>(async handler =>
         {
             // Arrange
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
 
             var command = new SetQtlsCommand(person.Trn!, QtsDate: null);
 
@@ -42,7 +42,7 @@ public partial class SetQtlsTests(OperationTestFixture operationTestFixture) : O
         {
             // Arrange
             var existingQtlsDate = new DateOnly(2025, 4, 1);
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithQtls(existingQtlsDate));
+            var person = await TestData.CreatePersonAsync(p => p.WithQtls(existingQtlsDate));
 
             var command = new SetQtlsCommand(person.Trn!, QtsDate: null);
 
@@ -74,7 +74,7 @@ public partial class SetQtlsTests(OperationTestFixture operationTestFixture) : O
         WithHandler<SetQtlsHandler>(async handler =>
         {
             // Arrange
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
 
             var qtlsDate = new DateOnly(2025, 4, 1);
             var command = new SetQtlsCommand(person.Trn!, qtlsDate);
@@ -111,7 +111,7 @@ public partial class SetQtlsTests(OperationTestFixture operationTestFixture) : O
         {
             // Arrange
             var qtlsDate = new DateOnly(2025, 4, 1);
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithQtls(qtlsDate));
+            var person = await TestData.CreatePersonAsync(p => p.WithQtls(qtlsDate));
 
             var command = new SetQtlsCommand(person.Trn!, qtlsDate);
 
@@ -132,7 +132,7 @@ public partial class SetQtlsTests(OperationTestFixture operationTestFixture) : O
         {
             // Arrange
             var existingQtsDate = new DateOnly(2025, 4, 1);
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithQtls(existingQtsDate));
+            var person = await TestData.CreatePersonAsync(p => p.WithQtls(existingQtsDate));
 
             var newQtlsDate = new DateOnly(2025, 4, 10);
             var command = new SetQtlsCommand(person.Trn!, newQtlsDate);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/OidcTests.cs
@@ -7,7 +7,7 @@ public class OidcTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact(Skip = "Flaky on CI")]
     public async Task SignInAndOut()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var coreIdentityVc = TestData.CreateOneLoginCoreIdentityVc(person.FirstName, person.LastName, person.DateOfBirth);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/SignInTests.cs
@@ -23,7 +23,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUser_MatchesWithNino()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber());
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -52,7 +52,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUserWithUnmatchedNino_MatchesWithTrn()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn().WithNationalInsuranceNumber(false));
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber(false));
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -86,7 +86,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUserWithoutNino_MatchesWithTrn()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn().WithNationalInsuranceNumber(false));
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber(false));
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -119,7 +119,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUser_DoesNotMatchWithNinoOrTrn()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn().WithNationalInsuranceNumber(false));
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber(false));
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -156,7 +156,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUserWithNeitherNinoNorTrn_DoesNotMatch()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn().WithNationalInsuranceNumber(false));
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber(false));
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -191,7 +191,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUserWithTrnTokenAndMatchingDetails_MatchesWithTrn()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn().WithNationalInsuranceNumber(false));
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber(false));
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -226,7 +226,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUserWithGetAnIdentityAccountAndMatchingDetails_MatchesWithTrn()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -264,7 +264,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUserWithGetAnIdentityAccountWithTrnAssociatedByTrnTokenAndMatchingDetails_MatchesWithTrn()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -303,7 +303,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_UnknownVerifiedUserWithGetAnIdentityAccountWithTrnAssociatedBySupportAndMatchingDetails_MatchesWithTrn()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var subject = TestData.CreateOneLoginUserSubject();
         var email = Faker.Internet.Email();
@@ -342,7 +342,7 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task SignIn_KnownUser()
     {
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.Email!));
@@ -364,7 +364,6 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
         var subject = TestData.CreateOneLoginUserSubject();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithTrnRequest(applicationUser.UserId, trnRequestId, identityVerified: true, oneLoginUserSubject: subject));
 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(subject: Option.Some(subject));
@@ -388,7 +387,6 @@ public class SignInTests(HostFixture hostFixture) : TestBase(hostFixture)
         var email = TestData.GenerateUniqueEmail();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(email)
             .WithTrnRequest(applicationUser.UserId, trnRequestId, identityVerified: true));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
@@ -97,7 +97,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -236,7 +236,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -256,7 +256,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequest_CreatesSupportTicketAndRedirectsToSupportRequestedSubmitted()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trnToken = await CreateTrnTokenAsync(person.Trn!);
         var applicationUser = await TestData.CreateApplicationUserAsync(isOidcClient: true);
         var state = CreateNewState(clientApplicationUserId: applicationUser.UserId, trnToken: trnToken);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/ConnectTests.cs
@@ -44,7 +44,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -122,7 +122,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/FoundTests.cs
@@ -34,7 +34,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -79,7 +79,7 @@ public class FoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NationalInsuranceNumberTests.cs
@@ -44,7 +44,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -148,7 +148,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -335,7 +335,7 @@ public class NationalInsuranceNumberTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(
             personId: null,
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotFoundTests.cs
@@ -48,7 +48,7 @@ public class NotFoundTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/NotVerifiedTests.cs
@@ -25,7 +25,7 @@ public class NotVerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/CheckAnswersTests.cs
@@ -599,12 +599,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture),
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithFirstName(state.FirstName!)
             .WithMiddleName(state.MiddleName)
             .WithLastName(state!.LastName!));
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithFirstName(state.FirstName!)
             .WithMiddleName(state.MiddleName)
             .WithLastName(state!.LastName!));
@@ -629,7 +627,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture),
         var journeyInstance = await CreateJourneyInstance(state);
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithFirstName(state.FirstName!)
             .WithMiddleName(state.MiddleName)
             .WithLastName(state!.LastName!)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
@@ -95,7 +95,7 @@ public class SupportRequestSubmittedTests(HostFixture hostFixture) : TestBase(ho
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/TrnTests.cs
@@ -46,7 +46,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -184,7 +184,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
         var ticket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, oneLoginUser);
@@ -418,7 +418,7 @@ public class TrnTests(HostFixture hostFixture) : TestBase(hostFixture)
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstanceAsync(state);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var person = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(
             personId: null,
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyHelperTests.cs
@@ -19,7 +19,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(person);
             Clock.Advance();
 
@@ -56,7 +56,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(person, email: Option.Some((string?)null));
             Clock.Advance();
 
@@ -108,7 +108,6 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var trnRequestId = Guid.NewGuid().ToString();
             var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: true, oneLoginUserSubject: subject));
 
             var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, sub: subject);
@@ -186,7 +185,6 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var trnRequestId = Guid.NewGuid().ToString();
             var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithEmail(email)
                 .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: true));
 
@@ -229,7 +227,6 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var trnRequestId = Guid.NewGuid().ToString();
             var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
             var person = await TestData.CreatePersonAsync(p => p
-                .WithoutTrn()
                 .WithEmail(email)
                 .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: true));
 
@@ -266,7 +263,6 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var trnRequestId = Guid.NewGuid().ToString();
             var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
             var person = await TestData.CreatePersonAsync(p => p
-                .WithoutTrn()
                 .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: false, oneLoginUserSubject: subject));
 
             var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: SignInJourneyHelper.AuthenticationOnlyVtr, sub: subject);
@@ -303,7 +299,6 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var trnRequestId = Guid.NewGuid().ToString();
             var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithEmail(email)
                 .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: false));
 
@@ -505,7 +500,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -564,7 +559,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -623,7 +618,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -682,7 +677,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var helper = CreateHelper(dbContext);
 
             var email = Faker.Internet.Email();
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -731,7 +726,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -780,7 +775,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -829,7 +824,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -888,7 +883,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -938,7 +933,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -988,7 +983,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -1034,7 +1029,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -1084,7 +1079,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             // Arrange
             var helper = CreateHelper(dbContext);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person = await TestData.CreatePersonAsync();
             var user = await TestData.CreateOneLoginUserAsync(personId: null);
             Clock.Advance();
 
@@ -1180,65 +1175,6 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
         });
 
     [Fact]
-    public Task TryMatchToTeachingRecord_MatchesWithoutTrn_ReturnsFalseAndDoesNotSetAuthenticationTicket() =>
-        WithDbContextAsync(async dbContext =>
-        {
-            // Arrange
-            var personMatchingServiceMock = new Mock<IPersonMatchingService>();
-            var helper = CreateHelper(dbContext, personMatchingServiceMock.Object);
-
-            var firstName = Faker.Name.Last();
-            var lastName = Faker.Name.Last();
-            var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-            var person = await TestData.CreatePersonAsync(p => p.WithoutTrn().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
-
-            var user = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([firstName, lastName], dateOfBirth));
-            Clock.Advance();
-
-            var state = new SignInJourneyState(
-                redirectUri: "/",
-                serviceName: "Test Service",
-                serviceUrl: "https://service",
-                oneLoginAuthenticationScheme: "dummy",
-                clientApplicationUserId: default);
-            var journeyInstance = await CreateJourneyInstanceAsync(state);
-
-            var authenticationTicket = CreateOneLoginAuthenticationTicket(
-                vtr: SignInJourneyHelper.AuthenticationOnlyVtr,
-                sub: user.Subject,
-                createCoreIdentityVc: false);
-            await helper.OnOneLoginCallbackAsync(journeyInstance, authenticationTicket);
-
-            await journeyInstance.UpdateStateAsync(state => state.SetNationalInsuranceNumber(true, person.NationalInsuranceNumber));
-
-            personMatchingServiceMock
-                .Setup(mock => mock.MatchOneLoginUserAsync(It.Is<OneLoginUserMatchRequest>(r =>
-                    r.Names.SequenceEqual(state.VerifiedNames!) &&
-                    r.DatesOfBirth.SequenceEqual(state.VerifiedDatesOfBirth!) &&
-                    r.NationalInsuranceNumber == state.NationalInsuranceNumber &&
-                    r.Trn == state.Trn)))
-                .ReturnsAsync(new OneLoginUserMatchResult(
-                    person.PersonId,
-                    person.Trn!,
-                    new Dictionary<PersonMatchedAttribute, string>()
-                    {
-                        { PersonMatchedAttribute.FullName, $"{person.FirstName} {person.LastName}" },
-                        { PersonMatchedAttribute.NationalInsuranceNumber, person.NationalInsuranceNumber! },
-                    }));
-
-            // Act
-            var result = await helper.TryMatchToTeachingRecordAsync(journeyInstance);
-
-            // Assert
-            Assert.False(result);
-
-            user = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == user.Subject);
-            Assert.Null(user.PersonId);
-
-            Assert.Null(state.AuthenticationTicket);
-        });
-
-    [Fact]
     public Task TryMatchToTeachingRecord_Matches_ReturnsTrueAndUpdatesOneLoginUserAssignsAuthenticationTicket() =>
         WithDbContextAsync(async dbContext =>
         {
@@ -1249,7 +1185,7 @@ public class SignInJourneyHelperTests(HostFixture hostFixture) : TestBase(hostFi
             var firstName = Faker.Name.Last();
             var lastName = Faker.Name.Last();
             var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
+            var person = await TestData.CreatePersonAsync(p => p.WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
 
             var user = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([firstName, lastName], dateOfBirth));
             Clock.Advance();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/V20250804/WebhookData/AlertCreatedNotificationMapperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/V20250804/WebhookData/AlertCreatedNotificationMapperTests.cs
@@ -13,7 +13,6 @@ public class AlertCreatedNotificationMapperTests(EventMapperFixture fixture) : E
                 .RandomOneExcept(a => a.InternalOnly);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));
 
             var alert = person.Alerts.Single();
@@ -44,7 +43,6 @@ public class AlertCreatedNotificationMapperTests(EventMapperFixture fixture) : E
                 .RandomOneExcept(a => !a.InternalOnly);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));
 
             var alert = person.Alerts.Single();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/V20250804/WebhookData/AlertDeletedNotificationMapperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/V20250804/WebhookData/AlertDeletedNotificationMapperTests.cs
@@ -14,7 +14,6 @@ public class AlertDeletedNotificationMapperTests(EventMapperFixture fixture) : E
                 .RandomOneExcept(a => a.InternalOnly);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));
 
             var alert = person.Alerts.Single();
@@ -60,7 +59,6 @@ public class AlertDeletedNotificationMapperTests(EventMapperFixture fixture) : E
                 .RandomOneExcept(a => !a.InternalOnly);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));
 
             var alert = person.Alerts.Single();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/V20250804/WebhookData/AlertUpdatedNotificationMapperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/ApiSchema/V20250804/WebhookData/AlertUpdatedNotificationMapperTests.cs
@@ -14,7 +14,6 @@ public class AlertUpdatedNotificationMapperTests(EventMapperFixture fixture) : E
                 .RandomOneExcept(a => a.InternalOnly);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));
 
             var alert = person.Alerts.Single();
@@ -62,7 +61,6 @@ public class AlertUpdatedNotificationMapperTests(EventMapperFixture fixture) : E
                 .RandomOneExcept(a => !a.InternalOnly);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));
 
             var alert = person.Alerts.Single();
@@ -101,7 +99,6 @@ public class AlertUpdatedNotificationMapperTests(EventMapperFixture fixture) : E
                 .RandomOneExcept(a => !a.InternalOnly);
 
             var person = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithAlert(a => a.WithAlertTypeId(alertType.AlertTypeId)));
 
             var alert = person.Alerts.Single();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
@@ -28,7 +28,6 @@ public class BatchSendInductionCompletedEmailsJobTests(NightlyEmailJobFixture db
         var inductionCompletedDate = new DateOnly(2021, 10, 10);
 
         var inductionCompletee1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithQts()
             .WithEmail(TestData.GenerateUniqueEmail()));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
@@ -17,7 +17,6 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.QtlsAndSetMembershipId, holdsFrom: Clock.Today)
             .WithEmail(TestData.GenerateUniqueEmail()));
 
@@ -56,7 +55,6 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.InternationalQualifiedTeacherStatusId, holdsFrom: Clock.Today)
             .WithEmail(TestData.GenerateUniqueEmail()));
 
@@ -95,7 +93,6 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.EarlyYearsTeacherStatus, holdsFrom: Clock.Today)
             .WithEmail(TestData.GenerateUniqueEmail()));
 
@@ -134,7 +131,6 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.QtlsAndSetMembershipId, holdsFrom: Clock.Today)
             .WithEmail(TestData.GenerateUniqueEmail()));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportAmendJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportAmendJobTests.cs
@@ -144,7 +144,6 @@ public class CapitaExportAmendJobTests(CapitaExportAmendJobFixture Fixture) : IC
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithLastName(lastName);
-            x.WithTrn();
             x.WithDateOfBirth(new DateOnly(1983, 01, 07));
             x.WithGender(Gender.Male);
             x.WithCreatedByTps(true);
@@ -258,7 +257,6 @@ public class CapitaExportAmendJobTests(CapitaExportAmendJobFixture Fixture) : IC
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithLastName(lastName);
-            x.WithTrn();
             x.WithDateOfBirth(new DateOnly(1983, 01, 07));
             x.WithGender(Gender.Male);
             x.WithCreatedByTps(true);
@@ -372,7 +370,6 @@ public class CapitaExportAmendJobTests(CapitaExportAmendJobFixture Fixture) : IC
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithLastName(lastName);
-            x.WithTrn();
             x.WithDateOfBirth(new DateOnly(1983, 01, 07));
             x.WithGender(Gender.Male);
             x.WithCreatedByTps(true);
@@ -480,7 +477,6 @@ public class CapitaExportAmendJobTests(CapitaExportAmendJobFixture Fixture) : IC
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithLastName(lastName);
-            x.WithTrn();
             x.WithDateOfBirth(new DateOnly(1983, 01, 07));
             x.WithGender(Gender.Male);
         });
@@ -560,7 +556,6 @@ public class CapitaExportAmendJobTests(CapitaExportAmendJobFixture Fixture) : IC
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithLastName(lastName);
-            x.WithTrn();
             x.WithDateOfBirth(new DateOnly(1983, 01, 07));
             x.WithGender(Gender.Male);
         });
@@ -640,7 +635,6 @@ public class CapitaExportAmendJobTests(CapitaExportAmendJobFixture Fixture) : IC
         var job = new CapitaExportAmendJob(blobServiceClientMock.Object, Fixture.Logger.Object, dbContext, Clock, jobOption);
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithDateOfBirth(new DateOnly(1983, 01, 07));
             x.WithGender(gender);
         });
@@ -723,7 +717,6 @@ public class CapitaExportAmendJobTests(CapitaExportAmendJobFixture Fixture) : IC
             var job = new CapitaExportAmendJob(blobServiceClientMock.Object, Fixture.Logger.Object, dbContext, Clock, jobOption);
             var person = await TestData.CreatePersonAsync(x =>
             {
-                x.WithTrn();
                 x.WithDateOfBirth(new DateOnly(1983, 01, 07));
                 x.WithGender(gender);
                 x.WithNationalInsuranceNumber(true);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportNewJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportNewJobTests.cs
@@ -45,12 +45,10 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var lastRunDate = DateTime.UtcNow.AddDays(-2);
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(Gender.Male);
         });
         var person2 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(Gender.Male);
         });
 
@@ -84,7 +82,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var lastRunDate = DateTime.UtcNow.AddDays(-2);
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(gender);
         });
 
@@ -134,7 +131,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         await using var dbContext = await DbFixture.DbHelper.DbContextFactory.CreateDbContextAsync();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(gender);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -169,7 +165,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var newLastName = Faker.Name.Last();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(gender);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -222,7 +217,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         Gender gender = Gender.Male;
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(gender);
             x.WithLastName(lastName);
         });
@@ -255,7 +249,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         await using var dbContext = await DbFixture.DbHelper.DbContextFactory.CreateDbContextAsync();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(Gender.Male);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -288,7 +281,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         await using var dbContext = await DbFixture.DbHelper.DbContextFactory.CreateDbContextAsync();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(Gender.Male);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -323,7 +315,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         await using var dbContext = await DbFixture.DbHelper.DbContextFactory.CreateDbContextAsync();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(Gender.Male);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -362,7 +353,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var originalastName = Faker.Name.Last();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithGender(gender);
             x.WithLastName(originalastName);
         });
@@ -410,7 +400,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var originalastName = Faker.Name.Last();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithLastName(originalastName);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -456,7 +445,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var originalastName = new string('a', 75);
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithLastName(originalastName);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -504,7 +492,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var originalastName = new string('a', 75);
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithLastName(originalastName);
         });
         var trsPerson = await dbContext.Persons.FirstAsync(x => x.PersonId == person1.PersonId);
@@ -606,7 +593,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var originalastName = Faker.Name.Last();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithLastName(originalastName);
             x.WithGender(Gender.Male);
         });
@@ -712,7 +698,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var originalastName = Faker.Name.Last();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithLastName(originalastName);
             x.WithGender(Gender.Male);
         });
@@ -810,7 +795,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var updateLastName1 = Faker.Name.Last();
         var person1 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithLastName(originalastName1);
             x.WithGender(Gender.Male);
         });
@@ -818,7 +802,6 @@ public class CapitaExportNewJobTests(CapitaExportNewJobFixture Fixture) : IClass
         var updateLastName2 = Faker.Name.Last();
         var person2 = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithLastName(originalastName2);
             x.WithGender(Gender.Male);
         });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Induction.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Induction.cs
@@ -20,7 +20,6 @@ public partial class EwcWalesImportJobTests
         var passDate = new DateOnly(2019, 09, 28);
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.WelshRId, holdDate);
             x.WithAlert();
         });
@@ -70,7 +69,6 @@ public partial class EwcWalesImportJobTests
         var passDate = Clock.Today.AddYears(-1).AddDays(2);
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.QtlsAndSetMembershipId)
                 .WithHoldsFrom(holdsDate)
@@ -125,7 +123,6 @@ public partial class EwcWalesImportJobTests
         var passDate = new DateOnly(2017, 09, 28);
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.WelshRId, holdsFrom);
         });
         var trn = person.Trn;
@@ -174,7 +171,7 @@ public partial class EwcWalesImportJobTests
         var expectedSuccessCount = 0;
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 1;
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trn1 = person.Trn;
         var inductionStartDate = new DateOnly(2024, 05, 01);
         var inductionPassDate = new DateOnly(2024, 10, 07);
@@ -228,7 +225,6 @@ public partial class EwcWalesImportJobTests
         });
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithQts(qtsDate);
             x.WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.WelshRId, holdsFrom);
         });
@@ -330,7 +326,6 @@ public partial class EwcWalesImportJobTests
         var passDate = DateTime.ParseExact("28/09/2017", "dd/MM/yyyy", CultureInfo.InvariantCulture);
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.WelshRId, passDate.ToDateOnlyWithDqtBstFix(isLocalTime: false));
         });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Qts.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Qts.cs
@@ -17,7 +17,7 @@ public partial class EwcWalesImportJobTests
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 1;
         var fileName = "QTS.csv";
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trn = person.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn},firstname,lastname,{person.DateOfBirth.ToString(QtsImporter.DATE_FORMAT)},{qtsStatus},04/04/2014,,,,,,,,,,,,,,,,,,,,,,,,\r\n";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -58,7 +58,7 @@ public partial class EwcWalesImportJobTests
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
         var fileName = "QTS.csv";
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trn = person.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn},firstname,lastname,{person.DateOfBirth.ToString(QtsImporter.DATE_FORMAT)},{qtsStatus},{awardedDate.ToString(QtsImporter.DATE_FORMAT)},,,,,,,,,,,,,,,,,,,,,,,,\r\n";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -105,7 +105,7 @@ public partial class EwcWalesImportJobTests
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
         var fileName = "QTS.csv";
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trn = person.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn},firstname,lastname,{person.DateOfBirth.ToString(QtsImporter.DATE_FORMAT)},{qtsStatus},{awardedDate.ToString(QtsImporter.DATE_FORMAT)},,,,,,,,,,,,,,,,,,,,,,,,\r\n";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -152,7 +152,7 @@ public partial class EwcWalesImportJobTests
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
         var fileName = "QTS.csv";
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trn = person.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn},firstname,lastname,{person.DateOfBirth.ToString(QtsImporter.DATE_FORMAT)},{qtsStatus},{awardedDate.ToString(QtsImporter.DATE_FORMAT)},,,,,,,,,,,,,,,,,,,,,,,,\r\n";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -198,7 +198,7 @@ public partial class EwcWalesImportJobTests
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
         var fileName = "QTS.csv";
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trn = person.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn},firstname,lastname,{person.DateOfBirth.ToString(QtsImporter.DATE_FORMAT)},{qtsStatus},{awardedDate.ToString(QtsImporter.DATE_FORMAT)},,,,,,,,,,,,,,,,,,,,,,,,\r\n";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -244,7 +244,7 @@ public partial class EwcWalesImportJobTests
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
         var fileName = "QTS.csv";
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trn = person.Trn;
         var csvContent = $"REFERENCE_NO,FIRST_NAME,LAST_NAME,DATE_OF_BIRTH,CODE,QTS_DATE\r\n{trn},firstname,lastname,{person.DateOfBirth.ToString(QtsImporter.DATE_FORMAT)},{qtsStatus},{awardedDate.ToString(QtsImporter.DATE_FORMAT)}\r\n";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -290,7 +290,6 @@ public partial class EwcWalesImportJobTests
         var fileName = "QTS.csv";
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithAlert();
         });
         var trn = person.Trn;
@@ -336,10 +335,10 @@ public partial class EwcWalesImportJobTests
         var expectedFailureRowCount = 1;
         var person1AwardedDate = new DateOnly(2011, 01, 04);
         var person2AwardedDate = new DateOnly(2014, 04, 04);
-        var person1 = await TestData.CreatePersonAsync(p => p.WithTrn()
+        var person1 = await TestData.CreatePersonAsync(p => p
             .WithQts()
             .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.WelshRId, person1AwardedDate));
-        var person2 = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person2 = await TestData.CreatePersonAsync();
         var expectedValueMessage = $"For TRN {person1.Trn} Date of Birth does not match";
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{person1.Trn},firstname,lastname,{person1.DateOfBirth.AddYears(-1).ToString(QtsImporter.DATE_FORMAT)},49,04/04/2014,,,,,,,,,,,,,,,,,,,,,,,,\r\n{person2.Trn},firstname,lastname,{person2.DateOfBirth.ToString(QtsImporter.DATE_FORMAT)},49,{person2AwardedDate.ToString(QtsImporter.DATE_FORMAT)},,,,,,,,,,,,,,,,,,,,,,,,\r\n";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -393,12 +392,12 @@ public partial class EwcWalesImportJobTests
         var person4AwardedDate = new DateOnly(2000, 03, 08);
         var person1QtsDate = new DateOnly(2000, 05, 04);
         var person2QtsDate = new DateOnly(2001, 08, 11);
-        var person1 = await TestData.CreatePersonAsync(p => p.WithTrn()
+        var person1 = await TestData.CreatePersonAsync(p => p
             .WithQts(person1QtsDate));
-        var person2 = await TestData.CreatePersonAsync(p => p.WithTrn()
+        var person2 = await TestData.CreatePersonAsync(p => p
             .WithQts(person2QtsDate));
-        var person3 = await TestData.CreatePersonAsync(x => x.WithTrn());
-        var person4 = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person3 = await TestData.CreatePersonAsync();
+        var person4 = await TestData.CreatePersonAsync();
         var expectedTotalRowCount = 4;
         var expectedSuccessCount = 2;
         var expectedDuplicateRowCount = 0;
@@ -470,7 +469,7 @@ public partial class EwcWalesImportJobTests
         var expectedSuccessCount = 0;
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 1;
-        var person1 = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person1 = await TestData.CreatePersonAsync();
         var trn1 = person1.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn1},firstname,lastname,{person1.DateOfBirth.ToString("dd/MM/yyyy")},{qtsStatus},04/04/2024,,,,,,,,,,,,,,,,,,,,,,,,";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -510,7 +509,7 @@ public partial class EwcWalesImportJobTests
         var expectedSuccessCount = 1;
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
-        var person1 = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person1 = await TestData.CreatePersonAsync();
         var trn1 = person1.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn1},firstname,lastname,{person1.DateOfBirth.ToString("dd/MM/yyyy")},{qtsStatus},{Clock.Today.AddDays(-10).ToString(QtsImporter.DATE_FORMAT)},,,,,,,,,,,,,,,,,,,,,,,,";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
@@ -553,7 +552,7 @@ public partial class EwcWalesImportJobTests
         var expectedSuccessCount = 1;
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
-        var person1 = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person1 = await TestData.CreatePersonAsync();
         var trn1 = person1.Trn;
         var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn1},firstname,lastname,{person1.DateOfBirth.ToString("dd/MM/yyyy")},{qtsStatus},04/04/1999,,,,,,,,,,,,,,,,,,,,,,,,";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
@@ -142,7 +142,6 @@ public class InductionImporterTests : IAsyncLifetime
         var person1AwardedDate = new DateOnly(2011, 01, 04);
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
                 .WithHoldsFrom(person1AwardedDate)
@@ -181,7 +180,6 @@ public class InductionImporterTests : IAsyncLifetime
         var qtsDate = Clock.Today.AddDays(-110);
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithQtls(qtsDate);
             x.WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
@@ -325,7 +323,6 @@ public class InductionImporterTests : IAsyncLifetime
         });
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
                 .WithHoldsFrom(Clock.Today.AddDays(-10))
@@ -412,7 +409,7 @@ public class InductionImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.ReferenceNumber = person.Trn!;
@@ -472,7 +469,7 @@ public class InductionImporterTests : IAsyncLifetime
         });
         var person1AwardedDate = new DateOnly(2011, 01, 04);
         var route = (await TestData.ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.RouteToProfessionalStatusTypeId == RouteToProfessionalStatusType.WelshRId).First();
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn()
+        var person = await TestData.CreatePersonAsync(p => p
             .WithQtls()
             .WithHoldsRouteToProfessionalStatus(route.RouteToProfessionalStatusTypeId, person1AwardedDate));
         var row = GetDefaultRow(x =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionStatusUpdatedSupportJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionStatusUpdatedSupportJobTests.cs
@@ -80,7 +80,7 @@ public class InductionStatusUpdatedSupportJobTests : IAsyncLifetime
         {
             {"LastRunDate", Clock.UtcNow.AddDays(-1).ToString("s", CultureInfo.InvariantCulture) }
         };
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trsPerson = context.Persons.Single(x => x.Trn == person.Trn);
         trsPerson.SetInductionStatus(
             fromInductionStatus,
@@ -132,7 +132,7 @@ public class InductionStatusUpdatedSupportJobTests : IAsyncLifetime
         {
             { "LastRunDate", Clock.UtcNow.AddDays(-1).ToString("s", CultureInfo.InvariantCulture) }
         };
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trsPerson = context.Persons.Single(x => x.Trn == person.Trn);
         trsPerson.SetInductionStatus(
             fromInductionStatus,
@@ -185,7 +185,7 @@ public class InductionStatusUpdatedSupportJobTests : IAsyncLifetime
         {
             { "LastRunDate", Clock.UtcNow.AddDays(-1).ToString("s", CultureInfo.InvariantCulture) }
         };
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var trsPerson = context.Persons.Single(x => x.Trn == person.Trn);
         trsPerson.SetInductionStatus(
             fromInductionStatus,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/QTSImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/QTSImporterTests.cs
@@ -90,7 +90,7 @@ public class QtsImporterTests : IAsyncLifetime
     public async Task Validate_WithMalformedDateOfBirth_ReturnsErrorMessages()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -110,7 +110,7 @@ public class QtsImporterTests : IAsyncLifetime
     public async Task Validate_WithMalformedQTSDate_ReturnsErrorMessages()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -130,7 +130,7 @@ public class QtsImporterTests : IAsyncLifetime
     public async Task Validate_ExistingTeacherDateOfBirthDoesNotMatch_ReturnsErrorMessage()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -156,7 +156,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -186,7 +186,6 @@ public class QtsImporterTests : IAsyncLifetime
         });
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
                 .WithHoldsFrom(holdsDate)
@@ -222,7 +221,6 @@ public class QtsImporterTests : IAsyncLifetime
         });
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
                 .WithHoldsFrom(holdsDate)
@@ -257,7 +255,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -286,7 +284,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -315,7 +313,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -344,7 +342,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -403,7 +401,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -432,7 +430,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithName("SomeName");
             x.WithAccountNumber(accountNumber);
         });
-        var person = await TestData.CreatePersonAsync(x => x.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var row = GetDefaultRow(x =>
         {
             x.QtsRefNo = person.Trn!;
@@ -488,7 +486,6 @@ public class QtsImporterTests : IAsyncLifetime
         });
         var person = await TestData.CreatePersonAsync(x =>
         {
-            x.WithTrn();
             x.WithAlert();
         });
         var row = GetDefaultRow(x =>
@@ -518,7 +515,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.WithAccountNumber(accountNumber);
         });
         var person1AwardedDate = new DateOnly(2011, 01, 04);
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn()
+        var person = await TestData.CreatePersonAsync(p => p
             .WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
                 .WithHoldsFrom(Clock.Today.AddDays(-10))

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SendQtsAwardedEmailJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/SendQtsAwardedEmailJobTests.cs
@@ -23,7 +23,7 @@ public class SendAytqInviteEmailJobTests(NightlyEmailJobFixture dbFixture) : Nig
                     BaseAddress = "https://aytq.com"
                 });
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithEmail(TestData.GenerateUniqueEmail()));
+            var person = await TestData.CreatePersonAsync(p => p.WithEmail(TestData.GenerateUniqueEmail()));
 
             var templateId = Guid.NewGuid().ToString();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.OneLogin.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.OneLogin.cs
@@ -31,7 +31,7 @@ public partial class PersonMatchingServiceTests
                 await dbContext.SaveChangesAsync();
             }
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName));
+            var person = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithFirstName(firstName));
             var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var employmentNino = TestData.GenerateChangedNationalInsuranceNumber(person.NationalInsuranceNumber!);
             var personEmployment = await TestData.CreateTpsEmploymentAsync(person, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), employmentNino);
@@ -98,8 +98,8 @@ public partial class PersonMatchingServiceTests
             var lastName = TestData.GenerateLastName();
             var dateOfBirth = TestData.GenerateDateOfBirth();
 
-            var person1 = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-            var person2 = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person1 = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person2 = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
             string[][] names = [[firstName, lastName]];
             DateOnly[] datesOfBirth = [dateOfBirth];
@@ -130,7 +130,7 @@ public partial class PersonMatchingServiceTests
             });
             await dbContext.SaveChangesAsync();
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(firstName));
+            var person = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithFirstName(firstName));
 
             string[][] names = [[person.FirstName, person.LastName], [alias, person.LastName]];
             DateOnly[] datesOfBirth = [person.DateOfBirth];
@@ -160,19 +160,19 @@ public partial class PersonMatchingServiceTests
             var alternativeNationalInsuranceNumber = TestData.GenerateChangedNationalInsuranceNumber(nationalInsuranceNumber);
 
             // Person who matches on last name & DOB
-            var person1 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person1 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
             // Person who matches on NINO
-            var person2 = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
+            var person2 = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
             var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var personEmployment = await TestData.CreateTpsEmploymentAsync(person2, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), usePersonNino ? alternativeNationalInsuranceNumber : nationalInsuranceNumber);
 
             // Person who matches on TRN
-            var person3 = await TestData.CreatePersonAsync(p => p.WithTrn());
+            var person3 = await TestData.CreatePersonAsync();
             var trn = person3.Trn!;
 
             // Person who matches on last name, DOB & TRN
-            var person4 = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+            var person4 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
             var trnTokenHintTrn = person4.Trn!;
 
             string[][] names = [[firstName, lastName]];

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.TrnRequest.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.TrnRequest.cs
@@ -34,7 +34,7 @@ public partial class PersonMatchingServiceTests
                 await dbContext.SaveChangesAsync();
             }
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber().WithFirstName(personFirstName).WithEmail(TestData.GenerateUniqueEmail()));
+            var person = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithFirstName(personFirstName).WithEmail(TestData.GenerateUniqueEmail()));
             var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var employmentNino = TestData.GenerateChangedNationalInsuranceNumber(person.NationalInsuranceNumber!);
             var personEmployment = await TestData.CreateTpsEmploymentAsync(person, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), employmentNino);
@@ -124,14 +124,12 @@ public partial class PersonMatchingServiceTests
 
             // Person matching on NINO, first name and last name
             var person1 = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithNationalInsuranceNumber(nationalInsuranceNumber)
                 .WithFirstName(firstName)
                 .WithLastName(lastName));
 
             // Person matching on first name, last name, DOB and email
             var person2 = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithFirstName(firstName)
                 .WithLastName(lastName)
                 .WithDateOfBirth(dateOfBirth)
@@ -139,7 +137,6 @@ public partial class PersonMatchingServiceTests
 
             // Person matching on first name, middle name and last name
             var person3 = await TestData.CreatePersonAsync(p => p
-                .WithTrn()
                 .WithFirstName(firstName)
                 .WithMiddleName(middleName)
                 .WithLastName(lastName));

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/PersonMatching/PersonMatchingServiceTests.cs
@@ -47,7 +47,7 @@ public partial class PersonMatchingServiceTests : IAsyncLifetime
             var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
             var alternativeNationalInsuranceNumber = TestData.GenerateChangedNationalInsuranceNumber(nationalInsuranceNumber);
 
-            var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
+            var person = await TestData.CreatePersonAsync(p => p.WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber(usePersonNino ? nationalInsuranceNumber : alternativeNationalInsuranceNumber));
             var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "321", establishmentNumber: "4321", establishmentStatusCode: 1);
             var personEmployment = await TestData.CreateTpsEmploymentAsync(person, establishment, new DateOnly(2023, 08, 03), new DateOnly(2024, 05, 25), EmploymentType.FullTime, new DateOnly(2024, 05, 25), usePersonNino ? alternativeNationalInsuranceNumber : nationalInsuranceNumber);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/TpsCsvExtractProcessorTests.cs
@@ -54,7 +54,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNonMatchingEstablishments_WhenCalledWithEstablishmentsNotMatchingEstablishmentsInTrs_SetsResultToInvalidEstablishment()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "124", establishmentNumber: "1235");
         var nonExistentEstablishmentNumber = "4321";
@@ -79,7 +79,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithNewEmploymentHistory_InsertsNewPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -108,7 +108,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithEndDateInTheFuture_SetsLastKnownEmployedDateToExtractDate()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -137,7 +137,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithWithdrawalIndicatorSet_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -166,7 +166,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WhenCalledWithLastKnownEmployedDateOlderThanFiveMonths_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "125", establishmentNumber: "1236");
         var startDate = new DateOnly(2023, 02, 03);
@@ -196,7 +196,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_ForLaCodeAndEstablishmentNumberWithMultipleEstablishmentEntries_MatchesToTheMostOpenEstablishment()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var laCode = "321";
         var establishmentNumber = "4321";
@@ -230,7 +230,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessNewEmploymentHistory_WithValidData_OnlyMatchesToLaCodeAndPostCodeForHigherEducationIfNoMatchOnLaCodeAndEstablishment()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var laCode1 = "322";
         var establishmentNumber1 = "4322";
@@ -264,7 +264,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithUpdatedEmploymentHistory_UpdatesPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -297,7 +297,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithEndDateInTheFuture_SetsLastKnownEmployedDateToExtractDate()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -325,7 +325,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithWithdrawalIndicatorSet_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -357,7 +357,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithLastKnownEmployedDateOlderThanFiveMonths_SetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -385,7 +385,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithWithdrawalIndicatorNowRemoved_ResetsEndDate()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -414,7 +414,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessUpdatedEmploymentHistory_WhenCalledWithUpdatedEmploymentHistoryWithNoChanges_SetsResultToValidNoChanges()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -438,7 +438,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task UpdateLatestEstablishmentVersions_WithEstablishmentChangingUrn_UpdatesPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 2); // Closed
         var establishment2 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "127", establishmentNumber: "1238", establishmentStatusCode: 1); // Open
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
@@ -461,7 +461,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task ProcessEndedEmployments_WithLastKnownEmployedDateGreaterThanThreeMonthsBeforeLastExtractDate_SetsEndDateOnPersonEmploymentRecord()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "128", establishmentNumber: "1239");
         var establishment2 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "128", establishmentNumber: "1240");
         var extractDate = new DateOnly(2024, 04, 25);
@@ -490,7 +490,7 @@ public class TpsCsvExtractProcessorTests : IAsyncLifetime
     public async Task BackfillEmployerEmailAddressInEmploymentHistory_WhenCalledWithTpsEmploymentRecordsWithoutEmployerEmailAddress_SetsEmployerEmailAddress()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var tpsCsvExtractId = Guid.NewGuid();
         var establishment = await TestData.CreateEstablishmentAsync(localAuthorityCode: "129", establishmentNumber: "1241");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/WorkforceData/WorkforceDataExporterTests.cs
@@ -36,7 +36,7 @@ public class WorkforceDataExporterTests : IAsyncLifetime
         var optionsAccessor = Mock.Of<IOptions<WorkforceDataExportOptions>>();
         var storageClientProvider = Mock.Of<IStorageClientProvider>();
         var storageClient = Mock.Of<StorageClient>();
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var establishment1 = await TestData.CreateEstablishmentAsync(localAuthorityCode: "126", establishmentNumber: "1237");
         var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
         var personPostcode = Faker.Address.UkPostCode();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/MergeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/MergeTests.cs
@@ -8,12 +8,10 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Merge_PersonsMatchOnAllFields()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithFirstName(person1.FirstName)
             .WithMiddleName(person1.MiddleName)
             .WithLastName(person1.LastName)
@@ -54,12 +52,10 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Merge_PersonsDifferOnAllFields()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
@@ -110,12 +106,10 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Merge_NavigateBack()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
@@ -171,12 +165,10 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Merge_CYA_ChangePrimaryPerson_NavigatesBackToCYA()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
@@ -232,12 +224,10 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Merge_CYA_ChangeDetails_NavigatesBackToCYA()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
@@ -293,12 +283,10 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Merge_CYA_ChangePrimaryPerson_ContinuesToCYA()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
@@ -365,12 +353,10 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Merge_CYA_ChangeDetails_ContinuesToCYA()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/ApiTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/ApiTrnRequestTests.cs
@@ -38,7 +38,7 @@ public class ApiTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
         await WithDbContext(dbContext =>
             dbContext.SupportTasks.Where(t => t.SupportTaskType == SupportTaskType.ApiTrnRequest).ExecuteDeleteAsync());
 
-        var match = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var match = await TestData.CreatePersonAsync();
 
         var applicationUser = await TestData.CreateApplicationUserAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestTests.cs
@@ -63,13 +63,11 @@ public class NpqTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Set up two records to merge with, where one has no conflicting info, one does have known conflicting info
         var matchedPerson1 = await TestData.CreatePersonAsync(p =>
         {
-            p.WithTrn();
             p.WithEmail(TestData.GenerateUniqueEmail());
             p.WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber());
         });
         var matchedPerson2 = await TestData.CreatePersonAsync(p =>
         {
-            p.WithTrn();
             p.WithEmail(TestData.GenerateUniqueEmail());
             p.WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber());
         });
@@ -135,13 +133,11 @@ public class NpqTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Set up two records to merge with, where one has no conflicting info, one does have known conflicting info
         var matchedPerson1 = await TestData.CreatePersonAsync(p =>
             {
-                p.WithTrn();
                 p.WithEmail(TestData.GenerateUniqueEmail());
                 p.WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber());
             });
         var matchedPerson2 = await TestData.CreatePersonAsync(p =>
         {
-            p.WithTrn();
             p.WithEmail(TestData.GenerateUniqueEmail());
             p.WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber());
         });
@@ -214,13 +210,11 @@ public class NpqTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Set up two records to merge with, where one has no conflicting info, one does have known conflicting info
         var matchedPerson1 = await TestData.CreatePersonAsync(p =>
         {
-            p.WithTrn();
             p.WithEmail(TestData.GenerateUniqueEmail());
             p.WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber());
         });
         var matchedPerson2 = await TestData.CreatePersonAsync(p =>
         {
-            p.WithTrn();
             p.WithEmail(TestData.GenerateUniqueEmail());
             p.WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber());
         });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/SupportTaskTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/SupportTaskTests.cs
@@ -5,7 +5,7 @@ public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Test]
     public async Task ConnectOneLoginUser_WithSuggestion()
     {
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithLastName("O'Reilly"));
+        var person = await TestData.CreatePersonAsync(p => p.WithLastName("O'Reilly"));
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -28,7 +28,7 @@ public class SupportTaskTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Test]
     public async Task ConnectOneLoginUser_WithoutSuggestions()
     {
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([TestData.GenerateFirstName(), TestData.GenerateLastName()], TestData.GenerateDateOfBirth()));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/IndexTests.cs
@@ -88,9 +88,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithSearchThatLooksLikeATrn_DisplaysMatchOnTrn()
     {
         // Arrange
-        var person1 = await TestData.CreatePersonAsync(b => b.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs).WithTrn());
-        var person2 = await TestData.CreatePersonAsync(b => b.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs).WithTrn());
-        var person3 = await TestData.CreatePersonAsync(b => b.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs).WithTrn());
+        var person1 = await TestData.CreatePersonAsync(b => b.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
+        var person2 = await TestData.CreatePersonAsync(b => b.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
+        var person3 = await TestData.CreatePersonAsync(b => b.WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
         var search = person1.Trn;
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons?search={search}");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CommonPageTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/CommonPageTests.cs
@@ -13,8 +13,7 @@ public class CommonPageTests(HostFixture hostFixture) : MergeTestBase(hostFixtur
     public async Task OtherTrnNotSelected_RedirectsToEnterTrnPage(string page, HttpMethod httpMethod)
     {
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/EnterTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/EnterTrnTests.cs
@@ -10,8 +10,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     public async Task Get_PopulatesThisTrnFromPersonRecord()
     {
         var person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -36,12 +35,10 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     public async Task Get_OtherTrnAlreadyEntered_ShowsOtherTrn()
     {
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,
@@ -68,8 +65,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -98,8 +94,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -128,8 +123,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -156,8 +150,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
@@ -184,8 +177,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var newTrn = await TestData.GenerateTrnAsync();
 
@@ -214,12 +206,10 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         await WithDbContext(async dbContext =>
         {
@@ -253,8 +243,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         await WithDbContext(async dbContext =>
         {
@@ -264,8 +253,7 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
         });
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,
@@ -293,12 +281,10 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithAlert(a => a.WithEndDate(null)));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,
@@ -329,15 +315,13 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithInductionStatus(i => i
                 .WithStatus(status)
                 .WithStartDate(new DateOnly(2024, 1, 1))
                 .WithCompletedDate(new DateOnly(2024, 1, 1))));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,
@@ -365,12 +349,10 @@ public class EnterTrnTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MatchesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MatchesTests.cs
@@ -11,7 +11,6 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         var personA = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithFirstName("Alfred")
             .WithMiddleName("The")
             .WithLastName("Great")
@@ -22,7 +21,6 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
 
         var personB = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithFirstName("Lily")
             .WithMiddleName("The")
             .WithLastName("Pink")
@@ -71,12 +69,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithAlert(a => a.WithEndDate(null)));
 
         var personB = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithAlert(a => a.WithEndDate(null))
             .WithAlert(a => a.WithEndDate(null)));
 
@@ -170,12 +166,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         await WithDbContext(async dbContext =>
         {
@@ -215,12 +209,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithAlert(a => a.WithEndDate(null)));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -260,12 +252,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithInductionStatus(i => i
                 .WithStatus(status)
                 .WithStartDate(new DateOnly(2024, 1, 1))
@@ -313,12 +303,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithAlert(a => a.WithEndDate(null))
             .WithInductionStatus(i => i
                 .WithStatus(status)
@@ -354,12 +342,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     public async Task Get_PrimaryPersonAlreadySelected_SelectsChosenPerson()
     {
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,
@@ -387,12 +373,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,
@@ -420,12 +404,10 @@ public class MatchesTests(HostFixture hostFixture) : MergeTestBase(hostFixture)
     {
         // Arrange
         var personA = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var personB = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             personA.PersonId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergeTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/Merge/MergeTestBase.cs
@@ -15,7 +15,6 @@ public class MergeTestBase(HostFixture hostFixture)
 
         var personA = await TestData.CreatePersonAsync(p => configurePersonA(p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithEmail(!useNullValues)
             .WithNationalInsuranceNumber(!useNullValues)
             .WithGender(!useNullValues)));
@@ -24,7 +23,6 @@ public class MergeTestBase(HostFixture hostFixture)
         {
             p
                 .WithPersonDataSource(TestDataPersonDataSource.Trs)
-                .WithTrn()
                 .WithFirstName(personA.FirstName)
                 .WithMiddleName(personA.MiddleName)
                 .WithLastName(personA.LastName)
@@ -56,14 +54,12 @@ public class MergeTestBase(HostFixture hostFixture)
     {
         var personA = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithEmail(!useNullValues)
             .WithNationalInsuranceNumber(!useNullValues)
             .WithGender(!useNullValues));
 
         var personB = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithFirstName(TestData.GenerateChangedFirstName(personA.FirstName))
             .WithMiddleName(TestData.GenerateChangedMiddleName(personA.MiddleName))
             .WithLastName(TestData.GenerateChangedLastName(personA.LastName))
@@ -81,7 +77,6 @@ public class MergeTestBase(HostFixture hostFixture)
     {
         var personA = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithEmail(!useNullValues)
             .WithNationalInsuranceNumber(!useNullValues)
             .WithGender(!useNullValues));
@@ -90,7 +85,6 @@ public class MergeTestBase(HostFixture hostFixture)
         {
             p
                 .WithPersonDataSource(TestDataPersonDataSource.Trs)
-                .WithTrn()
                 .WithFirstName(
                     differentAttribute != PersonMatchedAttribute.FirstName
                         ? personA.FirstName
@@ -145,7 +139,6 @@ public class MergeTestBase(HostFixture hostFixture)
     {
         var personA = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithEmail(!useNullValues)
             .WithNationalInsuranceNumber(!useNullValues)
             .WithGender(!useNullValues));
@@ -154,7 +147,6 @@ public class MergeTestBase(HostFixture hostFixture)
         {
             p
                 .WithPersonDataSource(TestDataPersonDataSource.Trs)
-                .WithTrn()
                 .WithFirstName(
                     matchedAttributes.Contains(PersonMatchedAttribute.FirstName)
                         ? personA.FirstName

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AddNoteTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AddNoteTests.cs
@@ -6,7 +6,7 @@ public class AddNoteTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ContentIsEmpty_ReturnsError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/notes/add")
         {
@@ -27,7 +27,7 @@ public class AddNoteTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ContentWithoutFile_CreatesNoteAndEventAndRedirects()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var text = Faker.Lorem.Paragraph();
 
@@ -65,7 +65,7 @@ public class AddNoteTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ContentWithFile_CreatesNoteAndEventAndRedirects()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var text = Faker.Lorem.Paragraph();
 
@@ -106,7 +106,7 @@ public class AddNoteTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task PersonIsDeactivated_ReturnsBadRequest(HttpMethod httpMethod)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         await WithDbContext(async dbContext =>
         {
             dbContext.Attach(person.Person);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/AlertsTests.cs
@@ -499,7 +499,7 @@ public class AlertsTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonStatus_EditLinksShownAsExpected(PersonStatus personStatus, bool canSeeEditLinks)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn()
+        var person = await TestData.CreatePersonAsync(p => p
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithEndDate(null))
             .WithAlert(a => a.WithAlertTypeId(AlertType.DbsAlertTypeId).WithStartDate(new DateOnly(2024, 1, 1)).WithEndDate(new DateOnly(2024, 10, 1))));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMergeEventTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMergeEventTests.cs
@@ -55,11 +55,9 @@ public class ChangeLogMergeEventTests : TestBase, IAsyncLifetime
     {
         _createdByUser = await TestData.CreateUserAsync();
         _person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
         _secondaryPerson = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
 
         await WithDbContext(async dbContext =>
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CheckAnswersTests.cs
@@ -71,7 +71,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
@@ -152,7 +152,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
         // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
-            p => p.WithTrn().WithQts());
+            p => p.WithQts());
         await WithDbContext(async dbContext =>
         {
             dbContext.Attach(person.Person);
@@ -324,7 +324,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
         // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
-            p => p.WithTrn().WithQts());
+            p => p.WithQts());
 
         await WithDbContext(async dbContext =>
         {
@@ -390,7 +390,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
         // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
-            p => p.WithTrn().WithQts());
+            p => p.WithQts());
         await WithDbContext(async dbContext =>
         {
             dbContext.Attach(person.Person);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
@@ -35,7 +35,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var updatedLastName = TestData.GenerateLastName();
         var createPersonResult = await TestData.CreatePersonAsync(b => b
             .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn()
             .WithEmail((string?)email)
             .WithNationalInsuranceNumber()
             .WithGender());
@@ -82,7 +81,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var updatedLastName = TestData.GenerateLastName();
         var createPersonResult = await TestData.CreatePersonAsync(b => b
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithEmail((string?)email)
             .WithNationalInsuranceNumber()
             .WithGender());
@@ -122,8 +120,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var createPersonResult = await TestData.CreatePersonAsync(b => b
-            .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithoutTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}");
 
@@ -136,7 +133,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal($"{createPersonResult.FirstName} {createPersonResult.MiddleName} {createPersonResult.LastName}", doc.GetElementByTestId("page-title")!.TrimmedText());
         Assert.Equal($"{createPersonResult.FirstName} {createPersonResult.MiddleName} {createPersonResult.LastName}", doc.GetSummaryListValueForKey("Name"));
         Assert.Equal(createPersonResult.DateOfBirth.ToString(UiDefaults.DateOnlyDisplayFormat), doc.GetSummaryListValueForKey("Date of birth"));
-        Assert.Equal(UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("TRN"));
         Assert.Equal(UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Email"));
         Assert.Equal(UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("National Insurance number"));
         Assert.Equal(UiDefaults.EmptyDisplayContent, doc.GetSummaryListValueForKey("Gender"));
@@ -165,8 +161,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs));
         Debug.Assert(person.Alerts.Count == 0);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");
@@ -238,7 +233,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn()
             .WithQts(awardDate));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");
@@ -268,7 +262,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn()
             .WithQtls(awardDate));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");
@@ -298,7 +291,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn()
             .WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.EarlyYearsTeacherStatus, awardDate));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");
@@ -328,7 +320,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn()
             .WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.EarlyYearsProfessionalStatus));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");
@@ -358,7 +349,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-            .WithTrn()
             .WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.PartialQualifiedTeacherStatus, awardDate));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");
@@ -689,11 +679,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var primaryPerson = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
         var secondaryPerson = await TestData.CreatePersonAsync(p => p
             .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn()
             .WithMergedWithPersonId(primaryPerson.PersonId));
 
         await WithDbContext(async dbContext =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -226,7 +226,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
 
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn().WithQts());
+        var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
         await WithDbContext(async dbContext =>
         {
@@ -284,7 +284,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
         // then set the induction status to the one being tested
         var person = await TestData.CreatePersonAsync(
-            p => p.WithTrn().WithQts());
+            p => p.WithQts());
         await WithDbContext(async dbContext =>
         {
             dbContext.Attach(person.Person);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/NotesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/NotesTests.cs
@@ -23,7 +23,7 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonWithoutNotes_ReturnsExpectedContent()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.ContactId}/notes");
 
@@ -42,7 +42,6 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithAlert(a => a
                 .WithAlertTypeId(AlertType.DbsAlertTypeId)
                 .WithStartDate(Clock.Today.AddDays(-30))
@@ -75,7 +74,6 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
         SetCurrentUser(TestUsers.GetUser(role: UserRoles.RecordManager));
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithAlert(a => a
                 .WithAlertTypeId(AlertType.DbsAlertTypeId)
                 .WithStartDate(Clock.Today.AddDays(-30))
@@ -104,7 +102,7 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_NoteWithoutAttachment_ReturnsExpectedContent()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var expectedNoteText = "Note without attachment";
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
@@ -136,7 +134,7 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_NoteWithAttachment_ReturnsExpectedContent()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var expectedNoteText = "Note without attachment";
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
@@ -170,7 +168,7 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_NoteWithHtml_ReturnsPlaintext()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var expectedNoteText = "Note without attachment";
         var htmlNote = $"<html><b>{expectedNoteText}<b><html>";
         var expectedCreatedBy = TestData.GenerateName();
@@ -194,7 +192,7 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_MultipleNotes_ReturnsContentInCorrectOrder()
     {
         // Arrange
-        var createPersonResult = await TestData.CreatePersonAsync(b => b.WithTrn());
+        var createPersonResult = await TestData.CreatePersonAsync();
         var expectedNoteText1 = "Note without attachment";
         var expectedCreatedBy1 = TestData.GenerateName();
         var createdByUserId1 = Guid.NewGuid();
@@ -254,7 +252,7 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonStatus_AddButtonShownAsExpected(PersonStatus personStatus, bool canSeeAddButton)
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         if (personStatus == PersonStatus.Deactivated)
         {
             await WithDbContext(async dbContext =>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/CommonPageTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/CommonPageTests.cs
@@ -92,10 +92,8 @@ public class CommonPageTests(HostFixture hostFixture) : SetStatusTestBase(hostFi
     {
         // Arrange
         var primaryPerson = await TestData.CreatePersonAsync(p => p
-            .WithPersonDataSource(TestDataPersonDataSource.Trs)
-            .WithTrn());
+            .WithPersonDataSource(TestDataPersonDataSource.Trs));
         var secondaryPerson = await CreatePersonWithCurrentStatus(PersonStatus.Deactivated, p => p
-            .WithTrn()
             .WithMergedWithPersonId(primaryPerson.PersonId));
 
         var stateBuilder = new SetStatusStateBuilder()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MatchesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MatchesTests.cs
@@ -112,7 +112,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
     {
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithAlert());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithAlert());
         var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
             applicationUser.UserId,
             t => t.WithMatchedPersons(matchedPerson.PersonId));
@@ -249,7 +249,6 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         var applicationUser = await TestData.CreateApplicationUserAsync();
 
         var matchedPerson = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(null)
             .WithNationalInsuranceNumber(false)
             .WithMiddleName(""));
@@ -318,7 +317,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
     {
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
 
         var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
             applicationUser.UserId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
@@ -6,7 +6,7 @@ public abstract class ResolveApiTrnRequestTestBase(HostFixture hostFixture) : Te
 {
     protected async Task<(SupportTask SupportTask, TestData.CreatePersonResult MatchedPerson)> CreateSupportTaskWithAllDifferences(Guid applicationUserId)
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
 
         var supportTask = await TestData.CreateApiTrnRequestSupportTaskAsync(
             applicationUserId,
@@ -32,7 +32,6 @@ public abstract class ResolveApiTrnRequestTestBase(HostFixture hostFixture) : Te
         {
             p
                 .WithPersonDataSource(TestDataPersonDataSource.CrmAndTrs)
-                .WithTrn()
                 .WithNationalInsuranceNumber()
                 .WithEmail(TestData.GenerateUniqueEmail())
                 .WithGender(TestData.GenerateGender());

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/ConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/ConnectTests.cs
@@ -27,7 +27,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -48,7 +48,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_TrnDoesNotExist_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -65,7 +65,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequest_ReturnsExpectedContent()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -102,7 +102,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -123,7 +123,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_TrnDoesNotExist_ReturnsBadRequest()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -140,7 +140,7 @@ public class ConnectTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequest_ClosesTaskConnectsUserToPersonAndRedirectsToSupportTaskList()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ConnectOneLoginUser/IndexTests.cs
@@ -27,7 +27,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -48,7 +48,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var statedNationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
         var statedTrn = person.Trn;
@@ -94,7 +94,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SupportTaskIsNotOpen_ReturnsNotFound()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -121,7 +121,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_NoSuggestionChosen_RendersError()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -141,7 +141,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequestFromSuggestion_RedirectsToConnectPage()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 
@@ -165,7 +165,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ValidRequestWithOverridenTrn_RedirectsToConnectPage()
     {
         // Arrange
-        var person = await TestData.CreatePersonAsync(p => p.WithTrn());
+        var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var supportTask = await TestData.CreateConnectOneLoginUserSupportTaskAsync(oneLoginUser.Subject);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/NpqTrnRequestTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/NpqTrnRequestTestBase.cs
@@ -6,7 +6,7 @@ public abstract class NpqTrnRequestTestBase(HostFixture hostFixture) : TestBase(
 {
     protected async Task<(SupportTask SupportTask, TestData.CreatePersonResult MatchedPerson)> CreateSupportTaskWithAllDifferences(Guid applicationUserId)
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
 
         var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(
             applicationUserId,
@@ -24,7 +24,6 @@ public abstract class NpqTrnRequestTestBase(HostFixture hostFixture) : TestBase(
         PersonMatchedAttribute differentAttribute)
     {
         var matchedPerson = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithNationalInsuranceNumber()
             .WithEmail(TestData.GenerateUniqueEmail()));
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/MatchesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/MatchesTests.cs
@@ -115,7 +115,6 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync(name: "NPQ");
         var matchedPerson = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber());
         var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(applicationUser.UserId, configure => configure.WithMatchedPersons(matchedPerson.PersonId));
@@ -148,7 +147,6 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         var applicationUser = await TestData.CreateApplicationUserAsync(name: "NPQ");
 
         var matchedPerson = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithNationalInsuranceNumber(false)
             .WithMiddleName(""));
 
@@ -190,7 +188,6 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         var applicationUser = await TestData.CreateApplicationUserAsync(name: "NPQ");
 
         var matchedPerson = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithNationalInsuranceNumber(false)
             .WithMiddleName(""));
 
@@ -230,7 +227,6 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         var applicationUser = await TestData.CreateApplicationUserAsync(name: "NPQ");
 
         var matchedPerson = await TestData.CreatePersonAsync(p => p
-            .WithTrn()
             .WithEmail("something+test@education.gov.uk"));
 
         var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(applicationUser.UserId, configure =>
@@ -263,7 +259,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
     {
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithAlert());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithAlert());
         var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(
             applicationUser.UserId,
             t => t.WithMatchedPersons(matchedPerson.PersonId));
@@ -410,7 +406,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
     {
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithNationalInsuranceNumber());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
 
         var supportTask = await TestData.CreateNpqTrnRequestSupportTaskAsync(
             applicationUser.UserId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/IndexTests.cs
@@ -433,7 +433,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture), IAsync
         DateTime? createdOn = null,
         Action<TestData.CreateApiTrnRequestSupportTaskBuilder>? configureApiTrnRequest = null)
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithEmail(TestData.GenerateUniqueEmail()).WithAlert().WithQts().WithEyts());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithEmail(TestData.GenerateUniqueEmail()).WithAlert().WithQts().WithEyts());
 
         if (applicationUserId is null)
         {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/ConfirmTests.cs
@@ -83,7 +83,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
 
     private async Task<SupportTask> CreateSupportTaskAsync(SupportTaskStatus status = SupportTaskStatus.Open)
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithEmail(TestData.GenerateUniqueEmail()).WithAlert().WithQts().WithEyts());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithEmail(TestData.GenerateUniqueEmail()).WithAlert().WithQts().WithEyts());
 
         var applicationUser = await TestData.CreateApplicationUserAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/IndexTests.cs
@@ -151,7 +151,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
     private async Task<SupportTask> CreateSupportTaskAsync(SupportTaskStatus status = SupportTaskStatus.Open)
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithTrn().WithEmail(TestData.GenerateUniqueEmail()).WithAlert().WithQts().WithEyts());
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithEmail(TestData.GenerateUniqueEmail()).WithAlert().WithQts().WithEyts());
 
         var applicationUser = await TestData.CreateApplicationUserAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateApiTrnRequestSupportTask.cs
@@ -172,7 +172,6 @@ public partial class TestData
                         var person = await testData.CreatePersonAsync(p =>
                         {
                             p
-                                .WithTrn()
                                 .WithFirstName(firstName)
                                 .WithMiddleName(middleName ?? string.Empty)
                                 .WithLastName(lastName)

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateNpqTrnRequestSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateNpqTrnRequestSupportTask.cs
@@ -168,7 +168,6 @@ public partial class TestData
                         var person = await testData.CreatePersonAsync(p =>
                         {
                             p
-                                .WithTrn()
                                 .WithFirstName(firstName)
                                 .WithMiddleName(middleName)
                                 .WithLastName(lastName)


### PR DESCRIPTION
There's no way to create a record in TRS without a TRN and we'll shortly be deleting the migrated records that don't have a TRN.