### PR TITLE
Enable EF's retry on failure

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -137,7 +137,9 @@ public class TrsDbContext : DbContext
 
     public static void ConfigureOptions(DbContextOptionsBuilder optionsBuilder, string? connectionString = null, int? commandTimeout = null)
     {
-        Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o.CommandTimeout(commandTimeout);
+        Action<NpgsqlDbContextOptionsBuilder> configureOptions = o => o
+            .CommandTimeout(commandTimeout)
+            .EnableRetryOnFailure();
 
         if (connectionString != null)
         {


### PR DESCRIPTION
We have a few errors in the logs for transient errors talking to the DB. This enable's EF's 'retry on failure' to hopefully solve those.