### PR TITLE
Consolidate email template IDs

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
@@ -91,7 +91,7 @@ public class CreateDateOfBirthChangeRequestHandler(
             var email = new Email
             {
                 EmailId = Guid.NewGuid(),
-                TemplateId = ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId,
+                TemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId,
                 EmailAddress = emailAddress!,
                 Personalization = new Dictionary<string, string>() { { ChangeRequestEmailConstants.FirstNameEmailPersonalisationKey, person.FirstName } }
             };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateDateOfBirthChangeRequest.cs
@@ -91,8 +91,8 @@ public class CreateDateOfBirthChangeRequestHandler(
             var email = new Email
             {
                 EmailId = Guid.NewGuid(),
-                TemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId,
-                EmailAddress = emailAddress!,
+                TemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmation,
+                EmailAddress = emailAddress,
                 Personalization = new Dictionary<string, string>() { { ChangeRequestEmailConstants.FirstNameEmailPersonalisationKey, person.FirstName } }
             };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
@@ -95,7 +95,7 @@ public class CreateNameChangeRequestHandler(
             var email = new Email
             {
                 EmailId = Guid.NewGuid(),
-                TemplateId = ChangeRequestEmailConstants.GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId,
+                TemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId,
                 EmailAddress = emailAddress!,
                 Personalization = new Dictionary<string, string>() { { ChangeRequestEmailConstants.FirstNameEmailPersonalisationKey, person.FirstName } }
             };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
@@ -95,8 +95,8 @@ public class CreateNameChangeRequestHandler(
             var email = new Email
             {
                 EmailId = Guid.NewGuid(),
-                TemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId,
-                EmailAddress = emailAddress!,
+                TemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameSubmittedEmailConfirmation,
+                EmailAddress = emailAddress,
                 Personalization = new Dictionary<string, string>() { { ChangeRequestEmailConstants.FirstNameEmailPersonalisationKey, person.FirstName } }
             };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EmailTemplateIds.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EmailTemplateIds.cs
@@ -1,14 +1,16 @@
+namespace TeachingRecordSystem.Core;
+
 public static class EmailTemplateIds
 {
-    public const string EytsAwardedEmailConfirmationTemplateId = "f85babdb-049b-4f32-9579-2a812acc0a2b";
-    public const string InternationalQtsAwardedEmailConfirmationTemplateId = "f4200027-de67-4a55-808a-b37ae2653660";
-    public const string QtsAwardedEmailConfirmationTemplateId = "68814f63-b63a-4f79-b7df-c52f5cd55710";
-    public const string QtlsLapsedTemplateId = "269cefcc-71ac-4ca0-b348-719d4ee6d9d2";
-    public const string InductionCompletedEmailConfirmationTemplateId = "8029faa8-8409-4423-a717-c142dfd2ba86";
-    public const string GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId = "6b734de9-0ff4-4f06-beeb-b10199aeae63";
-    public const string GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId = "95977d42-7bdd-4c9b-938c-76d934618694";
-    public const string GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId = "abe622ac-79b0-40b3-a29d-94f359a0f03e";
-    public const string GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId = "c20e4147-a6b9-46cd-a940-c9d6392eee50";
-    public const string GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId = "cf4b00de-8a2e-4e9c-a913-23725e7a2334";
-    public const string GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId = "bc790721-11c7-42e0-8f88-41ea96296602";
+    public const string EytsAwardedEmailConfirmation = "f85babdb-049b-4f32-9579-2a812acc0a2b";
+    public const string InternationalQtsAwardedEmailConfirmation = "f4200027-de67-4a55-808a-b37ae2653660";
+    public const string QtsAwardedEmailConfirmation = "68814f63-b63a-4f79-b7df-c52f5cd55710";
+    public const string QtlsLapsed = "269cefcc-71ac-4ca0-b348-719d4ee6d9d2";
+    public const string InductionCompletedEmailConfirmation = "8029faa8-8409-4423-a717-c142dfd2ba86";
+    public const string GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmation = "6b734de9-0ff4-4f06-beeb-b10199aeae63";
+    public const string GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmation = "95977d42-7bdd-4c9b-938c-76d934618694";
+    public const string GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmation = "abe622ac-79b0-40b3-a29d-94f359a0f03e";
+    public const string GetAnIdentityChangeOfNameSubmittedEmailConfirmation = "c20e4147-a6b9-46cd-a940-c9d6392eee50";
+    public const string GetAnIdentityChangeOfNameApprovedEmailConfirmation = "cf4b00de-8a2e-4e9c-a913-23725e7a2334";
+    public const string GetAnIdentityChangeOfNameRejectedEmailConfirmation = "bc790721-11c7-42e0-8f88-41ea96296602";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EmailTemplateIds.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EmailTemplateIds.cs
@@ -1,0 +1,14 @@
+public static class EmailTemplateIds
+{
+    public const string EytsAwardedEmailConfirmationTemplateId = "f85babdb-049b-4f32-9579-2a812acc0a2b";
+    public const string InternationalQtsAwardedEmailConfirmationTemplateId = "f4200027-de67-4a55-808a-b37ae2653660";
+    public const string QtsAwardedEmailConfirmationTemplateId = "68814f63-b63a-4f79-b7df-c52f5cd55710";
+    public const string QtlsLapsedTemplateId = "269cefcc-71ac-4ca0-b348-719d4ee6d9d2";
+    public const string InductionCompletedEmailConfirmationTemplateId = "8029faa8-8409-4423-a717-c142dfd2ba86";
+    public const string GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId = "6b734de9-0ff4-4f06-beeb-b10199aeae63";
+    public const string GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId = "95977d42-7bdd-4c9b-938c-76d934618694";
+    public const string GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId = "abe622ac-79b0-40b3-a29d-94f359a0f03e";
+    public const string GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId = "c20e4147-a6b9-46cd-a940-c9d6392eee50";
+    public const string GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId = "cf4b00de-8a2e-4e9c-a913-23725e7a2334";
+    public const string GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId = "bc790721-11c7-42e0-8f88-41ea96296602";
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BatchSendProfessionalStatusEmailsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BatchSendProfessionalStatusEmailsJob.cs
@@ -20,14 +20,6 @@ public class BatchSendProfessionalStatusEmailsJob(
         public const string LastHoldsFromEnd = "LastHoldsFromEnd";
     }
 
-    public static class TemplateIds
-    {
-        public const string EytsAwardedEmailConfirmationTemplateId = "f85babdb-049b-4f32-9579-2a812acc0a2b";
-        public const string InternationalQtsAwardedEmailConfirmationTemplateId = "f4200027-de67-4a55-808a-b37ae2653660";
-        public const string QtsAwardedEmailConfirmationTemplateId = "68814f63-b63a-4f79-b7df-c52f5cd55710";
-        public const string QtlsLapsedTemplateId = "269cefcc-71ac-4ca0-b348-719d4ee6d9d2";
-    }
-
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {
         // Ensure enqueued Hangfire jobs are run in the same transaction as the database changes
@@ -100,8 +92,8 @@ public class BatchSendProfessionalStatusEmailsJob(
             foreach (var qtsAwardee in qtsAwardees.DistinctBy(p => p.Trn))
             {
                 var templateId = qtsAwardee.RouteToProfessionalStatusTypeId == RouteToProfessionalStatusType.InternationalQualifiedTeacherStatusId
-                    ? TemplateIds.InternationalQtsAwardedEmailConfirmationTemplateId
-                    : TemplateIds.QtsAwardedEmailConfirmationTemplateId;
+                    ? EmailTemplateIds.InternationalQtsAwardedEmailConfirmationTemplateId
+                    : EmailTemplateIds.QtsAwardedEmailConfirmationTemplateId;
 
                 var personalization = new Dictionary<string, string>
                 {
@@ -169,7 +161,7 @@ public class BatchSendProfessionalStatusEmailsJob(
                 var email = new Email
                 {
                     EmailId = Guid.NewGuid(),
-                    TemplateId = TemplateIds.EytsAwardedEmailConfirmationTemplateId,
+                    TemplateId = EmailTemplateIds.EytsAwardedEmailConfirmationTemplateId,
                     EmailAddress = eytsAwardee.EmailAddress!,
                     Personalization = personalization,
                     Metadata = metadata
@@ -216,7 +208,7 @@ public class BatchSendProfessionalStatusEmailsJob(
                 var email = new Email
                 {
                     EmailId = Guid.NewGuid(),
-                    TemplateId = TemplateIds.QtlsLapsedTemplateId,
+                    TemplateId = EmailTemplateIds.QtlsLapsedTemplateId,
                     EmailAddress = qtlsLoser.EmailAddress!,
                     Personalization = new Dictionary<string, string>()
                 };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BatchSendProfessionalStatusEmailsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/BatchSendProfessionalStatusEmailsJob.cs
@@ -92,8 +92,8 @@ public class BatchSendProfessionalStatusEmailsJob(
             foreach (var qtsAwardee in qtsAwardees.DistinctBy(p => p.Trn))
             {
                 var templateId = qtsAwardee.RouteToProfessionalStatusTypeId == RouteToProfessionalStatusType.InternationalQualifiedTeacherStatusId
-                    ? EmailTemplateIds.InternationalQtsAwardedEmailConfirmationTemplateId
-                    : EmailTemplateIds.QtsAwardedEmailConfirmationTemplateId;
+                    ? EmailTemplateIds.InternationalQtsAwardedEmailConfirmation
+                    : EmailTemplateIds.QtsAwardedEmailConfirmation;
 
                 var personalization = new Dictionary<string, string>
                 {
@@ -161,7 +161,7 @@ public class BatchSendProfessionalStatusEmailsJob(
                 var email = new Email
                 {
                     EmailId = Guid.NewGuid(),
-                    TemplateId = EmailTemplateIds.EytsAwardedEmailConfirmationTemplateId,
+                    TemplateId = EmailTemplateIds.EytsAwardedEmailConfirmation,
                     EmailAddress = eytsAwardee.EmailAddress!,
                     Personalization = personalization,
                     Metadata = metadata
@@ -208,7 +208,7 @@ public class BatchSendProfessionalStatusEmailsJob(
                 var email = new Email
                 {
                     EmailId = Guid.NewGuid(),
-                    TemplateId = EmailTemplateIds.QtlsLapsedTemplateId,
+                    TemplateId = EmailTemplateIds.QtlsLapsed,
                     EmailAddress = qtlsLoser.EmailAddress!,
                     Personalization = new Dictionary<string, string>()
                 };

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
@@ -13,7 +13,6 @@ public class SendInductionCompletedEmailJob(
     IOptions<AccessYourTeachingQualificationsOptions> accessYourTeachingQualificationsOptions,
     IClock clock)
 {
-    private const string InductionCompletedEmailConfirmationTemplateId = "8029faa8-8409-4423-a717-c142dfd2ba86";
     private const string LinkToAccessYourQualificationsServicePersonalisationKey = "link to access your teaching qualifications service";
 
     private readonly AccessYourTeachingQualificationsOptions _accessYourTeachingQualificationsOptions = accessYourTeachingQualificationsOptions.Value;
@@ -34,7 +33,7 @@ public class SendInductionCompletedEmailJob(
             item.Personalization[LinkToAccessYourQualificationsServicePersonalisationKey] = $"{_accessYourTeachingQualificationsOptions.BaseAddress}{_accessYourTeachingQualificationsOptions.StartUrlPath}?trn_token={tokenResponse.TrnToken}";
         }
 
-        await notificationSender.SendEmailAsync(InductionCompletedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
+        await notificationSender.SendEmailAsync(EmailTemplateIds.InductionCompletedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
         item.EmailSent = true;
 
         dbContext.AddEventWithoutBroadcast(new InductionCompletedEmailSentEvent

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/SendInductionCompletedEmailJob.cs
@@ -33,7 +33,7 @@ public class SendInductionCompletedEmailJob(
             item.Personalization[LinkToAccessYourQualificationsServicePersonalisationKey] = $"{_accessYourTeachingQualificationsOptions.BaseAddress}{_accessYourTeachingQualificationsOptions.StartUrlPath}?trn_token={tokenResponse.TrnToken}";
         }
 
-        await notificationSender.SendEmailAsync(EmailTemplateIds.InductionCompletedEmailConfirmationTemplateId, item.EmailAddress, item.Personalization);
+        await notificationSender.SendEmailAsync(EmailTemplateIds.InductionCompletedEmailConfirmation, item.EmailAddress, item.Personalization);
         item.EmailSent = true;
 
         dbContext.AddEventWithoutBroadcast(new InductionCompletedEmailSentEvent

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTasks/ChangeRequestEmailConstants.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/SupportTasks/ChangeRequestEmailConstants.cs
@@ -2,11 +2,5 @@ namespace TeachingRecordSystem.Core.Models.SupportTasks;
 
 public static class ChangeRequestEmailConstants
 {
-    public const string GetAnIdentityChangeOfDateOfBirthSubmittedEmailConfirmationTemplateId = "6b734de9-0ff4-4f06-beeb-b10199aeae63";
-    public const string GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId = "95977d42-7bdd-4c9b-938c-76d934618694";
-    public const string GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId = "abe622ac-79b0-40b3-a29d-94f359a0f03e";
-    public const string GetAnIdentityChangeOfNameSubmittedEmailConfirmationTemplateId = "c20e4147-a6b9-46cd-a940-c9d6392eee50";
-    public const string GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId = "cf4b00de-8a2e-4e9c-a913-23725e7a2334";
-    public const string GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId = "bc790721-11c7-42e0-8f88-41ea96296602";
     public const string FirstNameEmailPersonalisationKey = "first name";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
@@ -91,7 +91,7 @@ public class AcceptModel(
             }
 
             emailAddress = string.IsNullOrEmpty(changeNameRequestData!.EmailAddress) ? Person!.EmailAddress : changeNameRequestData.EmailAddress;
-            emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId;
+            emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameApprovedEmailConfirmation;
 
             await dbContext.AddEventAndBroadcastAsync(approvedEvent);
         }
@@ -117,7 +117,7 @@ public class AcceptModel(
             };
 
             emailAddress = string.IsNullOrEmpty(changeDateOfBirthRequestData!.EmailAddress) ? Person!.EmailAddress : changeDateOfBirthRequestData.EmailAddress;
-            emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId;
+            emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmation;
 
             await dbContext.AddEventAndBroadcastAsync(approvedEvent);
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Accept.cshtml.cs
@@ -91,7 +91,7 @@ public class AcceptModel(
             }
 
             emailAddress = string.IsNullOrEmpty(changeNameRequestData!.EmailAddress) ? Person!.EmailAddress : changeNameRequestData.EmailAddress;
-            emailTemplateId = ChangeRequestEmailConstants.GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId;
+            emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId;
 
             await dbContext.AddEventAndBroadcastAsync(approvedEvent);
         }
@@ -117,7 +117,7 @@ public class AcceptModel(
             };
 
             emailAddress = string.IsNullOrEmpty(changeDateOfBirthRequestData!.EmailAddress) ? Person!.EmailAddress : changeDateOfBirthRequestData.EmailAddress;
-            emailTemplateId = ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId;
+            emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId;
 
             await dbContext.AddEventAndBroadcastAsync(approvedEvent);
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
@@ -120,7 +120,7 @@ public class RejectModel(
                 };
 
                 emailAddress = string.IsNullOrEmpty(changeNameRequestData!.EmailAddress) ? Person!.EmailAddress : changeNameRequestData.EmailAddress;
-                emailTemplateId = ChangeRequestEmailConstants.GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId;
+                emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId;
             }
             else if (ChangeType == SupportTaskType.ChangeDateOfBirthRequest)
             {
@@ -142,7 +142,7 @@ public class RejectModel(
                 };
 
                 emailAddress = string.IsNullOrEmpty(changeDateOfBirthRequestData!.EmailAddress) ? Person!.EmailAddress : changeDateOfBirthRequestData.EmailAddress;
-                emailTemplateId = ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId;
+                emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId;
             }
 
             await dbContext.AddEventAndBroadcastAsync(rejectedEvent);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ChangeRequests/EditChangeRequest/Reject.cshtml.cs
@@ -120,7 +120,7 @@ public class RejectModel(
                 };
 
                 emailAddress = string.IsNullOrEmpty(changeNameRequestData!.EmailAddress) ? Person!.EmailAddress : changeNameRequestData.EmailAddress;
-                emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId;
+                emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfNameRejectedEmailConfirmation;
             }
             else if (ChangeType == SupportTaskType.ChangeDateOfBirthRequest)
             {
@@ -142,7 +142,7 @@ public class RejectModel(
                 };
 
                 emailAddress = string.IsNullOrEmpty(changeDateOfBirthRequestData!.EmailAddress) ? Person!.EmailAddress : changeDateOfBirthRequestData.EmailAddress;
-                emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId;
+                emailTemplateId = EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmation;
             }
 
             await dbContext.AddEventAndBroadcastAsync(rejectedEvent);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
@@ -35,7 +35,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(BatchSendProfessionalStatusEmailsJob.TemplateIds.QtsAwardedEmailConfirmationTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.QtsAwardedEmailConfirmationTemplateId, email.TemplateId);
         Assert.Equal(person.FirstName, email.Personalization["first name"]);
         Assert.Equal(person.LastName, email.Personalization["last name"]);
         Assert.Equal(person.Trn, email.Metadata["Trn"].ToString());
@@ -73,7 +73,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(BatchSendProfessionalStatusEmailsJob.TemplateIds.InternationalQtsAwardedEmailConfirmationTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.InternationalQtsAwardedEmailConfirmationTemplateId, email.TemplateId);
         Assert.Equal(person.FirstName, email.Personalization["first name"]);
         Assert.Equal(person.LastName, email.Personalization["last name"]);
         Assert.Equal(person.Trn, email.Metadata["Trn"].ToString());
@@ -111,7 +111,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(BatchSendProfessionalStatusEmailsJob.TemplateIds.EytsAwardedEmailConfirmationTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.EytsAwardedEmailConfirmationTemplateId, email.TemplateId);
         Assert.Equal(person.FirstName, email.Personalization["first name"]);
         Assert.Equal(person.LastName, email.Personalization["last name"]);
         Assert.Equal(person.Trn, email.Metadata["Trn"].ToString());
@@ -165,7 +165,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(BatchSendProfessionalStatusEmailsJob.TemplateIds.QtlsLapsedTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.QtlsLapsedTemplateId, email.TemplateId);
 
         backgroundJobScheduler
             .Verify(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
@@ -35,7 +35,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(EmailTemplateIds.QtsAwardedEmailConfirmationTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.QtsAwardedEmailConfirmation, email.TemplateId);
         Assert.Equal(person.FirstName, email.Personalization["first name"]);
         Assert.Equal(person.LastName, email.Personalization["last name"]);
         Assert.Equal(person.Trn, email.Metadata["Trn"].ToString());
@@ -73,7 +73,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(EmailTemplateIds.InternationalQtsAwardedEmailConfirmationTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.InternationalQtsAwardedEmailConfirmation, email.TemplateId);
         Assert.Equal(person.FirstName, email.Personalization["first name"]);
         Assert.Equal(person.LastName, email.Personalization["last name"]);
         Assert.Equal(person.Trn, email.Metadata["Trn"].ToString());
@@ -111,7 +111,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(EmailTemplateIds.EytsAwardedEmailConfirmationTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.EytsAwardedEmailConfirmation, email.TemplateId);
         Assert.Equal(person.FirstName, email.Personalization["first name"]);
         Assert.Equal(person.LastName, email.Personalization["last name"]);
         Assert.Equal(person.Trn, email.Metadata["Trn"].ToString());
@@ -165,7 +165,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(NightlyEmailJobFixture db
         var email = await DbFixture.WithDbContextAsync(dbContext => dbContext.Emails.SingleOrDefaultAsync());
         Assert.NotNull(email);
         Assert.Equal(person.Email, email.EmailAddress);
-        Assert.Equal(EmailTemplateIds.QtlsLapsedTemplateId, email.TemplateId);
+        Assert.Equal(EmailTemplateIds.QtlsLapsed, email.TemplateId);
 
         backgroundJobScheduler
             .Verify(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/AcceptTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/AcceptTests.cs
@@ -155,7 +155,7 @@ public class AcceptTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfNameApprovedEmailConfirmation, email.TemplateId);
 
                 var updatedPerson = await dbContext.Persons
                     .SingleAsync(p => p.PersonId == createPersonResult.PersonId);
@@ -180,7 +180,7 @@ public class AcceptTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmation, email.TemplateId);
             }
         });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/AcceptTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/AcceptTests.cs
@@ -155,7 +155,7 @@ public class AcceptTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfNameApprovedEmailConfirmationTemplateId, email.TemplateId);
 
                 var updatedPerson = await dbContext.Persons
                     .SingleAsync(p => p.PersonId == createPersonResult.PersonId);
@@ -180,7 +180,7 @@ public class AcceptTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthApprovedEmailConfirmationTemplateId, email.TemplateId);
             }
         });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
@@ -179,7 +179,7 @@ public class RejectTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfNameRejectedEmailConfirmation, email.TemplateId);
             }
             else
             {
@@ -190,7 +190,7 @@ public class RejectTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmation, email.TemplateId);
             }
         });
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ChangeRequests/EditChangeRequest/RejectTests.cs
@@ -179,7 +179,7 @@ public class RejectTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfNameRejectedEmailConfirmationTemplateId, email.TemplateId);
             }
             else
             {
@@ -190,7 +190,7 @@ public class RejectTests : TestBase
                     .SingleOrDefaultAsync();
                 Assert.NotNull(email);
                 Assert.NotNull(email.SentOn);
-                Assert.Equal(ChangeRequestEmailConstants.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId, email.TemplateId);
+                Assert.Equal(EmailTemplateIds.GetAnIdentityChangeOfDateOfBirthRejectedEmailConfirmationTemplateId, email.TemplateId);
             }
         });
 


### PR DESCRIPTION
### Context

We currently have email template IDs scattered about in multiple places e.g. `ChangeRequestEmailConstants` and `BatchSendProfessionalStatusEmailsJob.TemplateIds`. We should move all of these into a common `EmailTemplateIds` class.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Run DQT integration tests locally (if appropriate)
