### PR TITLE
Reduce transaction isolation level for change name/DOB API requests

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
@@ -71,7 +71,10 @@ public class CreateDateOfBirthChangeRequestHandler(
         var getAnIdentityApplicationUserId = configuration.GetValue<Guid>("GetAnIdentityApplicationUserId");
 
         // Ensure enqueued Hangfire jobs are run in the same transaction as the database changes
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = new TransactionScope(
+            TransactionScopeOption.RequiresNew,
+            new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted },
+            TransactionScopeAsyncFlowOption.Enabled);
 
         var supportTask = PostgresModels.SupportTask.Create(
             SupportTaskType.ChangeDateOfBirthRequest,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
@@ -75,7 +75,10 @@ public class CreateNameChangeRequestHandler(
         var getAnIdentityApplicationUserId = configuration.GetValue<Guid>("GetAnIdentityApplicationUserId");
 
         // Ensure enqueued Hangfire jobs are run in the same transaction as the database changes
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = new TransactionScope(
+            TransactionScopeOption.RequiresNew,
+            new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted },
+            TransactionScopeAsyncFlowOption.Enabled);
 
         var supportTask = PostgresModels.SupportTask.Create(
             SupportTaskType.ChangeNameRequest,


### PR DESCRIPTION
We've got some timeouts in Sentry that are likely down to the `Serializable` isolation level.