### PR TITLE
Move dotnet publish into Dockerfile

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,10 +23,6 @@ jobs:
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # Pinned at v4.0.0
 
-      - uses: actions/setup-dotnet@v5
-        with:
-          global-json-file: global.json
-
       - name: Get Docker image tag
         id: image_tags
         run: |
@@ -38,14 +34,6 @@ jobs:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get cached packages
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            ~/.nuget/packages
-            ~/.local/share/.librarymanager/cache
-          key: ${{ hashFiles('**/packages.lock.json', '**/libman.json') }}
 
       - name: Docker build & push
         id: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,40 @@
-# syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.22
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23@sha256:732cd42c6f659814c9804ad7b05c7f761e83ef8379c5b2fdc3af673353caff73 AS build
+WORKDIR /source
+
+# Install pre-reqs for SASS compilation
+RUN apk add --no-cache gcompat
+
+COPY . ./
+RUN dotnet tool restore
+RUN dotnet restore
+RUN dotnet publish --no-restore --configuration Release
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.23@sha256:1201dde897ab436b7c6b386f6dbd4f9a3ca0245f9c5a8aac8f8bcdccb4c7d484
 ARG GIT_SHA
-ENV SENTRY_RELEASE=${GIT_SHA}
-ENV GIT_SHA=${GIT_SHA}
-ENV ASPNETCORE_HTTP_PORTS=3000
-COPY src/TeachingRecordSystem.Api/bin/Release/net10.0/publish/ Apps/Api/
-COPY src/TeachingRecordSystem.Cli/bin/Release/net10.0/publish/ Apps/TrsCli/
-COPY src/TeachingRecordSystem.SupportUi/bin/Release/net10.0/publish/ Apps/SupportUi/
-COPY src/TeachingRecordSystem.Worker/bin/Release/net10.0/publish/ Apps/Worker/
-COPY src/TeachingRecordSystem.AuthorizeAccess/bin/Release/net10.0/publish/ Apps/AuthorizeAccess/
-COPY db.sh Apps/db.sh
 WORKDIR /Apps
+COPY --from=build /source/src/TeachingRecordSystem.Api/bin/Release/net10.0/publish/ ./Api/
+COPY --from=build /source/src/TeachingRecordSystem.Cli/bin/Release/net10.0/publish/ ./TrsCli/
+COPY --from=build /source/src/TeachingRecordSystem.SupportUi/bin/Release/net10.0/publish/ ./SupportUi/
+COPY --from=build /source/src/TeachingRecordSystem.Worker/bin/Release/net10.0/publish/ ./Worker/
+COPY --from=build /source/src/TeachingRecordSystem.AuthorizeAccess/bin/Release/net10.0/publish/ ./AuthorizeAccess/
+COPY --from=build /source/db.sh .
 
-RUN chmod +x /Apps/db.sh
+RUN chmod +x ./db.sh
 
-# Install Culture prerequisities
-RUN apk add --no-cache \
-        tzdata \
-        icu-data-full \
-        icu-libs
-
-# Enable all cultures
+# Ensure culture data is available
+RUN apk add --no-cache tzdata icu-data-full icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-# Install Postgres client
 RUN apk --no-cache add postgresql17-client
 
 # Fix for invoking trscli
 RUN apk --no-cache add libc6-compat
 
-# Install SQL Server tools needed to be able to query the reporting DB to help debugging
-RUN apk add curl
-
-RUN curl -O https://download.microsoft.com/download/b/9/f/b9f3cce4-3925-46d4-9f46-da08869c6486/msodbcsql18_18.0.1.1-1_amd64.apk && \
-	curl -O https://download.microsoft.com/download/b/9/f/b9f3cce4-3925-46d4-9f46-da08869c6486/mssql-tools18_18.0.1.1-1_amd64.apk
-
-RUN apk add --allow-untrusted msodbcsql18_18.0.1.1-1_amd64.apk && \
-	apk add --allow-untrusted mssql-tools18_18.0.1.1-1_amd64.apk && \
-	rm -f msodbcsql18_18.0.1.1-1_amd64.apk mssql-tools18_18.0.1.1-1_amd64.apk
+ENV SENTRY_RELEASE=${GIT_SHA}
+ENV GIT_SHA=${GIT_SHA}
+ENV ASPNETCORE_HTTP_PORTS=3000
+ENV PATH="${PATH}:/Apps/TrsCli"
 
 RUN addgroup -S appgroup -g 20001 && adduser -S appuser -G appgroup -u 10001
 
 USER 10001
-
-ENV PATH="${PATH}:/Apps/TrsCli"

--- a/justfile
+++ b/justfile
@@ -85,7 +85,6 @@ watch-worker:
 
 # Build the Docker image
 docker-build *ARGS: restore
-  @dotnet publish -c Release --no-restore
   @docker build . {{ARGS}}
 
 # Set a configuration entry in user secrets for running the apps


### PR DESCRIPTION
With this `docker build` 'just works' (i.e. it doesn't rely on `dotnet publish` being run first). It also means the build is done from a more production-like environment (an Alpine-based Docker image).