### PR TITLE
Block anonymous access for app storage account

### DIFF
--- a/terraform/aks/storage.tf
+++ b/terraform/aks/storage.tf
@@ -7,6 +7,7 @@ resource "azurerm_storage_account" "app_storage" {
   account_kind                      = "StorageV2"
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
+  allow_nested_items_to_be_public   = false
 
   blob_properties {
     last_access_time_enabled = true


### PR DESCRIPTION
### Context

Our default practice is to disable anonymous access for storage accounts.
While the containers are set to private already, we should disallow at the account level too.

### Changes proposed in this pull request

Set to disallow for app_storage

### Guidance to review

make env terraform-plan (should show sa will be updated in place)

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally