### PR TITLE
Prevent tps matches highlighting first,middle,lastname if it's the sa…

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
@@ -41,17 +41,17 @@ public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(TrsDbCon
             var supportTask = GetSupportTask();
             var requestData = supportTask.TrnRequestMetadata!;
 
-            if (firstName == requestData.FirstName)
+            if (firstName.Equals(requestData.FirstName, StringComparison.OrdinalIgnoreCase))
             {
                 yield return PersonMatchedAttribute.FirstName;
             }
 
-            if (middleName == requestData.MiddleName || (string.IsNullOrWhiteSpace(requestData.MiddleName) && string.IsNullOrWhiteSpace(middleName)))
+            if (middleName.Equals(requestData.MiddleName, StringComparison.OrdinalIgnoreCase) || (string.IsNullOrWhiteSpace(requestData.MiddleName) && string.IsNullOrWhiteSpace(middleName)))
             {
                 yield return PersonMatchedAttribute.MiddleName;
             }
 
-            if (lastName == requestData.LastName)
+            if (lastName.Equals(requestData.LastName, StringComparison.OrdinalIgnoreCase))
             {
                 yield return PersonMatchedAttribute.LastName;
             }


### PR DESCRIPTION
Prevent highlighting changes in the teachers pension matches if the only difference is casing.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally