### PR TITLE
Added script to update oneloginuserupdated process events

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260507070548_UpdateOldOneLoginProcessEvents.Designer.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260507070548_UpdateOldOneLoginProcessEvents.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507070548_UpdateOldOneLoginProcessEvents")]
+    partial class UpdateOldOneLoginProcessEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260507070548_UpdateOldOneLoginProcessEvents.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260507070548_UpdateOldOneLoginProcessEvents.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateOldOneLoginProcessEvents : Migration
+    {
+        /// <inheritdoc />
+       protected override void Up(MigrationBuilder migrationBuilder) 
+        {
+            migrationBuilder.Sql(
+                """
+               /** Backup existing data for OneLoginEvents **/
+               CREATE TABLE public.process_events_backup_onelogin AS
+               SELECT *
+               FROM public.process_events
+               WHERE event_name IN (
+                   'OneLoginUserCreatedEvent',
+                   'OneLoginUserUpdatedEvent'
+               );
+               
+               WITH previous_events AS (
+                   SELECT
+                       current_evt.process_event_id,
+                       prev_evt.payload -> 'OneLoginUser' AS previous_onelogin_user
+                   FROM public.process_events current_evt
+               
+                   CROSS JOIN LATERAL (
+                       SELECT pe.*
+                       FROM public.process_events pe
+                       WHERE pe.event_name IN (
+                               'OneLoginUserCreatedEvent',
+                               'OneLoginUserUpdatedEvent'
+                             )
+               
+                         -- both events must have a OneLogin subject
+                         AND cardinality(pe.one_login_user_subjects) > 0
+                         AND cardinality(current_evt.one_login_user_subjects) > 0
+               
+                         -- same OneLogin subject
+                         AND pe.one_login_user_subjects[1]
+                             = current_evt.one_login_user_subjects[1]
+               
+                         -- older event only
+                         AND pe.created_on < current_evt.created_on
+               
+                       ORDER BY
+                           pe.created_on DESC,
+                           pe.process_event_id DESC
+               
+                       LIMIT 1
+                   ) prev_evt
+               
+                   WHERE current_evt.event_name = 'OneLoginUserUpdatedEvent'
+               )
+               
+               /** update OldOneLoginUser process_events **/
+               UPDATE public.process_events current_evt
+               SET payload = jsonb_set(
+                   current_evt.payload,
+                   '{OldOneLoginUser}',
+                   previous_events.previous_onelogin_user,
+                   true
+               )
+               FROM previous_events
+               WHERE previous_events.process_event_id = current_evt.process_event_id
+               
+                 AND (
+                     current_evt.payload -> 'OldOneLoginUser'
+                 ) IS DISTINCT FROM (
+                     previous_events.previous_onelogin_user
+                 );
+               """
+            );
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                DROP TABLE IF EXISTS public.process_events_backup_onelogin;
+                """
+            );
+        }
+
+    }
+}


### PR DESCRIPTION
### Context
https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/2?pane=issue&itemId=182662583&issue=DFE-Digital%7Cteaching-record-team-project-board%7C277

### Changes proposed in this pull request

This fixes OneLoginUserUpdated Process events that were created as a result of a bug whereby the OldOneLoginUser was being set to the new value, rather than keeping the old value.  

- Backup process_events for OneLoginUserUpdated and OneLoginUserCreated event types as a precaution.
- It sets the OldOneLoginUser property to that of the previous events OneLoginUser

### Guidance to review


### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally