### PR TITLE
Add DQT MQ reference data to LegacyDataCache

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/MandatoryQualification.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Events/Models/MandatoryQualification.cs
@@ -30,6 +30,6 @@ public record MandatoryQualificationProvider
 {
     public required Guid? MandatoryQualificationProviderId { get; init; }
     public required string? Name { get; init; }
-    public Guid? DqtMqEstablishmentId { get; init; }
+    public string? DqtMqEstablishmentValue { get; init; }
     public string? DqtMqEstablishmentName { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/LegacyDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/LegacyDataCache.cs
@@ -6,6 +6,60 @@ public class LegacyDataCache
 
     public static LegacyDataCache Instance { get; } = new();
 
+    public IReadOnlyCollection<MqEstablishment> MqEstablishments =
+    [
+        new("Liverpool John Moores University", "964",  true),
+        new("Plymouth University",  "965",  true),
+        new("Diploma in Professional Studies in Education for Teachers of Visually Handicapped Children - Moray House College of Education, Edinburgh", "10", false),
+        new("Diploma for Teachers of the Deaf - University College, Dublin", "100", false),
+        new("Diploma in Education of Deaf and Partially Hearing Children - Moray House College of Education, Edinburgh", "110", false),
+        new("Postgraduate Diploma in Education (Special Education: Hearing Impairment), University of Birmingham, School of Education", "120", false),
+        new("Diploma in Special Education (Hearing Impaired) - University of Swansea",  "130", false),
+        new("Postgraduate Diploma (Education of Deaf Children), University of Hertfordshire", "140", false),
+        new("Postgraduate Diploma in Deaf Education, University of Manchester, School of Psychological Sciences", "150", false),
+        new("BPhil in Education (Special Education: Hearing Impairment), University of Birmingham, School of Education", "160", false),
+        new("Diploma in Special Educational Needs: Hearing Impaired - Gwent College", "170", false),
+        new("BPhil in Multi-Sensory Impairment and Deafblindness, University of Birmingham, School of Education", "180", false),
+        new("Diploma in the Education and Psychology of Children with Special Needs - Multi-Sensory Impairment (Deaf - Blind) - University of London, Institute of Education in conjunction with Whitfield School, Walthamstow", "190", false),
+        new("BPhil for Teachers of Children with a Visual Impairment, University of Birmingham, School of Education", "20", false),
+        new("Diploma in the Education and Psychology of Children with Special Needs - Multi", "200", false),
+        new("Postgraduate Diploma in Multi-Sensory Impairment and Deafblindness, University of Birmingham, School of Education", "210", false),
+        new("MA in Deaf Education (Teacher of the Deaf Qualification), University of Leeds, School of Education", "220", false),
+        new("Postgraduate Diploma in Education Studies (Hearing Impairment), Oxford Brookes University, Westminster Institute of Education, in partnership with Mary Hare School",  "230", false),
+        new("Postgraduate Diploma (Teachers Working with Children with Multi-Sensory Impairment), Kingston University, School of Education, in partnership with Whitefield Schools and Centre", "240", false),
+        new("Postgraduate Diploma for Teachers of Children with Visual Impairment, University of Birmingham, School of Education", "30", false),
+        new("Diploma in the Education of Children with Disabilities of Sight - Cambridge Institute of Education", "40", false),
+        new("Graduate Diploma in Special and Inclusive Education: Disabilities of Sight, University of London Institute of Education", "50", false),
+        new("Diploma in Professional Practice in Education (SEN) in Visual Impairment - Manchester Metropolitan University", "60", false),
+        new("Diploma in Special Education (Visually Impaired) - University of Swansea", "70", false),
+        new("Diploma in Special Educational Needs: Visually Impaired - Gwent College", "80", false),
+        new("Masters Level: Mandatory Qualification for Teachers of Children with Visual Impairment, University of Plymouth, Faculty of Education, in partnership with the Sensory Consortium", "90", false),
+        new("Special courses of advanced study and courses leading to higher degrees and degrees in education other than BEd degrees", "950", false),
+        new("Bristol Polytechnic", "951", false),
+        new("Courses for teaching handicapped children other than the blind, deaf and partially hearing", "952", false),
+        new("One-year courses (originally known as Supplementary Courses)", "953", false),
+        new("University College, Swansea", "954", true),
+        new("University of Birmingham", "955", true),
+        new("University of Cambridge", "956", true),
+        new("University of Edinburgh", "957", true),
+        new("University of Hertfordshire", "958", true),
+        new("University of Leeds", "959", true),
+        new("University of London", "960", true),
+        new("University of Manchester", "961", true),
+        new("University of Newcastle-upon-Tyne", "962", true),
+        new("University of Oxford/Oxford Polytechnic", "963", true)
+    ];
+
+    public IReadOnlyCollection<MqSpecialism> MqSpecialisms =
+    [
+        new("Deaf education", "Deaf education", true),
+        new("N/A", "N/A", true),
+        new("Auditory Impairment", "Auditory", false),
+        new("Hearing", "Hearing", true),
+        new("Multi_Sensory Impairment", "Multi-Sensory", true),
+        new("Visual Impairment", "Visual", true)
+    ];
+
     public IReadOnlyCollection<SanctionCode> SanctionCodes =
     [
         new("FOR INTERNAL INFORMATION ONLY - known duplicate record", "T10", true),
@@ -76,11 +130,27 @@ public class LegacyDataCache
         new("Council Member  -  do not register", "Z2", false)
     ];
 
+    public IReadOnlyCollection<MqEstablishment> GetAllMqEstablishments(bool activeOnly = true) =>
+        MqEstablishments.Where(m => !activeOnly || m.Active).AsReadOnly();
+
+    public MqEstablishment GetMqEstablishmentByValue(string value) =>
+        MqEstablishments.Single(m => m.Value == value);
+
+    public IReadOnlyCollection<MqSpecialism> GetAllMqSpecialisms(bool activeOnly = true) =>
+        MqSpecialisms.Where(s => !activeOnly || s.Active).AsReadOnly();
+
+    public MqSpecialism GetMqSpecialismByValue(string value) =>
+        MqSpecialisms.Single(s => s.Value == value);
+
     public IReadOnlyCollection<SanctionCode> GetAllSanctionCodes(bool activeOnly = true) =>
         SanctionCodes.Where(s => !activeOnly || s.Active).AsReadOnly();
 
     public SanctionCode GetSanctionCodeByValue(string value) =>
         SanctionCodes.Single(s => s.Value == value);
+
+    public record MqEstablishment(string Name, string Value, bool Active);
+
+    public record MqSpecialism(string Name, string Value, bool Active);
 
     public record SanctionCode(string Name, string Value, bool Active);
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationSpecialism.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/MandatoryQualificationSpecialism.cs
@@ -43,7 +43,7 @@ public static class MandatoryQualificationSpecialismRegistry
 
     public static bool IsLegacy(this MandatoryQualificationSpecialism specialism) => _info[specialism].Legacy;
 
-    public static bool TryMapFromDqtMqEstablishment(string mqestablishmentValue, string dqtValue, [NotNullWhen(true)] out MandatoryQualificationSpecialism? specialism)
+    public static bool TryMapFromDqtSpecialism(string mqestablishmentValue, string dqtValue, [NotNullWhen(true)] out MandatoryQualificationSpecialism? specialism)
     {
         switch ((mqestablishmentValue, dqtValue))
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/ReferenceDataCache.cs
@@ -14,11 +14,9 @@ public class ReferenceDataCache(
     private object _routeTypesSyncObj = new();
 
     // CRM
-    private Task<dfeta_mqestablishment[]>? _mqEstablishmentsTask;
     private Task<Subject[]>? _getSubjectsTask;
     private Task<dfeta_teacherstatus[]>? _getTeacherStatusesTask;
     private Task<dfeta_earlyyearsstatus[]>? _getEarlyYearsStatusesTask;
-    private Task<dfeta_specialism[]>? _getSpecialismsTask;
     private Task<dfeta_hequalification[]>? _getHeQualificationsTask;
     private Task<dfeta_hesubject[]>? _getHeSubjectsTask;
     private Task<dfeta_country[]>? _getCountriesTask;
@@ -78,44 +76,6 @@ public class ReferenceDataCache(
     {
         var earlyYearsStatuses = await EnsureEarlyYearsStatusesAsync();
         return earlyYearsStatuses.Single(ey => ey.dfeta_Value == value, $"Could not find early years teacher status with value: '{value}'.");
-    }
-
-    public async Task<dfeta_specialism[]> GetMqSpecialismsAsync()
-    {
-        var specialisms = await EnsureSpecialismsAsync();
-        return specialisms.ToArray();
-    }
-
-    public async Task<dfeta_specialism> GetMqSpecialismByValueAsync(string value)
-    {
-        var specialisms = await EnsureSpecialismsAsync();
-        // build environment has some duplicate Specialisms, which prevent us using Single() here
-        return specialisms.First(s => s.dfeta_Value == value, $"Could not find MQ specialism with value: '{value}'.");
-    }
-
-    public async Task<dfeta_specialism> GetMqSpecialismByIdAsync(Guid specialismId)
-    {
-        var specialisms = await EnsureSpecialismsAsync();
-        return specialisms.Single(s => s.dfeta_specialismId == specialismId, $"Could not find MQ specialism with ID: '{specialismId}'.");
-    }
-
-    public async Task<dfeta_mqestablishment[]> GetMqEstablishmentsAsync()
-    {
-        var mqEstablishments = await EnsureMqEstablishmentsAsync();
-        return mqEstablishments.ToArray();
-    }
-
-    public async Task<dfeta_mqestablishment> GetMqEstablishmentByValueAsync(string value)
-    {
-        var mqEstablishments = await EnsureMqEstablishmentsAsync();
-        // build environment has some duplicate MQ Establishments, which prevent us using Single() here
-        return mqEstablishments.First(s => s.dfeta_Value == value, $"Could not find MQ establishment with value: '{value}'.");
-    }
-
-    public async Task<dfeta_mqestablishment> GetMqEstablishmentByIdAsync(Guid mqEstablishmentId)
-    {
-        var mqEstablishments = await EnsureMqEstablishmentsAsync();
-        return mqEstablishments.Single(s => s.dfeta_mqestablishmentId == mqEstablishmentId, $"Could not find MQ establishment with ID: '{mqEstablishmentId}'.");
     }
 
     public async Task<dfeta_hequalification[]> GetHeQualificationsAsync()
@@ -346,16 +306,6 @@ public class ReferenceDataCache(
             ref _getEarlyYearsStatusesTask,
             () => crmQueryDispatcher.ExecuteQueryAsync(new GetAllActiveEarlyYearsStatusesQuery()));
 
-    private Task<dfeta_specialism[]> EnsureSpecialismsAsync() =>
-        LazyInitializer.EnsureInitialized(
-            ref _getSpecialismsTask,
-            () => crmQueryDispatcher.ExecuteQueryAsync(new GetAllSpecialismsQuery()));
-
-    private Task<dfeta_mqestablishment[]> EnsureMqEstablishmentsAsync() =>
-        LazyInitializer.EnsureInitialized(
-            ref _mqEstablishmentsTask,
-            () => crmQueryDispatcher.ExecuteQueryAsync(new GetAllMqEstablishmentsQuery()));
-
     private Task<dfeta_hequalification[]> EnsureHeQualificationsAsync() =>
         LazyInitializer.EnsureInitialized(
             ref _getHeQualificationsTask,
@@ -503,8 +453,6 @@ public class ReferenceDataCache(
         await EnsureSubjectsAsync();
         await EnsureTeacherStatusesAsync();
         await EnsureEarlyYearsStatusesAsync();
-        await EnsureSpecialismsAsync();
-        await EnsureMqEstablishmentsAsync();
         await EnsureHeQualificationsAsync();
         await EnsureHeSubjectsAsync();
         await EnsureCountriesAsync();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 [Journey(JourneyNames.EditMqSpecialism), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(ReferenceDataCache referenceDataCache, TrsLinkGenerator linkGenerator) : PageModel
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
 {
     public JourneyInstance<EditMqSpecialismState>? JourneyInstance { get; set; }
 
@@ -62,8 +62,8 @@ public class IndexModel(ReferenceDataCache referenceDataCache, TrsLinkGenerator 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
 
-        var migratedFromDqtWithLegacySpecialism = qualificationInfo.MandatoryQualification.DqtSpecialismId is Guid dqtSpecialismId &&
-            MandatoryQualificationSpecialismRegistry.GetByDqtValue((await referenceDataCache.GetMqSpecialismByIdAsync(dqtSpecialismId)).dfeta_Value).IsLegacy();
+        var migratedFromDqtWithLegacySpecialism = qualificationInfo.MandatoryQualification.DqtSpecialismValue is string dqtSpecialismValue &&
+            MandatoryQualificationSpecialismRegistry.GetByDqtValue(dqtSpecialismValue).IsLegacy();
 
         Specialisms = MandatoryQualificationSpecialismRegistry.GetAll(includeLegacy: migratedFromDqtWithLegacySpecialism);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Qualifications/MqTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Qualifications/MqTests.cs
@@ -14,8 +14,8 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task AddMq()
     {
         var person = await TestData.CreatePersonAsync();
-        var mqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValueAsync("959"); // University of Leeds
-        var specialism = await TestData.ReferenceDataCache.GetMqSpecialismByValueAsync("Hearing");
+        var mqEstablishment = LegacyDataCache.Instance.GetMqEstablishmentByValue("959"); // University of Leeds
+        var specialism = LegacyDataCache.Instance.GetMqSpecialismByValue("Hearing");
         var startDate = new DateOnly(2021, 3, 1);
         var result = dfeta_qualification_dfeta_MQ_Status.Passed;
         var endDate = new DateOnly(2021, 11, 5);
@@ -32,14 +32,14 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnAddMqProviderPageAsync();
 
-        await page.FillAsync($"label:text-is('Training provider')", mqEstablishment.dfeta_name);
+        await page.FillAsync($"label:text-is('Training provider')", mqEstablishment.Name);
 
         await page.FocusAsync("button:text-is('Continue')");
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnAddMqSpecialismPageAsync();
 
-        await page.CheckAsync($"label{TextIsSelector(specialism.dfeta_name)}");
+        await page.CheckAsync($"label{TextIsSelector(specialism.Name)}");
 
         await page.ClickContinueButtonAsync();
 
@@ -69,8 +69,8 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Test]
     public async Task EditMqProvider()
     {
-        var oldMqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValueAsync("959"); // University of Leeds
-        var newMqEstablishment = await TestData.ReferenceDataCache.GetMqEstablishmentByValueAsync("961"); // University of Manchester
+        var oldMqEstablishment = LegacyDataCache.Instance.GetMqEstablishmentByValue("959"); // University of Leeds
+        var newMqEstablishment = LegacyDataCache.Instance.GetMqEstablishmentByValue("961"); // University of Manchester
         var changeReason = MqChangeProviderReasonOption.ChangeOfTrainingProvider;
         var changeReasonDetail = "My change reason detail";
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
@@ -88,7 +88,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnEditMqProviderPageAsync(qualificationId);
 
-        await page.FillAsync($"label:text-is('Training provider')", newMqEstablishment.dfeta_name);
+        await page.FillAsync($"label:text-is('Training provider')", newMqEstablishment.Name);
         await page.FocusAsync("button:text-is('Continue')");
         await page.ClickContinueButtonAsync();
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -187,8 +187,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = specialism,
                     Status = status,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
@@ -185,8 +185,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = specialism,
                     Status = status,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
@@ -168,8 +168,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = newProvider.MandatoryQualificationProviderId,
                         Name = newProvider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = qualification.Specialism,
                     Status = qualification.Status,
@@ -183,8 +183,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = oldProvider.MandatoryQualificationProviderId,
                         Name = oldProvider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = qualification.Specialism,
                     Status = qualification.Status,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
@@ -172,8 +172,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = newMqSpecialism,
                     Status = qualification.Status,
@@ -187,8 +187,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = oldMqSpecialism,
                     Status = qualification.Status,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
@@ -80,8 +80,8 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var specialism = MandatoryQualificationSpecialism.DeafEducation;
         Debug.Assert(MandatoryQualificationSpecialismRegistry.IsLegacy(specialism));
-        var dqtSpecialism = await TestData.ReferenceDataCache.GetMqSpecialismByValueAsync(specialism.GetDqtValue());
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithSpecialism(specialism, dqtSpecialism.dfeta_specialismId)));
+        var dqtSpecialism = LegacyDataCache.Instance.GetMqSpecialismByValue(specialism.GetDqtValue());
+        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithSpecialism(specialism, dqtSpecialism.Value)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
 
         var journeyInstance = await CreateJourneyInstanceAsync(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
@@ -172,8 +172,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = qualification.Specialism,
                     Status = qualification.Status,
@@ -187,8 +187,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = qualification.Specialism,
                     Status = qualification.Status,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/CheckAnswersTests.cs
@@ -291,8 +291,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = qualification.Specialism,
                     Status = newStatus,
@@ -306,8 +306,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     {
                         MandatoryQualificationProviderId = provider.MandatoryQualificationProviderId,
                         Name = provider.Name,
-                        DqtMqEstablishmentId = null,
-                        DqtMqEstablishmentName = null
+                        DqtMqEstablishmentName = null,
+                        DqtMqEstablishmentValue = null
                     },
                     Specialism = qualification.Specialism,
                     Status = oldStatus,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -795,9 +795,9 @@ public partial class TestData
     public class CreatePersonMandatoryQualificationBuilder
     {
         private Option<Guid?> _mandatoryQualificationProviderId;
-        private Option<Guid?> _mqEstablishmentId;
+        private Option<string?> _mqEstablishmentValue;
         private Option<MandatoryQualificationSpecialism?> _specialism;
-        private Option<Guid?> _dqtSpecialismId;
+        private Option<string?> _dqtSpecialismValue;
         private Option<MandatoryQualificationStatus?> _status;
         private Option<DateOnly?> _startDate;
         private Option<DateOnly?> _endDate;
@@ -810,34 +810,34 @@ public partial class TestData
         public CreatePersonMandatoryQualificationBuilder WithProvider(Guid? mandatoryQualificationProviderId)
         {
             _mandatoryQualificationProviderId = Option.Some(mandatoryQualificationProviderId);
-            _mqEstablishmentId = default;
+            _mqEstablishmentValue = default;
             return this;
         }
 
-        public CreatePersonMandatoryQualificationBuilder WithDqtMqEstablishment(dfeta_mqestablishment? mqEstablishment)
+        public CreatePersonMandatoryQualificationBuilder WithDqtMqEstablishment(string? mqEstablishmentValue)
         {
             Guid? mandatoryQualificationProviderId = null;
 
-            if (mqEstablishment is not null)
+            if (mqEstablishmentValue is not null)
             {
-                MandatoryQualificationProvider.TryMapFromDqtMqEstablishment(mqEstablishment, out var provider);
+                MandatoryQualificationProvider.TryMapFromDqtMqEstablishmentValue(mqEstablishmentValue, out var provider);
                 mandatoryQualificationProviderId = provider?.MandatoryQualificationProviderId;
             }
 
-            return WithDqtMqEstablishment(mqEstablishment, mandatoryQualificationProviderId);
+            return WithDqtMqEstablishment(mqEstablishmentValue, mandatoryQualificationProviderId);
         }
 
-        public CreatePersonMandatoryQualificationBuilder WithDqtMqEstablishment(dfeta_mqestablishment? mqEstablishment, Guid? mandatoryQualificationProviderId)
+        public CreatePersonMandatoryQualificationBuilder WithDqtMqEstablishment(string? mqEstablishmentValue, Guid? mandatoryQualificationProviderId)
         {
-            _mqEstablishmentId = Option.Some(mqEstablishment?.Id);
+            _mqEstablishmentValue = Option.Some(mqEstablishmentValue);
             _mandatoryQualificationProviderId = Option.Some(mandatoryQualificationProviderId);
             return this;
         }
 
-        public CreatePersonMandatoryQualificationBuilder WithSpecialism(MandatoryQualificationSpecialism? specialism, Guid? dqtSpecialismId = null)
+        public CreatePersonMandatoryQualificationBuilder WithSpecialism(MandatoryQualificationSpecialism? specialism, string? dqtSpecialismValue = null)
         {
             _specialism = Option.Some(specialism);
-            _dqtSpecialismId = Option.Some(dqtSpecialismId);
+            _dqtSpecialismValue = Option.Some(dqtSpecialismValue);
             return this;
         }
 
@@ -925,8 +925,8 @@ public partial class TestData
                 Specialism = specialism,
                 StartDate = startDate,
                 EndDate = endDate,
-                DqtSpecialismId = _dqtSpecialismId.ValueOr((Guid?)null),
-                DqtMqEstablishmentId = _mqEstablishmentId.ValueOr((Guid?)null)
+                DqtSpecialismValue = _dqtSpecialismValue.ValueOr((string?)null),
+                DqtMqEstablishmentValue = _mqEstablishmentValue.ValueOr((string?)null)
             };
 
             dbContext.MandatoryQualifications.Add(mq);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.DeleteMandatoryQualification.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.DeleteMandatoryQualification.cs
@@ -21,8 +21,8 @@ public partial class TestData
 
             qualification.DeletedOn = now;
 
-            var mqEstablishment = qualification.DqtMqEstablishmentId is Guid mqEstablishmentId ?
-                await ReferenceDataCache.GetMqEstablishmentByIdAsync(mqEstablishmentId) :
+            var mqEstablishment = qualification.DqtMqEstablishmentValue is string mqEstablishmentValue ?
+                LegacyDataCache.Instance.GetMqEstablishmentByValue(mqEstablishmentValue) :
                 null;
 
             var deletedEvent = new MandatoryQualificationDeletedEvent()
@@ -41,8 +41,8 @@ public partial class TestData
                             Name = qualification.ProviderId is not null ?
                                 qualification.Provider?.Name ?? throw new InvalidOperationException($"Missing {nameof(qualification.Provider)}.") :
                                 null,
-                            DqtMqEstablishmentId = mqEstablishment?.Id,
-                            DqtMqEstablishmentName = mqEstablishment?.dfeta_name
+                            DqtMqEstablishmentName = mqEstablishment?.Name,
+                            DqtMqEstablishmentValue = mqEstablishment?.Value
                         } :
                         null,
                     Specialism = qualification.Specialism,
@@ -52,11 +52,11 @@ public partial class TestData
                 },
                 DeletionReason = deletionReason ?? "Added in error",
                 DeletionReasonDetail = deletionReasonDetail,
-                EvidenceFile = evidenceFile is (Guid FileId, string Name) e ?
+                EvidenceFile = evidenceFile is (Guid FileId, string Name) ?
                     new EventModels.File()
                     {
-                        FileId = e.FileId,
-                        Name = e.Name
+                        FileId = FileId,
+                        Name = Name
                     } :
                     null
             };


### PR DESCRIPTION
We're still using DQT for MQ reference data in a few places. This adds that reference data to `LegacyDataCache` and amends lookups to use DQT's `dfeta_value` attribute instead of the environment-specific `id`. A job has already been run to populate the relevant fields in the DB.