### PR TITLE
Handle more access_denied errors

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/ErrorController.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Controllers/ErrorController.cs
@@ -6,6 +6,9 @@ namespace TeachingRecordSystem.AuthorizeAccess.Controllers;
 [Route("error")]
 public class ErrorController : Controller
 {
+    public const string ClientApplicationDisplayNameKey = "ClientApplicationDisplayName";
+    public const string ClientApplicationSignInUrlKey = "ClientApplicationSignInUrl";
+
     public IActionResult Error(int? code)
     {
         // If there is no error, return a 404

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/DropEventProcessor.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/DropEventProcessor.cs
@@ -1,0 +1,14 @@
+using Sentry.Extensibility;
+
+namespace TeachingRecordSystem.AuthorizeAccess.Infrastructure;
+
+public class DropEventProcessor : ISentryEventProcessor
+{
+    private DropEventProcessor()
+    {
+    }
+
+    public static DropEventProcessor Instance { get; } = new();
+
+    public SentryEvent? Process(SentryEvent @event) => null;
+}

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/OneLoginAuthenticationSchemeProvider.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/OneLoginAuthenticationSchemeProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Npgsql;
+using TeachingRecordSystem.AuthorizeAccess.Controllers;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
@@ -199,6 +200,23 @@ public sealed class OneLoginAuthenticationSchemeProvider(
 
         options.Events.OnAccessDenied = async context =>
         {
+            if (context.Request.Query["error_description"] == "Access denied for security reasons, a new authentication request may be successful")
+            {
+                // Don't log this error in Sentry, but do capture as a message for visibility
+                SentrySdk.ConfigureScope(s => s.AddEventProcessor(DropEventProcessor.Instance));
+                SentrySdk.CaptureMessage(
+                    $"Received 'access_denied' error with 'error_description': '{context.Request.Query["error_description"]}'.");
+
+                // Allow the exception to bubble-up, which will render our Error page, where the user can return to the calling service and retry.
+                // Add the calling service to the context so the Error page knows which service the request is for.
+                context.HttpContext.Items[ErrorController.ClientApplicationDisplayNameKey] = user.Name;
+                context.HttpContext.Items[ErrorController.ClientApplicationSignInUrlKey] =
+                    user.AppContent?.SignInUrl ??
+                    new Uri(user.RedirectUris!.First()).GetLeftPart(UriPartial.Authority);
+
+                return;
+            }
+
             // This handles the scenario where we've requested ID verification but One Login couldn't do it.
 
             if (context.Properties!.TryGetVectorsOfTrust(out var vtr) &&

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/GenericError.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/GenericError.cshtml
@@ -1,3 +1,4 @@
+@using static TeachingRecordSystem.AuthorizeAccess.Controllers.ErrorController
 @{
     Layout = "./_ErrorLayout";
     ViewBag.Title = "Sorry, there is a problem with the service";
@@ -5,7 +6,20 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
-        <p class="govuk-body">Try again later.</p>
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+        @if (Context.Items.TryGetValue(ClientApplicationDisplayNameKey, out var displayNameObj) && displayNameObj is string clientApplicationDisplayName &&
+            Context.Items.TryGetValue(ClientApplicationSignInUrlKey, out var signInUrlObj) && signInUrlObj is string clientApplicationSignInUrl)
+        {
+            <p class="govuk-body">
+                <a href="@clientApplicationSignInUrl" class="govuk-link">
+                    Return to @clientApplicationDisplayName and try again.
+                </a>
+            </p>
+        }
+        else
+        {
+            <p class="govuk-body">Try again later.</p>
+        }
     </div>
 </div>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/NotFound.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/NotFound.cshtml
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Page not found</h1>
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
         <p class="govuk-body">
             If you typed the web address, check it is correct.
         </p>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/AppContent.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Models/AppContent.cs
@@ -10,4 +10,5 @@ public record AppContent
     public string? OneLoginNoMatchesEmailSentFlashMessage { get; init; }
     public string? OneLoginNotConnectedEmailSentFlashMessage { get; init; }
     public string? OneLoginFoundPageLinkText { get; init; }
+    public string? SignInUrl { get; init; }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml
@@ -1,5 +1,4 @@
 @page "/application-users/{userId}"
-@using TeachingRecordSystem.Core.Models
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 @model TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.EditApplicationUser.IndexModel
 @inject TimeProvider Clock
@@ -13,7 +12,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <form action="@LinkGenerator.ApplicationUsers.EditApplicationUser.Index(Model.UserId!)" method="post">
+        <form action="@LinkGenerator.ApplicationUsers.EditApplicationUser.Index(Model.UserId)" method="post">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <govuk-input for="Name">
@@ -157,45 +156,49 @@
                             </govuk-radios-fieldset>
                         </govuk-radios>
 
-                        <h3 class="govuk-heading-s">App Content</h3>
+                        <h3 class="govuk-heading-s">App content</h3>
+
+                        <govuk-input for="SignInUrl" input-class="trs-monospace" type="url" spellcheck="false">
+                            <govuk-input-label class="govuk-label--s">Sign in URL</govuk-input-label>
+                        </govuk-input>
 
                         <govuk-input for="OneLoginCannotFindRecordEmailTemplateId" input-class="trs-monospace" spellcheck="false">
-                            <govuk-input-label class="govuk-label--s">One Login - Cannot Find Record Email Template ID</govuk-input-label>
+                            <govuk-input-label class="govuk-label--s">One Login - ‘cannot find record’ email template ID</govuk-input-label>
                             <govuk-input-hint>Leave blank to use default template</govuk-input-hint>
                         </govuk-input>
 
                         <govuk-input for="OneLoginNotVerifiedEmailTemplateId" input-class="trs-monospace" spellcheck="false">
-                            <govuk-input-label class="govuk-label--s">One Login - Not Verified Email Template ID</govuk-input-label>
+                            <govuk-input-label class="govuk-label--s">One Login - ‘not verified’ email template ID</govuk-input-label>
                             <govuk-input-hint>Leave blank to use default template</govuk-input-hint>
                         </govuk-input>
 
                         <govuk-input for="OneLoginRecordMatchedEmailTemplateId" input-class="trs-monospace" spellcheck="false">
-                            <govuk-input-label class="govuk-label--s">One Login - Record Matched Email Template ID</govuk-input-label>
+                            <govuk-input-label class="govuk-label--s">One Login - ‘record matched’ email template ID</govuk-input-label>
                             <govuk-input-hint>Leave blank to use default template</govuk-input-hint>
                         </govuk-input>
 
                         <govuk-input for="OneLoginNotConnectedEmailTemplateId" input-class="trs-monospace" spellcheck="false">
-                            <govuk-input-label class="govuk-label--s">One Login - Not Connected Email Template ID</govuk-input-label>
+                            <govuk-input-label class="govuk-label--s">One Login - ‘not connected’ email template ID</govuk-input-label>
                             <govuk-input-hint>Leave blank to use default template</govuk-input-hint>
                         </govuk-input>
 
                         <govuk-textarea for="OneLoginNoMatchesPageContentHtml" textarea-class="govuk-!-width-full trs-monospace" rows="10" spellcheck="false">
-                            <govuk-textarea-label class="govuk-label--s">One Login - No Matches Page Content</govuk-textarea-label>
+                            <govuk-textarea-label class="govuk-label--s">One Login - ‘no matches’ page content</govuk-textarea-label>
                             <govuk-textarea-hint>HTML content shown on the No Matches page when a user cannot be matched to a teaching record. Leave blank to use default content.</govuk-textarea-hint>
                         </govuk-textarea>
 
                         <govuk-textarea for="OneLoginNoMatchesEmailSentFlashMessage" textarea-class="govuk-!-width-full trs-monospace" rows="3" spellcheck="false">
-                            <govuk-textarea-label class="govuk-label--s">One Login - No Matches Email Sent Flash Message</govuk-textarea-label>
+                            <govuk-textarea-label class="govuk-label--s">One Login - ‘no matches’ email sent flash message</govuk-textarea-label>
                             <govuk-textarea-hint>Flash message shown when email is sent on No Matches page. Use {0} placeholder for name. Leave blank to use default message.</govuk-textarea-hint>
                         </govuk-textarea>
 
                         <govuk-textarea for="OneLoginNotConnectedEmailSentFlashMessage" textarea-class="govuk-!-width-full trs-monospace" rows="3" spellcheck="false">
-                            <govuk-textarea-label class="govuk-label--s">One Login - Not Connected Email Sent Flash Message</govuk-textarea-label>
+                            <govuk-textarea-label class="govuk-label--s">One Login - ‘not connected’ email sent flash message</govuk-textarea-label>
                             <govuk-textarea-hint>Flash message shown when email is sent on Not Connecting page (deferred policy only). Use {0} placeholder for name. Leave blank to use default message.</govuk-textarea-hint>
                         </govuk-textarea>
 
                         <govuk-textarea for="OneLoginFoundPageLinkText" textarea-class="govuk-!-width-full trs-monospace" rows="3" spellcheck="false">
-                            <govuk-textarea-label class="govuk-label--s">One Login - Found Page Link Text</govuk-textarea-label>
+                            <govuk-textarea-label class="govuk-label--s">One Login - ‘found’ page link text</govuk-textarea-label>
                             <govuk-textarea-hint>HTML text with link shown on the Found page. Use {0} placeholder for continue URL. Leave blank to use default text.</govuk-textarea-hint>
                         </govuk-textarea>
                     </govuk-checkboxes-item-conditional>

--- a/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml.cs
@@ -107,6 +107,8 @@ public class IndexModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
 
     public string? ShortName { get; set; }
 
+    public string? SignInUrl { get; set; }
+
     public void OnGet()
     {
         Name = _user!.Name;
@@ -132,6 +134,7 @@ public class IndexModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
         OneLoginNotConnectedEmailSentFlashMessage = _user.AppContent?.OneLoginNotConnectedEmailSentFlashMessage;
         OneLoginFoundPageLinkText = _user.AppContent?.OneLoginFoundPageLinkText;
         ShortName = _user.ShortName;
+        SignInUrl = _user.AppContent?.SignInUrl;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -209,12 +212,12 @@ public class IndexModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
             (!new HashSet<string>(_user.ApiRoles ?? []).SetEquals(new HashSet<string>(newApiRoles)) ? ApplicationUserUpdatedEventChanges.ApiRoles : 0) |
             (IsOidcClient != _user.IsOidcClient ? ApplicationUserUpdatedEventChanges.IsOidcClient : 0);
 
-        TeachingRecordSystem.Core.Models.AppContent? newAppContent = null;
+        AppContent? newAppContent = null;
 
         if (IsOidcClient)
         {
             var oldAppContent = _user.AppContent;
-            newAppContent = new TeachingRecordSystem.Core.Models.AppContent
+            newAppContent = new AppContent
             {
                 OneLoginCannotFindRecordEmailTemplateId = OneLoginCannotFindRecordEmailTemplateId,
                 OneLoginNotVerifiedEmailTemplateId = OneLoginNotVerifiedEmailTemplateId,
@@ -223,7 +226,8 @@ public class IndexModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
                 OneLoginNoMatchesPageContentHtml = OneLoginNoMatchesPageContentHtml,
                 OneLoginNoMatchesEmailSentFlashMessage = OneLoginNoMatchesEmailSentFlashMessage,
                 OneLoginNotConnectedEmailSentFlashMessage = OneLoginNotConnectedEmailSentFlashMessage,
-                OneLoginFoundPageLinkText = OneLoginFoundPageLinkText
+                OneLoginFoundPageLinkText = OneLoginFoundPageLinkText,
+                SignInUrl = SignInUrl
             };
             var appContentChanged = oldAppContent?.OneLoginCannotFindRecordEmailTemplateId != newAppContent.OneLoginCannotFindRecordEmailTemplateId ||
                                    oldAppContent?.OneLoginNotVerifiedEmailTemplateId != newAppContent.OneLoginNotVerifiedEmailTemplateId ||
@@ -232,7 +236,8 @@ public class IndexModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
                                    oldAppContent?.OneLoginNoMatchesPageContentHtml != newAppContent.OneLoginNoMatchesPageContentHtml ||
                                    oldAppContent?.OneLoginNoMatchesEmailSentFlashMessage != newAppContent.OneLoginNoMatchesEmailSentFlashMessage ||
                                    oldAppContent?.OneLoginNotConnectedEmailSentFlashMessage != newAppContent.OneLoginNotConnectedEmailSentFlashMessage ||
-                                   oldAppContent?.OneLoginFoundPageLinkText != newAppContent.OneLoginFoundPageLinkText;
+                                   oldAppContent?.OneLoginFoundPageLinkText != newAppContent.OneLoginFoundPageLinkText ||
+                                   oldAppContent?.SignInUrl != newAppContent.SignInUrl;
 
             changes |=
                 (ClientId != _user.ClientId ? ApplicationUserUpdatedEventChanges.ClientId : 0) |


### PR DESCRIPTION
We've got some `access_denied` error callbacks with an `error_description` of `Access denied for security reasons, a new authentication request may be successful`. The logs suggest that the user's session has gone away at the point so we can't continue as we don't have all the OAuth state around.

This change catches that error and renders our usual error page but with a link back to the calling service so the user can try again. 