### PR TITLE
Add short name to trs_users

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0107_UserShortName.sql
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0107_UserShortName.sql
@@ -1,0 +1,1 @@
+alter table trs_users add short_name nvarchar(25) default null

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -120,6 +120,7 @@
     <None Remove="Services\DqtReporting\Migrations\0100_ProcessTimestamps.sql" />
     <None Remove="Services\DqtReporting\Migrations\0101_RemoveUserShortName.sql" />
     <None Remove="Services\DqtReporting\Migrations\0106_UserRecordMatchingPolicy.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0107_UserShortName.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -273,6 +274,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0104_ProcessChangeReason.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0105_ProcessEventsOneLoginUserSubjects.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0106_UserRecordMatchingPolicy.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0107_UserShortName.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context

short name has previously been re-added back to users table. This is to re-add missing shortname column to reporting db.

### Changes proposed in this pull request

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally