### PR TITLE
Remove db.sh and replace with just recipes using konduit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ COPY --from=build /source/src/TeachingRecordSystem.Cli/bin/Release/net10.0/publi
 COPY --from=build /source/src/TeachingRecordSystem.SupportUi/bin/Release/net10.0/publish/ ./SupportUi/
 COPY --from=build /source/src/TeachingRecordSystem.Worker/bin/Release/net10.0/publish/ ./Worker/
 COPY --from=build /source/src/TeachingRecordSystem.AuthorizeAccess/bin/Release/net10.0/publish/ ./AuthorizeAccess/
-COPY --from=build /source/db.sh .
-
-RUN chmod +x ./db.sh
 
 # Ensure culture data is available
 RUN apk add --no-cache tzdata icu-data-full icu-libs

--- a/db.sh
+++ b/db.sh
@@ -1,8 +1,0 @@
-ENV_VARS=$(env | grep DefaultConnection | sed 's/^ConnectionStrings__DefaultConnection=//' | awk -v RS=';' -v FS='=' '
-/^Server/ { print "export PGHOST=" $2 }
-/^Database/ { print "export PGDATABASE=" $2 }
-/^User Id/ { print "export PGUSER=" $2 }
-/^Password/ { print "export PGPASSWORD=" substr($0, 10) }
-')
-eval "$ENV_VARS"
-psql "$@"

--- a/justfile
+++ b/justfile
@@ -113,3 +113,15 @@ _deploy branch environment:
 # Removes the cached DB schema version file for tests
 remove-tests-schema-cache:
   @dotnet run scripts/RemoveTestsSchemaCache.cs
+
+psql-dev: (make "install-konduit")
+  kubectl config use-context s189t01-tsc-test-aks
+  bin/konduit.sh -n tra-development -x -d trs -k s189t01-trs-dv-inf-kv trs-dev-worker -- psql
+
+psql-preprod: (make "install-konduit")
+  kubectl config use-context s189t01-tsc-test-aks
+  bin/konduit.sh -n tra-test -x -d trs -k s189t01-trs-pp-inf-kv trs-preprod-worker -- psql
+
+psql-prod: (make "install-konduit")
+  kubectl config use-context s189p01-tsc-production-aks
+  bin/konduit.sh -n tra-production -x -d trs -k s189p01-trs-pd-inf-kv trs-production-worker -- psql


### PR DESCRIPTION
We're likely moving to a shell-less container image so running db.sh to connect to postgres won't work. This replaces that script with some just recipes that use konduit instead.