### PR TITLE
Add SupportTaskTypeId to SupportTask

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250910100811_SupportTaskTypeId.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250910100811_SupportTaskTypeId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250910100811_SupportTaskTypeId")]
+    partial class SupportTaskTypeId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250910100811_SupportTaskTypeId.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20250910100811_SupportTaskTypeId.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SupportTaskTypeId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "support_task_type_id",
+                table: "support_tasks",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "support_task_type_id",
+                table: "support_tasks");
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -16,6 +16,7 @@ public class SupportTask
     public required DateTime CreatedOn { get; init; }
     public required DateTime UpdatedOn { get; set; }
     public required SupportTaskType SupportTaskType { get; init; }
+    public Guid? SupportTaskTypeId { get; init; }
     public required SupportTaskStatus Status { get; set; }
     public string? OneLoginUserSubject { get; init; }
     public Guid? PersonId { get; init; }
@@ -47,6 +48,7 @@ public class SupportTask
             CreatedOn = now,
             UpdatedOn = now,
             SupportTaskType = supportTaskType,
+            SupportTaskTypeId = supportTaskType.GetSupportTaskTypeId(),
             Status = SupportTaskStatus.Open,
             Data = data,
             PersonId = personId,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTaskType.cs
@@ -4,19 +4,19 @@ namespace TeachingRecordSystem.Core.Models;
 
 public enum SupportTaskType
 {
-    [SupportTaskTypeInfo("connect GOV.UK One Login user to a teaching record", SupportTaskCategory.OneLogin)]
+    [SupportTaskTypeInfo("connect GOV.UK One Login user to a teaching record", SupportTaskCategory.OneLogin, "4b76f9b8-c60e-4076-ac4b-d173f395dc71")]
     ConnectOneLoginUser = 1,
-    [SupportTaskTypeInfo("change name request", SupportTaskCategory.ChangeRequests)]
+    [SupportTaskTypeInfo("change name request", SupportTaskCategory.ChangeRequests, "6bc82e72-7592-4b05-a4ae-822fb52cad8d")]
     ChangeNameRequest = 2,
-    [SupportTaskTypeInfo("change date of birth request", SupportTaskCategory.ChangeRequests)]
+    [SupportTaskTypeInfo("change date of birth request", SupportTaskCategory.ChangeRequests, "b621cc79-b116-461e-be8d-593d6efd53cd")]
     ChangeDateOfBirthRequest = 3,
-    [SupportTaskTypeInfo("TRN request from API", SupportTaskCategory.TrnRequests)]
+    [SupportTaskTypeInfo("TRN request from API", SupportTaskCategory.TrnRequests, "37c27275-829c-4aa0-a47c-62a0092d0a71")]
     ApiTrnRequest = 4,
-    [SupportTaskTypeInfo("TRN request from NPQ", SupportTaskCategory.TrnRequests)]
+    [SupportTaskTypeInfo("TRN request from NPQ", SupportTaskCategory.TrnRequests, "3ca684d4-15de-4f12-b0fb-c5386360b171")]
     NpqTrnRequest = 5,
-    [SupportTaskTypeInfo("Manual checks needed", SupportTaskCategory.TrnRequests)]
+    [SupportTaskTypeInfo("Manual checks needed", SupportTaskCategory.TrnRequests, "80adb2e0-199c-4629-b494-4d052230a248")]
     TrnRequestManualChecksNeeded = 6,
-    [SupportTaskTypeInfo("Capita import potential duplicate", SupportTaskCategory.CapitaImport)]
+    [SupportTaskTypeInfo("Capita import potential duplicate", SupportTaskCategory.CapitaImport, "fdee6a10-6338-463a-b6df-e34a2b95a854")]
     CapitaImportPotentialDuplicate = 7
 }
 
@@ -35,6 +35,8 @@ public static class SupportTaskTypeRegistry
 
     public static string GetTitle(this SupportTaskType supportTaskType) => _info[supportTaskType].Title;
 
+    public static Guid GetSupportTaskTypeId(this SupportTaskType supportTaskType) => _info[supportTaskType].SupportTaskTypeId;
+
     private static SupportTaskTypeInfo GetInfo(SupportTaskType supportTaskType)
     {
         var attr = supportTaskType.GetType()
@@ -43,18 +45,19 @@ public static class SupportTaskTypeRegistry
             .GetCustomAttribute<SupportTaskTypeInfoAttribute>() ??
             throw new Exception($"{nameof(SupportTaskType)}.{supportTaskType} is missing the {nameof(SupportTaskTypeInfoAttribute)} attribute.");
 
-        return new SupportTaskTypeInfo(supportTaskType, attr.Name, attr.SupportTaskCategory);
+        return new SupportTaskTypeInfo(supportTaskType, attr.Name, attr.SupportTaskCategory, attr.SupportTaskTypeId);
     }
 }
 
-public sealed record SupportTaskTypeInfo(SupportTaskType Value, string Name, SupportTaskCategory SupportTaskCategory)
+public sealed record SupportTaskTypeInfo(SupportTaskType Value, string Name, SupportTaskCategory SupportTaskCategory, Guid SupportTaskTypeId)
 {
     public string Title => Name[0..1].ToUpper() + Name[1..];
 }
 
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-file sealed class SupportTaskTypeInfoAttribute(string name, SupportTaskCategory category) : Attribute
+file sealed class SupportTaskTypeInfoAttribute(string name, SupportTaskCategory category, string supportTaskTypeId) : Attribute
 {
+    public Guid SupportTaskTypeId { get; } = new Guid(supportTaskTypeId);
     public string Name => name;
     public SupportTaskCategory SupportTaskCategory => category;
 }


### PR DESCRIPTION
We need to get our reference data into the DB so it can be reported on, specifically the enum-based reference data like `SupportTaskType`.

This adds `SupportTaskTypeId` to `SupportTask` so we'll have both the new and old values being written (`SupportTask.SupportTaskType` will be replaced by `SupportTask.SupportTaskTypeId` eventually). A follow-up PR will back-fill `SupportTaskTypeId` and remove usage of `SupportTaskType`.