### PR TITLE
2683 validate infra docker image fix

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -39,3 +39,5 @@ jobs:
           validation-plan: ${{ matrix.validation_plan }}
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ terraform-init: vendor-modules
 	$(eval export TF_VAR_config=${CONFIG})
 	$(eval export TF_VAR_environment_short_name=$(CONFIG_SHORT))
 	$(eval export TF_VAR_azure_resource_prefix=$(AZURE_RESOURCE_PREFIX))
+	$(eval export TF_VAR_docker_image?=dummy-string)
 
 	[[ "${SP_AUTH}" != "true" ]] && az account set -s $(AZURE_SUBSCRIPTION) || true
 


### PR DESCRIPTION
### Context

Update the validate infra workflow which detects any changes in SD Infra Terraform so that it can access GCP 

### Changes proposed in this pull request

Update the GitHub action workflow validate-infrastructure.yml to access GCP variables defined in GitHub.

### Guidance to review

Manually test changes by altering terraform/aks/config/production.tfvars.json **enable_monitoring** and running locally the following command.
`make production terraform-plan CONFIRM_DEPLOY=1`
This will produce a Terraform update in place.

To validate the workflow once available. Make a test branch with a change to terraform/aks/config/production.tfvars.json **enable_monitoring**. Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
