### PR TITLE
Add short name to one login pages

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/IdVerification.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/IdVerification.cshtml
@@ -74,6 +74,11 @@
                                 link-template="@(direction => LinkGenerator.SupportTasks.OneLoginUserMatching.IdVerification(Model.Search, OneLoginUserIdVerificationSupportTasksSortByOption.Email, direction))">
                                 Email address
                             </th>
+                            <th scope="col" class="govuk-table__header trs-!-width-150"
+                                sort-direction="@(Model.SortBy == OneLoginUserIdVerificationSupportTasksSortByOption.Source ? Model.SortDirection : null)"
+                                link-template="@(direction => LinkGenerator.SupportTasks.OneLoginUserMatching.IdVerification(search: Model.Search, OneLoginUserIdVerificationSupportTasksSortByOption.Source, direction))">
+                                Source
+                            </th>
                         </tr>
                     </thead>
                     <tbody class="govuk-table__body" data-testid="results">
@@ -94,6 +99,9 @@
                                     <support-task-status-tag status="@result.Status"/>
                                 </td>
                                 <td class="govuk-table__cell" data-testid="email">@result.EmailAddress</td>
+                                <td class="govuk-table__cell" data-testid="source">
+                                    <tag color="TagColor.Auto">@result.SourceApplicationName</tag>
+                                </td>
                             </tr>
                         }
                     </tbody>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/RecordMatching.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/RecordMatching.cshtml
@@ -73,6 +73,12 @@
                                 link-template="@(direction => LinkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching(Model.Search, OneLoginUserRecordMatchingSupportTasksSortByOption.Email, direction))">
                                 Email address
                             </th>
+                            <th scope="col" class="govuk-table__header trs-!-width-150"
+                                sort-direction="@(Model.SortBy == OneLoginUserRecordMatchingSupportTasksSortByOption.Source ? Model.SortDirection : null)"
+                                link-template="@(direction => LinkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching(search: Model.Search, OneLoginUserRecordMatchingSupportTasksSortByOption.Source, direction))">
+                                Source
+                            </th>
+
                         </tr>
                     </thead>
                     <tbody class="govuk-table__body" data-testid="results">
@@ -93,6 +99,9 @@
                                     <support-task-status-tag status="@result.Status"/>
                                 </td>
                                 <td class="govuk-table__cell" data-testid="email">@result.EmailAddress</td>
+                                <td class="govuk-table__cell" data-testid="source">
+                                    <tag color="TagColor.Auto">@result.SourceApplicationName</tag>
+                                </td>
                             </tr>
                         }
                     </tbody>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserIdVerificationSupportTasksSearchResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserIdVerificationSupportTasksSearchResult.cs
@@ -12,7 +12,8 @@ public record OneLoginUserIdVerificationSupportTasksSearchResultItem(
     string FirstName,
     string LastName,
     string? EmailAddress,
-    DateTime CreatedOn) : ISupportTaskSearchResult
+    DateTime CreatedOn,
+    string SourceApplicationName) : ISupportTaskSearchResult
 {
     public string Name => $"{FirstName} {LastName}";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserIdVerificationSupportTasksSortByOption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserIdVerificationSupportTasksSortByOption.cs
@@ -5,5 +5,6 @@ public enum OneLoginUserIdVerificationSupportTasksSortByOption
     SupportTaskReference,
     Name,
     Email,
-    RequestedOn
+    RequestedOn,
+    Source
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserRecordMatchingSupportTasksSearchResult.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserRecordMatchingSupportTasksSearchResult.cs
@@ -13,7 +13,8 @@ public record OneLoginUserRecordMatchingSupportTasksSearchResultItem(
     string LastName,
     string[] OtherVerifiedNames,
     string? EmailAddress,
-    DateTime CreatedOn) : ISupportTaskSearchResult
+    DateTime CreatedOn,
+    string SourceApplicationName) : ISupportTaskSearchResult
 {
     public string Name => $"{FirstName} {LastName}";
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserRecordMatchingSupportTasksSortByOption.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/OneLoginUserRecordMatchingSupportTasksSortByOption.cs
@@ -5,5 +5,6 @@ public enum OneLoginUserRecordMatchingSupportTasksSortByOption
     SupportTaskReference,
     Name,
     Email,
-    RequestedOn
+    RequestedOn,
+    Source
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/SupportTaskSearchService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/SupportTaskSearchService.cs
@@ -343,14 +343,34 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
 
         var taskCount = tasks.Count;
 
+        var clientUserIds = tasks
+            .Select(t => ((OneLoginUserIdVerificationData)t.Data!).ClientApplicationUserId)
+            .Distinct()
+            .ToList();
+
+        var users = await dbContext.ApplicationUsers
+            .Where(u => clientUserIds.Contains(u.UserId))
+            .Select(u => new
+            {
+                u.UserId,
+                ShortName = (u.ShortName ?? u.Name)!
+            })
+            .ToDictionaryAsync(u => u.UserId, u => u.ShortName);
+
         var results = tasks
-            .Select(r => new OneLoginUserIdVerificationSupportTasksSearchResultItem(
-                r.SupportTaskReference,
-                r.Status,
-                (r.Data as OneLoginUserIdVerificationData)!.StatedFirstName,
-                (r.Data as OneLoginUserIdVerificationData)!.StatedLastName,
-                r.OneLoginUser!.EmailAddress,
-                r.CreatedOn))
+            .Select(r =>
+            {
+                var data = (OneLoginUserIdVerificationData)r.Data!;
+                return new OneLoginUserIdVerificationSupportTasksSearchResultItem(
+                    r.SupportTaskReference,
+                    r.Status,
+                    data.StatedFirstName,
+                    data.StatedLastName,
+                    r.OneLoginUser!.EmailAddress,
+                    r.CreatedOn,
+                    users[data.ClientApplicationUserId]!
+                );
+            })
             .AsQueryable();
 
         if (SearchTextIsDate(search, out var minDate, out var maxDate))
@@ -383,6 +403,7 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
                 .ThenBy(r => r.LastName, sortDirection),
             OneLoginUserIdVerificationSupportTasksSortByOption.Email => results.OrderBy(r => r.EmailAddress, sortDirection),
             OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn => results.OrderBy(r => r.CreatedOn, sortDirection).ThenBy(r => r.SupportTaskReference, sortDirection),
+            OneLoginUserIdVerificationSupportTasksSortByOption.Source => results.OrderBy(r => r.SourceApplicationName, sortDirection),
             _ => results
         }).GetPage(paginationOptions.PageNumber, paginationOptions.ItemsPerPage, totalFilteredTaskCount);
 
