### PR TITLE
Drop the OneLoginUserSubject FK on SupportTask

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
@@ -11,7 +11,6 @@ public class SupportTaskMapping : IEntityTypeConfiguration<SupportTask>
         builder.ToTable("support_tasks");
         builder.HasKey(p => p.SupportTaskReference);
         builder.Property(p => p.SupportTaskReference).HasMaxLength(16);
-        builder.HasOne<OneLoginUser>().WithMany().HasForeignKey(o => o.OneLoginUserSubject).HasConstraintName("fk_support_tasks_one_login_user");
         builder.HasOne<Person>(t => t.Person).WithMany().HasForeignKey(p => p.PersonId).HasConstraintName("fk_support_tasks_person");
         builder.HasIndex(t => t.OneLoginUserSubject);
         builder.HasIndex(t => t.PersonId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250901072501_DropSupportTaskOneLoginUserSubjectFk.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250901072501_DropSupportTaskOneLoginUserSubjectFk.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250901072501_DropSupportTaskOneLoginUserSubjectFk")]
+    partial class DropSupportTaskOneLoginUserSubjectFk
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250901072501_DropSupportTaskOneLoginUserSubjectFk.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250901072501_DropSupportTaskOneLoginUserSubjectFk.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropSupportTaskOneLoginUserSubjectFk : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_support_tasks_one_login_user",
+                table: "support_tasks");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "one_login_user_subject",
+                table: "support_tasks",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(255)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "one_login_user_subject",
+                table: "support_tasks",
+                type: "character varying(255)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_support_tasks_one_login_user",
+                table: "support_tasks",
+                column: "one_login_user_subject",
+                principalTable: "one_login_users",
+                principalColumn: "subject");
+        }
+    }
+}


### PR DESCRIPTION
We can't have an FK to `one_login_users` since we may not have created added the user there yet.