### PR TITLE
Fix connecting person to a One Login

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/OneLogin/GetMatchedAttributesOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/GetMatchedAttributesOptions.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.Core.Services.OneLogin;
+
+public record GetMatchedAttributesOptions
+{
+    public required Guid PersonId { get; init; }
+    public required IEnumerable<string[]> Names { get; init; }
+    public required IEnumerable<DateOnly> DatesOfBirth { get; init; }
+    public required string? EmailAddress { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/OneLogin/GetSuggestedPersonMatchesOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/GetSuggestedPersonMatchesOptions.cs
@@ -6,5 +6,4 @@ public record GetSuggestedPersonMatchesOptions(
     string? EmailAddress,
     string? NationalInsuranceNumber,
     string? Trn,
-    string? TrnTokenTrnHint,
-    Guid? PersonId = null);
+    string? TrnTokenTrnHint);

--- a/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -387,8 +387,9 @@ public class OneLoginService(
     public async Task<IReadOnlyCollection<MatchPersonResult>> GetSuggestedPersonMatchesAsync(GetSuggestedPersonMatchesOptions options)
     {
         // Return any record that matches on last name and DOB OR NINO OR TRN.
-        // If PersonId is provided, only match against that specific person.
         // Results should be ordered such that matches on TRN are returned before matches on NINO with matches on last name + DOB last.
+
+        // N.B. Keep this aligned with GetMatchedAttributesAsync()
 
         var firstNames = options.Names.Select(parts => parts.First()).ToArray();
         var lastNames = options.Names.Select(parts => parts.Skip(1).LastOrDefault()).Where(n => !string.IsNullOrEmpty(n)).ToArray();
@@ -404,8 +405,7 @@ public class OneLoginService(
                     :dates_of_birth dates_of_birth,
                     (:email_address COLLATE "case_insensitive") email_address,
                     :trns trns,
-                    array_remove(ARRAY[:national_insurance_number] COLLATE "case_insensitive", null)::varchar[] national_insurance_numbers,
-                    :person_id person_id
+                    array_remove(ARRAY[:national_insurance_number] COLLATE "case_insensitive", null)::varchar[] national_insurance_numbers
                 )
                 SELECT
                     p.person_id,
@@ -424,12 +424,11 @@ public class OneLoginService(
                     (SELECT ARRAY(SELECT UNNEST(p.national_insurance_numbers) INTERSECT SELECT UNNEST(vars.national_insurance_numbers))) matched_national_insurance_number
                 FROM persons p, vars
                 WHERE
-                    (vars.person_id IS NOT NULL AND p.person_id = vars.person_id) OR
-                    (vars.person_id IS NULL AND p.status = 0 AND (
+                    p.status = 0 AND (
                         (array_length(vars.last_names, 1) > 0 AND p.date_of_birth = ANY(vars.dates_of_birth) AND p.names && vars.last_names) OR
                         p.trn = ANY(vars.trns) OR
                         (array_length(vars.national_insurance_numbers, 1) > 0 AND p.national_insurance_numbers && vars.national_insurance_numbers)
-                    ))
+                    )
                 """,
                 // ReSharper disable FormatStringProblem
                 parameters:
@@ -445,8 +444,7 @@ public class OneLoginService(
                     {
                         Value = nationalInsuranceNumber ?? (object)DBNull.Value
                     },
-                    new NpgsqlParameter("trns", NpgsqlDbType.Varchar | NpgsqlDbType.Array) { Value = trns },
-                    new NpgsqlParameter("person_id", NpgsqlDbType.Uuid) { Value = options.PersonId ?? (object)DBNull.Value }
+                    new NpgsqlParameter("trns", NpgsqlDbType.Varchar | NpgsqlDbType.Array) { Value = trns }
                 ]
                 // ReSharper restore FormatStringProblem
             ).ToArrayAsync();
@@ -501,6 +499,73 @@ public class OneLoginService(
             .OrderByDescending(t => t.Score)
             .Select(t => t.Result)
             .AsReadOnly();
+    }
+
+    public async Task<IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>>> GetMatchedAttributesAsync(GetMatchedAttributesOptions options)
+    {
+        // N.B. Keep this aligned with GetSuggestedPersonMatchesAsync()
+
+        var firstNames = options.Names.Select(parts => parts.First()).ToArray();
+        var lastNames = options.Names.Select(parts => parts.Skip(1).LastOrDefault()).Where(n => !string.IsNullOrEmpty(n)).ToArray();
+
+        var results = await dbContext.Database.SqlQueryRaw<MatchedAttributesQueryResult>(
+                """
+                WITH vars AS (
+                    SELECT
+                    case when array_length(:first_names, 1) > 0 then (fn_split_names(:first_names, include_synonyms => true) collate "case_insensitive") else ARRAY[]::varchar[] end first_names,
+                    case when array_length(:last_names, 1) > 0 then (fn_split_names(:last_names, include_synonyms => false) collate "case_insensitive") else ARRAY[]::varchar[] end last_names,
+                    :dates_of_birth dates_of_birth,
+                    (:email_address COLLATE "case_insensitive") email_address,
+                    :person_id person_id
+                )
+                SELECT
+                    array_length(vars.first_names, 1) > 0 AND p.names && vars.first_names first_name_matches,
+                    (SELECT ARRAY(SELECT UNNEST(p.names) INTERSECT SELECT UNNEST(vars.first_names))) matched_first_name,
+                    array_length(vars.last_names, 1) > 0 AND p.names && vars.last_names last_name_matches,
+                    (SELECT ARRAY(SELECT UNNEST(p.names) INTERSECT SELECT UNNEST(vars.last_names))) matched_last_name,
+                    p.date_of_birth = ANY(vars.dates_of_birth) date_of_birth_matches,
+                    (SELECT ARRAY(SELECT p.date_of_birth INTERSECT SELECT UNNEST(vars.dates_of_birth))) matched_date_of_birth,
+                    CASE WHEN vars.email_address IS NOT NULL AND p.email_address = vars.email_address THEN true ELSE false END email_address_matches,
+                    p.email_address matched_email_address
+                FROM persons p, vars
+                WHERE p.person_id = vars.person_id
+                """,
+                // ReSharper disable FormatStringProblem
+                parameters:
+                [
+                    new NpgsqlParameter("person_id", options.PersonId),
+                    new NpgsqlParameter("last_names", lastNames),
+                    new NpgsqlParameter("first_names", firstNames),
+                    new NpgsqlParameter("email_address", NpgsqlDbType.Varchar)
+                    {
+                        Value = options.EmailAddress ?? (object)DBNull.Value
+                    },
+                    new NpgsqlParameter("dates_of_birth", options.DatesOfBirth.ToArray())
+                ]
+                // ReSharper restore FormatStringProblem
+            ).ToArrayAsync();
+
+        return results
+            .Select(r =>
+            {
+                var matchedAttributes = new List<KeyValuePair<PersonMatchedAttribute, string>>();
+
+                void AddMatchedAttribute(bool isMatched, PersonMatchedAttribute attributeType, Func<string> getValue)
+                {
+                    if (isMatched)
+                    {
+                        matchedAttributes.Add(KeyValuePair.Create(attributeType, getValue()));
+                    }
+                }
+
+                AddMatchedAttribute(r.FirstNameMatches, PersonMatchedAttribute.FirstName, () => r.MatchedFirstName.First());
+                AddMatchedAttribute(r.LastNameMatches, PersonMatchedAttribute.LastName, () => r.MatchedLastName.First());
+                AddMatchedAttribute(r.DateOfBirthMatches, PersonMatchedAttribute.DateOfBirth, () => r.MatchedDateOfBirth.First().ToString("yyyy-MM-dd"));
+                AddMatchedAttribute(r.EmailAddressMatches, PersonMatchedAttribute.EmailAddress, () => r.MatchedEmailAddress!);
+
+                return matchedAttributes;
+            })
+            .Single();
     }
 
     public Task<string?> GetPendingSupportTaskReferenceByUserAsync(string oneLoginUserSubject) =>
@@ -662,7 +727,15 @@ public class OneLoginService(
         string[] MatchedNationalInsuranceNumber);
 
     [UsedImplicitly]
-    private record MatchedAttributesQueryResult(string AttributeType, string AttributeValue);
+    private record MatchedAttributesQueryResult(
+        bool FirstNameMatches,
+        string[] MatchedFirstName,
+        bool LastNameMatches,
+        string[] MatchedLastName,
+        bool DateOfBirthMatches,
+        string? MatchedEmailAddress,
+        bool EmailAddressMatches,
+        DateOnly[] MatchedDateOfBirth);
 
     private record TryMatchToTrnRequestResult(string Trn);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml.cs
@@ -82,7 +82,7 @@ public class CheckAnswersModel(
 
         var processContext = new ProcessContext(ProcessType.PersonOneLoginUserConnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);
 
-        var matchedPerson = JourneyInstance!.State.MatchedPerson!;
+        var matchedAttributes = JourneyInstance!.State.MatchedAttributes!;
 
         if (oneLoginUser.VerifiedOn is null)
         {
@@ -98,9 +98,9 @@ public class CheckAnswersModel(
                     VerifiedNames = [verifiedNames],
                     VerifiedDatesOfBirth = person.DateOfBirth.HasValue ? [person.DateOfBirth.Value] : [],
                     CoreIdentityClaimVc = null,
-                    MatchedPersonId = matchedPerson.PersonId,
+                    MatchedPersonId = PersonId,
                     MatchRoute = OneLoginUserMatchRoute.SupportUi,
-                    MatchedAttributes = matchedPerson.MatchedAttributes
+                    MatchedAttributes = matchedAttributes
                 },
                 processContext);
         }
@@ -110,9 +110,9 @@ public class CheckAnswersModel(
                 new SetUserMatchedOptions
                 {
                     OneLoginUserSubject = JourneyInstance.State.Subject!,
-                    MatchedPersonId = matchedPerson.PersonId,
+                    MatchedPersonId = PersonId,
                     MatchRoute = OneLoginUserMatchRoute.SupportUi,
-                    MatchedAttributes = matchedPerson.MatchedAttributes
+                    MatchedAttributes = matchedAttributes
                 },
                 processContext);
         }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginState.cs
@@ -1,5 +1,3 @@
-using TeachingRecordSystem.Core.Services.OneLogin;
-
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 public class ConnectOneLoginState : IRegisterJourney
@@ -12,7 +10,7 @@ public class ConnectOneLoginState : IRegisterJourney
 
     public string? Subject { get; set; }
     public string? OneLoginEmailAddress { get; set; }
-    public MatchPersonResult? MatchedPerson { get; set; }
+    public IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>>? MatchedAttributes { get; set; }
     public ConnectOneLoginReason? ConnectReason { get; set; }
     public string? ReasonDetail { get; set; }
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Index.cshtml.cs
@@ -60,20 +60,20 @@ public class IndexModel(
             return this.PageWithErrors();
         }
 
-        var suggestedMatches = await oneLoginService.GetSuggestedPersonMatchesAsync(new GetSuggestedPersonMatchesOptions(
-            Names: oneLoginUser.VerifiedNames ?? [],
-            DatesOfBirth: oneLoginUser.VerifiedDatesOfBirth ?? [],
-            EmailAddress: oneLoginUser.EmailAddress,
-            NationalInsuranceNumber: null,
-            Trn: null,
-            TrnTokenTrnHint: null,
-            PersonId: PersonId));
+        var matchedAttributes = await oneLoginService.GetMatchedAttributesAsync(
+            new GetMatchedAttributesOptions
+            {
+                PersonId = PersonId,
+                Names = oneLoginUser.VerifiedNames ?? [],
+                DatesOfBirth = oneLoginUser.VerifiedDatesOfBirth ?? [],
+                EmailAddress = oneLoginUser.EmailAddress
+            });
 
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.Subject = oneLoginUser.Subject;
             state.OneLoginEmailAddress = oneLoginUser.EmailAddress;
-            state.MatchedPerson = suggestedMatches.FirstOrDefault();
+            state.MatchedAttributes = matchedAttributes;
         });
 
         return Redirect(linkGenerator.Persons.PersonDetail.ConnectOneLogin.Match(PersonId, JourneyInstance.InstanceId));

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Match.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Match.cshtml.cs
@@ -43,7 +43,7 @@ public class MatchModel(
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (JourneyInstance!.State.MatchedPerson is null)
+        if (JourneyInstance!.State.MatchedAttributes is null)
         {
             context.Result = NotFound();
             return;
@@ -68,7 +68,7 @@ public class MatchModel(
         OneLoginUserVerifiedNames = oneLoginUser.VerifiedNames;
         OneLoginUserVerifiedDatesOfBirth = oneLoginUser.VerifiedDatesOfBirth;
 
-        MatchedAttributeTypes = JourneyInstance.State.MatchedPerson.MatchedAttributes
+        MatchedAttributeTypes = JourneyInstance.State.MatchedAttributes
             .Select(a => a.Key)
             .ToArray();
 

--- a/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.OneLogin;
 
 namespace TeachingRecordSystem.Core.Tests.Services.OneLogin;
 
@@ -261,6 +262,162 @@ public partial class OneLoginServiceTests
             r => Assert.Equal(person2b.PersonId, r.PersonId),
             r => Assert.Equal(person1.PersonId, r.PersonId),
             r => Assert.Equal(person5.PersonId, r.PersonId));
+    }
+
+    [Fact]
+    public async Task GetMatchedAttributesAsync_WithMatchingNamesAndDateOfBirth_ReturnsExpectedAttributes()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+
+        string[][] names = [[person.FirstName, person.LastName]];
+        DateOnly[] datesOfBirth = [person.DateOfBirth];
+
+        // Act
+        var result = await WithServiceAsync(
+            s => s.GetMatchedAttributesAsync(new GetMatchedAttributesOptions
+            {
+                PersonId = person.PersonId,
+                Names = names,
+                DatesOfBirth = datesOfBirth,
+                EmailAddress = null
+            }));
+
+        // Assert
+        Assert.Contains(result, kvp => kvp.Key == PersonMatchedAttribute.FirstName && kvp.Value == person.FirstName);
+        Assert.Contains(result, kvp => kvp.Key == PersonMatchedAttribute.LastName && kvp.Value == person.LastName);
+        Assert.Contains(result, kvp => kvp.Key == PersonMatchedAttribute.DateOfBirth && kvp.Value == person.DateOfBirth.ToString("yyyy-MM-dd"));
+        Assert.DoesNotContain(result, kvp => kvp.Key == PersonMatchedAttribute.EmailAddress);
+    }
+
+    [Fact]
+    public async Task GetMatchedAttributesAsync_WithMatchingEmailAddress_ReturnsEmailAddressAttribute()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithEmailAddress());
+
+        string[][] names = [[person.FirstName, person.LastName]];
+        DateOnly[] datesOfBirth = [person.DateOfBirth];
+
+        // Act
+        var result = await WithServiceAsync(
+            s => s.GetMatchedAttributesAsync(new GetMatchedAttributesOptions
+            {
+                PersonId = person.PersonId,
+                Names = names,
+                DatesOfBirth = datesOfBirth,
+                EmailAddress = person.EmailAddress
+            }));
+
+        // Assert
+        Assert.Contains(result, kvp => kvp.Key == PersonMatchedAttribute.EmailAddress && kvp.Value == person.EmailAddress);
+    }
+
+    [Fact]
+    public async Task GetMatchedAttributesAsync_WithNonMatchingEmailAddress_DoesNotReturnEmailAddressAttribute()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p.WithEmailAddress());
+        var differentEmail = TestData.GenerateUniqueEmail();
+
+        string[][] names = [[person.FirstName, person.LastName]];
+        DateOnly[] datesOfBirth = [person.DateOfBirth];
+
+        // Act
+        var result = await WithServiceAsync(
+            s => s.GetMatchedAttributesAsync(new GetMatchedAttributesOptions
+            {
+                PersonId = person.PersonId,
+                Names = names,
+                DatesOfBirth = datesOfBirth,
+                EmailAddress = differentEmail
+            }));
+
+        // Assert
+        Assert.DoesNotContain(result, kvp => kvp.Key == PersonMatchedAttribute.EmailAddress);
+    }
+
+    [Fact]
+    public async Task GetMatchedAttributesAsync_WithNonMatchingNames_DoesNotReturnNameAttributes()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var differentFirstName = TestData.GenerateChangedFirstName(person.FirstName);
+        var differentLastName = TestData.GenerateChangedLastName(person.LastName);
+
+        string[][] names = [[differentFirstName, differentLastName]];
+        DateOnly[] datesOfBirth = [person.DateOfBirth];
+
+        // Act
+        var result = await WithServiceAsync(
+            s => s.GetMatchedAttributesAsync(new GetMatchedAttributesOptions
+            {
+                PersonId = person.PersonId,
+                Names = names,
+                DatesOfBirth = datesOfBirth,
+                EmailAddress = null
+            }));
+
+        // Assert
+        Assert.DoesNotContain(result, kvp => kvp.Key == PersonMatchedAttribute.FirstName);
+        Assert.DoesNotContain(result, kvp => kvp.Key == PersonMatchedAttribute.LastName);
+    }
+
+    [Fact]
+    public async Task GetMatchedAttributesAsync_WithNonMatchingDateOfBirth_DoesNotReturnDateOfBirthAttribute()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var differentDateOfBirth = TestData.GenerateChangedDateOfBirth(person.DateOfBirth);
+
+        string[][] names = [[person.FirstName, person.LastName]];
+        DateOnly[] datesOfBirth = [differentDateOfBirth];
+
+        // Act
+        var result = await WithServiceAsync(
+            s => s.GetMatchedAttributesAsync(new GetMatchedAttributesOptions
+            {
+                PersonId = person.PersonId,
+                Names = names,
+                DatesOfBirth = datesOfBirth,
+                EmailAddress = null
+            }));
+
+        // Assert
+        Assert.DoesNotContain(result, kvp => kvp.Key == PersonMatchedAttribute.DateOfBirth);
+    }
+
+    [Fact]
+    public async Task GetMatchedAttributesAsync_WithAlias_ReturnsFirstNameAttribute()
+    {
+        // Arrange
+        var firstName = Guid.NewGuid().ToString("N");  // No hyphens: fn_split_names splits on hyphens, which would fragment a standard GUID and break synonym lookup
+        var alias = TestData.GenerateFirstName();
+        await WithDbContextAsync(async dbContext =>
+        {
+            dbContext.NameSynonyms.Add(new NameSynonyms { Name = firstName, Synonyms = [alias] });
+            dbContext.NameSynonyms.Add(new NameSynonyms { Name = alias, Synonyms = [firstName] });
+            await dbContext.SaveChangesAsync();
+        });
+
+        var person = await TestData.CreatePersonAsync(p => p.WithFirstName(firstName));
+
+        string[][] names = [[alias, person.LastName]];
+        DateOnly[] datesOfBirth = [person.DateOfBirth];
+
+        // Act
+        var result = await WithServiceAsync(
+            s => s.GetMatchedAttributesAsync(new GetMatchedAttributesOptions
+            {
+                PersonId = person.PersonId,
+                Names = names,
+                DatesOfBirth = datesOfBirth,
+                EmailAddress = null
+            }));
+
+        // Assert
+        Assert.Contains(result, kvp => kvp.Key == PersonMatchedAttribute.FirstName);
+        Assert.Contains(result, kvp => kvp.Key == PersonMatchedAttribute.LastName);
     }
 
     private static readonly PersonMatchedAttribute[] _matchNameDobNinoAndTrnAttributes =

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
@@ -2,7 +2,6 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Optional;
 using TeachingRecordSystem.Core.Events.ChangeReasons;
-using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
@@ -39,7 +38,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -75,7 +74,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
@@ -123,7 +122,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.AnotherReason,
                 ReasonDetail = "Custom connection reason"
             },
@@ -157,7 +156,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
@@ -192,7 +191,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
@@ -266,7 +265,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
@@ -328,7 +327,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
@@ -365,7 +364,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.AnotherReason,
                 ReasonDetail = "Custom connection reason details"
             },

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/MatchTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/MatchTests.cs
@@ -1,6 +1,5 @@
 using AngleSharp.Dom;
 using Optional;
-using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
@@ -83,15 +82,11 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
-                        KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
-                        KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
-                    ]),
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
+                ]
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -147,14 +142,10 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
-                        KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName)
-                    ]),
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName)
+                ]
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -206,13 +197,9 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
-                    ]),
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
+                ]
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -249,8 +236,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
-
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -288,16 +274,12 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
-                        KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
-                        KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd")),
-                        KeyValuePair.Create(PersonMatchedAttribute.EmailAddress, person.EmailAddress!)
-                    ]),
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd")),
+                    KeyValuePair.Create(PersonMatchedAttribute.EmailAddress, person.EmailAddress!)
+                ]
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -333,11 +315,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    []),
-
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -370,11 +348,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    []),
-
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -420,14 +394,10 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
-                        KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName)
-                    ]),  // Name matches (one of the multiple names)
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName)
+                ]  // Name matches (one of the multiple names)
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -473,11 +443,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    []),  // No matched attributes - none of the names match
-
+                MatchedAttributes = []  // No matched attributes - none of the names match
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -522,13 +488,9 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
-                    ]),  // DOB matches (one of the multiple DOBs)
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
+                ]  // DOB matches (one of the multiple DOBs)
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -573,11 +535,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    []),
-
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -609,15 +567,11 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
-                        KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
-                        KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
-                    ]),
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
+                ]
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -649,15 +603,11 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
-                MatchedPerson = new MatchPersonResult(
-                    person.PersonId,
-                    person.Trn,
-                    [
-                        KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
-                        KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
-                        KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
-                    ]),
-
+                MatchedAttributes = [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
+                ]
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ReasonTests.cs
@@ -1,7 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using Optional;
-using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
@@ -38,7 +37,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -71,7 +70,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, []),
+                MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.AnotherReason,
                 ReasonDetail = "Test reason detail"
             },
@@ -111,7 +110,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -143,7 +142,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -178,7 +177,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -214,7 +213,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -254,7 +253,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -294,7 +293,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 
@@ -335,7 +334,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedPerson = new MatchPersonResult(person.PersonId, person.Trn, [])
+                MatchedAttributes = []
             },
             new KeyValuePair<string, object>("personId", person.PersonId));
 


### PR DESCRIPTION
Adds a separate `GetMatchedAttributesAsync()` method to `OneLoginService` instead of bolting on that functionality to `GetSuggestedMatchedAsync()`