### PR TITLE
Hide third party task tiles for users without permission

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
@@ -75,18 +75,21 @@
                 </div>
             }
 
-            <div class="trs-tile-section">
-                <h2 class="govuk-heading-m">Third-party tasks</h2>
-                <div class="trs-tile-row">
-                    <a href="@LinkGenerator.SupportTasks.IntegrationTransactions.Index()" class="trs-tile">
-                        <span class="trs-tile__title">Integration transactions</span>
-                    </a>
-                    <a href="@LinkGenerator.SupportTasks.TeacherPensions.Index()" class="trs-tile">
-                        <span class="trs-tile__count">@Model.SupportTaskCounts!.GetValueOrDefault(SupportTaskType.TeacherPensionsPotentialDuplicate)</span>
-                        <span class="trs-tile__title">Potential duplicates via Teachers&rsquo; Pensions</span>
-                    </a>
+            @if ((await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.SupportTasksEdit)).Succeeded)
+            {
+                <div class="trs-tile-section">
+                    <h2 class="govuk-heading-m">Third-party tasks</h2>
+                    <div class="trs-tile-row">
+                        <a href="@LinkGenerator.SupportTasks.IntegrationTransactions.Index()" class="trs-tile">
+                            <span class="trs-tile__title">Integration transactions</span>
+                        </a>
+                        <a href="@LinkGenerator.SupportTasks.TeacherPensions.Index()" class="trs-tile">
+                            <span class="trs-tile__count">@Model.SupportTaskCounts!.GetValueOrDefault(SupportTaskType.TeacherPensionsPotentialDuplicate)</span>
+                            <span class="trs-tile__title">Potential duplicates via Teachers&rsquo; Pensions</span>
+                        </a>
+                    </div>
                 </div>
-            </div>
+            }
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Context

Hide third party task tiles for viewers who do not have permission.

### Changes proposed in this pull request

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/2?filterQuery=&pane=issue&itemId=189941068&issue=DFE-Digital%7Cteaching-record-team-project-board%7C292

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally