### PR TITLE
Increase session and CSRF timeouts

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="FluentValidation" Version="12.1.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.13.0" />
-    <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.4.0" />
+    <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.4.2" />
     <PackageVersion Include="GovUk.Questions.AspNetCore" Version="0.1.0-alpha.0.94" />
     <PackageVersion Include="GovUk.Questions.AspNetCore.Testing" Version="0.1.0-alpha.0.94" />
     <PackageVersion Include="GovukNotify" Version="7.2.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Extensions.cs
@@ -46,7 +46,9 @@ public static class Extensions
             options.DefaultFileUploadJavaScriptEnhancements = true;
         });
 
-        services.AddSession();
+        // One Login has a one hour timeout on IDV journeys; we need to make sure our session cookies last that long too
+        // otherwise callbacks will fail due to the missing journey.
+        services.AddSession(options => options.IdleTimeout = TimeSpan.FromHours(1));
 
         services.AddGovUkQuestions();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
@@ -30,11 +30,11 @@
       },
       "GovUk.OneLogin.AspNetCore": {
         "type": "Direct",
-        "requested": "[0.4.0, )",
-        "resolved": "0.4.0",
-        "contentHash": "xmddqVvAp7m9B47sk9mczdGk/IjKca5dbnClcJCAOf/D4/sGbKbjavR2szu1uXWEIHU5v+TgegEia48LFed0IA==",
+        "requested": "[0.4.2, )",
+        "resolved": "0.4.2",
+        "contentHash": "q4jHwl6gJZnxoj0XBwj6WpJIDqdH7wwqYVwWysIMKM2qKV0+Y6S7qR9alOOkSzTYkMlaKwtS/gIYb1ehBqfUWw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.16"
+          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.25"
         }
       },
       "GovUk.Questions.AspNetCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.EndToEndTests/packages.lock.json
@@ -1109,7 +1109,7 @@
           "DartSassBuilder": "[1.1.0, )",
           "DfeAnalytics.AspNetCore": "[0.4.2, )",
           "GovUk.Frontend.AspNetCore": "[3.5.1, )",
-          "GovUk.OneLogin.AspNetCore": "[0.4.0, )",
+          "GovUk.OneLogin.AspNetCore": "[0.4.2, )",
           "GovUk.Questions.AspNetCore": "[0.1.0-alpha.0.94, )",
           "Humanizer.Core": "[3.0.10, )",
           "JetBrains.Annotations": "[2025.2.4, )",
@@ -1410,11 +1410,11 @@
       },
       "GovUk.OneLogin.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.0, )",
-        "resolved": "0.4.0",
-        "contentHash": "xmddqVvAp7m9B47sk9mczdGk/IjKca5dbnClcJCAOf/D4/sGbKbjavR2szu1uXWEIHU5v+TgegEia48LFed0IA==",
+        "requested": "[0.4.2, )",
+        "resolved": "0.4.2",
+        "contentHash": "q4jHwl6gJZnxoj0XBwj6WpJIDqdH7wwqYVwWysIMKM2qKV0+Y6S7qR9alOOkSzTYkMlaKwtS/gIYb1ehBqfUWw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.16"
+          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.25"
         }
       },
       "GovUk.Questions.AspNetCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
@@ -1103,7 +1103,7 @@
           "DartSassBuilder": "[1.1.0, )",
           "DfeAnalytics.AspNetCore": "[0.4.2, )",
           "GovUk.Frontend.AspNetCore": "[3.5.1, )",
-          "GovUk.OneLogin.AspNetCore": "[0.4.0, )",
+          "GovUk.OneLogin.AspNetCore": "[0.4.2, )",
           "GovUk.Questions.AspNetCore": "[0.1.0-alpha.0.94, )",
           "Humanizer.Core": "[3.0.10, )",
           "JetBrains.Annotations": "[2025.2.4, )",
@@ -1404,11 +1404,11 @@
       },
       "GovUk.OneLogin.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.0, )",
-        "resolved": "0.4.0",
-        "contentHash": "xmddqVvAp7m9B47sk9mczdGk/IjKca5dbnClcJCAOf/D4/sGbKbjavR2szu1uXWEIHU5v+TgegEia48LFed0IA==",
+        "requested": "[0.4.2, )",
+        "resolved": "0.4.2",
+        "contentHash": "q4jHwl6gJZnxoj0XBwj6WpJIDqdH7wwqYVwWysIMKM2qKV0+Y6S7qR9alOOkSzTYkMlaKwtS/gIYb1ehBqfUWw==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.16"
+          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.25"
         }
       },
       "GovUk.Questions.AspNetCore": {


### PR DESCRIPTION
We've got some errors in our logs for correlation errors and missing journeys after getting callbacks from One Login. One Login has a one hour allowance for IDV journeys but our session and CSRF tokens have a 15 minute timeout. This increases the session timeout to one hour and pulls in the latest OneLogin library, which increase the CSRF token lifetime to one hour.