@@ -404,17 +425,38 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
             .Where(t => t.SupportTaskType == SupportTaskType.OneLoginUserRecordMatching && t.Status != SupportTaskStatus.Closed)
             .ToListAsync();
 
+        var clientUserIds = tasks
+            .Select(t => ((OneLoginUserRecordMatchingData)t.Data!).ClientApplicationUserId)
+            .Distinct()
+            .ToList();
+
+        var users = await dbContext.ApplicationUsers.IgnoreQueryFilters()
+            .Where(u => clientUserIds.Contains(u.UserId))
+            .Select(u => new
+            {
+                u.UserId,
+                ShortName = (u.ShortName ?? u.Name)!
+            })
+            .ToDictionaryAsync(u => u.UserId, u => u.ShortName);
+
         var taskCount = tasks.Count;
 
         var results = tasks
-            .Select(r => new OneLoginUserRecordMatchingSupportTasksSearchResultItem(
-                r.SupportTaskReference,
-                r.Status,
-                (r.Data as OneLoginUserRecordMatchingData)!.VerifiedNames!.First().First(),
-                (r.Data as OneLoginUserRecordMatchingData)!.VerifiedNames!.First().Last(),
-                (r.Data as OneLoginUserRecordMatchingData)!.VerifiedNames!.Skip(1).SelectMany(n => n).ToArray(),
-                r.OneLoginUser!.EmailAddress,
-                r.CreatedOn))
+            .Select(r =>
+            {
+                var data = (r.Data as OneLoginUserRecordMatchingData)!;
+                var name = users[(r.Data as OneLoginUserRecordMatchingData)!.ClientApplicationUserId];
+                return new OneLoginUserRecordMatchingSupportTasksSearchResultItem(
+                    r.SupportTaskReference,
+                    r.Status,
+                    data.VerifiedNames!.First().First(),
+                    data.VerifiedNames!.First().Last(),
+                    data.VerifiedNames!.Skip(1).SelectMany(n => n).ToArray(),
+                    r.OneLoginUser!.EmailAddress,
+                    r.CreatedOn,
+                    name
+                );
+            })
             .AsQueryable();
 
         if (SearchTextIsDate(search, out var minDate, out var maxDate))
@@ -447,6 +489,7 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
                 .ThenBy(r => r.LastName, sortDirection),
             OneLoginUserRecordMatchingSupportTasksSortByOption.Email => results.OrderBy(r => r.EmailAddress, sortDirection),
             OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn => results.OrderBy(r => r.CreatedOn, sortDirection).ThenBy(r => r.SupportTaskReference, sortDirection),
+            OneLoginUserRecordMatchingSupportTasksSortByOption.Source => results.OrderBy(r => r.SourceApplicationName, sortDirection),
             _ => results
         }).GetPage(paginationOptions.PageNumber, paginationOptions.ItemsPerPage, totalFilteredTaskCount);
 

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserRecordMatchingTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserRecordMatchingTests.cs
@@ -8,7 +8,6 @@ public class OneLoginUserRecordMatchingTests(HostFixture hostFixture) : TestBase
     public async Task Match()
     {
         var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
-
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
 
         var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
@@ -42,7 +41,6 @@ public class OneLoginUserRecordMatchingTests(HostFixture hostFixture) : TestBase
     public async Task NoMatch()
     {
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
-
         var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject);
         var taskData = supportTask.GetData<OneLoginUserRecordMatchingData>();
         var firstName = taskData.VerifiedNames![0][0];
@@ -103,7 +101,6 @@ public class OneLoginUserRecordMatchingTests(HostFixture hostFixture) : TestBase
     public async Task StartMatchAndComeBackLater()
     {
         var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
-
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
 
         var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/IdVerificationTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/IdVerificationTests.cs
@@ -4,7 +4,6 @@ using AngleSharp.Html.Dom;
 using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.SupportUi;
 using TeachingRecordSystem.SupportUi.Services.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUserMatching;
@@ -18,14 +17,15 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
         // Arrange
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync(shortName: "xx");
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser1.Subject, configure =>
-                configure.WithStatedFirstName("Alphie").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2025,1,22, 1, 1, 1))),
+                configure.WithStatedFirstName("Alphie").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2025,1,22, 1, 1, 1)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser1.Subject, configure =>
-                configure.WithStatedFirstName("Bert").WithStatedLastName("Johnson").WithCreatedOn(new DateTime(2025,1,22, 1, 0, 0))),
+                configure.WithStatedFirstName("Bert").WithStatedLastName("Johnson").WithCreatedOn(new DateTime(2025,1,22, 1, 0, 0)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser2.Subject, configure =>
-                configure.WithStatedFirstName("Colin").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2025,1,20, 1, 1, 1)))
+                configure.WithStatedFirstName("Colin").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2025,1,20, 1, 1, 1)).WithClientApplicationUserId(applicationUser.UserId))
         };
         var expectedResults = supportTasksList
             .Join([oneLoginUser1, oneLoginUser2],
@@ -37,7 +37,8 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
                     ((OneLoginUserIdVerificationData)task.Data).StatedFirstName,
                     ((OneLoginUserIdVerificationData)task.Data).StatedLastName,
                     task.CreatedOn,
-                    user.EmailAddress
+                    user.EmailAddress,
+                    applicationUser.ShortName
                 })
             .ToArray();
 
