### PR TITLE
Increase session timeout & log auth warnings

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Extensions.cs
@@ -48,7 +48,7 @@ public static class Extensions
 
         // One Login has a one hour timeout on IDV journeys; we need to make sure our session cookies last that long too
         // otherwise callbacks will fail due to the missing journey.
-        services.AddSession(options => options.IdleTimeout = TimeSpan.FromHours(1));
+        services.AddSession(options => options.IdleTimeout = TimeSpan.FromHours(2));
 
         services.AddGovUkQuestions();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/appsettings.json
@@ -1,7 +1,10 @@
 {
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Override": {
+        "Microsoft.AspNetCore.Authentication": "Warning"
+      }
     },
     "Enrich": [ "FromLogContext" ],
     "Using": [ "Serilog.Expressions" ]


### PR DESCRIPTION
We're still seeing the odd authentication error with One Login. This further increases session timeout to be absolutely sure we have a valid journey around when the user returns from One Login. The log level is amended to capture authentication-related Warnings too.