### PR TITLE
Rename internal claims

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Extensions.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Extensions.cs
@@ -121,7 +121,7 @@ public static class Extensions
                     .RequireAssertion(ctx =>
                     {
                         var scopes = (ctx.User.FindFirstValue("scope") ?? string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                        var hasRequiredClaim = ctx.User.HasClaim(c => c.Type is "trn" or "trn_request_id");
+                        var hasRequiredClaim = ctx.User.HasClaim(c => c.Type is "trn" or AuthorizeAccessClaimTypes.TrnRequestId);
                         var isIdUser = scopes.Contains("dqt:read") && hasRequiredClaim;
                         var isAuthorizeAccessUser = scopes.Contains("teaching_record") && hasRequiredClaim;
                         return isIdUser || isAuthorizeAccessUser;

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ClaimsPrincipalCurrentUserProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Api/Infrastructure/Security/ClaimsPrincipalCurrentUserProvider.cs
@@ -11,7 +11,7 @@ public class ClaimsPrincipalCurrentUserProvider(IHttpContextAccessor httpContext
         var principal = httpContext.User;
 
         // If there's a TRN claim then it's either an access token from ID or from Teacher Auth (i.e. AuthorizeAccess).
-        if (principal.HasClaim(c => c.Type is "trn" or "trn_request_id"))
+        if (principal.HasClaim(c => c.Type is "trn" or AuthorizeAccessClaimTypes.TrnRequestId))
         {
             if (principal.HasClaim(c => c.Type == "scope" && c.Value.Contains("dqt:read")))
             {
@@ -21,10 +21,10 @@ public class ClaimsPrincipalCurrentUserProvider(IHttpContextAccessor httpContext
                 return true;
             }
 
-            if (principal.FindFirstValue("trs_user_id") is string trsUserId)
+            if (principal.FindFirstValue(AuthorizeAccessClaimTypes.TrsApplicationUserId) is string trsApplicationUserId)
             {
                 // Teacher Auth access token
-                userId = Guid.Parse(trsUserId);
+                userId = Guid.Parse(trsApplicationUserId);
                 return true;
             }
         }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/OAuth2Controller.cs
@@ -228,7 +228,7 @@ public class OAuth2Controller(
                 yield return Destinations.IdentityToken;
                 yield break;
 
-            case AuthorizeAccessClaimTypes.TrsUserId:
+            case AuthorizeAccessClaimTypes.TrsApplicationUserId:
                 yield return Destinations.AccessToken;
                 yield break;
 

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Test.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Test.cshtml
@@ -1,5 +1,4 @@
 @page "/test"
-@using GovUk.OneLogin.AspNetCore
 @using System.Security.Claims
 @model TeachingRecordSystem.AuthorizeAccess.Pages.TestModel
 @{
@@ -8,6 +7,6 @@
 
 <h1>Hello @User.FindFirstValue("person_id")</h1>
 
-<div data-testid="trn">@User.FindFirstValue("trn")</div>
+<div data-testid="trn">@User.FindFirstValue(AuthorizeAccessClaimTypes.Trn)</div>
 
-<div data-testid="trn-request-id">@User.FindFirstValue("trn_request_id")</div>
+<div data-testid="trn-request-id">@User.FindFirstValue(AuthorizeAccessClaimTypes.TrnRequestId)</div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
@@ -420,7 +420,7 @@ public class SignInJourneyCoordinator(
             new Claim(AuthorizeAccessClaimTypes.Subject, oneLoginPrincipal.FindFirstValue("sub")!),
             new Claim(AuthorizeAccessClaimTypes.Email, oneLoginPrincipal.FindFirstValue("email")!),
             new Claim(AuthorizeAccessClaimTypes.OneLoginIdToken, oneLoginIdToken),
-            new Claim(AuthorizeAccessClaimTypes.TrsUserId, state.ClientApplicationUserId.ToString())
+            new Claim(AuthorizeAccessClaimTypes.TrsApplicationUserId, state.ClientApplicationUserId.ToString())
         };
 
         claims.AddRange(specificClaims);

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/AuthorizeAccessClaimTypes.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/AuthorizeAccessClaimTypes.cs
@@ -5,9 +5,11 @@ public static class AuthorizeAccessClaimTypes
     public const string Email = "email";
     public const string Subject = "sub";
     public const string Trn = "trn";
-    public const string TrnRequestId = "trn_request_id";
-    public const string OneLoginIdToken = "_ta_olidt";
     public const string VerifiedName = "verified_name";
     public const string VerifiedDateOfBirth = "verified_date_of_birth";
-    public const string TrsUserId = "trs_user_id";
+
+    // Internal-only claims
+    public const string OneLoginIdToken = "_ta_olidt";
+    public const string TrsApplicationUserId = "_ta_auid";
+    public const string TrnRequestId = "_ta_trid";
 }

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/TestBase.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Api.IntegrationTests/TestBase.cs
@@ -91,7 +91,7 @@ public abstract class TestBase
     {
         Claim[] claims = [
             new("scope", "teaching_record"),
-            new("trn", trn)
+            new(AuthorizeAccessClaimTypes.Trn, trn)
         ];
 
         return GetHttpClientWithJwtAccessToken(claims, version);
@@ -101,8 +101,8 @@ public abstract class TestBase
     {
         Claim[] claims = [
             new("scope", "teaching_record"),
-            new("trn_request_id", trnRequestId),
-            new("trs_user_id", applicationUserId.ToString())
+            new(AuthorizeAccessClaimTypes.TrnRequestId, trnRequestId),
+            new(AuthorizeAccessClaimTypes.TrsApplicationUserId, applicationUserId.ToString())
         ];
 
         return GetHttpClientWithJwtAccessToken(claims, version);

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.EndToEndTests/HostFixture.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.EndToEndTests/HostFixture.cs
@@ -148,8 +148,8 @@ public sealed class HostFixture : InitializeDbFixture
     {
         Claim[] claims = [
             new("scope", "teaching_record"),
-            new("trn_request_id", trnRequestId),
-            new("trs_user_id", applicationUserId.ToString())
+            new(AuthorizeAccessClaimTypes.TrnRequestId, trnRequestId),
+            new(AuthorizeAccessClaimTypes.TrsApplicationUserId, applicationUserId.ToString())
         ];
 
         var subject = new ClaimsIdentity(claims);


### PR DESCRIPTION
Downstream services have seen claims like `trs_user_id` and assumed it's an ID they should be using. This gives all our internal-only claims suitably obscure names, to discourage services from using them.