### PR TITLE
Use command dispatcher in API unit tests

### DIFF
--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
@@ -56,11 +56,12 @@ public abstract class OperationTestBase
 
     protected Task<T> WithDbContextAsync<T>(Func<TrsDbContext, Task<T>> action) => DbFixture.WithDbContextAsync(action);
 
-    protected virtual async Task WithHandler<THandler>(Func<THandler, Task> action, params object[] parameters)
+    protected async Task<ApiResult<TResult>> ExecuteCommandAsync<TResult>(ICommand<TResult> command)
+        where TResult : notnull
     {
         var serviceScopeFactory = Services.GetRequiredService<IServiceScopeFactory>();
         using var scope = serviceScopeFactory.CreateScope();
-        var handler = ActivatorUtilities.CreateInstance<THandler>(scope.ServiceProvider, parameters);
-        await action(handler);
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ICommandDispatcher>();
+        return await dispatcher.DispatchAsync(command);
     }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Setup.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/Setup.cs
@@ -68,6 +68,7 @@ public static class Setup
                     (IClock)new ForwardToTestScopedClock(),
                     TestDataPersonDataSource.CrmAndTrs))
             .AddTrsBaseServices()
+            .AddApiCommands()
             .AddTestScoped<IClock>(tss => tss.Clock)
             .AddSingleton<FakeTrnGenerator>()
             .AddSingleton<ITrnGenerator>(sp => sp.GetRequiredService<FakeTrnGenerator>())

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/CreateDateOfBirthChangeTests.cs
@@ -6,73 +6,70 @@ namespace TeachingRecordSystem.Api.UnitTests.V3;
 public class CreateDateOfBirthChangeTests : OperationTestBase
 {
     [Test]
-    public Task HandleAsync_PersonDoesNotExist_ReturnsError() =>
-        WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
-        {
-            // Arrange
-            var command = await CreateCommand();
+    public async Task HandleAsync_PersonDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        var command = await CreateCommand();
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Assert
-            AssertError(result, ApiError.ErrorCodes.PersonNotFound);
-        });
-
-    [Test]
-    public Task HandleAsync_EvidenceFileDoesNotExist_ReturnsError() =>
-        WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
-        {
-            // Arrange
-            var createPersonResult = await TestData.CreatePersonAsync();
-            var command = await CreateCommand() with
-            {
-                Trn = createPersonResult.Trn!,
-                EvidenceFileUrl = "https://nonexistenturl.com"
-            };
-
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            AssertError(result, ApiError.ErrorCodes.SpecifiedResourceUrlDoesNotExist);
-        });
+        // Assert
+        AssertError(result, ApiError.ErrorCodes.PersonNotFound);
+    }
 
     [Test]
-    public Task HandleAsync_ValidRequest_CreatesSupportTaskAndSendsEmailAndReturnsTicketNumber() =>
-        WithHandler<CreateDateOfBirthChangeRequestHandler>(async handler =>
+    public async Task HandleAsync_EvidenceFileDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePersonAsync();
+        var command = await CreateCommand() with
         {
-            // Arrange
-            var createPersonResult = await TestData.CreatePersonAsync();
-            var command = await CreateCommand() with
-            {
-                Trn = createPersonResult.Trn!
-            };
+            Trn = createPersonResult.Trn!,
+            EvidenceFileUrl = "https://nonexistenturl.com"
+        };
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Assert
-            var success = AssertSuccess(result);
-            Assert.NotEmpty(success.CaseNumber);
+        // Assert
+        AssertError(result, ApiError.ErrorCodes.SpecifiedResourceUrlDoesNotExist);
+    }
 
