### PR TITLE
Fallback to 'Exempt' induction exemption reason

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -647,7 +647,7 @@ public class Person
 
         var routeLevelExemptionIds = holdsRoutes
             .Where(r => r.ExemptFromInduction == true)
-            .Select(r => r.RouteToProfessionalStatusType!.InductionExemptionReasonId!.Value)
+            .Select(r => r.RouteToProfessionalStatusType!.InductionExemptionReasonId ?? InductionExemptionReason.ExemptId)
             .Concat(holdsRoutes
                 .Where(r => r.ExemptFromInductionDueToQtsDate == true)
                 .Select(_ => InductionExemptionReason.QualifiedBefore7May2000Id));


### PR DESCRIPTION
We have a few route types with a missing exemption reason ID. This is a temporary workaround to use the general 'Exempt' reason until we have the more-specific reasons assigned.