### PR TITLE
Connect associated One Login user when resolving TRN request

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
+++ b/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
@@ -7,6 +7,7 @@ using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
+using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.Core.Services.Persons;
 using TeachingRecordSystem.Core.Services.SupportTasks;
 
@@ -17,6 +18,7 @@ public record TrnRequestInfo(TrnRequestMetadata TrnRequest, string? ResolvedPers
 public class TrnRequestService(
     TrsDbContext dbContext,
     IEventPublisher eventPublisher,
+    OneLoginService oneLoginService,
     SupportTaskService supportTaskService,
     PersonService personService,
     IOptions<AccessYourTeachingQualificationsOptions> aytqOptionsAccessor,
@@ -165,8 +167,12 @@ public class TrnRequestService(
 
         trnRequest.ResolvedPersonId = person.PersonId;
         trnRequest.Status = furtherChecksNeeded ? TrnRequestStatus.Pending : TrnRequestStatus.Completed;
+
         await TryEnsureTrnTokenAsync(trnRequest, person.Trn);
+
         await dbContext.SaveChangesAsync();
+
+        await EnsureOneLoginUserConnectedAsync(trnRequest, processContext);
 
         if (furtherChecksNeeded)
         {
@@ -233,6 +239,8 @@ public class TrnRequestService(
         await TryEnsureTrnTokenAsync(trnRequest, person.Trn);
 
         await dbContext.SaveChangesAsync();
+
+        await EnsureOneLoginUserConnectedAsync(trnRequest, processContext);
 
         if (publishTrnRequestUpdatedEvent)
         {
@@ -378,6 +386,41 @@ public class TrnRequestService(
             } while (await dbContext.AuthzRegistrationTokens.AnyAsync(t => t.Token == token));
 
             return token;
+        }
+    }
+
+    private async Task EnsureOneLoginUserConnectedAsync(TrnRequestMetadata trnRequest, ProcessContext processContext)
+    {
+        Debug.Assert(trnRequest.ResolvedPersonId.HasValue);
+
+        if (trnRequest.OneLoginUserSubject is string oneLoginUserSubject &&
+            await dbContext.OneLoginUsers.SingleOrDefaultAsync(u => u.Subject == oneLoginUserSubject) is { PersonId: null } oneLoginUser)
+        {
+            if (oneLoginUser.VerificationRoute is null)
+            {
+                throw new InvalidOperationException("User must be verified.");
+            }
+
+            var personId = trnRequest.ResolvedPersonId.Value;
+
+            var matchedAttributes = await oneLoginService.GetMatchedAttributesAsync(
+                new GetMatchedAttributesOptions
+                {
+                    PersonId = personId,
+                    Names = [[trnRequest.FirstName!, trnRequest.MiddleName ?? string.Empty, trnRequest.LastName!]],
+                    DatesOfBirth = [trnRequest.DateOfBirth],
+                    EmailAddress = trnRequest.EmailAddress
+                });
+
+            await oneLoginService.SetUserMatchedAsync(
+                new SetUserMatchedOptions
+                {
+                    OneLoginUserSubject = oneLoginUserSubject,
+                    MatchedPersonId = personId,
+                    MatchRoute = OneLoginUserMatchRoute.TrnRequest,
+                    MatchedAttributes = matchedAttributes
+                },
+                processContext);
         }
     }
 

--- a/tests/TeachingRecordSystem.Core.Tests/Services/TrnRequests/TrnRequestServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/TrnRequests/TrnRequestServiceTests.cs
@@ -859,7 +859,95 @@ public partial class TrnRequestServiceTests(ServiceFixture fixture) : ServiceTes
         Assert.NotNull(trnRequest.TrnToken);
     }
 
-    //...
+    [Fact]
+    public async Task ResolveTrnRequestWithMatchedPersonAsync_WithKnownOneLoginUser_ConnectsUserToPerson()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
+
+        var (trnRequest, matchedPerson) = await CreatePendingTrnRequestAndMatchingPerson(
+            applicationUser.UserId,
+            configureOptions: r => r with { OneLoginUserInfo = new CreateTrnRequestOptionsOneLoginUserInfo(oneLoginUser.Subject, true) });
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync(s => s.ResolveTrnRequestWithMatchedPersonAsync(trnRequest, (matchedPerson.PersonId, matchedPerson.Trn), processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updatedUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLoginUser.Subject);
+            Assert.Equal(matchedPerson.PersonId, updatedUser.PersonId);
+        });
+    }
+
+    [Fact]
+    public async Task ResolveTrnRequestWithMatchedPersonAsync_WithUnknownOneLoginUser_DoesNotThrow()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var unknownSubject = TestData.CreateOneLoginUserSubject();
+
+        var (trnRequest, matchedPerson) = await CreatePendingTrnRequestAndMatchingPerson(
+            applicationUser.UserId,
+            configureOptions: r => r with { OneLoginUserInfo = new CreateTrnRequestOptionsOneLoginUserInfo(unknownSubject, false) });
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() =>
+            WithServiceAsync(s => s.ResolveTrnRequestWithMatchedPersonAsync(trnRequest, (matchedPerson.PersonId, matchedPerson.Trn), processContext)));
+
+        // Assert
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task ResolveTrnRequestWithNewRecordAsync_WithKnownOneLoginUser_ConnectsUserToPerson()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
+
+        var (trnRequest, _) = await CreatePendingTrnRequestAndMatchingPerson(
+            applicationUser.UserId,
+            configureOptions: r => r with { OneLoginUserInfo = new CreateTrnRequestOptionsOneLoginUserInfo(oneLoginUser.Subject, true) });
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync(s => s.ResolveTrnRequestWithNewRecordAsync(trnRequest, processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updatedUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLoginUser.Subject);
+            Assert.Equal(trnRequest.ResolvedPersonId, updatedUser.PersonId);
+        });
+    }
+
+    [Fact]
+    public async Task ResolveTrnRequestWithNewRecordAsync_WithUnknownOneLoginUser_DoesNotThrow()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var unknownSubject = TestData.CreateOneLoginUserSubject();
+
+        var (trnRequest, _) = await CreatePendingTrnRequestAndMatchingPerson(
+            applicationUser.UserId,
+            configureOptions: r => r with { OneLoginUserInfo = new CreateTrnRequestOptionsOneLoginUserInfo(unknownSubject, false) });
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() =>
+            WithServiceAsync(s => s.ResolveTrnRequestWithNewRecordAsync(trnRequest, processContext)));
+
+        // Assert
+        Assert.Null(ex);
+    }
 
     private async Task<(TrnRequestMetadata TrnRequest, Person Person)> CreatePendingTrnRequestAndMatchingPerson(
         Guid applicationUserId,

--- a/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.Deferred.cs
+++ b/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.Deferred.cs
@@ -27,7 +27,7 @@ public partial class SignInTests
     [Fact]
     public async Task SignIn_DeferredRecordMatchingPolicy_UserHasPendingMatchingTask_ReturnsExistingTrnRequestIdAndSignsIn()
     {
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync();
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
         SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.EmailAddress!));
 
         var applicationUserId = HostFixture.DeferredRecordMatchingPolicyApplicationUserId;
@@ -52,7 +52,7 @@ public partial class SignInTests
     [Fact]
     public async Task SignIn_DeferredRecordMatchingPolicy_UserWasVerifiedViaSupportTaskButNotMatched_ReturnsExistingTrnRequestIdAndSignsIn()
     {
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync();
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
         SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.EmailAddress!));
 
         var applicationUserId = HostFixture.DeferredRecordMatchingPolicyApplicationUserId;


### PR DESCRIPTION
If we have a TRN request with a known One Login user attached (i.e. we have the One Login user in our DB already) then link the One Login to the resolved person.