### PR TITLE
Added missing Index pages and corrected "resolve" paths

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey/Index.cshtml
@@ -1,5 +1,5 @@
 @page "/api-keys/add"
-@model TeachingRecordSystem.SupportUi.Pages.ApiKeys.AddApiKeyModel
+@model TeachingRecordSystem.SupportUi.Pages.ApiKeys.AddApiKey.IndexModel
 @{
     ViewBag.Title = $"Add API key to {Model.ApplicationUserName}";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/AddApiKey/Index.cshtml.cs
@@ -7,10 +7,10 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
-namespace TeachingRecordSystem.SupportUi.Pages.ApiKeys;
+namespace TeachingRecordSystem.SupportUi.Pages.ApiKeys.AddApiKey;
 
 [Authorize(Policy = AuthorizationPolicies.UserManagement)]
-public class AddApiKeyModel(TrsDbContext dbContext, IClock clock, TrsLinkGenerator linkGenerator) : PageModel
+public class IndexModel(TrsDbContext dbContext, IClock clock, TrsLinkGenerator linkGenerator) : PageModel
 {
     [FromQuery]
     public Guid ApplicationUserId { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey/Index.cshtml
@@ -1,6 +1,6 @@
 @page "/api-keys/{apiKeyId}/{handler?}"
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
-@model TeachingRecordSystem.SupportUi.Pages.ApiKeys.EditApiKeyModel
+@model TeachingRecordSystem.SupportUi.Pages.ApiKeys.EditApiKey.IndexModel
 @{
     ViewBag.Title = $"Edit API key for {Model.ApplicationUserName}";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/EditApiKey/Index.cshtml.cs
@@ -6,10 +6,10 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
-namespace TeachingRecordSystem.SupportUi.Pages.ApiKeys;
+namespace TeachingRecordSystem.SupportUi.Pages.ApiKeys.EditApiKey;
 
 [Authorize(Policy = AuthorizationPolicies.UserManagement)]
-public class EditApiKeyModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IClock clock) : PageModel
+public class IndexModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IClock clock) : PageModel
 {
     private ApiKey? _apiKey;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApiKeys/TrsLinkGenerator.cs
@@ -2,9 +2,9 @@ namespace TeachingRecordSystem.SupportUi;
 
 public partial class TrsLinkGenerator
 {
-    public string AddApiKey(Guid applicationUserId) => GetRequiredPathByPage("/ApiKeys/AddApiKey", routeValues: new { applicationUserId });
+    public string AddApiKey(Guid applicationUserId) => GetRequiredPathByPage("/ApiKeys/AddApiKey/Index", routeValues: new { applicationUserId });
 
-    public string EditApiKey(Guid apiKeyId) => GetRequiredPathByPage("/ApiKeys/EditApiKey", routeValues: new { apiKeyId });
+    public string EditApiKey(Guid apiKeyId) => GetRequiredPathByPage("/ApiKeys/EditApiKey/Index", routeValues: new { apiKeyId });
 
-    public string ExpireApiKey(Guid apiKeyId) => GetRequiredPathByPage("/ApiKeys/EditApiKey", handler: "Expire", routeValues: new { apiKeyId });
+    public string ExpireApiKey(Guid apiKeyId) => GetRequiredPathByPage("/ApiKeys/EditApiKey/Index", handler: "Expire", routeValues: new { apiKeyId });
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser/Index.cshtml
@@ -1,5 +1,5 @@
 @page "/application-users/add"
-@model TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.AddApplicationUserModel
+@model TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.AddApplicationUser.IndexModel
 @{
     ViewBag.Title = "Add application user";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/AddApplicationUser/Index.cshtml.cs
@@ -6,10 +6,10 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
-namespace TeachingRecordSystem.SupportUi.Pages.ApplicationUsers;
+namespace TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.AddApplicationUser;
 
 [Authorize(Policy = AuthorizationPolicies.UserManagement)]
-public class AddApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IClock clock) : PageModel
+public class IndexModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IClock clock) : PageModel
 {
     [BindProperty]
     [Display(Name = "Name")]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml
@@ -1,6 +1,6 @@
 @page "/application-users/{userId}"
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
-@model TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.EditApplicationUserModel
+@model TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.EditApplicationUser.IndexModel
 @inject IClock Clock
 @{
     ViewBag.Title = $"Edit {Model.Name}";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml.cs
@@ -11,11 +11,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Infrastructure.ModelBinding;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
-namespace TeachingRecordSystem.SupportUi.Pages.ApplicationUsers;
+namespace TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.EditApplicationUser;
 
 [Authorize(Policy = AuthorizationPolicies.UserManagement)]
 [BindProperties]
-public class EditApplicationUserModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IClock clock) : PageModel
+public class IndexModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IClock clock) : PageModel
 {
     // From PathString
     private static readonly SearchValues<char> _validPathChars =

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/TrsLinkGenerator.cs
@@ -4,7 +4,7 @@ public partial class TrsLinkGenerator
 {
     public string ApplicationUsers() => GetRequiredPathByPage("/ApplicationUsers/Index");
 
-    public string AddApplicationUser() => GetRequiredPathByPage("/ApplicationUsers/AddApplicationUser");
+    public string AddApplicationUser() => GetRequiredPathByPage("/ApplicationUsers/AddApplicationUser/Index");
 
-    public string EditApplicationUser(Guid userId) => GetRequiredPathByPage("/ApplicationUsers/EditApplicationUser", routeValues: new { userId });
+    public string EditApplicationUser(Guid userId) => GetRequiredPathByPage("/ApplicationUsers/EditApplicationUser/Index", routeValues: new { userId });
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CommonJourneyPage.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CommonJourneyPage.cs
@@ -39,7 +39,7 @@ public abstract class CommonJourneyPage(
     {
         return pageName switch
         {
-            EditDetailsJourneyPage.PersonalDetails => LinkGenerator.PersonEditDetailsPersonalDetails(PersonId, JourneyInstance!.InstanceId, fromCheckAnswers),
+            EditDetailsJourneyPage.PersonalDetails => LinkGenerator.PersonEditDetails(PersonId, JourneyInstance!.InstanceId, fromCheckAnswers),
             EditDetailsJourneyPage.NameChangeReason => LinkGenerator.PersonEditDetailsNameChangeReason(PersonId, JourneyInstance!.InstanceId, fromCheckAnswers),
             EditDetailsJourneyPage.OtherDetailsChangeReason => LinkGenerator.PersonEditDetailsOtherDetailsChangeReason(PersonId, JourneyInstance!.InstanceId, fromCheckAnswers),
             EditDetailsJourneyPage.CheckAnswers => LinkGenerator.PersonEditDetailsCheckAnswers(PersonId, JourneyInstance!.InstanceId),

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/Index.cshtml
@@ -2,7 +2,7 @@
 @using TeachingRecordSystem.SupportUi.Pages.Common;
 @using TeachingRecordSystem.SupportUi.Pages.Shared
 @using Microsoft.AspNetCore.Mvc.ModelBinding
-@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDetails.PersonalDetailsModel
+@model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDetails.IndexModel
 @{
     Layout = "_Layout";
     ViewBag.Title = "Edit personal details";
@@ -32,7 +32,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <form action=@LinkGenerator.PersonEditDetailsPersonalDetails(Model.PersonId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers) method="post" data-testid="submit-form">
+        <form action=@LinkGenerator.PersonEditDetails(Model.PersonId, Model.JourneyInstance!.InstanceId, Model.FromCheckAnswers) method="post" data-testid="submit-form">
             <span class="govuk-caption-l" data-testid="edit-details-caption">@Model.PersonName</span>
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/Index.cshtml.cs
@@ -8,7 +8,7 @@ using TeachingRecordSystem.Core.Services.Files;
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.EditDetails;
 
 [Journey(JourneyNames.EditDetails), ActivatesJourney, RequireJourneyInstance]
-public class PersonalDetailsModel(
+public class IndexModel(
     TrsDbContext dbContext,
     IClock clock,
     TrsLinkGenerator linkGenerator,

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Induction.cshtml
@@ -94,7 +94,7 @@
                         @if (Model.CanWrite)
                         {
                             <govuk-summary-list-row-actions>
-                                <govuk-summary-list-row-action data-testid="change-induction-exempted-route" href="@LinkGenerator.RouteEditDetail(exemptedRoute.QualificationId, null, fromInductions: true)" visually-hidden-text="induction exemption reason">Change</govuk-summary-list-row-action>
+                                <govuk-summary-list-row-action data-testid="change-induction-exempted-route" href="@LinkGenerator.RouteEdit(exemptedRoute.QualificationId, fromInductions: true)" visually-hidden-text="induction exemption reason">Change</govuk-summary-list-row-action>
                             </govuk-summary-list-row-actions>
                         }
                     </govuk-summary-list-row>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -36,8 +36,8 @@ else
                 <govuk-summary-card-actions>
                     @if (Model.CanEdit)
                     {
-                        <govuk-summary-card-action href="@LinkGenerator.RouteEditDetail(professionalStatus.QualificationId, null)" visually-hidden-text="edit route" data-testid="edit-route-link-@professionalStatus.QualificationId">Edit route</govuk-summary-card-action>
-                        <govuk-summary-card-action href="@LinkGenerator.RouteDeleteChangeReason(professionalStatus.QualificationId, null)" visually-hidden-text="delete route" data-testid="delete-route-link-@professionalStatus.QualificationId">Delete route</govuk-summary-card-action>
+                        <govuk-summary-card-action href="@LinkGenerator.RouteEdit(professionalStatus.QualificationId)" visually-hidden-text="edit route" data-testid="edit-route-link-@professionalStatus.QualificationId">Edit route</govuk-summary-card-action>
+                        <govuk-summary-card-action href="@LinkGenerator.RouteDelete(professionalStatus.QualificationId)" visually-hidden-text="delete route" data-testid="delete-route-link-@professionalStatus.QualificationId">Delete route</govuk-summary-card-action>
                     }
                 </govuk-summary-card-actions>
                 <govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/TrsLinkGenerator.cs
@@ -26,8 +26,8 @@ public partial class TrsLinkGenerator
     public string PersonDetail(Guid personId) =>
         GetRequiredPathByPage("/Persons/PersonDetail/Index", routeValues: new { personId });
 
-    public string PersonEditDetailsPersonalDetails(Guid personId, JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        GetRequiredPathByPage("/Persons/PersonDetail/EditDetails/PersonalDetails", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string PersonEditDetails(Guid personId, JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
+        GetRequiredPathByPage("/Persons/PersonDetail/EditDetails/Index", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
     public string PersonEditDetailsNameChangeReason(Guid personId, JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/Persons/PersonDetail/EditDetails/NameChangeReason", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
@@ -39,7 +39,7 @@ public partial class TrsLinkGenerator
         GetRequiredPathByPage("/Persons/PersonDetail/EditDetails/CheckAnswers", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
     public string PersonEditDetailsCancel(Guid personId, JourneyInstanceId journeyInstanceId) =>
-        GetRequiredPathByPage("/Persons/PersonDetail/EditDetails/PersonalDetails", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+        GetRequiredPathByPage("/Persons/PersonDetail/EditDetails/Index", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
 
     public string PersonInductionEditStatus(Guid personId, JourneyInstanceId? journeyInstanceId, JourneyFromCheckYourAnswersPage? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/Persons/PersonDetail/EditInduction/Status", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/ChangeReason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/ChangeReason.cshtml.cs
@@ -8,7 +8,7 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
-[Journey(JourneyNames.DeleteRouteToProfessionalStatus), ActivatesJourney, RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
+[Journey(JourneyNames.DeleteRouteToProfessionalStatus), RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
 public class ChangeReasonModel(TrsLinkGenerator linkGenerator,
     IFileService fileService) : PageModel
 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/route/{qualificationId}/delete"
+@model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute.IndexModel
+@{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Index.cshtml.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
+
+[Journey(JourneyNames.DeleteRouteToProfessionalStatus), ActivatesJourney, RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<DeleteRouteState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid QualificationId { get; set; }
+
+    public IActionResult OnGet() => Redirect(linkGenerator.RouteDeleteChangeReason(QualificationId, JourneyInstance!.InstanceId));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Detail.cshtml.cs
@@ -5,7 +5,7 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
-[Journey(JourneyNames.EditRouteToProfessionalStatus), ActivatesJourney, RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
+[Journey(JourneyNames.EditRouteToProfessionalStatus), RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
 public class DetailModel(
     TrsLinkGenerator linkGenerator,
     ReferenceDataCache referenceDataCache) : PageModel

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/route/{qualificationId}/edit"
+@model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute.IndexModel
+@{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Index.cshtml.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
+
+[Journey(JourneyNames.EditRouteToProfessionalStatus), ActivatesJourney, RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<EditRouteState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public Guid QualificationId { get; set; }
+
+    [FromQuery]
+    public bool FromInductions { get; set; }
+
+    public IActionResult OnGet() => Redirect(linkGenerator.RouteEditDetail(QualificationId, JourneyInstance!.InstanceId, FromInductions));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/TrsLinkGenerator.cs
@@ -7,6 +7,8 @@ public partial class TrsLinkGenerator
     public string PersonRoute(Guid personId) =>
         GetRequiredPathByPage("/Persons/PersonDetail/Route", routeValues: new { personId });
 
+    public string RouteDelete(Guid qualificationId) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/Index", routeValues: new { qualificationId });
     public string RouteDeleteChangeReason(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/ChangeReason", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
     public string RouteDeleteChangeReasonCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
@@ -16,6 +18,8 @@ public partial class TrsLinkGenerator
     public string RouteDeleteCheckYourAnswersCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
 
+    public string RouteEdit(Guid qualificationId, bool? fromInductions = null) =>
+        GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Index", routeValues: new { qualificationId, fromInductions });
     public string RouteEditDetail(Guid qualificationId, JourneyInstanceId? journeyInstanceId, bool? fromInductions = null) =>
         GetRequiredPathByPage("/RoutesToProfessionalStatus/EditRoute/Detail", routeValues: new { qualificationId, fromInductions }, journeyInstanceId: journeyInstanceId);
     public string RouteEditDetailCancel(Guid qualificationId, JourneyInstanceId? journeyInstanceId) =>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Shared/_PersonDetail.cshtml
@@ -9,7 +9,7 @@
     @if (Model.CanChangeDetails)
     {
         <govuk-summary-card-actions>
-            <govuk-summary-card-action data-testid="change-details-link" href=@LinkGenerator.PersonEditDetailsPersonalDetails(Model.PersonId) visually-hidden-text="personal details">Change</govuk-summary-card-action>
+            <govuk-summary-card-action data-testid="change-details-link" href=@LinkGenerator.PersonEditDetails(Model.PersonId) visually-hidden-text="personal details">Change</govuk-summary-card-action>
         </govuk-summary-card-actions>
     }
     <govuk-summary-list>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Index.cshtml
@@ -58,7 +58,7 @@
                     {
                         <tr class="govuk-table__row" data-testid="task:@result.SupportTaskReference">
                             <th scope="row" class="govuk-table__header" data-testid="name">
-                                <a href="@LinkGenerator.ApiTrnRequestMatches(result.SupportTaskReference)" class="govuk-link">
+                                <a href="@LinkGenerator.ApiTrnRequestResolve(result.SupportTaskReference)" class="govuk-link">
                                     @result.FirstName @result.MiddleName @result.LastName
                                 </a>
                             </th>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/CheckAnswers.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/api-trn-requests/{supportTaskReference}/check-answers/{handler?}"
+@page "/support-tasks/api-trn-requests/{supportTaskReference}/resolve/check-answers/{handler?}"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.CheckAnswers
 @{
     ViewBag.Title = Model.CreatingNewRecord ? "Check details before creating a new record" : "Check details before updating the existing record";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/support-tasks/api-trn-requests/{supportTaskReference}/resolve"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.IndexModel
+@{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Index.cshtml.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
+
+[Journey(JourneyNames.ResolveApiTrnRequest), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<ResolveApiTrnRequestState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public string? SupportTaskReference { get; set; }
+
+    public IActionResult OnGet() => Redirect(linkGenerator.ApiTrnRequestMatches(SupportTaskReference, JourneyInstance!.InstanceId));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/api-trn-requests/{supportTaskReference}/matches/{handler?}"
+@page "/support-tasks/api-trn-requests/{supportTaskReference}/resolve/matches/{handler?}"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.Matches
 @{
     ViewBag.Title = $"Compare {Model.SourceApplicationUserName} request with potential matches";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Matches.cshtml.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
 
-[Journey(JourneyNames.ResolveApiTrnRequest), RequireJourneyInstance, ActivatesJourney]
+[Journey(JourneyNames.ResolveApiTrnRequest), RequireJourneyInstance]
 public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : ResolveApiTrnRequestPageModel(dbContext)
 {
     [FromRoute]

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/ApiTrnRequests/Resolve/Merge.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/api-trn-requests/{supportTaskReference}/merge/{handler?}"
+@page "/support-tasks/api-trn-requests/{supportTaskReference}/resolve/merge/{handler?}"
 @using TeachingRecordSystem.SupportUi.Pages.Shared
 @using static ResolveApiTrnRequestState
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve.Merge

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Conventions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Conventions.cs
@@ -14,7 +14,7 @@ public class Conventions : IConfigureFolderConventions
                 var relativePath = model.RelativePath;
 
                 // Exclude this specific file
-                if (relativePath.EndsWith("Index.cshtml", StringComparison.OrdinalIgnoreCase))
+                if (relativePath.EndsWith("NpqTrnRequests/Index.cshtml", StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Details.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Details.cshtml.cs
@@ -44,12 +44,12 @@ public class DetailsModel(TrsLinkGenerator linkGenerator, IFileService fileServi
         if (CreateRecord)
         {
             return (SupportTask!.TrnRequestMetadata!.PotentialDuplicate ?? false) ?
-               Redirect(linkGenerator.NpqTrnRequestMatches(SupportTaskReference)) :
-               Redirect(linkGenerator.NpqTrnRequestNoMatchesCheckAnswers(SupportTaskReference));
+               Redirect(linkGenerator.NpqTrnRequestResolve(SupportTaskReference)) :
+               Redirect(linkGenerator.NpqTrnRequestNoMatches(SupportTaskReference));
         }
         else
         {
-            return Redirect(linkGenerator.NpqTrnRequestRejectionReason(SupportTaskReference));
+            return Redirect(linkGenerator.NpqTrnRequestReject(SupportTaskReference));
         }
     }
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/NoMatches/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/NoMatches/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/support-tasks/npq-trn-requests/{supportTaskReference}/no-matches"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.NoMatches.IndexModel
+@{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/NoMatches/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/NoMatches/Index.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.NoMatches;
+
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    [FromRoute]
+    public string SupportTaskReference { get; set; }
+
+    public IActionResult OnGet() => Redirect(linkGenerator.NpqTrnRequestNoMatchesCheckAnswers(SupportTaskReference));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Reject/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Reject/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/support-tasks/npq-trn-requests/{supportTaskReference}/reject"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Reject.IndexModel
+@{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Reject/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Reject/Index.cshtml.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Reject;
+
+[Journey(JourneyNames.RejectNpqTrnRequest), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<RejectNpqTrnRequestState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public string SupportTaskReference { get; set; }
+
+    public IActionResult OnGet() => Redirect(linkGenerator.NpqTrnRequestRejectionReason(SupportTaskReference, JourneyInstance!.InstanceId));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Reject/RejectionReason.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Reject/RejectionReason.cshtml.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Reject;
 
-[Journey(JourneyNames.RejectNpqTrnRequest), RequireJourneyInstance, ActivatesJourney]
+[Journey(JourneyNames.RejectNpqTrnRequest), RequireJourneyInstance]
 public class RejectionReasonModel(TrsLinkGenerator linkGenerator) : PageModel
 {
     public string PersonName => StringHelper.JoinNonEmpty(' ', RequestData!.Name);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/CheckAnswers.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/CheckAnswers.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/npq-trn-requests/{supportTaskReference}/check-answers/{handler?}"
+@page "/support-tasks/npq-trn-requests/{supportTaskReference}/resolve/check-answers/{handler?}"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve.CheckAnswersModel
 @{
     ViewBag.Title = Model.CreatingNewRecord ? "Check details before creating record" : "Check details before updating record";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/support-tasks/npq-trn-requests/{supportTaskReference}/resolve"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve.IndexModel
+@{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Index.cshtml.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve;
+
+[Journey(JourneyNames.ResolveNpqTrnRequest), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<ResolveNpqTrnRequestState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public string SupportTaskReference { get; set; }
+
+    public IActionResult OnGet() => Redirect(linkGenerator.NpqTrnRequestMatches(SupportTaskReference, JourneyInstance!.InstanceId));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/npq-trn-requests/{supportTaskReference}/matches/{handler?}"
+@page "/support-tasks/npq-trn-requests/{supportTaskReference}/resolve/matches/{handler?}"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve.MatchesModel
 @{
     ViewBag.Title = "Compare potential duplicate records";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Matches.cshtml.cs
@@ -9,7 +9,7 @@ using TeachingRecordSystem.SupportUi.Pages.SupportTasks.ApiTrnRequests.Resolve;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve;
 
-[Journey(JourneyNames.ResolveNpqTrnRequest), RequireJourneyInstance, ActivatesJourney]
+[Journey(JourneyNames.ResolveNpqTrnRequest), RequireJourneyInstance]
 public class MatchesModel(TrsDbContext dbContext, TrsLinkGenerator linkGenerator, IFileService fileService) : ResolveNpqTrnRequestPageModel(dbContext)
 {
     public TrnRequestMetadata? RequestData { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Merge.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/NpqTrnRequests/Resolve/Merge.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/npq-trn-requests/{supportTaskReference}/merge/{handler?}"
+@page "/support-tasks/npq-trn-requests/{supportTaskReference}/resolve/merge/{handler?}"
 @using TeachingRecordSystem.SupportUi.Pages.Shared
 @using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve.ResolveNpqTrnRequestState
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.NpqTrnRequests.Resolve.MergeModel

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Index.cshtml
@@ -50,7 +50,7 @@
                     {
                         <tr class="govuk-table__row" data-testid="task:@result.SupportTaskReference">
                             <td scope="row" class="govuk-table__cell" data-testid="name">
-                                <a href="@LinkGenerator.TeacherPensionsMatches(result.SupportTaskReference)" class="govuk-link">
+                                <a href="@LinkGenerator.TeacherPensionsResolve(result.SupportTaskReference)" class="govuk-link">
                                     @result.Name
                                 </a>
                             </td>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.IndexModel
+@{
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Index.cshtml.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
+
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate), ActivatesJourney, RequireJourneyInstance]
+public class IndexModel(TrsLinkGenerator linkGenerator) : PageModel
+{
+    public JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>? JourneyInstance { get; set; }
+
+    [FromRoute]
+    public required string SupportTaskReference { get; init; }
+
+    public IActionResult OnGet() => Redirect(linkGenerator.TeacherPensionsMatches(SupportTaskReference, JourneyInstance!.InstanceId));
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-[Journey(JourneyNames.ResolveTpsPotentialDuplicate), RequireJourneyInstance, ActivatesJourney]
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate), RequireJourneyInstance]
 public class Matches(TrsDbContext dbContext, TrsLinkGenerator linkGenerator) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
 {
     public TrnRequestMetadata? RequestData { get; set; }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequestManualChecksNeeded/Resolve/Confirm.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequestManualChecksNeeded/Resolve/Confirm.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/manual-checks-needed/{supportTaskReference}/confirm"
+@page "/support-tasks/manual-checks-needed/{supportTaskReference}/resolve/confirm"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequestManualChecksNeeded.Resolve.Confirm
 @{
     ViewBag.Title = "Confirm you’ve completed the checks";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequestManualChecksNeeded/Resolve/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequestManualChecksNeeded/Resolve/Index.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/manual-checks-needed/{supportTaskReference}"
+@page "/support-tasks/manual-checks-needed/{supportTaskReference}/resolve"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequestManualChecksNeeded.Resolve.Index
 @{
     ViewBag.Title = "Review TRN request";

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrsLinkGenerator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrsLinkGenerator.cs
@@ -16,7 +16,7 @@ public partial class TrsLinkGenerator
         supportTaskType switch
         {
             SupportTaskType.ConnectOneLoginUser => ConnectOneLoginUserSupportTask(supportTaskReference),
-            SupportTaskType.ApiTrnRequest => ApiTrnRequestMatches(supportTaskReference),
+            SupportTaskType.ApiTrnRequest => ApiTrnRequestResolve(supportTaskReference),
             SupportTaskType.TrnRequestManualChecksNeeded => ResolveTrnRequestManualChecksNeeded(supportTaskReference),
             SupportTaskType.NpqTrnRequest => NpqTrnRequestDetailsPage(supportTaskReference),
             SupportTaskType.ChangeDateOfBirthRequest => EditChangeRequest(supportTaskReference),
@@ -27,6 +27,9 @@ public partial class TrsLinkGenerator
 
     public string ApiTrnRequests(string? search = null, ApiTrnRequestsSortByOption? sortBy = null, SortDirection? sortDirection = null, int? pageNumber = null) =>
         GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Index", routeValues: new { search, sortBy, sortDirection, pageNumber });
+
+    public string ApiTrnRequestResolve(string supportTaskReference) =>
+        GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Resolve/Index", routeValues: new { supportTaskReference });
 
     public string ApiTrnRequestMatches(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/SupportTasks/ApiTrnRequests/Resolve/Matches", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
@@ -46,6 +49,9 @@ public partial class TrsLinkGenerator
     public string NpqTrnRequestDetailsPageCancel(string supportTaskReference) =>
         GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/Details", routeValues: new { supportTaskReference }, handler: "Cancel");
 
+    public string NpqTrnRequestResolve(string supportTaskReference) =>
+        GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/Resolve/Index", routeValues: new { supportTaskReference });
+
     public string NpqTrnRequestMatches(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/Resolve/Matches", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
@@ -64,6 +70,9 @@ public partial class TrsLinkGenerator
     public string NpqTrnRequestMergeCheckAnswersCancel(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null) =>
         GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/Resolve/CheckAnswers", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId, handler: "Cancel");
 
+    public string NpqTrnRequestReject(string supportTaskReference) =>
+        GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/Reject/Index", routeValues: new { supportTaskReference });
+
     public string NpqTrnRequestRejectionReason(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/Reject/RejectionReason", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
 
@@ -75,6 +84,9 @@ public partial class TrsLinkGenerator
 
     public string NpqTrnRequestRejectionCheckAnswersCancel(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null) =>
         GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/Reject/CheckAnswers", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId, handler: "Cancel");
+
+    public string NpqTrnRequestNoMatches(string supportTaskReference) =>
+        GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/NoMatches/Index", routeValues: new { supportTaskReference });
 
     public string NpqTrnRequestNoMatchesCheckAnswers(string supportTaskReference) =>
         GetRequiredPathByPage("/SupportTasks/NpqTrnRequests/NoMatches/CheckAnswers", routeValues: new { supportTaskReference });
@@ -114,6 +126,9 @@ public partial class TrsLinkGenerator
 
     public string TeacherPensions(TeacherPensionsSortOptions? sortBy = null, SortDirection? sortDirection = null) =>
         GetRequiredPathByPage("/SupportTasks/TeacherPensions/Index", routeValues: new { sortBy, sortDirection });
+
+    public string TeacherPensionsResolve(string supportTaskReference) =>
+        GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/Index", routeValues: new { supportTaskReference });
 
     public string TeacherPensionsMatches(string supportTaskReference, JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
         GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/Matches", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/ApiTrnRequestTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/ApiTrnRequestTests.cs
@@ -20,12 +20,12 @@ public class ApiTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.ClickAsync($"a{TextIsSelector($"{requestData.FirstName} {requestData.MiddleName} {requestData.LastName}")}");
 
-        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches");
+        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches");
 
         await page.CheckAsync($"label{TextIsSelector("Create a new record from it")}");
         await page.ClickContinueButtonAsync();
 
-        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers");
+        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers");
         await page.ClickButtonAsync("Confirm and create record");
 
         await page.WaitForUrlPathAsync("/support-tasks/api-trn-requests");
@@ -66,16 +66,16 @@ public class ApiTrnRequestTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.ClickAsync($"a{TextIsSelector($"{requestData.FirstName} {requestData.MiddleName} {requestData.LastName}")}");
 
-        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches");
+        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches");
 
         await page.CheckAsync("label:text-is('Merge it with Record A')");
         await page.ClickContinueButtonAsync();
 
-        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge");
+        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge");
         await page.CheckAsync($"label{HasTextSelector(requestData.MiddleName)}");
         await page.ClickContinueButtonAsync();
 
-        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers");
+        await page.WaitForUrlPathAsync($"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers");
         await page.ClickButtonAsync("Confirm and update existing record");
 
         await page.WaitForUrlPathAsync("/support-tasks/api-trn-requests");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestPageExtensions.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/NpqTrnRequestPageExtensions.cs
@@ -11,13 +11,13 @@ public static class NpqTrnRequestPageExtensions
         page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/details");
 
     public static Task AssertOnMatchesPageAsync(this IPage page, string taskReference) =>
-        page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/matches");
+        page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/resolve/matches");
 
     public static Task AssertOnMergePageAsync(this IPage page, string taskReference) =>
-        page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/merge");
+        page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/resolve/merge");
 
     public static Task AssertOnMatchesCheckYourAnswersPageAsync(this IPage page, string taskReference) =>
-        page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/check-answers");
+        page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/resolve/check-answers");
 
     public static Task AssertOnNoMatchesCheckYourAnswersPageAsync(this IPage page, string taskReference) =>
         page.WaitForUrlPathAsync($"/support-tasks/npq-trn-requests/{taskReference}/no-matches/check-answers");

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKey/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKey/IndexTests.cs
@@ -1,8 +1,8 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
-namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApiKeys;
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApiKeys.AddApiKey;
 
-public class AddApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Test]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKey/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKey/IndexTests.cs
@@ -1,6 +1,6 @@
-namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApiKeys;
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApiKeys.EditApiKey;
 
-public class EditApiKeyTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Test]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUser/IndexTests.cs
@@ -1,8 +1,8 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
-namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApplicationUsers;
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApplicationUsers.AddApplicationUser;
 
-public class AddApplicationUserTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Test]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUser/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUser/IndexTests.cs
@@ -1,9 +1,9 @@
 using System.Security.Cryptography;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
-namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApplicationUsers;
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.ApplicationUsers.EditApplicationUser;
 
-public class EditApplicationUserTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Test]
     public async Task Get_UserDoesNotHavePermission_ReturnsForbidden()

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/PersonalDetailsTests.cs
@@ -237,7 +237,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.FirstName), "Enter the person\u2019s first name");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.FirstName), "Enter the person\u2019s first name");
     }
 
     [Test]
@@ -265,7 +265,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.FirstName), "Enter the person\u2019s first name");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.FirstName), "Enter the person\u2019s first name");
     }
 
     [Test]
@@ -293,7 +293,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.FirstName), "Person\u2019s first name must be 100 characters or less");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.FirstName), "Person\u2019s first name must be 100 characters or less");
     }
 
     [Test]
@@ -321,7 +321,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.MiddleName), "Person\u2019s middle name must be 100 characters or less");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.MiddleName), "Person\u2019s middle name must be 100 characters or less");
     }
 
     [Test]
@@ -349,7 +349,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.LastName), "Enter the person\u2019s last name");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.LastName), "Enter the person\u2019s last name");
     }
 
     [Test]
@@ -377,7 +377,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.LastName), "Enter the person\u2019s last name");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.LastName), "Enter the person\u2019s last name");
     }
 
     [Test]
@@ -405,7 +405,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.LastName), "Person\u2019s last name must be 100 characters or less");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.LastName), "Person\u2019s last name must be 100 characters or less");
     }
 
     [Test]
@@ -433,7 +433,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.DateOfBirth), "Enter the person\u2019s date of birth");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.DateOfBirth), "Enter the person\u2019s date of birth");
     }
 
     [Test]
@@ -461,7 +461,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.DateOfBirth), "Person\u2019s date of birth must be in the past");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.DateOfBirth), "Person\u2019s date of birth must be in the past");
     }
 
     [Test]
@@ -490,7 +490,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.EmailAddress), "Person\u2019s email address must be 100 characters or less");
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.EmailAddress), "Person\u2019s email address must be 100 characters or less");
     }
 
     [Test]
