### PR TITLE
Handle missing 'findBy' query param

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Requests/FindTeachersRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240101/Requests/FindTeachersRequest.cs
@@ -14,5 +14,5 @@ public record FindTeachersRequest
 
 public enum FindTeachersFindBy
 {
-    LastNameAndDateOfBirth = 1
+    LastNameAndDateOfBirth = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240606/Requests/FindPersonRequest.cs
@@ -14,5 +14,5 @@ public record FindPersonRequest
 
 public enum FindPersonFindBy
 {
-    LastNameAndDateOfBirth = 1
+    LastNameAndDateOfBirth = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240814/Requests/FindPersonRequest.cs
@@ -14,5 +14,5 @@ public record FindPersonRequest
 
 public enum FindPersonFindBy
 {
-    LastNameAndDateOfBirth = 1
+    LastNameAndDateOfBirth = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20240920/Requests/FindPersonRequest.cs
@@ -14,5 +14,5 @@ public record FindPersonRequest
 
 public enum FindPersonFindBy
 {
-    LastNameAndDateOfBirth = 1
+    LastNameAndDateOfBirth = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250203/Requests/FindPersonRequest.cs
@@ -14,5 +14,5 @@ public record FindPersonRequest
 
 public enum FindPersonFindBy
 {
-    LastNameAndDateOfBirth = 1
+    LastNameAndDateOfBirth = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250327/Requests/FindPersonRequest.cs
@@ -14,5 +14,5 @@ public record FindPersonRequest
 
 public enum FindPersonFindBy
 {
-    LastNameAndDateOfBirth = 1
+    LastNameAndDateOfBirth = 0
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250627/Requests/FindPersonRequest.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/V3/V20250627/Requests/FindPersonRequest.cs
@@ -14,5 +14,5 @@ public record FindPersonRequest
 
 public enum FindPersonFindBy
 {
-    LastNameAndDateOfBirth = 1
+    LastNameAndDateOfBirth = 0
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
@@ -37,7 +37,7 @@ public class FindTeachersTests : TestBase
     }
 
     [Theory]
-    [InlineData("", "Invalid matching policy.")]
+    [InlineData("", "The value '' is invalid.")]
     [InlineData("BadFindBy", "The value 'BadFindBy' is not valid for FindBy.")]
     public async Task Get_InvalidFindBy_ReturnsError(string findBy, string expectedErrorMessage)
     {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -36,7 +36,7 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
     }
 
     [Theory]
-    [InlineData("", "Invalid matching policy.")]
+    [InlineData("", "The value '' is invalid.")]
     [InlineData("BadFindBy", "The value 'BadFindBy' is not valid for FindBy.")]
     public async Task Get_InvalidFindBy_ReturnsError(string findBy, string expectedErrorMessage)
     {


### PR DESCRIPTION
Currently `GET /v3/persons` blows up with a 500 error; it should be returning a validation error. This fixes that.