### PR TITLE
prevent importing capita trn that already exists but is de-activated

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/CapitaImportJob.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Jobs/CapitaImportJob.cs
@@ -315,7 +315,7 @@ public class CapitaImportJob(BlobServiceClient blobServiceClient, ILogger<Capita
 
         // if a potential match is not found and the result of the import of this row would be to create a person
         // make sure that first name and last name are both present.
-        var person = await dbContext.Persons.FirstOrDefaultAsync(x => x.Trn == record.TRN);
+        var person = await dbContext.Persons.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Trn == record.TRN);
         if (person is null && string.IsNullOrEmpty(record.GetFirstName()))
         {
             errors.Add("Unable to create a new record without a firstname");
@@ -323,6 +323,11 @@ public class CapitaImportJob(BlobServiceClient blobServiceClient, ILogger<Capita
         if (person is null && string.IsNullOrEmpty(record.LastName))
         {
             errors.Add("Unable to create a new record without a lastname");
+        }
+
+        if (person is not null && person.Status == PersonStatus.Deactivated)
+        {
+            errors.Add($"de-activated record exists for trn {record.TRN}");
         }
 
         //dob


### PR DESCRIPTION
Update capita import to error if it finds an existing trn for the row that is being imported, but is de-activated.

**context:**
We received a record through the capita interface that would of resulted in new person being created with a trn that had been long de-activated. This PR updates the validation to fetch de-activated records and return an error if the record is de-activated.