-            await WithDbContextAsync(async dbContext =>
-            {
-                var supportTask = await dbContext.SupportTasks.SingleOrDefaultAsync(t => t.PersonId == createPersonResult.PersonId);
-                Assert.NotNull(supportTask);
-                Assert.Equal(SupportTaskType.ChangeDateOfBirthRequest, supportTask.SupportTaskType);
-                var requestData = supportTask.Data as ChangeDateOfBirthRequestData;
-                Assert.NotNull(requestData);
-                Assert.Equal(command.DateOfBirth, requestData.DateOfBirth);
-                Assert.Equal(command.EvidenceFileName, requestData.EvidenceFileName);
+    [Test]
+    public async Task HandleAsync_ValidRequest_CreatesSupportTaskAndSendsEmailAndReturnsTicketNumber()
+    {
+        // Arrange
+        var createPersonResult = await TestData.CreatePersonAsync();
+        var command = await CreateCommand() with
+        {
+            Trn = createPersonResult.Trn!
+        };
 
-                var email = await dbContext.Emails
-                    .Where(e => e.EmailAddress == command.EmailAddress)
-                    .SingleOrDefaultAsync();
-                Assert.NotNull(email);
-                Assert.NotNull(email.SentOn);
-            });
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        var success = AssertSuccess(result);
+        Assert.NotEmpty(success.CaseNumber);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var supportTask = await dbContext.SupportTasks.SingleOrDefaultAsync(t => t.PersonId == createPersonResult.PersonId);
+            Assert.NotNull(supportTask);
+            Assert.Equal(SupportTaskType.ChangeDateOfBirthRequest, supportTask.SupportTaskType);
+            var requestData = supportTask.Data as ChangeDateOfBirthRequestData;
+            Assert.NotNull(requestData);
+            Assert.Equal(command.DateOfBirth, requestData.DateOfBirth);
+            Assert.Equal(command.EvidenceFileName, requestData.EvidenceFileName);
+
+            var email = await dbContext.Emails
+                .Where(e => e.EmailAddress == command.EmailAddress)
+                .SingleOrDefaultAsync();
+            Assert.NotNull(email);
+            Assert.NotNull(email.SentOn);
         });
+    }
 
     private async Task<CreateDateOfBirthChangeRequestCommand> CreateCommand() =>
         new CreateDateOfBirthChangeRequestCommand()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetQtlsTests.cs
@@ -6,58 +6,55 @@ namespace TeachingRecordSystem.Api.UnitTests.V3;
 public class GetQtlsTests : OperationTestBase
 {
     [Test]
-    public Task HandleAsync_PersonDoesNotExist_ReturnsNotFoundError() =>
-        WithHandler<GetQtlsHandler>(async handler =>
-        {
-            // Arrange
-            var command = new GetQtlsCommand("0000000");
+    public async Task HandleAsync_PersonDoesNotExist_ReturnsNotFoundError()
+    {
+        // Arrange
+        var command = new GetQtlsCommand("0000000");
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Assert
-            AssertError(result, ApiError.ErrorCodes.PersonNotFound);
-        });
-
-    [Test]
-    public Task HandleAsync_PersonDoesNotHaveQtlsRoute_ReturnsNullQtsDate() =>
-        WithHandler<GetQtlsHandler>(async handler =>
-        {
-            // Arrange
-            var person = await TestData.CreatePersonAsync();
-
-            var command = new GetQtlsCommand(person.Trn!);
-
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            var success = AssertSuccess(result);
-            Assert.Equal(person.Trn, success.Trn);
-            Assert.Null(success.QtsDate);
-        });
+        // Assert
+        AssertError(result, ApiError.ErrorCodes.PersonNotFound);
+    }
 
     [Test]
-    public Task HandleAsync_PersonHasQtlsRoute_ReturnsAwardedDate() =>
-        WithHandler<GetQtlsHandler>(async handler =>
-        {
-            // Arrange
-            var qtlsDate = new DateOnly(2025, 5, 1);
+    public async Task HandleAsync_PersonDoesNotHaveQtlsRoute_ReturnsNullQtsDate()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
 
-            var person = await TestData.CreatePersonAsync(p => p
-                .WithRouteToProfessionalStatus(s => s
-                    .WithRouteType(RouteToProfessionalStatusType.QtlsAndSetMembershipId)
-                    .WithStatus(RouteToProfessionalStatusStatus.Holds)
-                    .WithHoldsFrom(qtlsDate)));
+        var command = new GetQtlsCommand(person.Trn!);
 
-            var command = new GetQtlsCommand(person.Trn!);
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        // Assert
+        var success = AssertSuccess(result);
+        Assert.Equal(person.Trn, success.Trn);
+        Assert.Null(success.QtsDate);
+    }
 
-            // Assert
-            var success = AssertSuccess(result);
-            Assert.Equal(person.Trn, success.Trn);
-            Assert.Equal(qtlsDate, success.QtsDate);
-        });
+    [Test]
+    public async Task HandleAsync_PersonHasQtlsRoute_ReturnsAwardedDate()
+    {
+        // Arrange
+        var qtlsDate = new DateOnly(2025, 5, 1);
+
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithRouteToProfessionalStatus(s => s
+                .WithRouteType(RouteToProfessionalStatusType.QtlsAndSetMembershipId)
+                .WithStatus(RouteToProfessionalStatusStatus.Holds)
+                .WithHoldsFrom(qtlsDate)));
+
+        var command = new GetQtlsCommand(person.Trn!);
+
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        var success = AssertSuccess(result);
+        Assert.Equal(person.Trn, success.Trn);
+        Assert.Equal(qtlsDate, success.QtsDate);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/GetTrnTests.cs
@@ -6,85 +6,81 @@ namespace TeachingRecordSystem.Api.UnitTests.V3;
 public class GetTrnTests : OperationTestBase
 {
     [Test]
-    public Task HandleAsync_PersonDoesNotExist_ReturnsError() =>
-        WithHandler<GetTrnHandler>(async handler =>
-        {
-            // Arrange
-            var trn = "0000000";
-            var command = new GetTrnCommand(trn);
+    public async Task HandleAsync_PersonDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        var trn = "0000000";
+        var command = new GetTrnCommand(trn);
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Assert
-            AssertError(result, ApiError.ErrorCodes.PersonNotFound);
-        });
-
-    [Test]
-    public Task HandleAsync_PersonExistsButIsNotActive_ReturnsError() =>
-        WithHandler<GetTrnHandler>(async handler =>
-        {
-            // Arrange
-            var person = await TestData.CreatePersonAsync();
-
-            await WithDbContextAsync(dbContext =>
-                dbContext.Persons
-                    .Where(p => p.PersonId == person.PersonId)
-                    .ExecuteUpdateAsync(u => u.SetProperty(p => p.Status, _ => PersonStatus.Deactivated)));
-
-            var command = new GetTrnCommand(person.Trn!);
-
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            AssertError(result, ApiError.ErrorCodes.RecordIsNotActive);
-        });
+        // Assert
+        AssertError(result, ApiError.ErrorCodes.PersonNotFound);
+    }
 
     [Test]
-    public Task HandleAsync_PersonIsMerged_ReturnsError() =>
-        WithHandler<GetTrnHandler>(async handler =>
-        {
-            // Arrange
-            var person = await TestData.CreatePersonAsync();
-            var anotherPerson = await TestData.CreatePersonAsync();
+    public async Task HandleAsync_PersonExistsButIsNotActive_ReturnsError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
 
-            await WithDbContextAsync(dbContext =>
-                dbContext.Persons
-                    .Where(p => p.PersonId == person.PersonId)
-                    .ExecuteUpdateAsync(u => u
-                        .SetProperty(p => p.Status, _ => PersonStatus.Deactivated)
-                        .SetProperty(p => p.MergedWithPersonId, _ => anotherPerson.PersonId)));
+        await WithDbContextAsync(dbContext =>
+            dbContext.Persons
+                .Where(p => p.PersonId == person.PersonId)
+                .ExecuteUpdateAsync(u => u.SetProperty(p => p.Status, _ => PersonStatus.Deactivated)));
 
-            var command = new GetTrnCommand(person.Trn!);
+        var command = new GetTrnCommand(person.Trn!);
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Assert
-            var error = AssertError(result, ApiError.ErrorCodes.RecordIsMerged);
-            Assert.Collection(
-                error.Data,
-                kvp =>
-                {
-                    Assert.Equal(ApiError.DataKeys.MergedWithTrn, kvp.Key);
-                    Assert.Equal(anotherPerson.Trn, kvp.Value);
-                });
-        });
+        // Assert
+        AssertError(result, ApiError.ErrorCodes.RecordIsNotActive);
+    }
 
     [Test]
