### PR TITLE
Fix creating webhook messages

### DIFF
--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/EventHandlers/CreateWebhookMessages.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/EventHandlers/CreateWebhookMessages.cs
@@ -1,16 +1,11 @@
-using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Services.Webhooks;
 
 namespace TeachingRecordSystem.Core.EventHandlers;
 
-public class CreateWebhookMessages(
-    TrsDbContext dbContext,
-    WebhookMessageFactory webhookMessageFactory) : IEventHandler
+public class CreateWebhookMessages(WebhookMessageFactory webhookMessageFactory) : IEventHandler
 {
     public async Task HandleEventAsync(IEvent @event, ProcessContext processContext, IEventScope eventScope)
     {
-        var messages = await webhookMessageFactory.CreateMessagesAsync(@event);
-        dbContext.WebhookMessages.AddRange(messages);
-        await dbContext.SaveChangesAsync();
+        await webhookMessageFactory.CreateMessagesAsync(@event);
     }
 }

--- a/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
+++ b/TeachingRecordSystem/src/TeachingRecordSystem.Core/Services/Webhooks/WebhookMessageFactory.cs
@@ -89,7 +89,6 @@ public class WebhookMessageFactory(
                 {
                     WebhookMessageId = id,
                     WebhookEndpointId = ep.WebhookEndpointId,
-                    WebhookEndpoint = ep,
                     CloudEventId = id.ToString(),
                     CloudEventType = cloudEventType,
                     Timestamp = timeProvider.UtcNow,
@@ -101,6 +100,15 @@ public class WebhookMessageFactory(
                     DeliveryErrors = []
                 };
             }));
+        }
+
+        dbContext.WebhookMessages.AddRange(messages);
+        await dbContext.SaveChangesAsync();
+
+        foreach (var message in messages)
+        {
+            dbContext.Entry(message).State = EntityState.Detached;
+            message.WebhookEndpoint = endpoints!.Single(e => e.WebhookEndpointId == message.WebhookEndpointId);
         }
 
         return messages;


### PR DESCRIPTION
We can't assign a detached `WebhookEndpoint` when adding `WebhookMessage` as EF thinks the endpoint is a new entity and tries to add it, causing a PK error. This amends `WebhookMessageFactory` to add the created messages itself (rather than the caller doing it) and then return a set of detached messages, with the endpoint assigned.