### PR TITLE
Don't treat record with matching single name & DOB as a suggested match

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -459,6 +459,15 @@ public class OneLoginService(
 
                 return new { Result = result, Score = score, MatchedAttributes = matchedAttributes };
             })
+            .Where(r =>
+            {
+                // Discard results that match on a single name and DOB only
+                var matchedAttributeTypes = r.MatchedAttributes.Select(a => a.Key).ToArray();
+                var matchedOnSingleName = matchedAttributeTypes.Intersect([PersonMatchedAttribute.FirstName, PersonMatchedAttribute.LastName]).Count() == 1;
+                var matchedOnDob = matchedAttributeTypes.Contains(PersonMatchedAttribute.DateOfBirth);
+                var matchOnSingleNameAndDobOnly = matchedAttributeTypes.Length is 2 && (matchedOnDob && matchedOnSingleName);
+                return !matchOnSingleNameAndDobOnly;
+            })
             .OrderByDescending(t => t.Score)
             .Select(t => t.Result)
             .AsReadOnly();

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
@@ -240,8 +240,8 @@ public partial class OneLoginServiceTests
         var person4 = await TestData.CreatePersonAsync(p => p.WithLastName(lastName).WithDateOfBirth(dateOfBirth));
         var trnTokenHintTrn = person4.Trn;
 
-        // person who matches on previous last name and DOB
-        var person5 = await TestData.CreatePersonAsync(p => p.WithFirstName(TestData.GenerateChangedFirstName(firstName)).WithLastName(TestData.GenerateChangedLastName(lastName))
+        // person who matches on first name, previous last name and DOB
+        var person5 = await TestData.CreatePersonAsync(p => p.WithFirstName(firstName).WithLastName(TestData.GenerateChangedLastName(lastName))
             .WithDateOfBirth(dateOfBirth)
             .WithPreviousNames((TestData.GenerateFirstName(), TestData.GenerateMiddleName(), lastName, Clock.UtcNow)));
 


### PR DESCRIPTION
We've got some obviously-wrong suggested matches in some of the One Login matching tasks. This removes those where there's only a single name (i.e. first or last name) and DOB match.