### PR TITLE
Simplify the Debug page

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/JourneySignInHandler.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Infrastructure/Security/JourneySignInHandler.cs
@@ -69,7 +69,9 @@ public class JourneySignInHandler(IJourneyInstanceProvider journeyInstanceProvid
 
         var ticket = new AuthenticationTicket(user, properties, _scheme.Name);
 
-        var result = await coordinator.OnOneLoginCallbackAsync(ticket);
+        var result = coordinator.ShowDebugPages ?
+            coordinator.OnOneLoginCallbackDebug(ticket) :
+            await coordinator.OnOneLoginCallbackAsync(ticket);
 
         await result.ExecuteAsync(_context);
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml
@@ -18,25 +18,20 @@
             <govuk-input for="Email" type="email" disabled="true" />
 
             <govuk-checkboxes for="AttemptedIdentityVerification">
-                <govuk-checkboxes-item value="@true" disabled="@Model.IsAlreadyVerified">Attempted identity verification</govuk-checkboxes-item>
+                <govuk-checkboxes-item value="@true" disabled="@Model.IdentityVerified">Attempted identity verification</govuk-checkboxes-item>
             </govuk-checkboxes>
 
-            @if (Model.IsAlreadyVerified)
-            {
-                <input type="hidden" asp-for="IdentityVerified" value="true" />
-            }
-
             <govuk-checkboxes for="IdentityVerified">
-                <govuk-checkboxes-item value="@true" disabled="@Model.IsAlreadyVerified">
+                <govuk-checkboxes-item value="@true" disabled="@Model.IdentityVerified">
                     Identity verified
-                    @if (Model.IsAlreadyVerified)
+                    @if (Model.IdentityVerified)
                     {
                         <text> (already verified in database)</text>
                     }
 
                     <govuk-checkboxes-item-conditional>
-                        <govuk-textarea for="VerifiedNames" disabled="@Model.IsAlreadyVerified" />
-                        <govuk-textarea for="VerifiedDatesOfBirth" disabled="@Model.IsAlreadyVerified" />
+                        <govuk-textarea for="VerifiedNames" disabled="@Model.IdentityVerified" />
+                        <govuk-textarea for="VerifiedDatesOfBirth" disabled="@Model.IdentityVerified" />
                     </govuk-checkboxes-item-conditional>
                 </govuk-checkboxes-item>
             </govuk-checkboxes>
@@ -64,10 +59,6 @@
                             <value>@Model.Person.NationalInsuranceNumber</value>
                         </row>
                     </govuk-summary-list>
-
-                    <govuk-checkboxes for="DetachPerson" class="govuk-checkboxes--small">
-                        <govuk-checkboxes-item value="@true">Detach teaching record</govuk-checkboxes-item>
-                    </govuk-checkboxes>
                 }
                 else
                 {

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/Pages/DebugIdentity.cshtml.cs
@@ -16,6 +16,7 @@ namespace TeachingRecordSystem.AuthorizeAccess.Pages;
 public class DebugIdentityModel(
     TrsDbContext dbContext,
     SignInJourneyCoordinator coordinator,
+    TimeProvider timeProvider,
     IOptions<AuthorizeAccessOptions> optionsAccessor) : PageModel
 {
     private OneLoginUser? _oneLoginUser;
@@ -45,34 +46,16 @@ public class DebugIdentityModel(
     [Display(Name = "Verified dates of birth")]
     public string? VerifiedDatesOfBirth { get; set; }
 
-    public string? CoreIdentityJwt { get; set; }
-
     public PersonInfo? Person { get; set; }
-
-    [BindProperty]
-    public bool DetachPerson { get; set; }
-
-    public bool IsAlreadyVerified { get; set; }
 
     public void OnGet()
     {
-        AttemptedIdentityVerification = coordinator.State.AttemptedIdentityVerification;
-        IdentityVerified = coordinator.State.IdentityVerified || IsAlreadyVerified;
+        IdentityVerified = _oneLoginUser!.VerificationRoute is not null;
 
         if (IdentityVerified)
         {
-            if (IsAlreadyVerified)
-            {
-                // Use stored verified info from database
-                VerifiedNames = string.Join("\n", _oneLoginUser!.VerifiedNames!.Select(name => string.Join(" ", name)));
-                VerifiedDatesOfBirth = string.Join("\n", _oneLoginUser!.VerifiedDatesOfBirth!.Select(dob => dob.ToString("dd/MM/yyyy")));
-            }
-            else
-            {
-                // Use verified info from journey state
-                VerifiedNames = string.Join("\n", coordinator.State.VerifiedNames!.Select(name => string.Join(" ", name)));
-                VerifiedDatesOfBirth = string.Join("\n", coordinator.State.VerifiedDatesOfBirth!.Select(dob => dob.ToString("dd/MM/yyyy")));
-            }
+            VerifiedNames = string.Join("\n", _oneLoginUser.VerifiedNames!.Select(name => string.Join(" ", name)));
+            VerifiedDatesOfBirth = string.Join("\n", _oneLoginUser.VerifiedDatesOfBirth!.Select(dob => dob.ToString("dd/MM/yyyy")));
         }
     }
 
@@ -81,13 +64,7 @@ public class DebugIdentityModel(
         string[][]? verifiedNames;
         DateOnly[]? verifiedDatesOfBirth;
 
-        // Skip validation if already verified (fields are disabled)
-        if (IsAlreadyVerified)
-        {
-            verifiedNames = _oneLoginUser!.VerifiedNames;
-            verifiedDatesOfBirth = _oneLoginUser!.VerifiedDatesOfBirth;
-        }
-        else if (IdentityVerified)
+        if (IdentityVerified)
         {
             verifiedNames = (VerifiedNames ?? string.Empty).Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Select(line => line.Split(' ', StringSplitOptions.RemoveEmptyEntries))
@@ -128,46 +105,28 @@ public class DebugIdentityModel(
             return this.PageWithErrors();
         }
 
-        if (_oneLoginUser!.PersonId is not null)
+        var alreadyVerified = _oneLoginUser!.VerificationRoute is not null;
+
+        if (!alreadyVerified && IdentityVerified)
         {
-            if (DetachPerson)
-            {
-                _oneLoginUser.ClearMatchedPerson();
-            }
-            else
-            {
-                coordinator.UpdateState(state => coordinator.Complete(state, _oneLoginUser.Person!.Trn));
-                return GetNextPage();
-            }
+            _oneLoginUser.SetVerified(
+                timeProvider.UtcNow,
+                OneLoginUserVerificationRoute.Support,
+                verifiedByApplicationUserId: null,
+                verifiedNames,
+                verifiedDatesOfBirth,
+                coreIdentityClaimVc: null);
+
+            await dbContext.SaveChangesAsync();
+        }
+        else if (AttemptedIdentityVerification)
+        {
+            coordinator.UpdateState(s => s.AttemptedIdentityVerification = true);
         }
 
-        // Don't re-verify if already verified in database (checkbox is disabled so can't change)
-        if (IdentityVerified && !IsAlreadyVerified)
-        {
-            await coordinator.OnUserVerifiedCoreAsync(verifiedNames!, verifiedDatesOfBirth!, coreIdentityClaimVc: null);
-        }
-        else if (!IdentityVerified)
-        {
-            _oneLoginUser.ClearVerifiedInfo();
-            coordinator.UpdateState(state => state.ClearVerified());
+        await coordinator.OnOneLoginCallbackAsync(coordinator.State.OneLoginAuthenticationTicket!);
 
-            if (AttemptedIdentityVerification)
-            {
-                return coordinator.OnVerificationFailed().ToActionResult();
-            }
-        }
-
-        if (IdentityVerified && coordinator.State.RecordMatchingPolicy is RecordMatchingPolicy.Deferred)
-        {
-            await coordinator.UpdateStateAsync(state => coordinator.CompleteWithDeferredMatchingAsync(state));
-            return GetNextPage();
-        }
-
-        await dbContext.SaveChangesAsync();
-
-        return GetNextPage();
-
-        IActionResult GetNextPage() => coordinator.GetNextPage().ToActionResult();
+        return coordinator.GetNextPage().ToActionResult();
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
@@ -196,9 +155,6 @@ public class DebugIdentityModel(
         {
             Person = new(person.PersonId, person.Trn, person.FirstName, person.LastName, person.DateOfBirth, person.NationalInsuranceNumber);
         }
-
-        // Check if user already has verified identity in database
-        IsAlreadyVerified = _oneLoginUser?.VerifiedOn is not null;
 
         await base.OnPageHandlerExecutionAsync(context, next);
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
@@ -45,6 +45,13 @@ public class SignInJourneyCoordinator(
     public IResult VerifyIdentityWithOneLogin() =>
         OneLoginChallenge(Vtrs.AuthenticationAndIdentityVerification);
 
+    public IResult OnOneLoginCallbackDebug(AuthenticationTicket ticket)
+    {
+        UpdateState(s => s.OneLoginAuthenticationTicket = ticket);
+
+        return SquashPathAndAdvanceTo(Links.DebugIdentity());
+    }
+
     public async Task<IResult> OnOneLoginCallbackAsync(AuthenticationTicket ticket)
     {
         if (!ticket.Properties.TryGetVectorsOfTrust(out var vtr))
@@ -61,11 +68,6 @@ public class SignInJourneyCoordinator(
             Debug.Assert(vtr.SequenceEqual([Vtrs.AuthenticationAndIdentityVerification]));
             Debug.Assert(State.OneLoginAuthenticationTicket is not null);
             await OnUserVerifiedAsync(ticket);
-        }
-
-        if (ShowDebugPages)
-        {
-            return SquashPathAndAdvanceTo(Links.DebugIdentity());
         }
 
         return GetNextPage();
@@ -113,24 +115,21 @@ public class SignInJourneyCoordinator(
                 state.SetVerified(oneLoginUser.VerifiedNames!, oneLoginUser.VerifiedDatesOfBirth!);
             }
 
-            if (!ShowDebugPages)
+            if (trn is not null)
             {
-                if (trn is not null)
-                {
-                    Complete(state, trn);
-                }
-                else if (existingTrnRequestId is not null)
-                {
-                    CompleteWithExistingTrnRequest(state, existingTrnRequestId);
-                }
-                else if (trn is null &&
-                    existingTrnRequestId is null &&
-                    pendingSupportTaskReference is null &&
-                    hasClosedIdVerificationSupportTask &&
-                    state.RecordMatchingPolicy == RecordMatchingPolicy.Deferred)
-                {
-                    await CompleteWithDeferredMatchingAsync(state, processContext);
-                }
+                Complete(state, trn);
+            }
+            else if (existingTrnRequestId is not null)
+            {
+                CompleteWithExistingTrnRequest(state, existingTrnRequestId);
+            }
+            else if (trn is null &&
+                existingTrnRequestId is null &&
+                pendingSupportTaskReference is null &&
+                hasClosedIdVerificationSupportTask &&
+                state.RecordMatchingPolicy == RecordMatchingPolicy.Deferred)
+            {
+                await CompleteWithDeferredMatchingAsync(state, processContext);
             }
         });
     }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/OneLoginUser.cs
@@ -79,21 +79,4 @@ public class OneLoginUser
         MatchRoute = route;
         MatchedAttributes = matchedAttributes?.ToArray();
     }
-
-    public void ClearVerifiedInfo()
-    {
-        // Used for testing only
-        VerifiedOn = null;
-        VerificationRoute = null;
-        VerifiedNames = null;
-        VerifiedDatesOfBirth = null;
-    }
-
-    public void ClearMatchedPerson()
-    {
-        // Used for testing only
-        PersonId = null;
-        MatchRoute = null;
-        MatchedAttributes = null;
-    }
 }


### PR DESCRIPTION
This simplifies the process by which the Debug page works in the following ways:
- The ability to detach and mark as a user as unverified is removed (since we have functionality in the Support UI for that now).
- The Debug page is now only shown on initial authentication callback, not ID verification.
- The Debug page itself now only changes the `OneLoginUser` entity in the DB rather than updating state directly. The coordinator methods are then re-used to handle all the state changes. This solves some of the problems we're seeing when the Debug page was in use but wasn't always doing the same thing as the non-Debug flow.

Closes https://github.com/DFE-Digital/teaching-record-team-project-board/issues/285