-    public Task HandleAsync_PersonExistsAndIsActive_ReturnsSuccess() =>
-        WithHandler<GetTrnHandler>(async handler =>
-        {
-            // Arrange
-            var person = await TestData.CreatePersonAsync();
-            Debug.Assert(person.Person.Status is PersonStatus.Active);
-            var command = new GetTrnCommand(person.Trn!);
+    public async Task HandleAsync_PersonIsMerged_ReturnsError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var anotherPerson = await TestData.CreatePersonAsync();
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        await WithDbContextAsync(dbContext =>
+            dbContext.Persons
+                .Where(p => p.PersonId == person.PersonId)
+                .ExecuteUpdateAsync(u => u
+                    .SetProperty(p => p.Status, _ => PersonStatus.Deactivated)
+                    .SetProperty(p => p.MergedWithPersonId, _ => anotherPerson.PersonId)));
 
-            // Assert
-            AssertSuccess(result);
-        });
+        var command = new GetTrnCommand(person.Trn!);
+
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        var error = AssertError(result, ApiError.ErrorCodes.RecordIsMerged);
+        Assert.Collection(
+            error.Data,
+            kvp =>
+            {
+                Assert.Equal(ApiError.DataKeys.MergedWithTrn, kvp.Key);
+                Assert.Equal(anotherPerson.Trn, kvp.Value);
+            });
+    }
+
+    [Test]
+    public async Task HandleAsync_PersonExistsAndIsActive_ReturnsSuccess()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        Debug.Assert(person.Person.Status is PersonStatus.Active);
+        var command = new GetTrnCommand(person.Trn!);
+
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        AssertSuccess(result);
+    }
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
@@ -6,160 +6,154 @@ namespace TeachingRecordSystem.Api.UnitTests.V3;
 public class SetQtlsTests : OperationTestBase
 {
     [Test]
-    public Task HandleAsync_PersonDoesNotExist_ReturnsError() =>
-        WithHandler<SetQtlsHandler>(async handler =>
-        {
-            // Arrange
-            var command = new SetQtlsCommand("0000000", QtsDate: null);
+    public async Task HandleAsync_PersonDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        var command = new SetQtlsCommand("0000000", QtsDate: null);
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Assert
-            AssertError(result, ApiError.ErrorCodes.PersonNotFound);
-        });
-
-    [Test]
-    public Task HandleAsync_NullQtsDateAndNoExistingRoute_DoesNotCreateEvent() =>
-        WithHandler<SetQtlsHandler>(async handler =>
-        {
-            // Arrange
-            var person = await TestData.CreatePersonAsync();
-
-            var command = new SetQtlsCommand(person.Trn!, QtsDate: null);
-
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            AssertSuccess(result);
-            EventObserver.AssertNoEventsSaved();
-        });
+        // Assert
+        AssertError(result, ApiError.ErrorCodes.PersonNotFound);
+    }
 
     [Test]
-    public Task HandleAsync_NullQtsDateAndExistingQtlsRoute_DeletesRouteAndSetsQtlsStatusToExpired() =>
-        WithHandler<SetQtlsHandler>(async handler =>
-        {
-            // Arrange
-            var existingQtlsDate = new DateOnly(2025, 4, 1);
-            var person = await TestData.CreatePersonAsync(p => p.WithQtls(existingQtlsDate));
+    public async Task HandleAsync_NullQtsDateAndNoExistingRoute_DoesNotCreateEvent()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
 
-            var command = new SetQtlsCommand(person.Trn!, QtsDate: null);
+        var command = new SetQtlsCommand(person.Trn!, QtsDate: null);
 
-            EventObserver.Clear();
+        // Act
+        var result = await ExecuteCommandAsync(command);
 
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            AssertSuccess(result);
-
-            var route = await GetQtlsRoute(person.PersonId);
-            Assert.Equal(Clock.UtcNow, route?.DeletedOn);
-
-            var qtlsStatus = await GetQtlsStatus(person.PersonId);
-            Assert.Equal(QtlsStatus.Expired, qtlsStatus);
-
-            EventObserver.AssertEventsSaved(e =>
-            {
-                var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
-                Assert.Equal(Clock.UtcNow, deletedEvent.CreatedUtc);
-                Assert.Equal(person.PersonId, deletedEvent.PersonId);
-                Assert.Equal(CurrentUserProvider.GetCurrentApplicationUser().UserId, deletedEvent.RaisedBy);
-            });
-        });
+        // Assert
+        AssertSuccess(result);
+        EventObserver.AssertNoEventsSaved();
+    }
 
     [Test]
