### PR TITLE
Add one login events to person change history

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -103,7 +103,7 @@ public class OneLoginService(
         {
             EventId = Guid.NewGuid(),
             OneLoginUser = oneLoginUserEventModel,
-            OldOneLoginUser = oneLoginUserEventModel,
+            OldOneLoginUser = oldOneLoginUserEventModel,
             Changes = OneLoginUserUpdatedEvent.GetChanges(oldOneLoginUserEventModel, oneLoginUserEventModel)
         };
 
@@ -112,21 +112,21 @@ public class OneLoginService(
 
     public async Task SetUserUnmatchedAsync(string oneLoginSubject, ProcessContext processContext)
     {
-        var user = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginSubject);
 
+        var user = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginSubject);
         await using var eventScope = eventPublisher.GetOrCreateEventScope(processContext);
 
         var oldOneLoginUserEventModel = EventModels.OneLoginUser.FromModel(user);
         user.SetUnmatched();
-
+        var oneLoginUserEventModel = EventModels.OneLoginUser.FromModel(user);
         await dbContext.SaveChangesAsync();
 
-        var oneLoginUserEventModel = EventModels.OneLoginUser.FromModel(user);
+
         var updatedEvent = new OneLoginUserUpdatedEvent
         {
             EventId = Guid.NewGuid(),
             OneLoginUser = oneLoginUserEventModel,
-            OldOneLoginUser = oneLoginUserEventModel,
+            OldOneLoginUser = oldOneLoginUserEventModel,
             Changes = OneLoginUserUpdatedEvent.GetChanges(oldOneLoginUserEventModel, oneLoginUserEventModel)
         };
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ChangeHistory.cshtml.cs
@@ -81,7 +81,8 @@ public class ChangeHistoryModel(
             nameof(LegacyEvents.ChangeNameRequestSupportTaskApprovedEvent),
             nameof(LegacyEvents.ChangeNameRequestSupportTaskRejectedEvent),
             nameof(LegacyEvents.ChangeDateOfBirthRequestSupportTaskApprovedEvent),
-            nameof(LegacyEvents.ChangeDateOfBirthRequestSupportTaskRejectedEvent)
+            nameof(LegacyEvents.ChangeDateOfBirthRequestSupportTaskRejectedEvent),
+            nameof(OneLoginUserUpdatedEvent)
         };
 
         var alertEventTypes = eventTypes.Where(et => et.StartsWith("Alert", StringComparison.Ordinal)).ToArray();
@@ -152,7 +153,11 @@ public class ChangeHistoryModel(
             ProcessType.PersonMergingInDqt,
             ProcessType.AlertCreating,
             ProcessType.AlertUpdating,
-            ProcessType.AlertDeleting
+            ProcessType.AlertDeleting,
+            ProcessType.PersonOneLoginUserDisconnecting,
+            ProcessType.PersonOneLoginUserConnecting,
+            ProcessType.OneLoginUserRecordMatchingSupportTaskCompleting,
+            ProcessType.OneLoginUserIdVerificationSupportTaskCompleting,
         };
 
         var processes = await dbContext.Processes

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Events.ChangeReasons;
 using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.Core.Services.Persons;
 
@@ -40,7 +41,15 @@ public class CheckAnswers(
 
     public async Task<IActionResult> OnPostAsync()
     {
-        var processContext = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, timeProvider.UtcNow, User.GetUserId());
+        var changeReason = new ChangeReasonWithDetailsAndEvidence()
+        {
+            Reason = Reason?.GetDisplayName(),
+            Details = JourneyInstance!.State.DisconnectReason == DisconnectOneLoginReason.AnotherReason
+                ? JourneyInstance.State.Detail
+                : null,
+            EvidenceFile = null
+        };
+        var processContext = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);
         var person = await dbContext.Persons.SingleAsync(x => x.PersonId == PersonId);
         if (JourneyInstance!.State.StayVerified == DisconnectOneLoginStayVerified.Yes)
         {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/OneLoginUserIdVerificationSupportTaskCompleting.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/OneLoginUserIdVerificationSupportTaskCompleting.cshtml
@@ -1,0 +1,19 @@
+@model TimelineItem<TimelineProcess>
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-process-id="@Model.ItemModel.Process.ProcessId">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">OneLogin Connected</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span>By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <row>
+                <key>Event Type</key>
+                <value use-empty-fallback>Task Connection</value>
+            </row>
+        </govuk-summary-list>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/OneLoginUserRecordMatchingSupportTaskCompleting.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/OneLoginUserRecordMatchingSupportTaskCompleting.cshtml
@@ -1,0 +1,20 @@
+@model TimelineItem<TimelineProcess>
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-process-id="@Model.ItemModel.Process.ProcessId">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">OneLogin Connected</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span>By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <row>
+                <key>Event Type</key>
+                <value use-empty-fallback>Task Connection</value>
+            </row>
+        </govuk-summary-list>
+    </div>
+</div>
+

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/PersonOneLoginUserConnecting.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/PersonOneLoginUserConnecting.cshtml
@@ -1,0 +1,19 @@
+@model TimelineItem<TimelineProcess>
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-process-id="@Model.ItemModel.Process.ProcessId">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">OneLogin Connected</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span>By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <row>
+                <key>Event Type</key>
+                <value use-empty-fallback>Manual Connection</value>
+            </row>
+        </govuk-summary-list>
+    </div>
+</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/PersonOneLoginUserDisconnecting.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Processes/PersonOneLoginUserDisconnecting.cshtml
@@ -1,0 +1,28 @@
+@using TeachingRecordSystem.Core.Events.ChangeReasons
+@model TimelineItem<TimelineProcess>
+@{
+    var changeReason = Model.ItemModel.Process.ChangeReason as ChangeReasonWithDetailsAndEvidence;
+    var reasonText = changeReason?.Details ?? "No reason provided";
+}
+
+<div class="moj-timeline__item govuk-!-padding-bottom-2" data-process-id="@Model.ItemModel.Process.ProcessId">
+    <div class="moj-timeline__header">
+        <h2 class="moj-timeline__title">OneLogin Disconnected</h2>
+    </div>
+    <p class="moj-timeline__date">
+        <span>By @Model.ItemModel.RaisedByUser.Name on</span>
+        <time datetime="@Model.Timestamp.ToString("O")">@Model.FormattedTimestamp</time>
+    </p>
+    <div class="moj-timeline__description">
+        <govuk-summary-list>
+            <row>
+                <key>Event Type</key>
+                <value use-empty-fallback>OneLogin Disconnected</value>
+            </row>
+            <row>
+                <key>Reason</key>
+                <value use-empty-fallback>@reasonText</value>
+            </row>
+        </govuk-summary-list>
+    </div>
+</div>

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/HostFixture.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Services.Notify;
+using TeachingRecordSystem.Core.Services.OneLogin;
+using TeachingRecordSystem.Core.Services.SupportTasks;
 using TeachingRecordSystem.SupportUi.Tests;
 using TeachingRecordSystem.SupportUi.Tests.Infrastructure.Security;
 using TeachingRecordSystem.TestCommon.Infrastructure;
@@ -92,7 +94,9 @@ public class HostFixture : InitializeDbFixture
                     .AddSingleton<IUserInstanceStateProvider, InMemoryInstanceStateProvider>()
                     .AddSingleton<INotificationSender, NoopNotificationSender>()
                     .AddSingleton<IStartupFilter, ExecuteScheduledJobsStartupFilter>()
-                    .AddStartupTask<AddTestRouteTypesStartupTask>();
+                    .AddStartupTask<AddTestRouteTypesStartupTask>()
+                    .AddOneLoginService()
+                    .AddSupportTaskServices();
 
                 TestScopedServices.ConfigureServices(services);
             });

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
@@ -1,0 +1,188 @@
+using Optional;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Events.ChangeReasons;
+using TeachingRecordSystem.Core.Services.OneLogin;
+using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail;
+
+public partial class ChangeHistoryTests
+{
+    [Fact]
+    public async Task Get_PersonOneLoginUserConnecting_RendersExpectedEntry()
+    {
+        // Arrange
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(matchedPerson);
+        var user = await TestData.CreateUserAsync();
+        var process = new ProcessContext(ProcessType.PersonOneLoginUserConnecting, Clock.UtcNow, user.UserId);
+
+        await OneLoginService.SetUserMatchedAsync(
+            new SetUserMatchedOptions
+            {
+                OneLoginUserSubject = oneLoginUser.Subject!,
+                MatchedPersonId = matchedPerson.PersonId,
+                MatchRoute = OneLoginUserMatchRoute.SupportUi,
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd"))
+                ]
+            },
+            process);
+
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{matchedPerson.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertHasChangeHistoryEntry(
+            process.ProcessId,
+            "OneLogin Connected",
+            user.Name,
+            process.Now,
+            [
+                ("Event Type", "Manual Connection")
+            ]);
+    }
+
+    [Fact]
+    public async Task Get_PersonOneLoginUserDisconnecting_RendersExpectedEntry()
+    {
+        // Arrange
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(matchedPerson);
+        var user = await TestData.CreateUserAsync();
+        var reason = new ChangeReasonWithDetailsAndEvidence()
+        {
+            Details = "these are details",
+            EvidenceFile = null,
+            Reason = "this is the reason"
+        };
+        var process = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, Clock.UtcNow, user.UserId, reason);
+
+        await OneLoginService.SetUserUnmatchedAsync(oneLoginUser.Subject!, process);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{matchedPerson.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertHasChangeHistoryEntry(
+            process.ProcessId,
+            "OneLogin Disconnected",
+            user.Name,
+            process.Now,
+            [
+                ("Event Type", "OneLogin Disconnected"),
+                ("Reason", reason.Details)
+            ]);
+    }
+
+    [Fact]
+    public async Task Get_OneLoginUserRecordMatchingSupportTaskCompleting_RendersExpectedEntry()
+    {
+        // Arrange
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true, email: Option.Some(matchedPerson.EmailAddress));
+        var user = await TestData.CreateUserAsync();
+
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t
+                .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
+                .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
+                .WithStatedTrn(matchedPerson.Trn!));
+
+        var process = new ProcessContext(ProcessType.OneLoginUserRecordMatchingSupportTaskCompleting, Clock.UtcNow, user.UserId);
+        await OneLoginSupportTaskService.ResolveRecordMatchingSupportTaskAsync(
+            new ConnectedOutcomeOptions
+            {
+                MatchedPersonId = matchedPerson.PersonId,
+                MatchedAttributes =
+                [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd"))
+                ],
+                SupportTask = supportTask,
+                Trn = matchedPerson.Trn
+            },
+            process);
+
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{matchedPerson.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertHasChangeHistoryEntry(
+            process.ProcessId,
+            "OneLogin Connected",
+            user.Name,
+            process.Now,
+            [
+                ("Event Type", "Task Connection")
+            ]);
+    }
+
+    [Fact]
+    public async Task Get_OneLoginUserVerificationTaskCompleting_RendersExpectedEntry()
+    {
+        // Arrange
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
+
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject,
+            t => t
+                .WithStatedFirstName(matchedPerson.FirstName)
+                .WithStatedLastName(matchedPerson.LastName)
+                .WithStatedDateOfBirth(matchedPerson.DateOfBirth)
+                .WithStatedTrn(matchedPerson.Trn!));
+
+        var options = new VerifiedAndConnectedOutcomeOptions
+        {
+            SupportTask = supportTask,
+            MatchedPersonId = matchedPerson.PersonId,
+            MatchedAttributes =
+            [
+                KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson.FirstName),
+                KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
+                KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
+                KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
+            ]
+        };
+
+        var processContext = new ProcessContext(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, Clock.UtcNow, SystemUser.SystemUserId);
+
+        await OneLoginSupportTaskService.ResolveVerificationSupportTaskAsync(options, processContext);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{matchedPerson.PersonId}/change-history");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        doc.AssertHasChangeHistoryEntry(
+            processContext.ProcessId,
+            "OneLogin Connected",
+            SystemUser.SystemUserName,
+            processContext.Now,
+            [
+                ("Event Type", "Task Connection")
+            ]);
+    }
+}

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -5,6 +5,8 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.Files;
 using TeachingRecordSystem.Core.Services.GetAnIdentityApi;
+using TeachingRecordSystem.Core.Services.OneLogin;
+using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Services.AzureActiveDirectory;
 using TeachingRecordSystem.TestCommon.Infrastructure;
@@ -36,6 +38,10 @@ public abstract class TestBase
     protected CaptureEventObserver EventObserver => TestScopedServices.GetCurrent().EventObserver;
 
     protected FakeTimeProvider Clock => TestScopedServices.GetCurrent().Clock;
+
+    protected OneLoginUserMatchingSupportTaskService OneLoginSupportTaskService => HostFixture.Services.GetRequiredService<OneLoginUserMatchingSupportTaskService>();
+
+    protected OneLoginService OneLoginService => HostFixture.Services.GetRequiredService<OneLoginService>();
 
     protected Mock<IAadUserService> AzureActiveDirectoryUserServiceMock =>
         TestScopedServices.GetCurrent().AzureActiveDirectoryUserServiceMock;


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/22?pane=issue&itemId=170516488&issue=DFE-Digital%7Cteaching-record-team-project-board%7C118

### Changes proposed in this pull request

- Add one login events to person change history tab.
- Bug fix in SetUserUnmatchedAsync

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally