### PR TITLE
Fix up interruption panel styles

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Found.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Found.cshtml
@@ -5,7 +5,7 @@
 }
 
 <form method="post">
-    <govuk-panel class="trs-panel--left">
+    <govuk-panel class="govuk-panel govuk-panel--interruption trs-panel--left">
         <govuk-panel-title>
             @ViewBag.Title
         </govuk-panel-title>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NoTrn.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NoTrn.cshtml
@@ -12,17 +12,18 @@
             A teacher reference number (TRN) is a 7-digit number that uniquely identifies you in the education sector in England.
         </p>
 
-        <p class="govuk-body">
+        <p class="govuk-body govuk-!-margin-bottom-0">
             You’ll have a TRN if you:
-            <ul class="govuk-list govuk-list--bullet">
-                <li>hold qualified teacher status (QTS) in England or Wales</li>
-                <li>hold early years teacher status (EYTS) in England</li>
-                <li>hold a national professional qualification (NPQ)</li>
-                <li>are working towards QTS, EYTS or an NPQ</li>
-                <li>contribute to the Teachers’ Pension Scheme in England or Wales</li>
-                <li>have a relevant restriction in relation to teaching in England</li>
-            </ul>
         </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>hold qualified teacher status (QTS) in England or Wales</li>
+            <li>hold early years teacher status (EYTS) in England</li>
+            <li>hold a national professional qualification (NPQ)</li>
+            <li>are working towards QTS, EYTS or an NPQ</li>
+            <li>contribute to the Teachers’ Pension Scheme in England or Wales</li>
+            <li>have a relevant restriction in relation to teaching in England</li>
+        </ul>
 
         <p class="govuk-body">
             You may not have one yet if you work in early years, further education or qualified as a teacher outside of England.

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotVerified.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/NotVerified.cshtml
@@ -22,14 +22,15 @@
 
             <p class="govuk-body govuk-!-margin-bottom-0">
                 We’ll ask for:
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>your name</li>
-                    <li>your date of birth</li>
-                    <li>your National Insurance number</li>
-                    <li>your teacher reference number (TRN)</li>
-                    <li>proof of your identity, such as a passport or driving licence</li>
-                </ul>
             </p>
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>your name</li>
+                <li>your date of birth</li>
+                <li>your National Insurance number</li>
+                <li>your teacher reference number (TRN)</li>
+                <li>proof of your identity, such as a passport or driving licence</li>
+            </ul>
 
             <button class="trs-panel--interruption__link-button govuk-!-margin-bottom-0">Verify using my personal details</button>
         </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/wwwroot/Styles/site.scss
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/wwwroot/Styles/site.scss
@@ -4,21 +4,6 @@
 
 .trs-panel--left {
   text-align: left;
-
-  .govuk-body, .govuk-body-l {
-    color: govuk-colour("white");
-  }
-
-  .govuk-button,
-  .govuk-button:disabled:hover {
-    color: $govuk-text-colour;
-    background-color: govuk-colour("white");
-    box-shadow: 0 2px 0 govuk-colour("dark-grey");
-  }
-
-  .govuk-button:hover {
-    background-color: govuk-colour("mid-grey");
-  }
 }
 
 .trs-empty-fallback {
@@ -27,10 +12,10 @@
 
 .trs-panel--interruption__link-button {
   @extend .govuk-link;
-  @extend .govuk-body;
+  @extend .govuk-link--inverse;
   background: none;
   border: 0;
-  color: govuk-colour("white") !important;
   cursor: pointer;
-  @include govuk-font($size: 19, $line-height: 19px);
+  padding: 0;
+  @include govuk-font($size: 19);
 }


### PR DESCRIPTION
Fixes contrast on one of the link buttons in an interruption panel. Also removes some redundant classes and moves `<ul>`s outside of `<p>` tags.