### PR TITLE
Add columns for DQT MQ specialism and provider values

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationMapping.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/MandatoryQualificationMapping.cs
@@ -15,5 +15,7 @@ public class MandatoryQualificationMapping : IEntityTypeConfiguration<MandatoryQ
         builder.Property(q => q.StartDate).HasColumnName("start_date");
         builder.Property(q => q.EndDate).HasColumnName("end_date");
         builder.HasIndex(q => q.DqtQualificationId).HasFilter("dqt_qualification_id is not null").IsUnique();
+        builder.Property(q => q.DqtMqEstablishmentValue).HasMaxLength(3);
+        builder.Property(q => q.DqtSpecialismValue).HasMaxLength(3);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250908115743_MqDqtReferenceValues.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250908115743_MqDqtReferenceValues.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250908115743_MqDqtReferenceValues")]
+    partial class MqDqtReferenceValues
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250908115743_MqDqtReferenceValues.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250908115743_MqDqtReferenceValues.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class MqDqtReferenceValues : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "dqt_mq_establishment_value",
+                table: "qualifications",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "dqt_specialism_value",
+                table: "qualifications",
+                type: "character varying(3)",
+                maxLength: 3,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "dqt_mq_establishment_value",
+                table: "qualifications");
+
+            migrationBuilder.DropColumn(
+                name: "dqt_specialism_value",
+                table: "qualifications");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -16,7 +16,9 @@ public class MandatoryQualification : Qualification
 
     public Guid? DqtQualificationId { get; set; }
     public Guid? DqtMqEstablishmentId { get; set; }
+    public string? DqtMqEstablishmentValue { get; set; }
     public Guid? DqtSpecialismId { get; set; }
+    public string? DqtSpecialismValue { get; set; }
 
     public static MandatoryQualification Create(
         Guid personId,


### PR DESCRIPTION
Currently we use DQT's ID GUIDs to refer to legacy MQ providers and specialisms. We need to migrate those to string values instead (since those are stable across environments and it's what we're doing everywhere else). This adds two new columns to store those values. A separate job will follow to populate these values.