### PR TITLE
Add mechanism for constructing FormFlow state instances

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/IJourneyStateFactory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/IJourneyStateFactory.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace TeachingRecordSystem.WebCommon.FormFlow;
+
+public interface IJourneyStateFactory<TState>
+{
+    Task<TState> CreateAsync(CreateJourneyStateContext context);
+}
+
+public record CreateJourneyStateContext(JourneyDescriptor Journey, HttpContext HttpContext)
+{
+    public RouteData RouteData => HttpContext.GetRouteData();
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/JourneyInstance.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/JourneyInstance.cs
@@ -17,7 +17,7 @@ public class JourneyInstance
         _stateProvider = stateProvider;
         StateType = stateType;
         InstanceId = instanceId;
-        Properties = properties ?? PropertiesBuilder.CreateEmpty();
+        Properties = properties;
         State = state;
         Completed = completed;
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/ServiceCollectionExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/ServiceCollectionExtensions.cs
@@ -46,6 +46,10 @@ public static class ServiceCollectionExtensions
             options.Conventions.Add(new BindJourneyInstancePropertiesConvention());
         });
 
+        services.Scan(s => s
+            .FromAssemblies(typeof(IJourneyStateFactory<>).Assembly)
+            .AddClasses(t => t.AssignableTo(typeof(IJourneyStateFactory<>))).AsImplementedInterfaces());
+
         return services;
     }
 


### PR DESCRIPTION
Currently we use a pattern where the first page of a journey calls an `EnsureInitialized` method on journey state types to set up the initial journey state. This is a little clunky and in some cases this method can be called multiple times for a particular journey instance. It also means we can't use `required` properties and everything has to be nullable.

This adds an alternative mechanism - `IJourneyStateFactory<T>`. When the journey is created, if a class is found implementing that interface then its `CreateAsync()` method is called to create the state instance. We pass along the `JourneyDescriptor` and `HttpContext` so that the factory can access any identifiers for the journey instance.