### PR TITLE
Add interfaces for API commands and handlers

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/ApiResult.cs
@@ -72,10 +72,3 @@ public class ApiResultActionResultBuilder<TResult>(ApiResult<TResult> result, Fu
         return this;
     }
 }
-
-public sealed class Unit
-{
-    private Unit() { }
-
-    public static Unit Instance { get; } = new();
-}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Extensions.cs
@@ -1,0 +1,17 @@
+namespace TeachingRecordSystem.Api;
+
+public static class Extensions
+{
+    public static IServiceCollection AddApiCommands(this IServiceCollection services)
+    {
+        services.Scan(scan =>
+            scan.FromAssemblyOf<Program>()
+                .AddClasses(filter => filter.AssignableTo(typeof(ICommandHandler<,>)))
+                .AsImplementedInterfaces()
+                .WithTransientLifetime());
+
+        services.AddTransient<ICommandDispatcher, CommandDispatcher>();
+
+        return services;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/ICommand.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/ICommand.cs
@@ -1,0 +1,3 @@
+namespace TeachingRecordSystem.Api;
+
+public interface ICommand<TResult> where TResult : notnull;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/ICommandDispatcher.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/ICommandDispatcher.cs
@@ -1,0 +1,37 @@
+namespace TeachingRecordSystem.Api;
+
+public interface ICommandDispatcher
+{
+    Task<ApiResult<TResult>> DispatchAsync<TResult>(ICommand<TResult> command)
+        where TResult : notnull;
+}
+
+public class CommandDispatcher(IServiceProvider serviceProvider) : ICommandDispatcher
+{
+    public async Task<ApiResult<TResult>> DispatchAsync<TResult>(ICommand<TResult> command)
+        where TResult : notnull
+    {
+        var handler = serviceProvider.GetRequiredService(typeof(ICommandHandler<,>).MakeGenericType(command.GetType(), typeof(TResult)));
+
+        var wrapperHandlerType = typeof(CommandHandler<,>).MakeGenericType(command.GetType(), typeof(TResult));
+        var wrappedHandler = (CommandHandler<TResult>)Activator.CreateInstance(wrapperHandlerType, handler)!;
+
+        return await wrappedHandler.ExecuteAsync(command);
+    }
+
+    private abstract class CommandHandler<T> where T : notnull
+    {
+        public abstract Task<ApiResult<T>> ExecuteAsync(ICommand<T> query);
+    }
+
+    private class CommandHandler<TCommand, TResult>(ICommandHandler<TCommand, TResult> innerHandler) : CommandHandler<TResult>
+        where TCommand : ICommand<TResult>
+        where TResult : notnull
+    {
+        public override Task<ApiResult<TResult>> ExecuteAsync(
+            ICommand<TResult> command)
+        {
+            return innerHandler.ExecuteAsync((TCommand)command);
+        }
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/ICommandHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/ICommandHandler.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Api;
+
+public interface ICommandHandler<TCommand, TResult> where TCommand : ICommand<TResult> where TResult : notnull
+{
+    Task<ApiResult<TResult>> ExecuteAsync(TCommand command);
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Program.cs
@@ -161,11 +161,6 @@ services
 services.Scan(scan =>
 {
     scan.FromAssemblyOf<Program>()
-        .AddClasses(filter => filter.InNamespaces("TeachingRecordSystem.Api.V3.Implementation.Operations").Where(type => type.Name.EndsWith("Handler")))
-            .AsSelf()
-            .WithTransientLifetime();
-
-    scan.FromAssemblyOf<Program>()
         .AddClasses(filter => filter.AssignableTo(typeof(ITypeConverter<,>)))
             .AsSelf()
             .WithTransientLifetime();
@@ -204,7 +199,8 @@ services
     .AddAccessYourTeachingQualificationsOptions(configuration, env)
     .AddFileService()
     .AddTransient<GetPersonHelper>()
-    .AddPersonMatching();
+    .AddPersonMatching()
+    .AddApiCommands();
 
 if (env.IsDevelopment() || env.IsProduction())
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateNameChangeRequest.cs
@@ -9,7 +9,7 @@ using TeachingRecordSystem.Core.Services.Files;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record CreateNameChangeRequestCommand
+public record CreateNameChangeRequestCommand : ICommand<CreateNameChangeRequestResult>
 {
     public required string Trn { get; init; }
     public required string FirstName { get; init; }
@@ -28,11 +28,12 @@ public class CreateNameChangeRequestHandler(
     IHttpClientFactory httpClientFactory,
     TrsDbContext dbContext,
     IFileService fileService,
-    IClock clock)
+    IClock clock) :
+    ICommandHandler<CreateNameChangeRequestCommand, CreateNameChangeRequestResult>
 {
     private readonly HttpClient _downloadEvidenceFileHttpClient = httpClientFactory.CreateClient("EvidenceFiles");
 
-    public async Task<ApiResult<CreateNameChangeRequestResult>> HandleAsync(CreateNameChangeRequestCommand command)
+    public async Task<ApiResult<CreateNameChangeRequestResult>> ExecuteAsync(CreateNameChangeRequestCommand command)
     {
         var person = await dbContext.Persons
             .Where(p => p.Trn == command.Trn)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/CreateTrnRequest.cs
@@ -10,7 +10,7 @@ using Gender = TeachingRecordSystem.Core.Models.Gender;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record CreateTrnRequestCommand
+public record CreateTrnRequestCommand : ICommand<TrnRequestInfo>
 {
     public required string RequestId { get; init; }
     public required string FirstName { get; init; }
@@ -30,9 +30,10 @@ public class CreateTrnRequestHandler(
     TrnRequestService trnRequestService,
     ICurrentUserProvider currentUserProvider,
     ITrnGenerator trnGenerator,
-    IClock clock)
+    IClock clock) :
+    ICommandHandler<CreateTrnRequestCommand, TrnRequestInfo>
 {
-    public async Task<ApiResult<TrnRequestInfo>> HandleAsync(CreateTrnRequestCommand command)
+    public async Task<ApiResult<TrnRequestInfo>> ExecuteAsync(CreateTrnRequestCommand command)
     {
         var (currentApplicationUserId, _) = currentUserProvider.GetCurrentApplicationUser();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonByLastNameAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonByLastNameAndDateOfBirth.cs
@@ -3,14 +3,15 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record FindPersonByLastNameAndDateOfBirthCommand(string LastName, DateOnly DateOfBirth);
+public record FindPersonByLastNameAndDateOfBirthCommand(string LastName, DateOnly DateOfBirth) : ICommand<FindPersonsResult>;
 
 public class FindPersonByLastNameAndDateOfBirthHandler(
     TrsDbContext dbContext,
     ReferenceDataCache referenceDataCache) :
-    FindPersonsHandlerBase(dbContext, referenceDataCache)
+    FindPersonsHandlerBase(dbContext, referenceDataCache),
+    ICommandHandler<FindPersonByLastNameAndDateOfBirthCommand, FindPersonsResult>
 {
-    public async Task<ApiResult<FindPersonsResult>> HandleAsync(FindPersonByLastNameAndDateOfBirthCommand command)
+    public async Task<ApiResult<FindPersonsResult>> ExecuteAsync(FindPersonByLastNameAndDateOfBirthCommand command)
     {
         var matchedPersons = await DbContext.Database.SqlQueryRaw<Result>(
                 """

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
@@ -2,14 +2,15 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record FindPersonsByTrnAndDateOfBirthCommand(IEnumerable<(string Trn, DateOnly DateOfBirth)> Persons);
+public record FindPersonsByTrnAndDateOfBirthCommand(IEnumerable<(string Trn, DateOnly DateOfBirth)> Persons) : ICommand<FindPersonsResult>;
 
 public class FindPersonsByTrnAndDateOfBirthHandler(
     TrsDbContext dbContext,
     ReferenceDataCache referenceDataCache) :
-    FindPersonsHandlerBase(dbContext, referenceDataCache)
+    FindPersonsHandlerBase(dbContext, referenceDataCache),
+    ICommandHandler<FindPersonsByTrnAndDateOfBirthCommand, FindPersonsResult>
 {
-    public async Task<ApiResult<FindPersonsResult>> HandleAsync(FindPersonsByTrnAndDateOfBirthCommand command)
+    public async Task<ApiResult<FindPersonsResult>> ExecuteAsync(FindPersonsByTrnAndDateOfBirthCommand command)
     {
         var trns = command.Persons
             .Where(t => !string.IsNullOrEmpty(t.Trn))

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetPerson.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetPerson.cs
@@ -19,7 +19,8 @@ public record GetPersonCommand(
     GetPersonCommandIncludes Include,
     DateOnly? DateOfBirth,
     string? NationalInsuranceNumber,
-    GetPersonCommandOptions? Options = null);
+    GetPersonCommandOptions? Options = null) :
+    ICommand<GetPersonResult>;
 
 public record GetPersonCommandOptions
 {
@@ -173,9 +174,10 @@ public record GetPersonResultRouteToProfessionalStatusInductionExemption
     public required IReadOnlyCollection<PostgresModels.InductionExemptionReason> ExemptionReasons { get; init; }
 }
 
-public class GetPersonHandler(TrsDbContext dbContext, ReferenceDataCache referenceDataCache)
+public class GetPersonHandler(TrsDbContext dbContext, ReferenceDataCache referenceDataCache) :
+    ICommandHandler<GetPersonCommand, GetPersonResult>
 {
-    public async Task<ApiResult<GetPersonResult>> HandleAsync(GetPersonCommand command)
+    public async Task<ApiResult<GetPersonResult>> ExecuteAsync(GetPersonCommand command)
     {
         var options = command.Options ?? new GetPersonCommandOptions();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetQtls.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetQtls.cs
@@ -4,11 +4,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record GetQtlsCommand(string Trn);
+public record GetQtlsCommand(string Trn) : ICommand<QtlsResult>;
 
-public class GetQtlsHandler(TrsDbContext dbContext)
+public class GetQtlsHandler(TrsDbContext dbContext) : ICommandHandler<GetQtlsCommand, QtlsResult>
 {
-    public async Task<ApiResult<QtlsResult>> HandleAsync(GetQtlsCommand command)
+    public async Task<ApiResult<QtlsResult>> ExecuteAsync(GetQtlsCommand command)
     {
         var person = await dbContext.Persons
             .Include(p => p.Qualifications)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrn.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrn.cs
@@ -1,12 +1,12 @@
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record GetTrnCommand(string Trn);
+public record GetTrnCommand(string Trn) : ICommand<GetTrnResult>;
 
 public record GetTrnResult;
 
-public class GetTrnHandler(GetPersonHelper getPersonHelper)
+public class GetTrnHandler(GetPersonHelper getPersonHelper) : ICommandHandler<GetTrnCommand, GetTrnResult>
 {
-    public async Task<ApiResult<GetTrnResult>> HandleAsync(GetTrnCommand command)
+    public async Task<ApiResult<GetTrnResult>> ExecuteAsync(GetTrnCommand command)
     {
         var getPersonResult = await getPersonHelper.GetPersonByTrnAsync(command.Trn);
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/GetTrnRequest.cs
@@ -5,11 +5,12 @@ using TeachingRecordSystem.Core.Services.TrnRequests;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record GetTrnRequestCommand(string RequestId);
+public record GetTrnRequestCommand(string RequestId) : ICommand<TrnRequestInfo>;
 
-public class GetTrnRequestHandler(TrsDbContext dbContext, TrnRequestService trnRequestService, ICurrentUserProvider currentUserProvider)
+public class GetTrnRequestHandler(TrsDbContext dbContext, TrnRequestService trnRequestService, ICurrentUserProvider currentUserProvider) :
+    ICommandHandler<GetTrnRequestCommand, TrnRequestInfo>
 {
-    public async Task<ApiResult<TrnRequestInfo>> HandleAsync(GetTrnRequestCommand command)
+    public async Task<ApiResult<TrnRequestInfo>> ExecuteAsync(GetTrnRequestCommand command)
     {
         var (currentApplicationUserId, _) = currentUserProvider.GetCurrentApplicationUser();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetCpdInductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetCpdInductionStatus.cs
@@ -8,13 +8,15 @@ public record SetCpdInductionStatusCommand(
     InductionStatus Status,
     DateOnly? StartDate,
     DateOnly? CompletedDate,
-    DateTime CpdModifiedOn);
+    DateTime CpdModifiedOn) :
+    ICommand<SetCpdInductionStatusResult>;
 
 public record SetCpdInductionStatusResult;
 
-public class SetCpdInductionStatusHandler(TrsDbContext dbContext, ICurrentUserProvider currentUserProvider, IClock clock)
+public class SetCpdInductionStatusHandler(TrsDbContext dbContext, ICurrentUserProvider currentUserProvider, IClock clock) :
+    ICommandHandler<SetCpdInductionStatusCommand, SetCpdInductionStatusResult>
 {
-    public async Task<ApiResult<SetCpdInductionStatusResult>> HandleAsync(SetCpdInductionStatusCommand command)
+    public async Task<ApiResult<SetCpdInductionStatusResult>> ExecuteAsync(SetCpdInductionStatusCommand command)
     {
         if (command.Status is not InductionStatus.RequiredToComplete and not InductionStatus.InProgress
             and not InductionStatus.Passed and not InductionStatus.Failed)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetDeceased.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetDeceased.cs
@@ -3,14 +3,17 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record SetDeceasedCommand(string Trn, DateOnly DateOfDeath);
+public record SetDeceasedCommand(string Trn, DateOnly DateOfDeath) : ICommand<SetDeceasedResult>;
+
+public record SetDeceasedResult;
 
 public class SetDeceasedHandler(
     TrsDbContext dbContext,
     ICurrentUserProvider currentUserProvider,
-    IClock clock)
+    IClock clock) :
+    ICommandHandler<SetDeceasedCommand, SetDeceasedResult>
 {
-    public async Task<ApiResult<Unit>> HandleAsync(SetDeceasedCommand command)
+    public async Task<ApiResult<SetDeceasedResult>> ExecuteAsync(SetDeceasedCommand command)
     {
         var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.Trn == command.Trn);
 
@@ -41,6 +44,6 @@ public class SetDeceasedHandler(
 
         await dbContext.SaveChangesAsync();
 
-        return Unit.Instance;
+        return new SetDeceasedResult();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetPii.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetPii.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record SetPiiCommand
+public record SetPiiCommand : ICommand<SetPiiResult>
 {
     public required string Trn { get; init; }
     public required string FirstName { get; init; }
@@ -15,12 +15,15 @@ public record SetPiiCommand
     public required Gender? Gender { get; init; }
 }
 
+public record SetPiiResult;
+
 public class SetPiiHandler(
     TrsDbContext dbContext,
     ICurrentUserProvider currentUserProvider,
-    IClock clock)
+    IClock clock) :
+    ICommandHandler<SetPiiCommand, SetPiiResult>
 {
-    public async Task<ApiResult<Unit>> HandleAsync(SetPiiCommand command)
+    public async Task<ApiResult<SetPiiResult>> ExecuteAsync(SetPiiCommand command)
     {
         var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.Trn == command.Trn);
 
@@ -77,6 +80,6 @@ public class SetPiiHandler(
 
         await dbContext.SaveChangesAsync();
 
-        return Unit.Instance;
+        return new SetPiiResult();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetQtls.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetQtls.cs
@@ -4,15 +4,16 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record SetQtlsCommand(string Trn, DateOnly? QtsDate);
+public record SetQtlsCommand(string Trn, DateOnly? QtsDate) : ICommand<QtlsResult>;
 
 public class SetQtlsHandler(
     TrsDbContext dbContext,
     ReferenceDataCache referenceDataCache,
     ICurrentUserProvider currentUserProvider,
-    IClock clock)
+    IClock clock) :
+    ICommandHandler<SetQtlsCommand, QtlsResult>
 {
-    public async Task<ApiResult<QtlsResult>> HandleAsync(SetQtlsCommand command)
+    public async Task<ApiResult<QtlsResult>> ExecuteAsync(SetQtlsCommand command)
     {
         var person = await dbContext.Persons
             .Include(p => p.Qualifications)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetRouteToProfessionalStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetRouteToProfessionalStatus.cs
@@ -17,7 +17,8 @@ public record SetRouteToProfessionalStatusCommand(
     string? TrainingCountryReference,
     string? TrainingProviderUkprn,
     Guid? DegreeTypeId,
-    bool? IsExemptFromInduction);
+    bool? IsExemptFromInduction) :
+    ICommand<SetRouteToProfessionalStatusResult>;
 
 public record SetRouteToProfessionalStatusCommandTrainingAgeSpecialism(
     TrainingAgeSpecialismType Type,
@@ -30,7 +31,8 @@ public class SetRouteToProfessionalStatusHandler(
     TrsDbContext dbContext,
     ICurrentUserProvider currentUserProvider,
     ReferenceDataCache referenceDataCache,
-    IClock clock)
+    IClock clock) :
+    ICommandHandler<SetRouteToProfessionalStatusCommand, SetRouteToProfessionalStatusResult>
 {
     private static readonly IReadOnlyCollection<Guid> _permittedRouteTypeIds =
     [
@@ -67,7 +69,7 @@ public class SetRouteToProfessionalStatusHandler(
         new("20F67E38-F117-4B42-BBFC-5812AA717B94")
     ];
 
-    public async Task<ApiResult<SetRouteToProfessionalStatusResult>> HandleAsync(SetRouteToProfessionalStatusCommand command)
+    public async Task<ApiResult<SetRouteToProfessionalStatusResult>> ExecuteAsync(SetRouteToProfessionalStatusCommand command)
     {
         var person = await dbContext.Persons
             .Where(p => p.Trn == command.Trn)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetWelshInductionStatus.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/SetWelshInductionStatus.cs
@@ -3,16 +3,17 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.Api.V3.Implementation.Operations;
 
-public record SetWelshInductionStatusCommand(string Trn, bool Passed, DateOnly StartDate, DateOnly CompletedDate);
+public record SetWelshInductionStatusCommand(string Trn, bool Passed, DateOnly StartDate, DateOnly CompletedDate) : ICommand<SetWelshInductionStatusResult>;
 
 public record SetWelshInductionStatusResult;
 
 public class SetWelshInductionStatusHandler(
     TrsDbContext dbContext,
     ICurrentUserProvider currentUserProvider,
-    IClock clock)
+    IClock clock) :
+    ICommandHandler<SetWelshInductionStatusCommand, SetWelshInductionStatusResult>
 {
-    public async Task<ApiResult<SetWelshInductionStatusResult>> HandleAsync(SetWelshInductionStatusCommand command)
+    public async Task<ApiResult<SetWelshInductionStatusResult>> ExecuteAsync(SetWelshInductionStatusCommand command)
     {
         var person = await dbContext.Persons
             .Include(p => p.Qualifications)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Controllers/TeachersController.cs
@@ -10,7 +10,7 @@ using TeachingRecordSystem.Api.V3.V20240101.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240101.Controllers;
 
 [Route("teachers")]
-public class TeachersController(IMapper mapper) : ControllerBase
+public class TeachersController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpGet("{trn}")]
     [SwaggerOperation(
@@ -23,8 +23,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
     public async Task<IActionResult> GetAsync(
         [FromRoute] string trn,
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include)
     {
         var command = new GetPersonCommand(
             trn,
@@ -36,7 +35,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
                 ApplyLegacyAlertsBehavior = true
             });
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);
@@ -51,8 +50,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
     public async Task<IActionResult> CreateNameChangeAsync(
-        [FromBody] CreateNameChangeRequestRequest request,
-        [FromServices] CreateNameChangeRequestHandler handler)
+        [FromBody] CreateNameChangeRequestRequest request)
     {
         var command = new CreateNameChangeRequestCommand()
         {
@@ -65,7 +63,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
             EmailAddress = null
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(_ => NoContent());
     }
@@ -79,8 +77,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
     public async Task<IActionResult> CreateDateOfBirthChangeAsync(
-        [FromBody] CreateDateOfBirthChangeRequestRequest request,
-        [FromServices] CreateDateOfBirthChangeRequestHandler handler)
+        [FromBody] CreateDateOfBirthChangeRequestRequest request)
     {
         var command = new CreateDateOfBirthChangeRequestCommand()
         {
@@ -91,7 +88,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
             EmailAddress = null
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(_ => NoContent());
     }
@@ -104,12 +101,10 @@ public class TeachersController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindTeachersResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindTeachersAsync(
-        FindTeachersRequest request,
-        [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)
+    public async Task<IActionResult> FindTeachersAsync(FindTeachersRequest request)
     {
         var command = new FindPersonByLastNameAndDateOfBirthCommand(request.LastName!, request.DateOfBirth!.Value);
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r =>
             Ok(new FindTeachersResponse()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240307/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240307/Controllers/TrnRequestsController.cs
@@ -10,7 +10,7 @@ namespace TeachingRecordSystem.Api.V3.V20240307.Controllers;
 
 [Route("trn-requests")]
 [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.CreateTrn)]
-public class TrnRequestsController(IMapper mapper) : ControllerBase
+public class TrnRequestsController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpPost("")]
     [SwaggerOperation(
@@ -25,8 +25,7 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> CreateTrnRequestAsync(
-        [FromBody] CreateTrnRequestRequest request,
-        [FromServices] CreateTrnRequestHandler handler)
+        [FromBody] CreateTrnRequestRequest request)
     {
         var command = new CreateTrnRequestCommand()
         {
@@ -42,7 +41,7 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
             Gender = null,
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
             .MapErrorCode(ApiError.ErrorCodes.TrnRequestAlreadyCreated, StatusCodes.Status409Conflict);
@@ -58,12 +57,10 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
         """)]
     [ProducesResponseType(typeof(TrnRequestInfo), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTrnRequestAsync(
-        [FromQuery] string requestId,
-        [FromServices] GetTrnRequestHandler handler)
+    public async Task<IActionResult> GetTrnRequestAsync([FromQuery] string requestId)
     {
         var command = new GetTrnRequestCommand(requestId);
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
             .MapErrorCode(ApiError.ErrorCodes.TrnRequestDoesNotExist, StatusCodes.Status404NotFound);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240412/Controllers/TeacherController.cs
@@ -10,7 +10,7 @@ using TeachingRecordSystem.Api.V3.V20240412.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240412.Controllers;
 
 [Route("teacher")]
-public class TeacherController(IMapper mapper) : ControllerBase
+public class TeacherController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpPost("name-changes")]
     [SwaggerOperation(
@@ -20,9 +20,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(CreateNameChangeResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
-    public async Task<IActionResult> CreateNameChangeAsync(
-        [FromBody] CreateNameChangeRequestRequest request,
-        [FromServices] CreateNameChangeRequestHandler handler)
+    public async Task<IActionResult> CreateNameChangeAsync([FromBody] CreateNameChangeRequestRequest request)
     {
         var command = new CreateNameChangeRequestCommand()
         {
@@ -35,7 +33,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
             EmailAddress = request.Email
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<CreateNameChangeResponse>(r)));
     }
@@ -48,9 +46,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(CreateDateOfBirthChangeResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
-    public async Task<IActionResult> CreateDateOfBirthChangeAsync(
-        [FromBody] CreateDateOfBirthChangeRequestRequest request,
-        [FromServices] CreateDateOfBirthChangeRequestHandler handler)
+    public async Task<IActionResult> CreateDateOfBirthChangeAsync([FromBody] CreateDateOfBirthChangeRequestRequest request)
     {
         var command = new CreateDateOfBirthChangeRequestCommand()
         {
@@ -61,7 +57,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
             EmailAddress = request.Email
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<CreateDateOfBirthChangeResponse>(r)));
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeacherController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeacherController.cs
@@ -11,7 +11,7 @@ using TeachingRecordSystem.Api.V3.V20240416.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240416.Controllers;
 
 [Route("teacher")]
-public class TeacherController(IMapper mapper) : ControllerBase
+public class TeacherController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
@@ -22,8 +22,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetTeacherResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetAsync(
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include)
     {
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
@@ -35,7 +34,7 @@ public class TeacherController(IMapper mapper) : ControllerBase
                 ApplyLegacyAlertsBehavior = true
             });
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240416/Controllers/TeachersController.cs
@@ -10,7 +10,7 @@ using TeachingRecordSystem.Api.V3.V20240416.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240416.Controllers;
 
 [Route("teachers")]
-public class TeachersController(IMapper mapper) : ControllerBase
+public class TeachersController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpGet("{trn}")]
     [SwaggerOperation(
@@ -24,8 +24,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
     public async Task<IActionResult> GetAsync(
         [FromRoute] string trn,
         [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetTeacherRequestIncludes? include,
-        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth)
     {
         var command = new GetPersonCommand(
             trn,
@@ -37,7 +36,7 @@ public class TeachersController(IMapper mapper) : ControllerBase
                 ApplyLegacyAlertsBehavior = true
             });
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetTeacherResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/PersonController.cs
@@ -11,7 +11,7 @@ using TeachingRecordSystem.Api.V3.V20240606.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
 
 [Route("person")]
-public class PersonController(IMapper mapper) : ControllerBase
+public class PersonController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
@@ -22,8 +22,7 @@ public class PersonController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetAsync(
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include)
     {
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
@@ -35,7 +34,7 @@ public class PersonController(IMapper mapper) : ControllerBase
                 ApplyLegacyAlertsBehavior = true
             });
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);
@@ -50,8 +49,7 @@ public class PersonController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     public async Task<IActionResult> CreateNameChangeAsync(
-        [FromBody] CreateNameChangeRequestRequest request,
-        [FromServices] CreateNameChangeRequestHandler handler)
+        [FromBody] CreateNameChangeRequestRequest request)
     {
         var command = new CreateNameChangeRequestCommand()
         {
@@ -64,7 +62,7 @@ public class PersonController(IMapper mapper) : ControllerBase
             EmailAddress = request.EmailAddress
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<CreateNameChangeResponse>(r)));
     }
@@ -78,8 +76,7 @@ public class PersonController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     public async Task<IActionResult> CreateDateOfBirthChangeAsync(
-        [FromBody] CreateDateOfBirthChangeRequestRequest request,
-        [FromServices] CreateDateOfBirthChangeRequestHandler handler)
+        [FromBody] CreateDateOfBirthChangeRequestRequest request)
     {
         var command = new CreateDateOfBirthChangeRequestCommand()
         {
@@ -90,7 +87,7 @@ public class PersonController(IMapper mapper) : ControllerBase
             EmailAddress = request.EmailAddress
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<CreateDateOfBirthChangeResponse>(r)));
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Controllers/TrnRequestsController.cs
@@ -10,7 +10,7 @@ namespace TeachingRecordSystem.Api.V3.V20240606.Controllers;
 
 [Route("trn-requests")]
 [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.CreateTrn)]
-public class TrnRequestsController(IMapper mapper) : ControllerBase
+public class TrnRequestsController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpPost("")]
     [SwaggerOperation(
@@ -24,9 +24,7 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(TrnRequestInfo), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> CreateTrnRequestAsync(
-        [FromBody] CreateTrnRequestRequest request,
-        [FromServices] CreateTrnRequestHandler handler)
+    public async Task<IActionResult> CreateTrnRequestAsync([FromBody] CreateTrnRequestRequest request)
     {
         var command = new CreateTrnRequestCommand()
         {
@@ -41,7 +39,7 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
             OneLoginUserSubject = null,
             Gender = null
         };
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
             .MapErrorCode(ApiError.ErrorCodes.TrnRequestAlreadyCreated, StatusCodes.Status409Conflict);
@@ -57,12 +55,10 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
         """)]
     [ProducesResponseType(typeof(TrnRequestInfo), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetTrnRequestAsync(
-        [FromQuery] string requestId,
-        [FromServices] GetTrnRequestHandler handler)
+    public async Task<IActionResult> GetTrnRequestAsync([FromQuery] string requestId)
     {
         var command = new GetTrnRequestCommand(requestId);
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
             .MapErrorCode(ApiError.ErrorCodes.TrnRequestDoesNotExist, StatusCodes.Status404NotFound);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonController.cs
@@ -11,7 +11,7 @@ using TeachingRecordSystem.Api.V3.V20240920.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240920.Controllers;
 
 [Route("person")]
-public class PersonController(IMapper mapper) : ControllerBase
+public class PersonController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
@@ -22,8 +22,7 @@ public class PersonController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetAsync(
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include)
     {
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
@@ -31,7 +30,7 @@ public class PersonController(IMapper mapper) : ControllerBase
             DateOfBirth: null,
             NationalInsuranceNumber: null);
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Controllers/PersonsController.cs
@@ -10,7 +10,7 @@ using TeachingRecordSystem.Api.V3.V20240920.Responses;
 namespace TeachingRecordSystem.Api.V3.V20240920.Controllers;
 
 [Route("persons")]
-public class PersonsController(IMapper mapper) : ControllerBase
+public class PersonsController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpGet("{trn}")]
     [SwaggerOperation(
@@ -24,8 +24,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
     public async Task<IActionResult> GetAsync(
         [FromRoute] string trn,
         [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
-        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth)
     {
         include ??= GetPersonRequestIncludes.None;
 
@@ -39,7 +38,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
                 ApplyAppropriateBodyUserRestrictions = User.IsInRole(ApiRoles.AppropriateBody)
             });
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)
@@ -54,12 +53,10 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindPersonsAsync(
-        [FromBody] FindPersonsRequest request,
-        [FromServices] FindPersonsByTrnAndDateOfBirthHandler handler)
+    public async Task<IActionResult> FindPersonsAsync([FromBody] FindPersonsRequest request)
     {
         var command = new FindPersonsByTrnAndDateOfBirthCommand(request.Persons.Select(p => (p.Trn, p.DateOfBirth)));
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
         return result.ToActionResult(r => Ok(mapper.Map<FindPersonsResponse>(r)));
     }
 
@@ -71,12 +68,10 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindPersonsAsync(
-        FindPersonRequest request,
-        [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)
+    public async Task<IActionResult> FindPersonsAsync(FindPersonRequest request)
     {
         var command = new FindPersonByLastNameAndDateOfBirthCommand(request.LastName!, request.DateOfBirth!.Value);
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r =>
             Ok(new FindPersonResponse()
@@ -97,11 +92,10 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.UpdatePerson)]
     public async Task<IActionResult> DeceasedAsync(
         [FromRoute] string trn,
-        [FromBody] SetDeceasedRequest request,
-        [FromServices] SetDeceasedHandler handler)
+        [FromBody] SetDeceasedRequest request)
     {
         var command = new SetDeceasedCommand(trn, request.DateOfDeath);
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
         return result.ToActionResult(_ => NoContent());
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/PersonController.cs
@@ -11,7 +11,7 @@ using TeachingRecordSystem.Api.V3.V20250203.Responses;
 namespace TeachingRecordSystem.Api.V3.V20250203.Controllers;
 
 [Route("person")]
-public class PersonController(IMapper mapper) : ControllerBase
+public class PersonController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
@@ -22,8 +22,7 @@ public class PersonController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetAsync(
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include)
     {
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
@@ -31,7 +30,7 @@ public class PersonController(IMapper mapper) : ControllerBase
             DateOfBirth: null,
             NationalInsuranceNumber: null);
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/TrnRequestsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Controllers/TrnRequestsController.cs
@@ -11,7 +11,7 @@ namespace TeachingRecordSystem.Api.V3.V20250203.Controllers;
 
 [Route("trn-requests")]
 [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.CreateTrn)]
-public class TrnRequestsController(IMapper mapper) : ControllerBase
+public class TrnRequestsController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpPost("")]
     [SwaggerOperation(
@@ -26,9 +26,7 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [MapError(10029, statusCode: StatusCodes.Status409Conflict)]
-    public async Task<IActionResult> CreateTrnRequestAsync(
-        [FromBody] CreateTrnRequestRequest request,
-        [FromServices] CreateTrnRequestHandler handler)
+    public async Task<IActionResult> CreateTrnRequestAsync([FromBody] CreateTrnRequestRequest request)
     {
         var command = new CreateTrnRequestCommand()
         {
@@ -44,7 +42,7 @@ public class TrnRequestsController(IMapper mapper) : ControllerBase
             Gender = request.Person.Gender is Gender gender ? mapper.Map<Core.Models.Gender>(gender) : null
         };
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<TrnRequestInfo>(r)))
             .MapErrorCode(ApiError.ErrorCodes.TrnRequestAlreadyCreated, StatusCodes.Status409Conflict);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonController.cs
@@ -11,7 +11,7 @@ using TeachingRecordSystem.Api.V3.V20250327.Responses;
 namespace TeachingRecordSystem.Api.V3.V20250327.Controllers;
 
 [Route("person")]
-public class PersonController(IMapper mapper) : ControllerBase
+public class PersonController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
@@ -22,8 +22,7 @@ public class PersonController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetAsync(
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include)
     {
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
@@ -31,7 +30,7 @@ public class PersonController(IMapper mapper) : ControllerBase
             DateOfBirth: null,
             NationalInsuranceNumber: null);
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Controllers/PersonsController.cs
@@ -10,7 +10,7 @@ using TeachingRecordSystem.Api.V3.V20250327.Responses;
 namespace TeachingRecordSystem.Api.V3.V20250327.Controllers;
 
 [Route("persons")]
-public class PersonsController(IMapper mapper) : ControllerBase
+public class PersonsController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [HttpGet("{trn}")]
     [SwaggerOperation(
@@ -25,8 +25,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
         [FromRoute] string trn,
         [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
         [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified dateOfBirth, if provided.")] DateOnly? dateOfBirth,
-        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified nationalInsuranceNumber, if provided.")] string? nationalInsuranceNumber,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, SwaggerParameter("Adds an additional check that the record has the specified nationalInsuranceNumber, if provided.")] string? nationalInsuranceNumber)
     {
         include ??= GetPersonRequestIncludes.None;
 
@@ -46,7 +45,7 @@ public class PersonsController(IMapper mapper) : ControllerBase
                 ApplyAppropriateBodyUserRestrictions = User.IsInRole(ApiRoles.AppropriateBody)
             });
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result
             .ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
@@ -62,12 +61,10 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindPersonsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindPersonsAsync(
-        [FromBody] FindPersonsRequest request,
-        [FromServices] FindPersonsByTrnAndDateOfBirthHandler handler)
+    public async Task<IActionResult> FindPersonsAsync([FromBody] FindPersonsRequest request)
     {
         var command = new FindPersonsByTrnAndDateOfBirthCommand(request.Persons.Select(p => (p.Trn, p.DateOfBirth)));
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
         return result.ToActionResult(r => Ok(mapper.Map<FindPersonsResponse>(r)));
     }
 
@@ -79,12 +76,10 @@ public class PersonsController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(FindPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.GetPerson)]
-    public async Task<IActionResult> FindPersonsAsync(
-        FindPersonRequest request,
-        [FromServices] FindPersonByLastNameAndDateOfBirthHandler handler)
+    public async Task<IActionResult> FindPersonsAsync(FindPersonRequest request)
     {
         var command = new FindPersonByLastNameAndDateOfBirthCommand(request.LastName!, request.DateOfBirth!.Value);
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r =>
             Ok(new FindPersonResponse()

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250627/Controllers/PersonController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250627/Controllers/PersonController.cs
@@ -11,7 +11,7 @@ using TeachingRecordSystem.Api.V3.V20250627.Responses;
 namespace TeachingRecordSystem.Api.V3.V20250627.Controllers;
 
 [Route("person")]
-public class PersonController(IMapper mapper) : ControllerBase
+public class PersonController(ICommandDispatcher commandDispatcher, IMapper mapper) : ControllerBase
 {
     [Authorize(AuthorizationPolicies.IdentityUserWithTrn)]
     [HttpGet]
@@ -22,8 +22,7 @@ public class PersonController(IMapper mapper) : ControllerBase
     [ProducesResponseType(typeof(GetPersonResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetAsync(
-        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include,
-        [FromServices] GetPersonHandler handler)
+        [FromQuery, ModelBinder(typeof(FlagsEnumStringListModelBinder)), SwaggerParameter("The additional properties to include in the response.")] GetPersonRequestIncludes? include)
     {
         var command = new GetPersonCommand(
             Trn: User.FindFirstValue("trn")!,
@@ -31,7 +30,7 @@ public class PersonController(IMapper mapper) : ControllerBase
             DateOfBirth: null,
             NationalInsuranceNumber: null);
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(r => Ok(mapper.Map<GetPersonResponse>(r)))
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status403Forbidden);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250905/Controllers/TrnsController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250905/Controllers/TrnsController.cs
@@ -7,7 +7,7 @@ using TeachingRecordSystem.Api.V3.Implementation.Operations;
 namespace TeachingRecordSystem.Api.V3.V20250905.Controllers;
 
 [Route("trns")]
-public class TrnsController : ControllerBase
+public class TrnsController(ICommandDispatcher commandDispatcher) : ControllerBase
 {
     [HttpGet("{trn}")]
     [ActionName("GetTrn")]
@@ -21,10 +21,9 @@ public class TrnsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [Authorize(Policy = AuthorizationPolicies.ApiKey)]
     public async Task<IActionResult> GetTrnAsync(
-        [FromRoute] string trn,
-        [FromServices] GetTrnHandler handler)
+        [FromRoute] string trn)
     {
-        var result = await handler.HandleAsync(new GetTrnCommand(trn));
+        var result = await commandDispatcher.DispatchAsync(new GetTrnCommand(trn));
 
         return result.ToActionResult(_ => NoContent())
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.EwcWales.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/VNext/Controllers/PersonsController.EwcWales.cs
@@ -8,7 +8,7 @@ using TeachingRecordSystem.Api.V3.VNext.Requests;
 namespace TeachingRecordSystem.Api.V3.VNext.Controllers;
 
 [Route("persons")]
-public class PersonsController : ControllerBase
+public class PersonsController(ICommandDispatcher commandDispatcher) : ControllerBase
 {
     [HttpPut("{trn}/welsh-induction")]
     [SwaggerOperation(
@@ -21,8 +21,7 @@ public class PersonsController : ControllerBase
     [Authorize(Policy = AuthorizationPolicies.ApiKey, Roles = ApiRoles.SetWelshInduction)]
     public async Task<IActionResult> SetWelshInductionStatusAsync(
         [FromRoute] string trn,
-        [FromBody] SetWelshInductionStatusRequest request,
-        [FromServices] SetWelshInductionStatusHandler handler)
+        [FromBody] SetWelshInductionStatusRequest request)
     {
         var command = new SetWelshInductionStatusCommand(
             trn,
@@ -30,7 +29,7 @@ public class PersonsController : ControllerBase
             request.StartDate,
             request.CompletedDate);
 
-        var result = await handler.HandleAsync(command);
+        var result = await commandDispatcher.DispatchAsync(command);
 
         return result.ToActionResult(_ => NoContent())
             .MapErrorCode(ApiError.ErrorCodes.PersonNotFound, StatusCodes.Status404NotFound);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
@@ -56,7 +56,7 @@ public abstract class OperationTestBase
 
     protected Task<T> WithDbContextAsync<T>(Func<TrsDbContext, Task<T>> action) => DbFixture.WithDbContextAsync(action);
 
-    protected virtual async Task WithHandler<THandler>(Func<THandler, Task> action, params object[] parameters) where THandler : notnull
+    protected virtual async Task WithHandler<THandler>(Func<THandler, Task> action, params object[] parameters)
     {
         var serviceScopeFactory = Services.GetRequiredService<IServiceScopeFactory>();
         using var scope = serviceScopeFactory.CreateScope();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
@@ -13,7 +13,7 @@ public class CreateDateOfBirthChangeTests : OperationTestBase
             var command = await CreateCommand();
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.PersonNotFound);
@@ -32,7 +32,7 @@ public class CreateDateOfBirthChangeTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.SpecifiedResourceUrlDoesNotExist);
@@ -50,7 +50,7 @@ public class CreateDateOfBirthChangeTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateNameChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateNameChangeTests.cs
@@ -13,7 +13,7 @@ public class CreateNameChangeTests : OperationTestBase
             var command = await CreateCommand();
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.PersonNotFound);
@@ -32,7 +32,7 @@ public class CreateNameChangeTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.SpecifiedResourceUrlDoesNotExist);
@@ -49,7 +49,7 @@ public class CreateNameChangeTests : OperationTestBase
                 Trn = createPersonResult.Trn!
             };
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateTrnRequestTests.cs
@@ -46,7 +46,7 @@ public class CreateTrnRequestTests : OperationTestBase
                 .WithTrnRequest(applicationUserId, command.RequestId));
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
             AssertError(result, 10029);  // Cannot resubmit request
         });
 
@@ -64,7 +64,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var metadata = await WithDbContextAsync(dbContext =>
@@ -85,7 +85,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);
@@ -102,7 +102,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);
@@ -155,7 +155,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -193,7 +193,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -231,7 +231,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -266,7 +266,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -309,7 +309,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -358,7 +358,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -401,7 +401,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -452,7 +452,7 @@ public class CreateTrnRequestTests : OperationTestBase
             };
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -487,7 +487,7 @@ public class CreateTrnRequestTests : OperationTestBase
             var command = CreateCommand();
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests.cs
@@ -13,7 +13,7 @@ public class GetQtlsTests : OperationTestBase
             var command = new GetQtlsCommand("0000000");
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.PersonNotFound);
@@ -29,7 +29,7 @@ public class GetQtlsTests : OperationTestBase
             var command = new GetQtlsCommand(person.Trn!);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);
@@ -53,7 +53,7 @@ public class GetQtlsTests : OperationTestBase
             var command = new GetQtlsCommand(person.Trn!);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = AssertSuccess(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnRequestTests.cs
@@ -29,7 +29,7 @@ public class GetTrnRequestTests : OperationTestBase
             var command = new GetTrnRequestCommand(requestId);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.TrnRequestDoesNotExist);
@@ -50,7 +50,7 @@ public class GetTrnRequestTests : OperationTestBase
             var command = new GetTrnRequestCommand(requestId);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = result.GetSuccess();
@@ -74,7 +74,7 @@ public class GetTrnRequestTests : OperationTestBase
             var command = new GetTrnRequestCommand(requestId);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var success = result.GetSuccess();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnTests.cs
@@ -14,7 +14,7 @@ public class GetTrnTests : OperationTestBase
             var command = new GetTrnCommand(trn);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.PersonNotFound);
@@ -35,7 +35,7 @@ public class GetTrnTests : OperationTestBase
             var command = new GetTrnCommand(person.Trn!);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.RecordIsNotActive);
@@ -59,7 +59,7 @@ public class GetTrnTests : OperationTestBase
             var command = new GetTrnCommand(person.Trn!);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             var error = AssertError(result, ApiError.ErrorCodes.RecordIsMerged);
@@ -82,7 +82,7 @@ public class GetTrnTests : OperationTestBase
             var command = new GetTrnCommand(person.Trn!);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
@@ -13,7 +13,7 @@ public class SetQtlsTests : OperationTestBase
             var command = new SetQtlsCommand("0000000", QtsDate: null);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertError(result, ApiError.ErrorCodes.PersonNotFound);
@@ -29,7 +29,7 @@ public class SetQtlsTests : OperationTestBase
             var command = new SetQtlsCommand(person.Trn!, QtsDate: null);
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);
@@ -49,7 +49,7 @@ public class SetQtlsTests : OperationTestBase
             EventObserver.Clear();
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);
@@ -82,7 +82,7 @@ public class SetQtlsTests : OperationTestBase
             EventObserver.Clear();
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);
@@ -118,7 +118,7 @@ public class SetQtlsTests : OperationTestBase
             EventObserver.Clear();
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);
@@ -140,7 +140,7 @@ public class SetQtlsTests : OperationTestBase
             EventObserver.Clear();
 
             // Act
-            var result = await handler.HandleAsync(command);
+            var result = await handler.ExecuteAsync(command);
 
             // Assert
             AssertSuccess(result);


### PR DESCRIPTION
This also adds a layer of indirection - `ICommandDispatcher` - so that we can wrap command execution with cross-cutting concerns (like managing DB transactions).