### PR TITLE
Stop adding trailing newline to itr rowdata

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/EwcWalesImport/InductionImporter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/EwcWalesImport/InductionImporter.cs
@@ -93,8 +93,8 @@ public class InductionImporter
 
                         foreach (var validationMessage in validationFailures.ValidationFailures)
                         {
-                            itrFailureMessage.AppendLine(validationMessage);
-                            failureMessage.AppendLine(validationMessage);
+                            itrFailureMessage.AppendLine($"{validationMessage};");
+                            failureMessage.AppendLine($"{validationMessage};");
                         }
                     }
                     else
@@ -118,8 +118,8 @@ public class InductionImporter
                         //soft validation errors can be appended to the IntegrationTransactionRecord Failure message
                         foreach (var validationMessage in validationFailures.ValidationFailures)
                         {
-                            itrFailureMessage.AppendLine(validationMessage);
-                            failureMessage.AppendLine(validationMessage);
+                            itrFailureMessage.AppendLine($"{validationMessage};");
+                            failureMessage.AppendLine($"{validationMessage};");
                         }
 
                         //increase failurecount if row is processable or if there are validation failures
@@ -181,7 +181,7 @@ public class InductionImporter
         using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
         {
             csv.WriteRecord(row);
-            csv.NextRecord();
+            csv.Flush();
             return writer.ToString();
         }
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/EwcWalesImport/QtsImporter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/EwcWalesImport/QtsImporter.cs
@@ -87,8 +87,8 @@ public class QtsImporter
                 {
                     foreach (var error in validationFailures.Errors)
                     {
-                        failureMessage.AppendLine(error);
-                        itrFailureMessage.AppendLine(error);
+                        failureMessage.AppendLine($"{error};");
+                        itrFailureMessage.AppendLine($"{error};");
                     }
                 }
                 else
@@ -142,8 +142,8 @@ public class QtsImporter
                     //soft validation errors can be appended to the IntegrationTransactionRecord Failure message
                     foreach (var validationMessage in validationFailures.ValidationFailures)
                     {
-                        itrFailureMessage.AppendLine(validationMessage);
-                        failureMessage.AppendLine(validationMessage);
+                        itrFailureMessage.AppendLine($"{validationMessage};");
+                        failureMessage.AppendLine($"{validationMessage}");
                     }
                 }
 
@@ -204,7 +204,7 @@ public class QtsImporter
         using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
         {
             csv.WriteRecord(row);
-            csv.NextRecord();
+            csv.Flush();
             return writer.ToString();
         }
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/QTSImporterTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/QTSImporterTests.cs
@@ -367,7 +367,7 @@ public class QtsImporterTests : IAsyncLifetime
             x.QtsRefNo = person.Trn!;
             return x;
         });
-        var expectedJson = $"{row.QtsRefNo},{row.Forename},{row.Surname},{row.DateOfBirth},{row.QtsStatus},{row.QtsDate},{row.IttStartMonth},{row.IttStartYear},{row.IttEndDate},{row.ITTCourseLength},{row.IttEstabLeaCode},{row.IttEstabCode},{row.IttQualCode},{row.IttClassCode},{row.IttSubjectCode1},{row.IttSubjectCode2},{row.IttMinAgeRange},{row.IttMaxAgeRange},{row.IttMinSpAgeRange},{row.IttMaxSpAgeRange},{row.PqCourseLength},{row.PqYearOfAward},{row.Country},{row.PqEstabCode},{row.PqQualCode},{row.Honours},{row.PqClassCode},{row.PqSubjectCode1},{row.PqSubjectCode2},{row.PqSubjectCode3}\r\n";
+        var expectedJson = $"{row.QtsRefNo},{row.Forename},{row.Surname},{row.DateOfBirth},{row.QtsStatus},{row.QtsDate},{row.IttStartMonth},{row.IttStartYear},{row.IttEndDate},{row.ITTCourseLength},{row.IttEstabLeaCode},{row.IttEstabCode},{row.IttQualCode},{row.IttClassCode},{row.IttSubjectCode1},{row.IttSubjectCode2},{row.IttMinAgeRange},{row.IttMaxAgeRange},{row.IttMinSpAgeRange},{row.IttMaxSpAgeRange},{row.PqCourseLength},{row.PqYearOfAward},{row.Country},{row.PqEstabCode},{row.PqQualCode},{row.Honours},{row.PqClassCode},{row.PqSubjectCode1},{row.PqSubjectCode2},{row.PqSubjectCode3}";
 
         // Act
         var json = Importer.ConvertToCsvString(row);


### PR DESCRIPTION
Currently when ITR failures are exported, each row has a trailing \r, this PR removes the trailing carriage return and also separates the validation errors by a semi colon, making it easier to see the reasons the ewc wales job failed. 