@@ -58,12 +59,14 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
         AssertRowHasContent(topRow, "task-name-and-id", expectedFirstResult.SupportTaskReference);
         AssertRowHasContent(topRow, "email", expectedFirstResult.EmailAddress!);
         AssertRowHasContent(topRow, "requested-on", expectedFirstResult.CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
+        AssertRowHasContent(topRow, "source", expectedFirstResult.ShortName!);
 
         var nextRow = resultRows[1];
         var expectedNextResult = expectedResults[1];
         AssertRowHasContent(nextRow, "task-name-and-id", expectedNextResult.SupportTaskReference);
         AssertRowHasContent(nextRow, "email", expectedNextResult.EmailAddress!);
         AssertRowHasContent(nextRow, "requested-on", expectedNextResult.CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
+        AssertRowHasContent(nextRow, "source", expectedFirstResult.ShortName!);
     }
 
     [Theory]
@@ -98,25 +101,31 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
         AssertRowHasContent(resultRows[1], "task-name-and-id", expectedNextResult.SupportTaskReference);
     }
 
-    [Theory]
-    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Ascending)]
-    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Descending)]
-    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn, SortDirection.Ascending)]
-    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn, SortDirection.Descending)]
-    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Email, SortDirection.Ascending)]
-    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Email, SortDirection.Descending)]
-    public async Task Get_OrderListByOption_OrdersList(OneLoginUserIdVerificationSupportTasksSortByOption sortBy, SortDirection sortDirection)
+    [Fact]
+    public async Task Get_RecordsWithNoApplicationShortname_ShowApplicationName()
     {
         // Arrange
+        var sortBy = OneLoginUserIdVerificationSupportTasksSortByOption.Email;
+        var sortDirection = SortDirection.Ascending;
+        var applicationUser1 = await TestData.CreateApplicationUserAsync(name: "Access your Teaching Qualifications");
+        var applicationUser2 = await TestData.CreateApplicationUserAsync(name: "National Professional Qualification");
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Aaron@example.com"), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Sam@example.com"), verifiedInfo: null);
         var supportTask1 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser1.Subject, options => options
             .WithStatedFirstName("Aaron")
-            .WithStatedLastName("Aerosmith"));
+            .WithStatedLastName("Aerosmith")
+            .WithClientApplicationUserId(applicationUser1.UserId));
         Clock.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser2.Subject, options => options
             .WithStatedFirstName("Sam")
-            .WithStatedLastName("Smith"));
+            .WithStatedLastName("Smith")
+            .WithClientApplicationUserId(applicationUser2.UserId));
+
+        var applicationUsers = new Dictionary<Guid, string>
+        {
+            { applicationUser1.UserId, applicationUser1.Name! },
+            { applicationUser2.UserId, applicationUser2.Name! }
+        };
 
         var expectedResults = (new[] { supportTask1, supportTask2 })
             .Join([oneLoginUser1, oneLoginUser2],
@@ -129,7 +138,73 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
                     ((OneLoginUserIdVerificationData)task.Data).StatedLastName,
                     task.Status,
                     task.CreatedOn,
-                    user.EmailAddress
+                    user.EmailAddress,
+                    ShortName = applicationUsers[((OneLoginUserIdVerificationData)task.Data).ClientApplicationUserId]
+                });
+
+        var expectedResultsOrdered = expectedResults.OrderBy(s => s.EmailAddress).ToArray();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/one-login-user-matching/id-verification?sortBy={sortBy}&sortDirection={sortDirection}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var resultRows = doc.GetElementByTestId("results")?
+            .QuerySelectorAll("tbody > tr");
+
+        Assert.NotNull(resultRows);
+        AssertRowHasContent(resultRows[0], "source", expectedResultsOrdered[0].ShortName!);
+        AssertRowHasContent(resultRows[1], "source", expectedResultsOrdered[1].ShortName!);
+    }
+
+    [Theory]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Ascending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Descending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn, SortDirection.Ascending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn, SortDirection.Descending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Email, SortDirection.Ascending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Email, SortDirection.Descending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Source, SortDirection.Ascending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Source, SortDirection.Descending)]
+    public async Task Get_OrderListByOption_OrdersList(OneLoginUserIdVerificationSupportTasksSortByOption sortBy, SortDirection sortDirection)
+    {
+        // Arrange
+        var applicationUser1 = await TestData.CreateApplicationUserAsync(name: "Access your Teaching Qualifications", shortName: "AYTQ");
+        var applicationUser2 = await TestData.CreateApplicationUserAsync(name: "National Professional Qualification", shortName: "NPQ");
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Aaron@example.com"), verifiedInfo: null);
+        var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Sam@example.com"), verifiedInfo: null);
+        var supportTask1 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser1.Subject, options => options
+            .WithStatedFirstName("Aaron")
+            .WithStatedLastName("Aerosmith")
+            .WithClientApplicationUserId(applicationUser1.UserId));
+        Clock.Advance(TimeSpan.FromDays(1));
+        var supportTask2 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser2.Subject, options => options
+            .WithStatedFirstName("Sam")
+            .WithStatedLastName("Smith")
+            .WithClientApplicationUserId(applicationUser2.UserId));
+
+        var applicationUsers = new Dictionary<Guid, string>
+        {
+            { applicationUser1.UserId, applicationUser1.ShortName! },
+            { applicationUser2.UserId, applicationUser2.ShortName! }
+        };
+
+        var expectedResults = (new[] { supportTask1, supportTask2 })
+            .Join([oneLoginUser1, oneLoginUser2],
+                task => ((OneLoginUserIdVerificationData)task.Data).OneLoginUserSubject,
+                user => user.Subject,
+                (task, user) => new
+                {
+                    task.SupportTaskReference,
+                    ((OneLoginUserIdVerificationData)task.Data).StatedFirstName,
+                    ((OneLoginUserIdVerificationData)task.Data).StatedLastName,
+                    task.Status,
+                    task.CreatedOn,
+                    user.EmailAddress,
+                    ShortName = applicationUsers[((OneLoginUserIdVerificationData)task.Data).ClientApplicationUserId]
                 });
 
         var expectedResultsOrdered = (sortBy switch
@@ -146,6 +221,9 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
             OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn => sortDirection == SortDirection.Ascending
                 ? expectedResults.OrderBy(s => s.CreatedOn)
                 : expectedResults.OrderByDescending(s => s.CreatedOn),
+            OneLoginUserIdVerificationSupportTasksSortByOption.Source => sortDirection == SortDirection.Ascending
+                ? expectedResults.OrderBy(s => s.ShortName)
+                : expectedResults.OrderByDescending(s => s.ShortName),
             _ => expectedResults
         }).ToArray();
 
