### PR TITLE
prevent page from returing bad request incorrectly

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml.cs
@@ -82,13 +82,6 @@ public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : R
             Trn = person.Trn!;
         }
 
-        if (RequestData.PotentialDuplicate != true ||
-            RequestData.Matches is not { MatchedPersons.Count: >= 1 })
-        {
-            context.Result = BadRequest();
-            return;
-        }
-
         var matchedPersonIds = JourneyInstance!.State.MatchedPersonIds.ToArray();
 
         PotentialDuplicates = (await DbContext.Persons


### PR DESCRIPTION
OnPageHandlerExecutionAsync was previously using the matchedpersons from trn_request_metadata row, rather than using the refreshed ids from state.