### PR TITLE
Don't show partial matches if there's a single exact match

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -309,9 +309,6 @@ public class OneLoginService(
 
     public virtual async Task<MatchPersonResult?> MatchPersonAsync(MatchPersonOptions options)
     {
-        // A One Login is matched if there is exactly one Person with a matching
-        // first name, last name, DOB AND either NINO or TRN.
-
         var suggestedMatches = await GetSuggestedPersonMatchesAsync(
             new GetSuggestedPersonMatchesOptions(
                 options.Names,
@@ -320,6 +317,14 @@ public class OneLoginService(
                 options.NationalInsuranceNumber,
                 options.Trn,
                 options.TrnTokenTrnHint));
+
+        return MatchPerson(suggestedMatches);
+    }
+
+    public virtual MatchPersonResult? MatchPerson(IReadOnlyCollection<MatchPersonResult> suggestedMatches)
+    {
+        // A One Login is matched if there is exactly one Person with a matching
+        // first name, last name, DOB AND either NINO or TRN.
 
         var candidates = new List<MatchPersonResult>();
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
@@ -70,6 +70,12 @@ public class ResolveOneLoginUserMatchingStateFactory(
                 EmailAddress: emailAddress,
                 Trn: requestData.StatedTrn,
                 TrnTokenTrnHint: requestData.TrnTokenTrn));
+
+            var matchResult = oneLoginService.MatchPerson(suggestedMatches);
+            if (matchResult is not null)
+            {
+                suggestedMatches = [matchResult];
+            }
         }
 
         AppContent? appContent = null;
@@ -93,7 +99,13 @@ public class ResolveOneLoginUserMatchingStateFactory(
         }
 
         return supportTask.ResolveJourneySavedState?.GetState<ResolveOneLoginUserMatchingState>() is { } existingState ?
-            existingState with { MatchedPersons = suggestedMatches, AppContent = appContent, RecordMatchingPolicy = recordMatchingPolicy, SavedJourneyState = supportTask.ResolveJourneySavedState } :
+            existingState with
+            {
+                MatchedPersons = suggestedMatches,
+                AppContent = appContent,
+                RecordMatchingPolicy = recordMatchingPolicy,
+                SavedJourneyState = supportTask.ResolveJourneySavedState
+            } :
             new ResolveOneLoginUserMatchingState
             {
                 MatchedPersons = suggestedMatches,


### PR DESCRIPTION
Don't display all candidate records if the matching rules have produced a single match.

There's no sense in displaying partial matches if we've got one exact match.