### PR TITLE
Change pre-production postgres server sku

### DIFF
--- a/terraform/aks/config/pre-production.tfvars.json
+++ b/terraform/aks/config/pre-production.tfvars.json
@@ -10,7 +10,7 @@
   "postgres_server_version": "17",
   "enable_logit": true,
   "worker_max_memory": "8Gi",
-  "postgres_flexible_server_sku": "GP_Standard_D2ads_v5",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
   "postgres_azure_storage_mb": 262144,
   "enable_dfe_analytics_federated_auth": true,
   "pg_airbyte_enabled": true,


### PR DESCRIPTION
### Context

Pre-production postgres server is set to GP_Standard_D2ads_v5
This is non-standard and should be changed to GP_Standard_D2ds_v5

This is an in-place update, but it will cause a 10-15 minute outage while the server is updated.

### Changes proposed in this pull request

Update postgres_flexible_server_sku in tfvars

### Guidance to review

make pre-production terraform-plan

<img width="636" height="142" alt="image" src="https://github.com/user-attachments/assets/d372fcb7-51ca-458e-98b8-02084494950f" />


### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally