### PR TITLE
Wrapped entire chain of jobs being queued in a transaction

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ImportTpsCsvExtractFileJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/ImportTpsCsvExtractFileJob.cs
@@ -24,12 +24,12 @@ public class ImportTpsCsvExtractFileJob(
             new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted },
             TransactionScopeAsyncFlowOption.Enabled);
         var importJobId = await backgroundJobScheduler.EnqueueAsync<TpsCsvExtractFileImporter>(j => j.ImportFileAsync(tpsCsvExtractId, pendingImportFileNames[0], cancellationToken));
-        txn.Complete();
         var archiveJobId = await backgroundJobScheduler.ContinueJobWithAsync<ITpsExtractStorageService>(importJobId, j => j.ArchiveFileAsync(pendingImportFileNames[0], cancellationToken));
         var copyJobId = await backgroundJobScheduler.ContinueJobWithAsync<TpsCsvExtractFileImporter>(archiveJobId, j => j.CopyValidFormatDataToStagingAsync(tpsCsvExtractId, cancellationToken));
         var processInvalidTrnsJobId = await backgroundJobScheduler.ContinueJobWithAsync<TpsCsvExtractProcessor>(copyJobId, j => j.ProcessNonMatchingTrnsAsync(tpsCsvExtractId, cancellationToken));
         var processInvalidEstablishmentsJobId = await backgroundJobScheduler.ContinueJobWithAsync<TpsCsvExtractProcessor>(processInvalidTrnsJobId, j => j.ProcessNonMatchingEstablishmentsAsync(tpsCsvExtractId, cancellationToken));
         var processNewEmploymentHistoryJobId = await backgroundJobScheduler.ContinueJobWithAsync<TpsCsvExtractProcessor>(processInvalidEstablishmentsJobId, j => j.ProcessNewEmploymentHistoryAsync(tpsCsvExtractId, cancellationToken));
         var processUpdatedEmploymentHistoryJobId = await backgroundJobScheduler.ContinueJobWithAsync<TpsCsvExtractProcessor>(processNewEmploymentHistoryJobId, j => j.ProcessUpdatedEmploymentHistoryAsync(tpsCsvExtractId, cancellationToken));
+        txn.Complete();
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/RefreshEstablishmentsJob.cs
@@ -14,7 +14,7 @@ public class RefreshEstablishmentsJob(IBackgroundJobScheduler backgroundJobSched
             new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted },
             TransactionScopeAsyncFlowOption.Enabled);
         var refreshJobId = await backgroundJobScheduler.EnqueueAsync<EstablishmentRefresher>(j => j.RefreshEstablishmentsAsync(cancellationToken));
-        txn.Complete();
         await backgroundJobScheduler.ContinueJobWithAsync<TpsCsvExtractProcessor>(refreshJobId, j => j.UpdateLatestEstablishmentVersionsAsync(cancellationToken));
+        txn.Complete();
     }
 }


### PR DESCRIPTION
### Context

when there is a chain of jobs starting with an `Enqueue..` and following with `ContinueWith..` they all need to be wrapped in a single transaction