### PR TITLE
Prevent users submitting NPQ TRN request multiple times

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/State/DbUserInstanceStateProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.WebCommon/FormFlow/State/DbUserInstanceStateProvider.cs
@@ -18,7 +18,7 @@ public class DbWithHttpContextTransactionUserInstanceStateProvider(
 
     public override async Task CompleteInstanceAsync(JourneyInstanceId instanceId, Type stateType)
     {
-        using var dbContext = await dbContextFactory.CreateDbContextAsync();
+        var dbContext = await EnsureDbContextAsync();
         var userId = currentUserIdProvider.GetCurrentUserId();
         await CompleteInstanceAsync(instanceId, stateType, userId, dbContext);
     }


### PR DESCRIPTION
We're getting some duplicate NPQ TRN requests coming through, likely because users are hitting Submit multiple times.

This adds a 'select ... for update` on the journey state so that only one request can be updating it at once. That combined with the flag we set - `HasPendingTrnRequest` - when the request is actually created should fix this.