@@ -167,6 +245,8 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
         AssertRowHasContent(resultRows[1], "status", expectedResultsOrdered[1].Status.GetDisplayName()!);
         AssertRowHasContent(resultRows[0], "requested-on", expectedResultsOrdered[0].CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
         AssertRowHasContent(resultRows[1], "requested-on", expectedResultsOrdered[1].CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
+        AssertRowHasContent(resultRows[0], "source", expectedResultsOrdered[0].ShortName!);
+        AssertRowHasContent(resultRows[1], "source", expectedResultsOrdered[1].ShortName!);
     }
 
     [Theory]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/RecordMatchingTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/RecordMatchingTests.cs
@@ -4,7 +4,6 @@ using AngleSharp.Html.Dom;
 using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.SupportUi;
 using TeachingRecordSystem.SupportUi.Services.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUserMatching;
@@ -18,15 +17,23 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         // Arrange
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync(shortName: "x");
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", "Smith"]).WithCreatedOn(new DateTime(2025,1,22, 1, 1, 1))),
+                configure.WithVerifiedNames(["Alphie", "Smith"])
+                    .WithCreatedOn(new DateTime(2025,1,22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, configure =>
-                configure.WithVerifiedNames(["Bert", "Johnson"]).WithCreatedOn(new DateTime(2025,1,22, 1, 0, 0))),
+                configure.WithVerifiedNames(["Bert", "Johnson"])
+                    .WithCreatedOn(new DateTime(2025,1,22, 1, 0, 0))
+                    .WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", "Smith"]).WithCreatedOn(new DateTime(2025,1,20, 1, 1, 1)))
+                configure.WithVerifiedNames(["Colin", "Smith"])
+                    .WithCreatedOn(new DateTime(2025,1,20, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId))
         };
+
         var expectedResults = supportTasksList
             .Join([oneLoginUser1, oneLoginUser2],
                 task => ((OneLoginUserRecordMatchingData)task.Data).OneLoginUserSubject,
@@ -37,7 +44,8 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
                     FirstName = ((OneLoginUserRecordMatchingData)task.Data).VerifiedNames!.First().First(),
                     LastName = ((OneLoginUserRecordMatchingData)task.Data).VerifiedNames!.First().Last(),
                     task.CreatedOn,
-                    user.EmailAddress
+                    user.EmailAddress,
+                    applicationUser.ShortName
                 })
             .ToArray();
 
@@ -58,12 +66,14 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         AssertRowHasContent(topRow, "task-name-and-id", expectedFirstResult.SupportTaskReference);
         AssertRowHasContent(topRow, "email", expectedFirstResult.EmailAddress!);
         AssertRowHasContent(topRow, "requested-on", expectedFirstResult.CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
+        AssertRowHasContent(topRow, "source", expectedFirstResult.ShortName!);
 
         var nextRow = resultRows[1];
         var expectedNextResult = expectedResults[1];
         AssertRowHasContent(nextRow, "task-name-and-id", expectedNextResult.SupportTaskReference);
         AssertRowHasContent(nextRow, "email", expectedNextResult.EmailAddress!);
         AssertRowHasContent(nextRow, "requested-on", expectedNextResult.CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
+        AssertRowHasContent(nextRow, "source", expectedFirstResult.ShortName!);
     }
 
     [Theory]
@@ -98,23 +108,29 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         AssertRowHasContent(resultRows[1], "task-name-and-id", expectedNextResult.SupportTaskReference);
     }
 
-    [Theory]
-    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending)]
-    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Descending)]
-    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn, SortDirection.Ascending)]
-    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn, SortDirection.Descending)]
-    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Email, SortDirection.Ascending)]
-    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Email, SortDirection.Descending)]
-    public async Task Get_OrderListByOption_OrdersList(OneLoginUserRecordMatchingSupportTasksSortByOption sortBy, SortDirection sortDirection)
+    [Fact]
+    public async Task Get_RecordsWithNoApplicationShortname_ShowApplicationName()
     {
         // Arrange
+        var sortBy = OneLoginUserRecordMatchingSupportTasksSortByOption.Email;
+        var sortDirection = SortDirection.Ascending;
+        var applicationUser1 = await TestData.CreateApplicationUserAsync(name: "Access your Teaching Qualifications");
+        var applicationUser2 = await TestData.CreateApplicationUserAsync(name: "National Professional Qualification");
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Aaron@example.com"), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Sam@example.com"), verifiedInfo: null);
         var supportTask1 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, options => options
-            .WithVerifiedNames(["Aaron", "Aerosmith"]));
+            .WithVerifiedNames(["Aaron", "Aerosmith"])
+            .WithClientApplicationUserId(applicationUser1.UserId));
         Clock.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, options => options