-    public Task HandleAsync_NonNullQtsDateAndNoExistingRoute_CreatesRouteAndSetsQtlsStatusToActive() =>
-        WithHandler<SetQtlsHandler>(async handler =>
+    public async Task HandleAsync_NullQtsDateAndExistingQtlsRoute_DeletesRouteAndSetsQtlsStatusToExpired()
+    {
+        // Arrange
+        var existingQtlsDate = new DateOnly(2025, 4, 1);
+        var person = await TestData.CreatePersonAsync(p => p.WithQtls(existingQtlsDate));
+
+        var command = new SetQtlsCommand(person.Trn!, QtsDate: null);
+
+        EventObserver.Clear();
+
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        AssertSuccess(result);
+
+        var route = await GetQtlsRoute(person.PersonId);
+        Assert.Equal(Clock.UtcNow, route?.DeletedOn);
+
+        var qtlsStatus = await GetQtlsStatus(person.PersonId);
+        Assert.Equal(QtlsStatus.Expired, qtlsStatus);
+
+        EventObserver.AssertEventsSaved(e =>
         {
-            // Arrange
-            var person = await TestData.CreatePersonAsync();
-
-            var qtlsDate = new DateOnly(2025, 4, 1);
-            var command = new SetQtlsCommand(person.Trn!, qtlsDate);
-
-            EventObserver.Clear();
-
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            AssertSuccess(result);
-
-            var route = await GetQtlsRoute(person.PersonId);
-            Assert.NotNull(route);
-            Assert.Equal(qtlsDate, route.HoldsFrom);
-            Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-            Assert.Equal(Clock.UtcNow, route.CreatedOn);
-
-            var qtlsStatus = await GetQtlsStatus(person.PersonId);
-            Assert.Equal(QtlsStatus.Active, qtlsStatus);
-
-            EventObserver.AssertEventsSaved(e =>
-            {
-                var createdEvent = Assert.IsType<RouteToProfessionalStatusCreatedEvent>(e);
-                Assert.Equal(Clock.UtcNow, createdEvent.CreatedUtc);
-                Assert.Equal(person.PersonId, createdEvent.PersonId);
-                Assert.Equal(CurrentUserProvider.GetCurrentApplicationUser().UserId, createdEvent.RaisedBy);
-            });
+            var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
+            Assert.Equal(Clock.UtcNow, deletedEvent.CreatedUtc);
+            Assert.Equal(person.PersonId, deletedEvent.PersonId);
+            Assert.Equal(CurrentUserProvider.GetCurrentApplicationUser().UserId, deletedEvent.RaisedBy);
         });
+    }
 
     [Test]
-    public Task HandleAsync_NonNullQtsDateAndExistingRouteHoldsFromMatches_DoesNotCreateEvent() =>
-        WithHandler<SetQtlsHandler>(async handler =>
+    public async Task HandleAsync_NonNullQtsDateAndNoExistingRoute_CreatesRouteAndSetsQtlsStatusToActive()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+
+        var qtlsDate = new DateOnly(2025, 4, 1);
+        var command = new SetQtlsCommand(person.Trn!, qtlsDate);
+
+        EventObserver.Clear();
+
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        AssertSuccess(result);
+
+        var route = await GetQtlsRoute(person.PersonId);
+        Assert.NotNull(route);
+        Assert.Equal(qtlsDate, route.HoldsFrom);
+        Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
+        Assert.Equal(Clock.UtcNow, route.CreatedOn);
+
+        var qtlsStatus = await GetQtlsStatus(person.PersonId);
+        Assert.Equal(QtlsStatus.Active, qtlsStatus);
+
+        EventObserver.AssertEventsSaved(e =>
         {
-            // Arrange
-            var qtlsDate = new DateOnly(2025, 4, 1);
-            var person = await TestData.CreatePersonAsync(p => p.WithQtls(qtlsDate));
-
-            var command = new SetQtlsCommand(person.Trn!, qtlsDate);
-
-            EventObserver.Clear();
-
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            AssertSuccess(result);
-
-            EventObserver.AssertNoEventsSaved();
+            var createdEvent = Assert.IsType<RouteToProfessionalStatusCreatedEvent>(e);
+            Assert.Equal(Clock.UtcNow, createdEvent.CreatedUtc);
+            Assert.Equal(person.PersonId, createdEvent.PersonId);
+            Assert.Equal(CurrentUserProvider.GetCurrentApplicationUser().UserId, createdEvent.RaisedBy);
         });
+    }
 
     [Test]
-    public Task HandleAsync_NonNullQtsDateAndExistingRouteHoldFromDoesNotMatch_UpdatesRoute() =>
-        WithHandler<SetQtlsHandler>(async handler =>
+    public async Task HandleAsync_NonNullQtsDateAndExistingRouteHoldsFromMatches_DoesNotCreateEvent()
+    {
+        // Arrange
+        var qtlsDate = new DateOnly(2025, 4, 1);
+        var person = await TestData.CreatePersonAsync(p => p.WithQtls(qtlsDate));
+
+        var command = new SetQtlsCommand(person.Trn!, qtlsDate);
+
+        EventObserver.Clear();
+
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        AssertSuccess(result);
+
+        EventObserver.AssertNoEventsSaved();
+    }
+
+    [Test]
+    public async Task HandleAsync_NonNullQtsDateAndExistingRouteHoldFromDoesNotMatch_UpdatesRoute()
+    {
+        // Arrange
+        var existingQtsDate = new DateOnly(2025, 4, 1);
+        var person = await TestData.CreatePersonAsync(p => p.WithQtls(existingQtsDate));
+
+        var newQtlsDate = new DateOnly(2025, 4, 10);
+        var command = new SetQtlsCommand(person.Trn!, newQtlsDate);
+
+        EventObserver.Clear();
+
+        // Act
+        var result = await ExecuteCommandAsync(command);
+
+        // Assert
+        AssertSuccess(result);
+
+        var route = await GetQtlsRoute(person.PersonId);
+        Assert.NotNull(route);
+        Assert.Equal(newQtlsDate, route.HoldsFrom);
+        Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
+        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+
+        EventObserver.AssertEventsSaved(e =>
         {
-            // Arrange
-            var existingQtsDate = new DateOnly(2025, 4, 1);
-            var person = await TestData.CreatePersonAsync(p => p.WithQtls(existingQtsDate));
-
-            var newQtlsDate = new DateOnly(2025, 4, 10);
-            var command = new SetQtlsCommand(person.Trn!, newQtlsDate);
-
-            EventObserver.Clear();
-
-            // Act
-            var result = await handler.ExecuteAsync(command);
-
-            // Assert
-            AssertSuccess(result);
-
-            var route = await GetQtlsRoute(person.PersonId);
-            Assert.NotNull(route);
-            Assert.Equal(newQtlsDate, route.HoldsFrom);
-            Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-            Assert.Equal(Clock.UtcNow, route.UpdatedOn);
-
-            EventObserver.AssertEventsSaved(e =>
-            {
-                var updatedEvent = Assert.IsType<RouteToProfessionalStatusUpdatedEvent>(e);
-                Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
-                Assert.Equal(person.PersonId, updatedEvent.PersonId);
-                Assert.Equal(CurrentUserProvider.GetCurrentApplicationUser().UserId, updatedEvent.RaisedBy);
-                Assert.True(updatedEvent.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.HoldsFrom));
-            });
+            var updatedEvent = Assert.IsType<RouteToProfessionalStatusUpdatedEvent>(e);
+            Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
+            Assert.Equal(person.PersonId, updatedEvent.PersonId);
+            Assert.Equal(CurrentUserProvider.GetCurrentApplicationUser().UserId, updatedEvent.RaisedBy);
+            Assert.True(updatedEvent.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.HoldsFrom));
         });
+    }
 
     private Task<RouteToProfessionalStatus?> GetQtlsRoute(Guid personId) =>
         WithDbContextAsync(dbContext =>


### PR DESCRIPTION
We can't wrap execution (e.g. to create a transaction) if we're targeting the handlers directly.

Best reviewed with 'Hide whitespace' enabled.