### PR TITLE
Fix too long state parameter

### DIFF
--- a/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.AuthorizeAccess/SignInJourneyCoordinator.cs
@@ -442,6 +442,13 @@ public class SignInJourneyCoordinator(
         var delegatedProperties = new AuthenticationProperties();
         delegatedProperties.SetVectorsOfTrust([vtr]);
         delegatedProperties.Items.Add(JourneySignInHandler.PropertyKeys.JourneyInstanceId, InstanceId.ToString());
+
+        // Ensure RedirectUri is set.
+        // (By default RedirectUri will be set to the current URL, which is often quite large.
+        // That then gets bundled into the `state` parameter and can end up with a URL that's over OneLogin's limits.)
+        // The actual value is unimportant since we intercept the callback and handle the redirect ourselves.
+        delegatedProperties.RedirectUri = "/";
+
         return Results.Challenge(delegatedProperties, authenticationSchemes: [State.OneLoginAuthenticationScheme]);
     }
 


### PR DESCRIPTION
We've had issues when running TeacherAuth with EYTFI in production as the authorize URL is too long. (It's the `state` parameter specifically that's too large.) It's the `RedirectUri` that's being assigned by the Open ID handler (as we don't set one) that's causing `state` to be large.

This change explicitly sets `RedirectUri` to be `/`. The actual value here is unimportant since we intercept the callback and handle our own redirects; it just has to be something non-`null` to prevent the default from getting assigned.