-            .WithVerifiedNames(["Sam", "Smith"]));
+            .WithVerifiedNames(["Sam", "Smith"])
+            .WithClientApplicationUserId(applicationUser2.UserId));
+
+        var applicationUsers = new Dictionary<Guid, string>
+        {
+            { applicationUser1.UserId, applicationUser1.Name! },
+            { applicationUser2.UserId, applicationUser2.Name! }
+        };
 
         var expectedResults = (new[] { supportTask1, supportTask2 })
             .Join([oneLoginUser1, oneLoginUser2],
@@ -127,7 +143,71 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
                     LastName = ((OneLoginUserRecordMatchingData)task.Data).VerifiedNames!.First().Last(),
                     task.Status,
                     task.CreatedOn,
-                    user.EmailAddress
+                    user.EmailAddress,
+                    ShortName = applicationUsers[((OneLoginUserRecordMatchingData)task.Data).ClientApplicationUserId]
+                });
+
+        var expectedResultsOrdered = expectedResults.OrderBy(s => s.ShortName).ToArray();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/one-login-user-matching/record-matching?sortBy={sortBy}&sortDirection={sortDirection}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var resultRows = doc.GetElementByTestId("results")?
+            .QuerySelectorAll("tbody > tr");
+
+        Assert.NotNull(resultRows);
+        AssertRowHasContent(resultRows[0], "source", expectedResultsOrdered[0].ShortName!);
+        AssertRowHasContent(resultRows[1], "source", expectedResultsOrdered[1].ShortName!);
+    }
+
+    [Theory]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Descending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn, SortDirection.Ascending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn, SortDirection.Descending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Email, SortDirection.Ascending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Email, SortDirection.Descending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Source, SortDirection.Descending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Source, SortDirection.Ascending)]
+    public async Task Get_OrderListByOption_OrdersList(OneLoginUserRecordMatchingSupportTasksSortByOption sortBy, SortDirection sortDirection)
+    {
+        // Arrange
+        var applicationUser1 = await TestData.CreateApplicationUserAsync(name: "Access your Teaching Qualifications", shortName: "AYTQ");
+        var applicationUser2 = await TestData.CreateApplicationUserAsync(name: "National Professional Qualification", shortName: "NPQ");
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Aaron@example.com"), verifiedInfo: null);
+        var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Sam@example.com"), verifiedInfo: null);
+        var supportTask1 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, options => options
+            .WithVerifiedNames(["Aaron", "Aerosmith"])
+            .WithClientApplicationUserId(applicationUser1.UserId));
+        Clock.Advance(TimeSpan.FromDays(1));
+        var supportTask2 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, options => options
+            .WithVerifiedNames(["Sam", "Smith"])
+            .WithClientApplicationUserId(applicationUser2.UserId));
+
+        var applicationUsers = new Dictionary<Guid, string>
+        {
+            { applicationUser1.UserId, applicationUser1.ShortName! },
+            { applicationUser2.UserId, applicationUser2.ShortName! }
+        };
+
+        var expectedResults = (new[] { supportTask1, supportTask2 })
+            .Join([oneLoginUser1, oneLoginUser2],
+                task => ((OneLoginUserRecordMatchingData)task.Data).OneLoginUserSubject,
+                user => user.Subject,
+                (task, user) => new
+                {
+                    task.SupportTaskReference,
+                    FirstName = ((OneLoginUserRecordMatchingData)task.Data).VerifiedNames!.First().First(),
+                    LastName = ((OneLoginUserRecordMatchingData)task.Data).VerifiedNames!.First().Last(),
+                    task.Status,
+                    task.CreatedOn,
+                    user.EmailAddress,
+                    ShortName = applicationUsers[((OneLoginUserRecordMatchingData)task.Data).ClientApplicationUserId]
                 });
 
         var expectedResultsOrdered = (sortBy switch
@@ -144,6 +224,9 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
             OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn => sortDirection == SortDirection.Ascending
                 ? expectedResults.OrderBy(s => s.CreatedOn)
                 : expectedResults.OrderByDescending(s => s.CreatedOn),
+            OneLoginUserRecordMatchingSupportTasksSortByOption.Source => sortDirection == SortDirection.Ascending
+                ? expectedResults.OrderBy(s => s.ShortName)
+                : expectedResults.OrderByDescending(s => s.ShortName),
             _ => expectedResults
         }).ToArray();
 
@@ -165,6 +248,8 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         AssertRowHasContent(resultRows[1], "status", expectedResultsOrdered[1].Status.GetDisplayName()!);
         AssertRowHasContent(resultRows[0], "requested-on", expectedResultsOrdered[0].CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
         AssertRowHasContent(resultRows[1], "requested-on", expectedResultsOrdered[1].CreatedOn.ToString(WebConstants.DateOnlyDisplayFormat));
+        AssertRowHasContent(resultRows[0], "source", expectedResultsOrdered[0].ShortName!);
+        AssertRowHasContent(resultRows[1], "source", expectedResultsOrdered[1].ShortName!);
     }
 
     [Theory]
@@ -204,6 +289,7 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         // Arrange
         var pageSize = 20;
         var page = 1;
+
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("Aaron@example.com"), verifiedInfo: null);
 
         // Create multiple pages

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnectTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnectTests.cs
@@ -236,6 +236,7 @@ public class ConfirmConnectTests(HostFixture hostFixture) : ResolveOneLoginUserM
     private async Task<(OneLoginUser User, SupportTask SupportTask, Person MatchedPerson)> CreateUserSupportTaskAndMatchingPerson(bool isRecordMatchingOnlySupportTask)
     {
         var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        var applicationUser = await TestData.CreateApplicationUserAsync();
 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
 
@@ -244,13 +245,15 @@ public class ConfirmConnectTests(HostFixture hostFixture) : ResolveOneLoginUserM
                 oneLoginUser.Subject, t => t
                     .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
                     .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
-                    .WithStatedTrn(matchedPerson.Trn!)) :
+                    .WithStatedTrn(matchedPerson.Trn!)
+                    .WithClientApplicationUserId(applicationUser.UserId)) :
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
                 oneLoginUser.Subject, t => t
                     .WithStatedFirstName(matchedPerson.FirstName)
                     .WithStatedLastName(matchedPerson.LastName)
                     .WithStatedDateOfBirth(matchedPerson.DateOfBirth)
