### PR TITLE
Refine One Login user matching rules to handle mis-matched last name

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -347,7 +347,8 @@ public class OneLoginService(
     public virtual MatchPersonResult? MatchPerson(IReadOnlyCollection<MatchPersonResult> suggestedMatches)
     {
         // A One Login is matched if there is exactly one Person with a matching
-        // first name, last name, DOB AND either NINO or TRN.
+        // first name, last name, DOB AND either NINO or TRN *OR*
+        // first name, DOB, NINO and TRN.
 
         var candidates = new List<MatchPersonResult>();
 
@@ -356,16 +357,14 @@ public class OneLoginService(
             var matchedAttributes = match.MatchedAttributes;
             var matchedAttributeTypes = matchedAttributes.Select(kvp => kvp.Key).ToArray();
 
-            var requiredAttributeTypes = new[]
-            {
-                PersonMatchedAttribute.FirstName,
-                PersonMatchedAttribute.LastName,
-                PersonMatchedAttribute.DateOfBirth
-            };
+            var firstNameMatched = matchedAttributeTypes.Contains(PersonMatchedAttribute.FirstName);
+            var lastNameMatched = matchedAttributeTypes.Contains(PersonMatchedAttribute.LastName);
+            var dateOfBirthMatched = matchedAttributeTypes.Contains(PersonMatchedAttribute.DateOfBirth);
+            var nationalInsuranceNumberMatched = matchedAttributeTypes.Contains(PersonMatchedAttribute.NationalInsuranceNumber);
+            var trnMatched = matchedAttributeTypes.Contains(PersonMatchedAttribute.Trn);
 
-            if (!requiredAttributeTypes.Except(matchedAttributeTypes).Any() &&
-                (matchedAttributeTypes.Contains(PersonMatchedAttribute.NationalInsuranceNumber) ||
-                 matchedAttributeTypes.Contains(PersonMatchedAttribute.Trn)))
+            if ((firstNameMatched && lastNameMatched && dateOfBirthMatched && (nationalInsuranceNumberMatched || trnMatched)) ||
+                (firstNameMatched && dateOfBirthMatched && nationalInsuranceNumberMatched && trnMatched))
             {
                 candidates.Add(new MatchPersonResult(
                     match.PersonId,

--- a/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
+++ b/TeachingRecordSystem/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
@@ -37,7 +37,7 @@ public partial class OneLoginServiceTests
 
         string[][] names = nameOption switch
         {
-            OneLogin.NameArgumentOption.NoFullName => [[person.FirstName]],
+            OneLogin.NameArgumentOption.MatchesFirstNameOnly => [[person.FirstName]],
             OneLogin.NameArgumentOption.MatchesPersonName => [[person.FirstName, person.LastName]],
             OneLogin.NameArgumentOption.MultipleSpecifiedAndOneMatchesPersonName => [[person.FirstName, person.LastName], [TestData.GenerateChangedFirstName([person.FirstName, alias, person.MiddleName, person.LastName]), person.LastName]],
             OneLogin.NameArgumentOption.MatchesAlias => [[alias!, person.LastName]],
@@ -532,22 +532,22 @@ public partial class OneLoginServiceTests
             _matchNameDobAndNinoAttributes
         },
 
+        // Matches on first name, DOB, TRN and NINO but not first name
+        {
+            OneLogin.NameArgumentOption.MatchesFirstNameOnly,
+            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
+            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
+            OneLogin.TrnArgumentOption.SpecifiedAndMatches,
+            /*expectMatch: */ true,
+            [PersonMatchedAttribute.FirstName, PersonMatchedAttribute.DateOfBirth, PersonMatchedAttribute.NationalInsuranceNumber, PersonMatchedAttribute.Trn]
+        },
+        
 
         // *** No match cases ***
 
         // Missing names
         {
             OneLogin.NameArgumentOption.NotSpecified,
-            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
-            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
-            OneLogin.TrnArgumentOption.SpecifiedAndMatches,
-            /*expectMatch: */ false,
-            null
-        },
-
-        // Missing full name
-        {
-            OneLogin.NameArgumentOption.NoFullName,
             OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
             OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
             OneLogin.TrnArgumentOption.SpecifiedAndMatches,
@@ -641,7 +641,7 @@ public partial class OneLoginServiceTests
         public enum NameArgumentOption
         {
             NotSpecified,
-            NoFullName,
+            MatchesFirstNameOnly,
             MatchesPersonName,
             MultipleSpecifiedAndOneMatchesPersonName,
             MatchesAlias,


### PR DESCRIPTION
We have a lot of support tasks being created because last names don't match. This relaxes the matching rules so that if all other attributes match (except last name), we consider the record a match.