### PR TITLE
Fix Hangfire dashboard

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -204,7 +204,7 @@ app.UseMiddleware<AppendSecurityResponseHeadersMiddleware>();
 app.UseStaticFiles();
 
 app.UseRouting();
-app.UseTransactions();
+app.UseWhen(ctx => !ctx.Request.Path.StartsWithSegments("/_hangfire"), a => a.UseTransactions());
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
For some reason the Hangfire dashboard doesn't work with our `TransactionScope` stuff. This disables that middleware for Hangfire's endpoints.