### PR TITLE
Update Get a TRN page content

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
@@ -16,7 +16,7 @@
         <p class="govuk-body">Do not use this service if:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>you’ve forgotten your TRN or you’re not sure if you have one - use the <a class="govuk-link" href="https://find-a-lost-trn.education.gov.uk/start">Find a lost TRN</a> service instead</li>
-            <li>you need a TRN because you’re a mentor for a trainee or early career teacher - <a href="https://manage-training-for-early-career-teachers.education.gov.uk/participants/start-registration/get-a-trn" class="govuk-link">request one via Galaxkey</a> instead</li>
+            <li>you need a TRN because you’re a mentor for a trainee or early career teacher - email <a href="mailto:mentor.trnrequest@education.gov.uk">mentor.trnrequest@education.gov.uk</a> with ‘Mentor TRN request’ in the subject line instead</li>
             <li>you need a TRN for a different reason - <a class="govuk-link" href="https://www.gov.uk/guidance/teacher-reference-number-trn#what-youll-need-a-trn-for">find out what you need a TRN for</a></li>
         </ul>
     </div>


### PR DESCRIPTION
### Context

SD Ops & Support team has fed back that the process for a mentor of a trainee or early career teacher requesting a TRN via Galxkey has changed and the request needs to be submitted via Zendesk

We need to update the guidance on the start page of the Get a TRN service so that the users do not submit the requests to old folder.

https://trello.com/c/bNHnp4ET/1618-update-content-on-get-a-trn-service-start-page

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