-                    .WithStatedTrn(matchedPerson.Trn!));
+                    .WithStatedTrn(matchedPerson.Trn!)
+                    .WithClientApplicationUserId(applicationUser.UserId));
 
         return (oneLoginUser, supportTask, matchedPerson.Person);
     }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchOneLoginIdVerificationSupportTasks.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchOneLoginIdVerificationSupportTasks.cs
@@ -12,22 +12,26 @@ public partial class SupportTaskSearchServiceTests
     [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Email, SortDirection.Ascending)]
     [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Ascending)]
     [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn, SortDirection.Ascending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Source, SortDirection.Ascending)]
     [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.SupportTaskReference, SortDirection.Descending)]
     [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Email, SortDirection.Descending)]
     [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Descending)]
     [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn, SortDirection.Descending)]
+    [InlineData(OneLoginUserIdVerificationSupportTasksSortByOption.Source, SortDirection.Descending)]
     public async Task SearchOneLoginIdVerificationSupportTasks_ReturnsOrderedResults(OneLoginUserIdVerificationSupportTasksSortByOption sortBy, SortDirection sortDirection)
     {
         // Arrange
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUsers = new OneLoginUser[] { oneLoginUser1, oneLoginUser2 };
-
+        var applicationUser = await TestData.CreateApplicationUserAsync(shortName: "TEST");
         var supportTasks = new SupportTask[] {
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser1.Subject, configure =>
-                configure.WithCreatedOn(new DateTime(2000,10,10,1,1,1, DateTimeKind.Utc))),
+                configure.WithCreatedOn(new DateTime(2000,10,10,1,1,1, DateTimeKind.Utc))
+                    .WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser2.Subject, configure =>
-                configure.WithCreatedOn(new DateTime(2000,10,11,1,1,1, DateTimeKind.Utc)))
+                configure.WithCreatedOn(new DateTime(2000,10,11,1,1,1, DateTimeKind.Utc))
+                    .WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserIdVerificationSupportTasksOptions(Search: null, sortBy, sortDirection);
@@ -42,7 +46,8 @@ public partial class SupportTaskSearchServiceTests
                     ((OneLoginUserIdVerificationData)task.Data)!.StatedFirstName,
                     ((OneLoginUserIdVerificationData)task.Data)!.StatedLastName,
                     task.CreatedOn,
-                    user.EmailAddress
+                    user.EmailAddress,
+                    applicationUser.ShortName
                 });
         var paginationOptions = new PaginationOptions(PageNumber: 1);
 
@@ -65,6 +70,9 @@ public partial class SupportTaskSearchServiceTests
             OneLoginUserIdVerificationSupportTasksSortByOption.RequestedOn => sortDirection == SortDirection.Ascending
                 ? expectedResults.OrderBy(s => s.CreatedOn)
                 : expectedResults.OrderByDescending(s => s.CreatedOn),
+            OneLoginUserIdVerificationSupportTasksSortByOption.Source => sortDirection == SortDirection.Ascending
+                ? expectedResults.OrderBy(s => s.ShortName)
+                : expectedResults.OrderByDescending(s => s.ShortName),
             _ => expectedResults
         }).ToArray();
 
@@ -74,6 +82,7 @@ public partial class SupportTaskSearchServiceTests
         Assert.Equal(expectedResultsOrdered.Select(r => r.CreatedOn), results.SearchResults.Select(r => r.CreatedOn));
         Assert.Equal(expectedResultsOrdered.Select(r => r.StatedFirstName), results.SearchResults.Select(r => r.FirstName));
         Assert.Equal(expectedResultsOrdered.Select(r => r.StatedLastName), results.SearchResults.Select(r => r.LastName));
+        Assert.Equal(expectedResultsOrdered.Select(r => r.ShortName), results.SearchResults.Select(r => r.SourceApplicationName));
     }
 
     [Theory]
@@ -119,19 +128,20 @@ public partial class SupportTaskSearchServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync("x");
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("Alphie").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2000,10,1,1,1,1))),
+                configure.WithStatedFirstName("Alphie").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2000,10,1,1,1,1)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("Bert").WithCreatedOn(new DateTime(2000,9,1,1,2,1))),
+                configure.WithStatedFirstName("Bert").WithCreatedOn(new DateTime(2000,9,1,1,2,1)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("Colin").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2000,8,1,1,3,1))),
+                configure.WithStatedFirstName("Colin").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2000,8,1,1,3,1)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("David").WithCreatedOn(new DateTime(2000,11,1,1,4,1))),
+                configure.WithStatedFirstName("David").WithCreatedOn(new DateTime(2000,11,1,1,4,1)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("Edward").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2000,10,1,1,5,1)))
+                configure.WithStatedFirstName("Edward").WithStatedLastName("Smith").WithCreatedOn(new DateTime(2000,10,1,1,5,1)).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserIdVerificationSupportTasksOptions(Search: search, OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Ascending);
@@ -161,15 +171,16 @@ public partial class SupportTaskSearchServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync();
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("Alphie").WithCreatedOn(new DateTime(2025,1,20))),
+                configure.WithStatedFirstName("Alphie").WithCreatedOn(new DateTime(2025,1,20)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("Bert").WithCreatedOn(new DateTime(2025,1,20))),
+                configure.WithStatedFirstName("Bert").WithCreatedOn(new DateTime(2025,1,20)).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithStatedFirstName("Colin").WithCreatedOn(new DateTime(2025,1,21)))
+                configure.WithStatedFirstName("Colin").WithCreatedOn(new DateTime(2025,1,21)).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserIdVerificationSupportTasksOptions(Search: searchText, OneLoginUserIdVerificationSupportTasksSortByOption.Name, SortDirection.Ascending);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchOneLoginUserRecordMatchingSupportTasks.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchOneLoginUserRecordMatchingSupportTasks.cs
@@ -12,22 +12,29 @@ public partial class SupportTaskSearchServiceTests
     [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Email, SortDirection.Ascending)]
     [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending)]
     [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn, SortDirection.Ascending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Source, SortDirection.Ascending)]
     [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.SupportTaskReference, SortDirection.Descending)]
     [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Email, SortDirection.Descending)]
     [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Descending)]
     [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn, SortDirection.Descending)]
