### PR TITLE
Add new command to set a persons date of death.

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.MarkDeceasedCommand.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Commands.MarkDeceasedCommand.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.GetAnIdentity;
+using TeachingRecordSystem.Core.Services.OneLogin;
+using TeachingRecordSystem.Core.Services.Persons;
+using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.Core.Services.TrnRequests;
+using TeachingRecordSystem.Core.Services.Webhooks;
+
+namespace TeachingRecordSystem.Cli;
+
+public partial class Commands
+{
+    public static Command MarkDeceasedCommand(IConfiguration configuration)
+    {
+        var trn = new Option<string>("--trn") { Required = true };
+        var dateOfDeath = new Option<DateOnly>("--date-of-death") { Required = true };
+        var connectionStringOption = new Option<string>("--connection-string") { Required = true };
+        var configuredConnectionString = configuration.GetConnectionString("DefaultConnection");
+        if (configuredConnectionString is not null)
+        {
+            connectionStringOption.DefaultValueFactory = _ => configuredConnectionString;
+        }
+
+        var command =
+            new Command("mark-deceased",
+                "Marks a person as deceased")
+            {
+                trn, connectionStringOption,dateOfDeath
+            };
+
+        command.SetAction(async parseResult =>
+        {
+            var connectionString = parseResult.GetRequiredValue(connectionStringOption);
+            var environment = new HostingEnvironment { EnvironmentName = Environments.Production };
+
+            var services = new ServiceCollection()
+                .AddClock()
+                .AddDatabase(connectionString)
+                .AddTrnRequestService(configuration)
+                .AddPersonService()
+                .AddOneLoginService()
+                .AddSupportTaskService()
+                .AddWebhookOptions(configuration)
+                .AddWebhookDeliveryService(configuration)
+                .AddWebhookMessageFactory()
+                .AddMemoryCache()
+                .AddIdentityApi(configuration)
+                .AddEventPublisher()
+                .AddBackgroundJobScheduler(environment)
+                .AddHangfire(environment);
+
+            services.AddDbContext<IdDbContext>(
+                options => options.UseInMemoryDatabase("TeacherAuthId"),
+                contextLifetime: ServiceLifetime.Transient);
+
+            var serviceProvider = services.BuildServiceProvider();
+            using var scope = serviceProvider.CreateScope();
+            var personService = scope.ServiceProvider.GetRequiredService<PersonService>();
+            var dbContext = scope.ServiceProvider.GetRequiredService<TrsDbContext>();
+            var processContext = new ProcessContext(processType: ProcessType.PersonDeceased, now: DateTime.UtcNow,
+                SystemUser.SystemUserId);
+            var person = await dbContext.Persons.SingleAsync(x => x.Trn == parseResult.GetRequiredValue(trn));
+            await personService.DeactivatePersonAsync(
+                new DeactivatePersonOptions(
+                    PersonId: person.PersonId,
+                    DateOfDeath: parseResult.GetRequiredValue(dateOfDeath)),
+                processContext);
+        });
+
+        return command;
+    }
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Program.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Cli/Program.cs
@@ -18,7 +18,8 @@ var rootCommand = new RootCommand("Development tools for the Teaching Record Sys
     Commands.CreateResetTrnRequestCommand(configuration),
     Commands.CreateImportCapitaFileCommand(configuration),
     Commands.CreateImportClaimTestDataCommand(configuration),
-    Commands.CorrectQualificationStartDate(configuration)
+    Commands.CorrectQualificationStartDate(configuration),
+    Commands.MarkDeceasedCommand(configuration)
 };
 
 var parseResult = rootCommand.Parse(args);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Cli.Tests/CommandTests/MarkDeceasedTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Cli.Tests/CommandTests/MarkDeceasedTests.cs
@@ -1,0 +1,74 @@
+using System.CommandLine;
+
+namespace TeachingRecordSystem.Cli.Tests.CommandTests;
+
+public class MarkDeceasedTests(IServiceProvider services) : CommandTestBase(services)
+{
+    [Fact]
+    public async Task MissingTrnOption_ReturnsError()
+    {
+        // Arrange
+        var command = GetCommand();
+
+        var parseResult = command.Parse([
+            "mark-deceased"
+        ]);
+
+        // Act
+        var result = await parseResult.InvokeAsync();
+
+        // Assert
+        Assert.Contains(parseResult.Errors, e => e.Message == "Option '--trn' is required.");
+    }
+
+    [Fact]
+    public async Task MissingDateOfDeathOption_ReturnsError()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+
+        var command = GetCommand();
+
+        var parseResult = command.Parse([
+            "mark-deceased", "--trn", person.Trn
+        ]);
+
+        // Act
+        var result = await parseResult.InvokeAsync();
+
+        // Assert
+        Assert.Contains(parseResult.Errors, e => e.Message == "Option '--date-of-death' is required.");
+    }
+
+    [Fact]
+    public async Task ValidInvocation_DeactivatesPerson()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var dateOfDeath = Clock.Today.AddDays(-1);
+
+        var command = GetCommand();
+
+        var parseResult = command.Parse([
+            "mark-deceased", "--trn", person.Trn,"--date-of-death", dateOfDeath.ToString()
+        ]);
+
+        // Act
+        var result = await parseResult.InvokeAsync();
+
+        // Assert
+        Assert.Equal(0, result);
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updatePerson = await dbContext.Persons
+                .IgnoreQueryFilters()
+                .SingleOrDefaultAsync(t => t.Trn == person.Trn);
+
+            Assert.NotNull(updatePerson?.DateOfDeath);
+            Assert.Equal(dateOfDeath, updatePerson.DateOfDeath);
+        });
+    }
+
+    private Command GetCommand() => Commands.MarkDeceasedCommand(Configuration);
+}
+


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/18?pane=issue&itemId=173999513&issue=DFE-Digital%7Cteaching-record-team-project-board%7C183

A new command to make it easier to mark a person as deceased.

### Changes proposed in this pull request

Add new  cli command to mark a person as deceased.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally