### PR TITLE
Added job to allocate TRNs to Person records with HasEyps which currently have null TRN

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/TrnAllocatedEvent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/TrnAllocatedEvent.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Events;
+
+public record TrnAllocatedEvent : EventBase, IEventWithPersonId
+{
+    public required Guid PersonId { get; init; }
+    public required string Trn { get; init; }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/AllocateTrnsToPersonsWithEyps.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/AllocateTrnsToPersonsWithEyps.cs
@@ -1,0 +1,62 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Services.Files;
+using TeachingRecordSystem.Core.Services.TrnGeneration;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+public class AllocateTrnsToPersonsWithEyps(
+    TrsDbContext dbContext,
+    ITrnGenerator trnGenerator,
+    IFileService fileService,
+    IClock clock)
+{
+    public async Task ExecuteAsync(bool dryRun, CancellationToken cancellationToken)
+    {
+        using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        // Get all persons where HasEyps has been set to true but there is no TRN
+        var personsWithHasEypsAndNoTrn = await dbContext.Persons
+            .Where(p => p.HasEyps && p.Trn == null)
+            .ToListAsync(cancellationToken);
+
+        var updatedPersons = new List<Guid>();
+
+        // Update all persons where HasEyps has been set to true but there is no TRN
+        foreach (var person in personsWithHasEypsAndNoTrn)
+        {
+            var newTrn = await trnGenerator.GenerateTrnAsync();
+            person.Trn = newTrn;
+            dbContext.AddEventWithoutBroadcast(new TrnAllocatedEvent()
+            {
+                EventId = Guid.NewGuid(),
+                CreatedUtc = clock.UtcNow,
+                PersonId = person.PersonId,
+                RaisedBy = DataStore.Postgres.Models.SystemUser.SystemUserId,
+                Trn = newTrn
+            });
+
+            updatedPersons.Add(person.PersonId);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        if (!dryRun)
+        {
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        if (updatedPersons.Count == 0)
+        {
+            return;
+        }
+
+        using var stream = new MemoryStream();
+        using var writer = new StreamWriter(stream);
+        using var csv = new CsvHelper.CsvWriter(writer, System.Globalization.CultureInfo.InvariantCulture);
+        await csv.WriteRecordsAsync(updatedPersons.Select(p => new { PersonId = p }), cancellationToken);
+        await writer.FlushAsync();
+        stream.Position = 0;
+
+        await fileService.UploadFileAsync($"allocatetrntopersonswitheyps{clock.UtcNow:yyyyMMddHHmmss}.csv", stream, "text/csv");
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/HostApplicationBuilderExtensions.cs
@@ -155,6 +155,9 @@ public static class HostApplicationBuilderExtensions
                 recurringJobManager.RemoveIfExists("ResetIncorrectHasEypsOnPersonsJob (dry-run)");
                 recurringJobManager.RemoveIfExists("ResetIncorrectHasEypsOnPersonsJob");
 
+                recurringJobManager.RemoveIfExists("SetMissingHasEypsOnPersonsJob (dry-run)");
+                recurringJobManager.RemoveIfExists("SetMissingHasEypsOnPersonsJob");
+
                 recurringJobManager.AddOrUpdate<CpdInductionImporterJob>(
                     nameof(CpdInductionImporterJob),
                     job => job.ExecuteAsync(CancellationToken.None),
@@ -261,13 +264,13 @@ public static class HostApplicationBuilderExtensions
                     job => job.ExecuteAsync(CancellationToken.None),
                     CapitaExportAmendJob.JobSchedule);
 
-                recurringJobManager.AddOrUpdate<SetMissingHasEypsOnPersonsJob>(
-                    $"{nameof(SetMissingHasEypsOnPersonsJob)} (dry-run)",
+                recurringJobManager.AddOrUpdate<AllocateTrnsToPersonsWithEyps>(
+                    $"{nameof(AllocateTrnsToPersonsWithEyps)} (dry-run)",
                     job => job.ExecuteAsync(/*dryRun: */true, CancellationToken.None),
                     Cron.Never);
 
-                recurringJobManager.AddOrUpdate<SetMissingHasEypsOnPersonsJob>(
-                    nameof(SetMissingHasEypsOnPersonsJob),
+                recurringJobManager.AddOrUpdate<AllocateTrnsToPersonsWithEyps>(
+                    nameof(AllocateTrnsToPersonsWithEyps),
                     job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None),
                     Cron.Never);
 


### PR DESCRIPTION
### Context

Before we delete all records without TRNs we need to ensure all persons with EYPS have a TRN.

### Changes proposed in this pull request

Create a job that allocates TRNs to any Person that has EYPS and doesn’t already have a TRN.

The job should output a CSV to blob storage with the Person ID of all records that have been updated.

The job should have a ‘dry run’ mode which doesn’t actually update any records but does output the CSV report of records that would be updated.

Every record that has a TRN allocated should have a `TrnAllocatedEvent` added for the `Person`.