@@ -536,7 +536,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         }
         else
         {
-            await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.EmailAddress), "Enter a valid email address");
+            await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.EmailAddress), "Enter a valid email address");
         }
     }
 
@@ -617,7 +617,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         }
         else
         {
-            await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.NationalInsuranceNumber), "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C");
+            await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.NationalInsuranceNumber), "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C");
         }
     }
 
@@ -662,7 +662,7 @@ public class PersonalDetailsTests(HostFixture hostFixture) : TestBase(hostFixtur
         }
         else
         {
-            await AssertEx.HtmlResponseHasErrorAsync(response, nameof(PersonalDetailsModel.NationalInsuranceNumber), "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C");
+            await AssertEx.HtmlResponseHasErrorAsync(response, nameof(IndexModel.NationalInsuranceNumber), "Enter a National Insurance number that is 2 letters, 6 numbers, then A, B, C or D, like QQ 12 34 56 C");
         }
     }
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/CheckAnswersTests.cs
@@ -39,7 +39,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -47,7 +47,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -70,7 +70,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -78,7 +78,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -106,7 +106,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -167,7 +167,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -196,7 +196,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -228,7 +228,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -254,12 +254,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
                 PersonId = CreateNewRecordPersonIdSentinel
             });
 
-        var expectedBackLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}";
-        var expectedChangeLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedBackLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -287,12 +287,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
                 PersonAttributeSourcesSet = true
             });
 
