### PR TITLE
Normalize TRN and NINO in OL support task pages

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -362,7 +362,7 @@ public class OneLoginService(
 
         var firstNames = options.Names.Select(parts => parts.First()).ToArray();
         var lastNames = options.Names.Select(parts => parts.Skip(1).LastOrDefault()).Where(n => !string.IsNullOrEmpty(n)).ToArray();
-        var trns = new[] { options.Trn, options.TrnTokenTrnHint }.Where(trn => trn is not null).Distinct().Select(NormalizeTrn).ToArray();
+        var trns = new[] { options.Trn, options.TrnTokenTrnHint }.Where(trn => trn is not null).Distinct().Select(TrnHelper.NormalizeTrn).ToArray();
         var nationalInsuranceNumber = NationalInsuranceNumber.Normalize(options.NationalInsuranceNumber);
 
         var results = await dbContext.Database.SqlQueryRaw<SuggestionsQueryResult>(
@@ -557,9 +557,6 @@ public class OneLoginService(
 
         return oneLoginUser;
     }
-
-    private static string? NormalizeTrn(string? value) =>
-        string.IsNullOrEmpty(value) ? null : new(value.Where(char.IsAsciiDigit).ToArray());
 
     private async Task<TryMatchToTrnRequestResult?> TryMatchToTrnRequestAsync(OneLoginUser oneLoginUser, ProcessContext processContext)
     {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnHelper.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/TrnHelper.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core;
+
+public static class TrnHelper
+{
+    public static string? NormalizeTrn(string? value) =>
+        string.IsNullOrEmpty(value) ? null : new(value.Where(char.IsAsciiDigit).ToArray());
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
@@ -147,8 +147,8 @@ public class Matches(
         var firstVerifiedOrStatedName = data.VerifiedOrStatedNames!.First();
         Name = $"{firstVerifiedOrStatedName.First()} {firstVerifiedOrStatedName.LastOrDefault()}";
         DateOfBirth = data.VerifiedOrStatedDatesOfBirth!.First();
-        NationalInsuranceNumber = data.StatedNationalInsuranceNumber;
-        Trn = data.StatedTrn;
+        NationalInsuranceNumber = Core.NationalInsuranceNumber.Normalize(data.StatedNationalInsuranceNumber);
+        Trn = TrnHelper.NormalizeTrn(data.StatedTrn);
         EmailAddress = oneLoginUser.EmailAddress;
 
         var matchedPersonIds = JourneyInstance.State.MatchedPersons.Select(m => m.PersonId).ToArray();

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
@@ -78,8 +78,8 @@ public class VerifyModel(ISafeFileService safeFileService, SupportUiLinkGenerato
         var data = supportTask.GetData<OneLoginUserIdVerificationData>();
         Name = data.StatedFirstName + " " + data.StatedLastName;
         DateOfBirth = data.StatedDateOfBirth;
-        NationalInsuranceNumber = data.StatedNationalInsuranceNumber;
-        Trn = data.StatedTrn;
+        NationalInsuranceNumber = Core.NationalInsuranceNumber.Normalize(data.StatedNationalInsuranceNumber);
+        Trn = TrnHelper.NormalizeTrn(data.StatedTrn);
         EmailAddress = oneLoginUser.EmailAddress;
 
         var fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TrnHelperTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/TrnHelperTests.cs
@@ -1,0 +1,22 @@
+namespace TeachingRecordSystem.Core.Tests;
+
+public class TrnHelperTests
+{
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("1234567", "1234567")]
+    [InlineData("01/23456", "0123456")]
+    [InlineData("123 4567", "1234567")]
+    [InlineData("12-34567", "1234567")]
+    public void NormalizeTrn_WithVariousInputs_ReturnsExpectedResult(string? input, string? expected)
+    {
+        // Arrange
+
+        // Act
+        var result = TrnHelper.NormalizeTrn(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/MatchesTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/MatchesTests.cs
@@ -2,6 +2,7 @@ using AngleSharp.Dom;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
+using CoreNationalInsuranceNumber = TeachingRecordSystem.Core.NationalInsuranceNumber;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUserMatching.Resolve;
 
@@ -120,8 +121,62 @@ public class MatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatching
         Assert.Equal($"{firstVerifiedOrStatedName.First()} {firstVerifiedOrStatedName.Last()}", requestDetails.GetSummaryListValueByKey("Name"));
         Assert.Equal(supportTaskData.VerifiedOrStatedDatesOfBirth!.First().ToString(WebConstants.DateOnlyDisplayFormat), requestDetails.GetSummaryListValueByKey("Date of birth"));
         Assert.Equal(oneLoginUser.EmailAddress, requestDetails.GetSummaryListValueByKey("Email address"));
-        Assert.Equal(supportTaskData.StatedNationalInsuranceNumber, requestDetails.GetSummaryListValueByKey("National Insurance number"));
-        Assert.Equal(supportTaskData.StatedTrn, requestDetails.GetSummaryListValueByKey("TRN"));
+        Assert.Equal(CoreNationalInsuranceNumber.Normalize(supportTaskData.StatedNationalInsuranceNumber), requestDetails.GetSummaryListValueByKey("National Insurance number"));
+        Assert.Equal(TrnHelper.NormalizeTrn(supportTaskData.StatedTrn), requestDetails.GetSummaryListValueByKey("TRN"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Get_ValidRequest_WithNonNormalizedTrnAndNino_ShowsNormalizedValues(bool isRecordMatchingOnlySupportTask)
+    {
+        // Arrange
+        var matchedPerson = await TestData.CreatePersonAsync();
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
+        var nonNormalizedTrn = "01/23456";
+        var normalizedTrn = "0123456";
+        var nonNormalizedNino = "ab 12 34 56 c";
+        var normalizedNino = "AB123456C";
+        var supportTask = isRecordMatchingOnlySupportTask ?
+            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+                oneLoginUser.Subject, t => t
+                    .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
+                    .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
+                    .WithStatedTrn(nonNormalizedTrn)
+                    .WithStatedNationalInsuranceNumber(nonNormalizedNino)) :
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser.Subject, t => t
+                    .WithStatedFirstName(matchedPerson.FirstName)
+                    .WithStatedLastName(matchedPerson.LastName)
+                    .WithStatedDateOfBirth(matchedPerson.DateOfBirth)
+                    .WithStatedTrn(nonNormalizedTrn)
+                    .WithStatedNationalInsuranceNumber(nonNormalizedNino));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            supportTask.SupportTaskReference,
+            state => state.Verified = true,
+            new MatchPersonResult(
+                matchedPerson.PersonId,
+                matchedPerson.Trn,
+                [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd"))
+                ]));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocumentAsync();
+        var requestDetails = doc.GetElementByTestId("request");
+        Assert.NotNull(requestDetails);
+        Assert.Equal(normalizedNino, requestDetails.GetSummaryListValueByKey("National Insurance number"));
+        Assert.Equal(normalizedTrn, requestDetails.GetSummaryListValueByKey("TRN"));
     }
 
     [Theory]

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
+using CoreNationalInsuranceNumber = TeachingRecordSystem.Core.NationalInsuranceNumber;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUserMatching.Resolve;
 
@@ -34,8 +35,8 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
         Assert.Equal($"{requestData.StatedFirstName} {requestData.StatedLastName}", doc.GetSummaryListValueByKey("Name"));
         Assert.Equal(requestData.StatedDateOfBirth.ToString(WebConstants.DateOnlyDisplayFormat), doc.GetSummaryListValueByKey("Date of birth"));
         Assert.Equal(oneLoginUser.EmailAddress, doc.GetSummaryListValueByKey("Email address"));
-        Assert.Equal(requestData.StatedTrn, doc.GetSummaryListValueByKey("TRN"));
-        Assert.Equal(requestData.StatedNationalInsuranceNumber, doc.GetSummaryListValueByKey("National Insurance number"));
+        Assert.Equal(TrnHelper.NormalizeTrn(requestData.StatedTrn), doc.GetSummaryListValueByKey("TRN"));
+        Assert.Equal(CoreNationalInsuranceNumber.Normalize(requestData.StatedNationalInsuranceNumber), doc.GetSummaryListValueByKey("National Insurance number"));
         if (evidenceIsPdf)
         {
             Assert.NotNull(doc.GetElementByTestId($"pdf-{requestData.EvidenceFileId}"));
@@ -46,6 +47,38 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
             Assert.NotNull(doc.GetElementByTestId($"image-{requestData.EvidenceFileId}"));
             Assert.Null(doc.GetElementByTestId($"pdf-{requestData.EvidenceFileId}"));
         }
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_WithNonNormalizedTrnAndNino_RendersNormalizedValues()
+    {
+        // Arrange
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
+        var nonNormalizedTrn = "01/23456";
+        var normalizedTrn = "0123456";
+        var nonNormalizedNino = "ab 12 34 56 c";
+        var normalizedNino = "AB123456C";
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject,
+            b => b
+                .WithStatedTrn(nonNormalizedTrn)
+                .WithStatedNationalInsuranceNumber(nonNormalizedNino));
+
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/verify?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        Assert.Equal(normalizedTrn, doc.GetSummaryListValueByKey("TRN"));
+        Assert.Equal(normalizedNino, doc.GetSummaryListValueByKey("National Insurance number"));
     }
 
     [Theory]


### PR DESCRIPTION
We allow users to enter TRNs in formats like '01/23456' and NINOs like 'ab 12 34 56 c'. This change amends the support task journeys where we play back these fields to display values in their normalized forms e.g. '0123456' and 'AB123456C', respectively.