### PR TITLE
Fix webhook-endpoint update command when no cloud-event-types specified

### DIFF
--- a/src/TeachingRecordSystem.Cli/Commands.WebhookEndpoint.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.WebhookEndpoint.cs
@@ -291,7 +291,8 @@ public partial class Commands
                         changes |= WebhookEndpointUpdatedChanges.Address;
                     }
 
-                    if (parseResult.GetValue(cloudEventTypesOption) is { } cloudEventTypes)
+                    if (parseResult.GetResult(cloudEventTypesOption)?.Implicit is false &&
+                        parseResult.GetValue(cloudEventTypesOption) is { } cloudEventTypes)
                     {
                         endpoint.CloudEventTypes = cloudEventTypes.Order().ToList();
                         changes |= WebhookEndpointUpdatedChanges.CloudEventTypes;


### PR DESCRIPTION
Adds a check that `--cloud-event-types` was actually specified, since the default value is an empty array and we end up clearing the set of cloud event types otherwise.
