### PR TITLE
Support using TRN in URL instead of Person ID

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RedirectWithPersonIdFilter.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/RedirectWithPersonIdFilter.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+public partial class RedirectWithPersonIdFilter(TrsDbContext dbContext) : IAsyncResourceFilter
+{
+    [GeneratedRegex(@"^\/persons\/([0-9]{7})($|\/)")]
+    private static partial Regex _personWithTrnPathRegex();
+
+    public static int Order => -1000;
+
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        var matched = _personWithTrnPathRegex().Match(context.HttpContext.Request.Path);
+
+        if (matched.Success)
+        {
+            var trn = matched.Groups[1].Value;
+
+            var person = await dbContext.Persons
+                .Where(p => p.Trn == trn)
+                .Select(p => new { p.PersonId })
+                .SingleOrDefaultAsync();
+
+            if (person is not null)
+            {
+                var newUrl = context.HttpContext.Request.Path.ToString().Replace($"/persons/{trn}", $"/persons/{person.PersonId}");
+                context.Result = new RedirectResult(newUrl, permanent: false, preserveMethod: true);
+                return;
+            }
+        }
+
+        await next();
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -4,6 +4,7 @@ using Joonasw.AspNetCore.SecurityHeaders;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -108,6 +109,7 @@ builder.Services
 
         options.Filters.Add(new AuthorizeFilter(policy));
         options.Filters.Add(new CheckUserExistsFilter());
+        options.Filters.Add(new ServiceFilterAttribute<RedirectWithPersonIdFilter> { Order = RedirectWithPersonIdFilter.Order });
         options.Filters.Add(new NoCachePageFilter());
         options.Filters.Add(new RequireActivePersonFilter());
 
@@ -151,6 +153,7 @@ builder.Services
     .AddTransient<TrsLinkGenerator>()
     .AddTransient<ICurrentUserIdProvider, HttpContextCurrentUserIdProvider>()
     .AddTransient<CheckMandatoryQualificationExistsFilter>()
+    .AddTransient<RedirectWithPersonIdFilter>()
     .AddTransient<CheckUserExistsFilter>()
     .AddTransient<RequireClosedAlertFilter>()
     .AddTransient<RequireOpenAlertFilter>()


### PR DESCRIPTION
It's useful to be able to use TRN instead of Person ID in URLs in the support console. This adds a filter to make it so.