+    [InlineData(OneLoginUserRecordMatchingSupportTasksSortByOption.Source, SortDirection.Descending)]
     public async Task SearchOneLoginUserRecordMatchingSupportTasks_ReturnsOrderedResults(OneLoginUserRecordMatchingSupportTasksSortByOption sortBy, SortDirection sortDirection)
     {
         // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUsers = new OneLoginUser[] { oneLoginUser1, oneLoginUser2 };
 
         var supportTasks = new SupportTask[] {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, configure =>
-                configure.WithCreatedOn(new DateTime(2000,10,10,1,1,1, DateTimeKind.Utc))),
+                configure.WithCreatedOn(new DateTime(2000,10,10,1,1,1, DateTimeKind.Utc))
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, configure =>
-                configure.WithCreatedOn(new DateTime(2000,10,11,1,1,1, DateTimeKind.Utc)))
+                configure.WithCreatedOn(new DateTime(2000,10,11,1,1,1, DateTimeKind.Utc))
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserRecordMatchingSupportTasksOptions(Search: null, sortBy, sortDirection);
@@ -42,7 +49,8 @@ public partial class SupportTaskSearchServiceTests
                     FirstName = ((OneLoginUserRecordMatchingData)task.Data)!.VerifiedNames!.First().First(),
                     LastName = ((OneLoginUserRecordMatchingData)task.Data)!.VerifiedNames!.First().Last(),
                     task.CreatedOn,
-                    user.EmailAddress
+                    user.EmailAddress,
+                    ShortName = task.TrnRequestMetadata!.ApplicationUser!.ShortName ?? task.TrnRequestMetadata!.ApplicationUser!.Name
                 });
         var paginationOptions = new PaginationOptions(PageNumber: 1);
 
@@ -65,6 +73,9 @@ public partial class SupportTaskSearchServiceTests
             OneLoginUserRecordMatchingSupportTasksSortByOption.RequestedOn => sortDirection == SortDirection.Ascending
                 ? expectedResults.OrderBy(s => s.CreatedOn)
                 : expectedResults.OrderByDescending(s => s.CreatedOn),
+            OneLoginUserRecordMatchingSupportTasksSortByOption.Source => sortDirection == SortDirection.Ascending
+                ? expectedResults.OrderBy(s => s.ShortName)
+                : expectedResults.OrderByDescending(s => s.ShortName),
             _ => expectedResults
         }).ToArray();
 
@@ -74,6 +85,7 @@ public partial class SupportTaskSearchServiceTests
         Assert.Equal(expectedResultsOrdered.Select(r => r.CreatedOn), results.SearchResults.Select(r => r.CreatedOn));
         Assert.Equal(expectedResultsOrdered.Select(r => r.FirstName), results.SearchResults.Select(r => r.FirstName));
         Assert.Equal(expectedResultsOrdered.Select(r => r.LastName), results.SearchResults.Select(r => r.LastName));
+        Assert.Equal(expectedResultsOrdered.Select(r => r.ShortName), results.SearchResults.Select(r => r.SourceApplicationName));
     }
 
     [Theory]
