### PR TITLE
make check for email case-insensitive

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/Index.cshtml
@@ -25,12 +25,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 class="govuk-heading-m">Before you start</h2>
-        <p class="govuk-body">You’ll need your:</p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li>NPQ application ID - you can find this in your NPQ online account or registration confirmation email</li>
-            <li>National Insurance number (if you have one)</li>
-        </ul>
-
+        <p class="govuk-body">You’ll need your National Insurance number (if you have one).</p>
         <p class="govuk-body">You’ll also need proof of your identity, for example a:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>passport</li>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PersonalEmail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/RequestTrn/PersonalEmail.cshtml.cs
@@ -62,7 +62,8 @@ public class PersonalEmailModel(AuthorizeAccessLinkGenerator linkGenerator, TrsD
     {
         var openTasks = await dbContext.SupportTasks
             .Where(s => s.Status == SupportTaskStatus.Open && s.SupportTaskType == SupportTaskType.NpqTrnRequest)
-            .Where(s => s.TrnRequestMetadata!.EmailAddress == emailAddress)
+                .Where(s => s.TrnRequestMetadata!.EmailAddress != null &&
+                        s.TrnRequestMetadata.EmailAddress.ToLower() == emailAddress.ToLower())
             .AnyAsync();
         return openTasks;
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PersonalEmailTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/RequestTrn/PersonalEmailTests.cs
@@ -22,24 +22,26 @@ public class PersonalEmailTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal($"/request-trn/submitted?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
-    [Fact]
-    public async Task Post_RequestForEmailWithOpenTasks_RedirectsToEmailInUse()
+    [Theory]
+    [InlineData("test@example.com", "test@example.com")]
+    [InlineData("test@example.com", "Test@example.com")]
+    [InlineData("test@example.com", "test@Example.com")]
+    public async Task Post_RequestForEmailWithOpenTasks_RedirectsToEmailInUse(string openTaskEmail, string requestEmail)
     {
         // Arrange
-        var email = Faker.Internet.Email();
         var state = CreateNewState();
         var journeyInstance = await CreateJourneyInstance(state);
         var person = await TestData.CreatePersonAsync();
 
         await TestData.CreateNpqTrnRequestSupportTaskAsync(ApplicationUser.NpqApplicationUserGuid, configure => configure
-            .WithEmailAddress(email)
+            .WithEmailAddress(openTaskEmail)
             .WithStatus(SupportTaskStatus.Open));
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/request-trn/personal-email?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
-                { "PersonalEmail", email }
+                { "PersonalEmail", requestEmail }
             })
         };
 


### PR DESCRIPTION
### Context
When a request for a TRN comes in via NPQ, there's an attempt to stop duplicate requests by checking for open requests with the same email. That check doesn't ignore case so User@example.com would be seen as different to user@example.com. Do a case-insensitive check instead.

### Changes proposed in this pull request
https://trello.com/c/7uWCUmOn/1642-update-email-checks-to-remove-case-sensitivity