-        var expectedBackLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}";
-        var expectedChangeLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedBackLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -321,7 +321,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -329,7 +329,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -352,7 +352,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -360,7 +360,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -391,7 +391,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -465,7 +465,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -529,7 +529,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -574,7 +574,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MatchesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MatchesTests.cs
@@ -12,7 +12,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         // Arrange
         var taskReference = SupportTask.GenerateSupportTaskReference();
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/{taskReference}/matches");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/{taskReference}/resolve/matches");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -30,7 +30,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
             applicationUser.UserId,
             t => t.WithStatus(SupportTaskStatus.Closed));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -54,7 +54,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -91,7 +91,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -121,7 +121,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -146,7 +146,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -171,7 +171,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -203,7 +203,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -233,7 +233,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -271,7 +271,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -333,7 +333,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -401,7 +401,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -450,7 +450,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -476,7 +476,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -499,7 +499,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -524,7 +524,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -535,7 +535,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -555,7 +555,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -566,7 +566,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -600,7 +600,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", selectedPersonId } }
         };
@@ -647,7 +647,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", selectedPersonId } }
         };

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MergeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ApiTrnRequests/Resolve/MergeTests.cs
@@ -20,7 +20,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -28,7 +28,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -44,7 +44,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -52,7 +52,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -73,7 +73,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -104,7 +104,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -156,7 +156,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -196,7 +196,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -228,7 +228,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -250,7 +250,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -261,7 +261,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -277,7 +277,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -288,7 +288,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -314,7 +314,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -340,7 +340,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -374,7 +374,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder
             {
@@ -394,7 +394,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/api-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/CheckAnswersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/CheckAnswersTests.cs
@@ -40,7 +40,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -48,7 +48,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -71,7 +71,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -79,7 +79,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -107,7 +107,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -168,7 +168,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -197,7 +197,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -229,7 +229,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -256,12 +256,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
                 PersonAttributeSourcesSet = true
             });
 