@@ -83,20 +95,31 @@ public partial class SupportTaskSearchServiceTests
     public async Task SearchOneLoginUserRecordMatchingSupportTasks_ReturnsPagedResults(int pageNumber, int expectedResultCount, string[] expectedRecords)
     {
         // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
+        var trnRequestId3 = Guid.NewGuid().ToString();
+        var trnRequestId4 = Guid.NewGuid().ToString();
+        var trnRequestId5 = Guid.NewGuid().ToString();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,10,1,1,1,1))),
+                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,10,1,1,1,1))
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,9,1,1,2,1))),
+                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,9,1,1,2,1))
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,8,1,1,3,1))),
+                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,8,1,1,3,1))
+                    .WithTrnRequest(trnRequestId3).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["David", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,11,1,1,4,1))),
+                configure.WithVerifiedNames(["David", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,11,1,1,4,1))
+                    .WithTrnRequest(trnRequestId4).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Edward", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,10,1,1,5,1)))
+                configure.WithVerifiedNames(["Edward", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,10,1,1,5,1))
+                    .WithTrnRequest(trnRequestId5).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserRecordMatchingSupportTasksOptions(Search: null, OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending);
@@ -119,19 +142,30 @@ public partial class SupportTaskSearchServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
+        var trnRequestId3 = Guid.NewGuid().ToString();
+        var trnRequestId4 = Guid.NewGuid().ToString();
+        var trnRequestId5 = Guid.NewGuid().ToString();
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", "Smith"]).WithCreatedOn(new DateTime(2000,10,1,1,1,1))),
+                configure.WithVerifiedNames(["Alphie", "Smith"]).WithCreatedOn(new DateTime(2000,10,1,1,1,1))
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,9,1,1,2,1))),
+                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,9,1,1,2,1))
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", "Smith"]).WithCreatedOn(new DateTime(2000,8,1,1,3,1))),
+                configure.WithVerifiedNames(["Colin", "Smith"]).WithCreatedOn(new DateTime(2000,8,1,1,3,1))
+                    .WithTrnRequest(trnRequestId3).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["David", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,11,1,1,4,1))),
+                configure.WithVerifiedNames(["David", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2000,11,1,1,4,1))
+                    .WithTrnRequest(trnRequestId4).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Edward", "Smith"]).WithCreatedOn(new DateTime(2000,10,1,1,5,1)))
+                configure.WithVerifiedNames(["Edward", "Smith"]).WithCreatedOn(new DateTime(2000,10,1,1,5,1))
+                    .WithTrnRequest(trnRequestId5).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserRecordMatchingSupportTasksOptions(Search: search, OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending);
@@ -161,15 +195,22 @@ public partial class SupportTaskSearchServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
+        var trnRequestId3 = Guid.NewGuid().ToString();
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2025,1,20))),
+                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2025,1,20))
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2025,1,20))),
+                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2025,1,20))
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2025,1,21)))
+                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()]).WithCreatedOn(new DateTime(2025,1,21))
+                    .WithTrnRequest(trnRequestId3).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserRecordMatchingSupportTasksOptions(Search: searchText, OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending);
@@ -193,15 +234,22 @@ public partial class SupportTaskSearchServiceTests
         // Arrange
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>("alphie@example.com"), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
+        var trnRequestId3 = Guid.NewGuid().ToString();
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()])),
+                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, configure =>
-                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()])),
+                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()]))
+                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId3).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserRecordMatchingSupportTasksOptions(Search: searchText, OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending);
@@ -229,15 +277,22 @@ public partial class SupportTaskSearchServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
+        var trnRequestId3 = Guid.NewGuid().ToString();
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", "Smith"])),
+                configure.WithVerifiedNames(["Alphie", "Smith"])
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", "Jones"], ["Alfy", "Jonas"])),
+                configure.WithVerifiedNames(["Alphie", "Jones"], ["Alfy", "Jonas"])
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", "Jones"]))
+                configure.WithVerifiedNames(["Colin", "Jones"])
+                    .WithTrnRequest(trnRequestId3).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var options = new OneLoginUserRecordMatchingSupportTasksOptions(Search: searchText, OneLoginUserRecordMatchingSupportTasksSortByOption.Name, SortDirection.Ascending);
@@ -257,15 +312,22 @@ public partial class SupportTaskSearchServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
+        var trnRequestId3 = Guid.NewGuid().ToString();
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()])),
+                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()])),
+                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()]))
+                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId3).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         foreach (var task in supportTasksList)
@@ -290,15 +352,22 @@ public partial class SupportTaskSearchServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequestId1 = Guid.NewGuid().ToString();
+        var trnRequestId2 = Guid.NewGuid().ToString();
+        var trnRequestId3 = Guid.NewGuid().ToString();
 
         var supportTasksList = new List<SupportTask>
         {
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()])),
+                configure.WithVerifiedNames(["Alphie", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId1).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()])),
+                configure.WithVerifiedNames(["Bert", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId2).WithClientApplicationUserId(applicationUser.UserId)),
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject, configure =>
-                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()]))
+                configure.WithVerifiedNames(["Colin", TestData.GenerateLastName()])
+                    .WithTrnRequest(trnRequestId3).WithClientApplicationUserId(applicationUser.UserId))
         };
 
         var search = "TASK-123";

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUserRecordMatchingSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUserRecordMatchingSupportTask.cs
@@ -91,13 +91,14 @@ public partial class TestData
 
         public async Task<SupportTask> ExecuteAsync(TestData testData)
         {
+            var applicationUser = await testData.CreateApplicationUserAsync();
             var emailAddress = _emailAddress.ValueOr(testData.GenerateUniqueEmail());
             var verifiedNames = _verifiedNames.ValueOr([[testData.GenerateFirstName(), testData.GenerateLastName()]]);
             var verifiedDateOfBirth = _verifiedDateOfBirth.ValueOr(testData.GenerateDateOfBirth);
             var statedNationalInsuranceNumber = _statedNationalInsuranceNumber.ValueOr(testData.GenerateNationalInsuranceNumber);
             var statedTrn = _statedTrn.ValueOr(await testData.GenerateTrnAsync());
             var trnTokenTrn = _trnTokenTrn.ValueOrDefault();
-            var clientApplicationUserId = _clientApplicationUserId.ValueOr(Guid.NewGuid());
+            var clientApplicationUserId = _clientApplicationUserId.ValueOr(applicationUser.UserId);
             var status = _status.ValueOr(SupportTaskStatus.Open);
             var createdOn = _createdOn.ValueOr(testData.Clock.UtcNow);
             var trnRequestId = _trnRequestId.ValueOrDefault();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.OneLoginUserIdVerificationSupportTask.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.TestCommon/TestData.OneLoginUserIdVerificationSupportTask.cs
@@ -99,6 +99,7 @@ public partial class TestData
         public Task<SupportTask> ExecuteAsync(TestData testData) =>
             testData.WithDbContextAsync(async dbContext =>
             {
+                var applicationUser = await testData.CreateApplicationUserAsync();
                 var statedFirstName = _statedFirstName.ValueOr(testData.GenerateFirstName);
                 var statedLastName = _statedLastName.ValueOr(testData.GenerateLastName);
                 var statedDateOfBirth = _statedDateOfBirth.ValueOr(testData.GenerateDateOfBirth);
@@ -107,7 +108,7 @@ public partial class TestData
                 var evidenceFileId = _evidenceFileId.ValueOr(Guid.NewGuid());
                 var evidenceFileName = _evidenceFileName.ValueOr("evidence.pdf");
                 var trnTokenTrn = _trnTokenTrn.ValueOrDefault();
-                var clientApplicationUserId = _clientApplicationUserId.ValueOrDefault();
+                var clientApplicationUserId = _clientApplicationUserId.ValueOr(applicationUser.UserId);
                 var status = _status.ValueOr(SupportTaskStatus.Open);
                 var createdOn = _createdOn.ValueOr(testData.Clock.UtcNow);
 


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/22?pane=issue&itemId=168960922&issue=DFE-Digital%7Cteaching-record-team-project-board%7C56

Add application short name to one login task screens.

### Changes proposed in this pull request


### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally