### PR TITLE
Update OneLogin library to increase NonceLifetime to one hour

### DIFF
--- a/TeachingRecordSystem/Directory.Packages.props
+++ b/TeachingRecordSystem/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Faker.Net" Version="2.0.163" />
     <PackageVersion Include="FluentValidation" Version="12.1.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.4.2" />
+    <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.4.3" />
     <PackageVersion Include="GovUk.Questions.AspNetCore" Version="0.1.0-alpha.0.94" />
     <PackageVersion Include="GovUk.Questions.AspNetCore.Testing" Version="0.1.0-alpha.0.94" />
     <PackageVersion Include="GovukNotify" Version="7.2.0" />

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
@@ -28,11 +28,11 @@
       },
       "GovUk.OneLogin.AspNetCore": {
         "type": "Direct",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "q4jHwl6gJZnxoj0XBwj6WpJIDqdH7wwqYVwWysIMKM2qKV0+Y6S7qR9alOOkSzTYkMlaKwtS/gIYb1ehBqfUWw==",
+        "requested": "[0.4.3, )",
+        "resolved": "0.4.3",
+        "contentHash": "ImkDGUH6bkg7fSroHJqOzsQjS86q0drmOba3rXyZI13SRmA7xfuwVSRCmZde7QPsRgnCUGTaa4ksQlGR5mMXEA==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.25"
+          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.26"
         }
       },
       "GovUk.Questions.AspNetCore": {
@@ -194,7 +194,8 @@
         "resolved": "11.11.0",
         "contentHash": "viTKWaMbL3yJYgGI0DiCeavNbE9UPMWFVK2XS9nYXGbm3NDMd0/L5ER4wBzmTtW3BYh3SrlSXm9RACiKZ6stlA==",
         "dependencies": {
-          "FluentValidation": "11.11.0"
+          "FluentValidation": "11.11.0",
+          "Microsoft.Extensions.Dependencyinjection.Abstractions": "2.1.0"
         }
       },
       "Google.Api.Gax": {
@@ -394,6 +395,11 @@
         "type": "Transitive",
         "resolved": "10.3.0",
         "contentHash": "b3gmxtyX0n8bQFuZ679f8QiOWqjeZKFc6XXPUsYNFzMcWi0Q44Ej3pB41N/QQ0maX380kmOMF36bLSBHNThXAg=="
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "8/CtASu80UIoyG+r8FstrmZW5GLtXxzoYpjj3jV0FKZCL5CiFgSH3pAmqut/dC68mu7N1bU6v0UtKKL3gCUQGQ=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
@@ -1029,7 +1029,7 @@
           "DartSassBuilder": "[1.1.0, )",
           "DfeAnalytics.AspNetCore": "[0.4.3-alpha.0.3, )",
           "GovUk.Frontend.AspNetCore": "[4.1.0, )",
-          "GovUk.OneLogin.AspNetCore": "[0.4.2, )",
+          "GovUk.OneLogin.AspNetCore": "[0.4.3, )",
           "GovUk.Questions.AspNetCore": "[0.1.0-alpha.0.94, )",
           "Humanizer.Core": "[3.0.10, )",
           "JetBrains.Annotations": "[2025.2.4, )",
@@ -1315,11 +1315,11 @@
       },
       "GovUk.OneLogin.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "q4jHwl6gJZnxoj0XBwj6WpJIDqdH7wwqYVwWysIMKM2qKV0+Y6S7qR9alOOkSzTYkMlaKwtS/gIYb1ehBqfUWw==",
+        "requested": "[0.4.3, )",
+        "resolved": "0.4.3",
+        "contentHash": "ImkDGUH6bkg7fSroHJqOzsQjS86q0drmOba3rXyZI13SRmA7xfuwVSRCmZde7QPsRgnCUGTaa4ksQlGR5mMXEA==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.25"
+          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.26"
         }
       },
       "GovUk.Questions.AspNetCore": {

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
@@ -1675,7 +1675,7 @@
           "DartSassBuilder": "[1.1.0, )",
           "DfeAnalytics.AspNetCore": "[0.4.3-alpha.0.3, )",
           "GovUk.Frontend.AspNetCore": "[4.1.0, )",
-          "GovUk.OneLogin.AspNetCore": "[0.4.2, )",
+          "GovUk.OneLogin.AspNetCore": "[0.4.3, )",
           "GovUk.Questions.AspNetCore": "[0.1.0-alpha.0.94, )",
           "Humanizer.Core": "[3.0.10, )",
           "JetBrains.Annotations": "[2025.2.4, )",
@@ -1997,11 +1997,11 @@
       },
       "GovUk.OneLogin.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "q4jHwl6gJZnxoj0XBwj6WpJIDqdH7wwqYVwWysIMKM2qKV0+Y6S7qR9alOOkSzTYkMlaKwtS/gIYb1ehBqfUWw==",
+        "requested": "[0.4.3, )",
+        "resolved": "0.4.3",
+        "contentHash": "ImkDGUH6bkg7fSroHJqOzsQjS86q0drmOba3rXyZI13SRmA7xfuwVSRCmZde7QPsRgnCUGTaa4ksQlGR5mMXEA==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.25"
+          "Microsoft.AspNetCore.Authentication.OpenIdConnect": "8.0.26"
         }
       },
       "GovUk.Questions.AspNetCore": {


### PR DESCRIPTION
Hopefully this will resolve the last of our timeout-related issues.

https://github.com/DFE-Digital/govuk-onelogin-aspnetcore/commit/7553d9c935e3aa01710fa4917dc5abe27ba6d354