### PR TITLE
Add missing config

### DIFF
--- a/TeachingRecordSystem/appsettings.aks_pre-production_shared.json
+++ b/TeachingRecordSystem/appsettings.aks_pre-production_shared.json
@@ -13,6 +13,12 @@
       "education.gov.uk"
     ]
   },
+  "TrnRequests": {
+    "FlagFurtherChecksRequiredFromUserIds": [
+      "291623c1-c041-4712-b54f-d013689d7ef1",
+      "5e1e1a03-7b7d-42fc-a39a-15bcfde02683"
+    ]
+  },
   "Webhooks": {
     "CanonicalDomain": "https://preprod.teacher-qualifications-api.education.gov.uk",
     "SigningKeyId": "key1",

--- a/TeachingRecordSystem/appsettings.aks_production_shared.json
+++ b/TeachingRecordSystem/appsettings.aks_production_shared.json
@@ -10,6 +10,12 @@
   "TrnGenerationApi": {
     "BaseAddress": "https://trn-generation-api.education.gov.uk"
   },
+  "TrnRequests": {
+    "FlagFurtherChecksRequiredFromUserIds": [
+      "f9f959fe-0344-4e09-90cc-937f6710cddd",
+      "cb0fe8ee-2ee8-42a9-b266-96a5831fb30a"
+    ]
+  },
   "Webhooks": {
     "CanonicalDomain": "https://teacher-qualifications-api.education.gov.uk",
     "SigningKeyId": "key1",

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.aks_pre-production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.aks_pre-production.json
@@ -1,9 +1,5 @@
 {
   "AllowVNextEndpoints": true,
-  "AllowContactPiiUpdatesFromUserIds": [
-    "291623c1-c041-4712-b54f-d013689d7ef1",
-    "66232438-611b-4db5-add6-92e3a45ffe81"
-  ],
   "EnabledFeatures": [ ],
   "GetAnIdentityApplicationUserId": "987e7a43-f8e2-43a7-8901-952c81015c0d"
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.aks_production.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/appsettings.aks_production.json
@@ -7,9 +7,6 @@
       }
     }
   },
-  "AllowContactPiiUpdatesFromUserIds": [
-    "f9f959fe-0344-4e09-90cc-937f6710cddd"
-  ],
   "EnabledFeatures": [ ],
   "GetAnIdentityApplicationUserId": "b4ba6d5f-305f-4f0c-a66e-91bb1c1d0e91"
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/Extensions.cs
@@ -9,8 +9,12 @@ public static class Extensions
     public static IServiceCollection AddTrnRequestService(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddTransient<TrnRequestService>();
-        services.AddOptions<TrnRequestOptions>().Configure(options =>
-            options.AllowContactPiiUpdatesFromUserIds = configuration.GetSection("AllowContactPiiUpdatesFromUserIds").Get<Guid[]>() ?? []);
+
+        services.AddOptions<TrnRequestOptions>()
+            .Bind(configuration.GetSection("TrnRequests"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
         return services;
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestOptions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestOptions.cs
@@ -2,7 +2,6 @@ namespace TeachingRecordSystem.Core.Services.TrnRequests;
 
 public class TrnRequestOptions
 {
-    public Guid[] AllowContactPiiUpdatesFromUserIds { get; set; } = [];
     public Guid[] FlagFurtherChecksRequiredFromUserIds { get; set; } = [];
 }
 


### PR DESCRIPTION
`FlagFurtherChecksRequiredFromUserIds` isn't populated for any environment. Also removes `AllowContactPiiUpdatesFromUserIds` since we're not using that any more.