### PR TITLE
Add ContinueToApplication to Journey Path

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/CheckAnswers.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/CheckAnswers.cshtml.cs
@@ -45,6 +45,8 @@ public class CheckAnswersModel(
         SupportTask supportTask;
         string? trnRequestId = null;
 
+        var pathStepUrls = new List<string> { coordinator.Links.SupportRequestSubmitted() };
+
         if (IdentityVerified)
         {
             if (state.RecordMatchingPolicy == RecordMatchingPolicy.Deferred)
@@ -54,6 +56,8 @@ public class CheckAnswersModel(
                     trnRequestId = await coordinator.CompleteWithDeferredMatchingAsync(state);
                     return state;
                 });
+
+                pathStepUrls.Add(coordinator.Links.ContinueToApplication());
             }
 
             supportTask = await oneLoginUserMatchingSupportTaskService.CreateRecordMatchingSupportTaskAsync(
@@ -92,9 +96,10 @@ public class CheckAnswersModel(
 
         coordinator.UpdateState(s => s.CreatedSupportTaskReference = supportTask.SupportTaskReference);
 
-        return coordinator.AdvanceTo(
-            links => links.SupportRequestSubmitted(),
-            new PushStepOptions { SetAsFirstStep = true });  // Prevents the user from going back to any page before 'SupportRequestSubmitted'
+        var newPath = new JourneyPath(pathStepUrls.Select(coordinator.CreateStepFromUrl));
+        coordinator.UnsafeSetPath(newPath);
+
+        return Redirect(pathStepUrls.First());  // SupportRequestSubmitted
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
@@ -265,12 +265,6 @@ public class SignInJourneyCoordinator(
             return Path.Steps.Last();
         }
 
-        // Allow continue to application to be accessed from Found page
-        if (HttpContext.Request.GetEncodedPathAndQuery() == Links.ContinueToApplication())
-        {
-            return Path.Steps.Last();
-        }
-
         return base.GetCurrentStep();
     }
 
@@ -320,16 +314,16 @@ public class SignInJourneyCoordinator(
 
             UpdateState(state => Complete(state, matchedTrn));
 
-            var nextUrl = SquashPathAndAdvanceTo(Links.Found()).Url;
+            var nextUrl = SquashPathAndAdvanceTo(Links.Found(), additionalStepUrls: Links.ContinueToApplication()).Url;
             return new RedirectResult(nextUrl);
         }
 
         return null;
     }
 
-    private RedirectHttpResult SquashPathAndAdvanceTo(string url, bool includeRedirectUri = true)
+    private RedirectHttpResult SquashPathAndAdvanceTo(string url, bool includeRedirectUri = true, params IEnumerable<string> additionalStepUrls)
     {
-        var urls = new List<string>(2) { url };
+        var urls = new List<string> { url };
 
         // Ensure the RedirectUri is included in the path
         if (includeRedirectUri)
@@ -337,11 +331,13 @@ public class SignInJourneyCoordinator(
             urls.Insert(0, GetRedirectUri());
         }
 
+        urls.AddRange(additionalStepUrls);
+
         var steps = urls.Select(CreateStepFromUrl);
         var path = new JourneyPath(steps);
         UnsafeSetPath(path);
 
-        return (RedirectHttpResult)Results.Redirect(urls.Last());
+        return (RedirectHttpResult)Results.Redirect(url);
     }
 
     public void Complete(SignInJourneyState state, string trn)


### PR DESCRIPTION
We have a few 'Current step not found in journey path.' errors in Sentry from the `ContinueToApplication` page. This is being triggered by `GetBackLink()` from the Layout page somehow (even though the particular condition that's called under shouldn't be happening here). This change ensures that page is in the journey steps, to avoid this problem.