### PR TITLE
Handle records without DOB in find by DOB & last name API operation

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/Implementation/Operations/FindPersonsByTrnAndDateOfBirth.cs
@@ -18,7 +18,7 @@ public class FindPersonsByTrnAndDateOfBirthHandler(
             .ToArray();
 
         var persons = await DbContext.Persons
-            .Where(p => trns.Contains(p.Trn))
+            .Where(p => trns.Contains(p.Trn) && p.DateOfBirth != null)
             .Select(p => new { p.PersonId, p.DateOfBirth, p.Trn })
             .ToArrayAsync();
 


### PR DESCRIPTION
We've got some records without a DOB, even though that's not really valid. This is a small work-around to the 'find by DOB & last name' API endpoint to exclude records without a DOB from the DB query. It won't fix other API endpoints but it does at least prevent API calls that would be returning a 404 any way from returning a 500.