-        var expectedBackLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}";
-        var expectedChangeLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedBackLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -289,12 +289,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
                 PersonAttributeSourcesSet = true
             });
 
-        var expectedBackLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}";
-        var expectedChangeLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedBackLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -323,7 +323,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -331,7 +331,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -354,7 +354,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -362,7 +362,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -415,7 +415,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -530,7 +530,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -573,7 +573,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -636,7 +636,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : NpqTrnRequestTestBase(
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/MatchesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/MatchesTests.cs
@@ -9,7 +9,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 {
     [Test]
     [Arguments(false, "details")]
-    [Arguments(true, "check-answers")]
+    [Arguments(true, "resolve/check-answers")]
     public async Task Get_HasExpectedBackLink(bool fromCheckAnswers, string expectedBackLink)
     {
         // Arrange
@@ -28,7 +28,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}" + (fromCheckAnswers ? "&fromCheckAnswers=true" : ""));
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}" + (fromCheckAnswers ? "&fromCheckAnswers=true" : ""));
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -52,7 +52,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         // Arrange
         var taskReference = SupportTask.GenerateSupportTaskReference();
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/npq-trn-requests/{taskReference}/matches");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/npq-trn-requests/{taskReference}/resolve/matches");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -70,7 +70,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
             applicationUser.UserId,
             t => t.WithStatus(SupportTaskStatus.Closed));
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -93,7 +93,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -127,7 +127,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -169,7 +169,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -213,7 +213,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -259,7 +259,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -292,7 +292,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -317,7 +317,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -342,7 +342,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -367,7 +367,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -399,7 +399,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -429,7 +429,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -499,7 +499,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -532,7 +532,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -558,7 +558,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -581,7 +581,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -606,7 +606,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -617,7 +617,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -637,7 +637,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", personId } }
         };
@@ -648,7 +648,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -679,7 +679,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", selectedPersonId } }
         };
@@ -720,7 +720,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder { { "PersonId", selectedPersonId } }
         };
@@ -761,7 +761,7 @@ public class MatchesTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostF
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/MergeTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/NpqTrnRequests/Resolve/MergeTests.cs
@@ -9,8 +9,8 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.NpqTrnRequ
 public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFixture)
 {
     [Test]
-    [Arguments(false, "matches")]
-    [Arguments(true, "check-answers")]
+    [Arguments(false, "resolve/matches")]
+    [Arguments(true, "resolve/check-answers")]
     public async Task Get_HasExpectedBackLink(bool fromCheckAnswers, string expectedBackLink)
     {
         // Arrange
@@ -29,7 +29,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}" + (fromCheckAnswers ? "&fromCheckAnswers=true" : ""));
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}" + (fromCheckAnswers ? "&fromCheckAnswers=true" : ""));
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -57,7 +57,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -65,7 +65,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -87,7 +87,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -95,7 +95,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -116,7 +116,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -147,7 +147,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -196,7 +196,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -233,7 +233,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -265,7 +265,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -293,7 +293,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -304,7 +304,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -326,7 +326,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -337,7 +337,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
     }
 
@@ -359,7 +359,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -385,7 +385,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -414,7 +414,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Post,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder
             {
@@ -431,7 +431,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal(
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -453,7 +453,7 @@ public class MergeTests(HostFixture hostFixture) : NpqTrnRequestTestBase(hostFix
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/npq-trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/ConfirmTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/ConfirmTests.cs
@@ -9,7 +9,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTaskReference = SupportTask.GenerateSupportTaskReference();
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTaskReference}/confirm");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTaskReference}/resolve/confirm");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -23,7 +23,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTask = await CreateSupportTaskAsync(SupportTaskStatus.Closed);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/confirm");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve/confirm");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -37,7 +37,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTaskReference = SupportTask.GenerateSupportTaskReference();
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTaskReference}/confirm");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTaskReference}/resolve/confirm");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -51,7 +51,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTask = await CreateSupportTaskAsync(SupportTaskStatus.Closed);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/confirm");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve/confirm");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -65,7 +65,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTask = await CreateSupportTaskAsync();
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/confirm");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve/confirm");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/IndexTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/IndexTests.cs
@@ -9,7 +9,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTaskReference = SupportTask.GenerateSupportTaskReference();
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTaskReference}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTaskReference}/resolve");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -23,7 +23,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTask = await CreateSupportTaskAsync(SupportTaskStatus.Closed);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -37,7 +37,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTask = await CreateSupportTaskAsync();
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -64,7 +64,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTaskReference = SupportTask.GenerateSupportTaskReference();
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTaskReference}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTaskReference}/resolve");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -78,7 +78,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var supportTask = await CreateSupportTaskAsync(SupportTaskStatus.Closed);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -93,7 +93,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var supportTask = await CreateSupportTaskAsync();
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve")
         {
             Content = new FormUrlEncodedContentBuilder
             {
@@ -106,7 +106,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/confirm", response.Headers.Location?.ToString());
+        Assert.Equal($"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve/confirm", response.Headers.Location?.ToString());
     }
 
     [Test]
@@ -115,7 +115,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var supportTask = await CreateSupportTaskAsync();
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -133,7 +133,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var supportTask = await CreateSupportTaskAsync();
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/manual-checks-needed/{supportTask.SupportTaskReference}/resolve")
         {
             Content = new FormUrlEncodedContentBuilder
             {


### PR DESCRIPTION
### Context

A number of journeys in the TRS Console are missing an Index page + some of the URLs are not quite right e.g. missing /resolve for the resolve support task journeys.

### Changes proposed in this pull request

Add an Index page for any journeys which are missing one (this can activate the journey and simply redirect to the first “proper” page in the journey) OR rename the obvious first page in the journey to be Index.
Correct paths as necessary.