### PR TITLE
Fix sign in for users with InProgress tasks

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -478,25 +478,24 @@ public class OneLoginService(
             .AsReadOnly();
     }
 
-    public async Task<string?> GetPendingSupportTaskReferenceByUserAsync(string oneLoginUserSubject)
-    {
-        var task = await dbContext.SupportTasks
+    public Task<string?> GetPendingSupportTaskReferenceByUserAsync(string oneLoginUserSubject) =>
+        dbContext.SupportTasks
             .Where(t => t.OneLoginUserSubject == oneLoginUserSubject && t.Status != SupportTaskStatus.Closed)
             .OrderBy(t => t.CreatedOn)
+            .Select(t => t.SupportTaskReference)
             .FirstOrDefaultAsync();
-
-        return task?.SupportTaskReference;
-    }
 
     public async Task<bool> HasClosedIdVerificationSupportTaskAsync(string oneLoginUserSubject)
     {
-        var closedIdVerificationTasks = await dbContext.SupportTasks
-            .Where(t => t.OneLoginUserSubject == oneLoginUserSubject &&
-                       t.Status == SupportTaskStatus.Closed &&
-                       t.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
-            .ToListAsync();
+        var closedIdVerificationTaskData = await dbContext.SupportTasks
+            .Where(t =>
+                t.OneLoginUserSubject == oneLoginUserSubject &&
+                t.Status == SupportTaskStatus.Closed &&
+                t.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
+            .Select(t => t.Data)
+            .ToArrayAsync();
 
-        return closedIdVerificationTasks.Any(t => ((OneLoginUserIdVerificationData)t.Data).Outcome != OneLoginUserIdVerificationOutcome.NotVerified);
+        return closedIdVerificationTaskData.Any(t => ((OneLoginUserIdVerificationData)t).Outcome != OneLoginUserIdVerificationOutcome.NotVerified);
     }
 
     public async Task<OneLoginUser> OnSignInAsync(string sub, string email, ProcessContext processContext)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml
@@ -30,7 +30,7 @@
                 </row>
                 <row>
                     <key>TRN</key>
-                    <value>@Model.Trn</value>
+                    <value use-empty-fallback>@Model.Trn</value>
                 </row>
                 <row>
                     <key>National Insurance number</key>


### PR DESCRIPTION
Authz was blowing up when retrieving support tasks for users with a non-null `ResolveJourneySavedState`, since it doesn't have the `SupportUi` assembly around with the respective type in. This fixes that by altering the queries to return only the data we need. 

https://dfe-teacher-services.sentry.io/issues/7417607032/

I've also fixed the 'TRN' row in the support task resolution journey to have the 'Not provided' fallback for users without a TRN.