### PR TITLE
Use Trs to locate auth tokens

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -249,14 +249,15 @@ public class OneLoginService(
     {
         Person? getAnIdentityPerson = null;
         OneLoginUserMatchRoute? matchRoute = null;
-        IdTrnToken? trnTokenModel = null;
+        AuthzRegistrationToken? trnTokenModel = null;
 
         // First try and match on TRN Token
         if (trnToken is not null)
         {
             var utcNow = timeProvider.UtcNow;
-            trnTokenModel = await WithIdDbContextAsync(c => c.TrnTokens.SingleOrDefaultAsync(
-                t => t.TrnToken == trnToken && t.ExpiresUtc > utcNow && t.UserId == null));
+
+            trnTokenModel = await dbContext.AuthzRegistrationTokens.SingleOrDefaultAsync(
+                t => t.Token == trnToken && t.ExpiresUtc > utcNow && t.IsActive == true);
             if (trnTokenModel is not null)
             {
                 getAnIdentityPerson = await dbContext.Persons.SingleOrDefaultAsync(p => p.Trn == trnTokenModel.Trn);
@@ -302,8 +303,8 @@ public class OneLoginService(
         if (trnTokenModel is not null)
         {
             // Invalidate the token
-            trnTokenModel.UserId = _teacherAuthIdUserIdSentinel;
-            await WithIdDbContextAsync(c => c.SaveChangesAsync());
+            trnTokenModel.IsActive = false;
+            await dbContext.SaveChangesAsync();
         }
 
         return new(getAnIdentityPerson.PersonId, getAnIdentityPerson.Trn, MatchRoute: matchRoute, matchedAttributes);

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
@@ -8,12 +8,14 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
 using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Jobs.Scheduling;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
 using static TeachingRecordSystem.AuthorizeAccess.SignInJourneyCoordinator.Vtrs;
 using static TeachingRecordSystem.Core.Services.OneLogin.IdModelTypes;
 using RecordMatchingPolicy = TeachingRecordSystem.Core.Models.RecordMatchingPolicy;
+using User = TeachingRecordSystem.Core.Services.OneLogin.User;
 
 namespace TeachingRecordSystem.AuthorizeAccess.Tests;
 
@@ -994,7 +996,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
         Clock.Advance(TimeSpan.FromDays(1));
 
-        var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!);
+        var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!, isActive: true);
 
         var firstName = person.FirstName;
         var lastName = person.LastName;
@@ -1152,7 +1154,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
         Clock.Advance(TimeSpan.FromDays(1));
 
-        var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!, userId: Guid.NewGuid());
+        var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!, userId: Guid.NewGuid(), isActive: false);
 
         await WithJourneyCoordinatorAsync(
             (instanceId, processId) => new SignInJourneyState(
@@ -1489,25 +1491,24 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         }
     }
 
-    private async Task<string> CreateTrnToken(string trn, string email, TimeSpan? expires = null, Guid? userId = null)
+    private async Task<string> CreateTrnToken(string trn, string email, TimeSpan? expires = null, Guid? userId = null, bool isActive = true)
     {
         var trnToken = Guid.NewGuid().ToString();
         var expiresUtc = Clock.UtcNow.Add(expires ?? TimeSpan.FromHours(1));
 
-        using (var idDbContext = HostFixture.Services.GetRequiredService<IdDbContext>())
+        await WithDbContextAsync(async dbContext =>
         {
-            idDbContext.TrnTokens.Add(new IdTrnToken()
+            dbContext.AuthzRegistrationTokens.Add(new AuthzRegistrationToken()
             {
-                TrnToken = trnToken,
+                Token = trnToken,
                 Trn = trn,
                 CreatedUtc = Clock.UtcNow,
                 ExpiresUtc = expiresUtc,
-                Email = email,
-                UserId = userId
+                EmailAddress = email,
+                IsActive = isActive
             });
-
-            await idDbContext.SaveChangesAsync();
-        }
+            await dbContext.SaveChangesAsync();
+        });
 
         return trnToken;
     }

--- a/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.cs
+++ b/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Playwright;
 using Optional;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.OneLogin;
 using static TeachingRecordSystem.Core.Services.OneLogin.IdModelTypes;
+using User = TeachingRecordSystem.Core.Services.OneLogin.User;
 
 namespace TeachingRecordSystem.EndToEndTests.AuthorizeAccessJourneys;
 
@@ -168,20 +170,19 @@ public partial class SignInTests(HostFixture hostFixture) : TestBase(hostFixture
 
         var trnToken = Guid.NewGuid().ToString();
 
-        using (var idDbContext = HostFixture.AuthorizeAccessHostServices.GetRequiredService<IdDbContext>())
+        await WithDbContextAsync(async dbContext =>
         {
-            idDbContext.TrnTokens.Add(new IdTrnToken()
+            dbContext.AuthzRegistrationTokens.Add(new AuthzRegistrationToken()
             {
-                TrnToken = trnToken,
+                Token = trnToken,
                 Trn = person.Trn,
                 CreatedUtc = TimeProvider.UtcNow,
                 ExpiresUtc = TimeProvider.UtcNow.AddDays(1),
-                Email = email,
-                UserId = null
+                EmailAddress = email,
+                IsActive = true
             });
-
-            await idDbContext.SaveChangesAsync();
-        }
+            await dbContext.SaveChangesAsync();
+        });
 
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/2?pane=issue&itemId=180781654&issue=DFE-Digital%7Cteaching-record-team-project-board%7C266

### Changes proposed in this pull request

Update OneLoginService to match tokens from TRS `authz_registration_tokens ` table rather than ID `trn_tokens`. 

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally