### PR TITLE
Add more robust file type checking

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
+    <PackageVersion Include="Mime-Detective" Version="25.8.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="morelinq" Version="4.4.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.3" />

--- a/src/TeachingRecordSystem.Api/packages.lock.json
+++ b/src/TeachingRecordSystem.Api/packages.lock.json
@@ -753,6 +753,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1053,6 +1054,12 @@
           "Microsoft.IdentityModel.Protocols": "8.0.1",
           "System.IdentityModel.Tokens.Jwt": "8.0.1"
         }
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "morelinq": {
         "type": "CentralTransitive",

--- a/src/TeachingRecordSystem.AuthorizeAccess/GlobalUsings.cs
+++ b/src/TeachingRecordSystem.AuthorizeAccess/GlobalUsings.cs
@@ -1,2 +1,3 @@
 global using FluentValidation;
+global using TeachingRecordSystem.WebCommon.Validation;
 global using WebConstants = TeachingRecordSystem.WebCommon.WebConstants;

--- a/src/TeachingRecordSystem.AuthorizeAccess/Pages/ProofOfIdentity.cshtml.cs
+++ b/src/TeachingRecordSystem.AuthorizeAccess/Pages/ProofOfIdentity.cshtml.cs
@@ -5,6 +5,7 @@ using TeachingRecordSystem.Core.Services.Files;
 namespace TeachingRecordSystem.AuthorizeAccess.Pages;
 
 [Journey(SignInJourneyCoordinator.JourneyName)]
+[EnableRequestBuffering]
 public class ProofOfIdentity(SignInJourneyCoordinator coordinator, ISafeFileService fileService) : PageModel
 {
     public const int MaxFileSizeMb = 10;
@@ -15,18 +16,10 @@ public class ProofOfIdentity(SignInJourneyCoordinator coordinator, ISafeFileServ
             .Cascade(CascadeMode.Stop)
             .NotNull()
             .WithMessage("Select a file")
-            .Must((_, file) =>
-            {
-                var allowedTypes = new[] { "image/jpeg", "image/png", "application/pdf" };
-                return allowedTypes.Contains(file!.ContentType);
-            })
-            .WithMessage("The file must be a PDF, JPG, or PNG")
-            .Must((_, file) =>
-            {
-                var maxFileSizeInBytes = MaxFileSizeMb * 1024 * 1024; // 10 MB
-                return file!.Length <= maxFileSizeInBytes;
-            })
+            .MaxFileSize(MaxFileSizeMb)
             .WithMessage($"The file must be no larger than {MaxFileSizeMb}MB")
+            .PermittedFileType(["image/jpeg", "image/png", "application/pdf"])
+            .WithMessage("The file must be a PDF, JPG, or PNG")
     };
 
     [BindProperty]
@@ -38,10 +31,12 @@ public class ProofOfIdentity(SignInJourneyCoordinator coordinator, ISafeFileServ
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await _validator.ValidateAndThrowAsync(this);
+        var validationContext = ValidationContext<ProofOfIdentity>.CreateWithOptions(this, options => options.ThrowOnFailures());
+        await _validator.ValidateAsync(validationContext);
 
-        using var stream = File!.OpenReadStream();
-        if (!await fileService.TrySafeUploadAsync(stream, File.ContentType, out var fileId))
+        await using var stream = File!.OpenReadStream();
+
+        if (!await fileService.TrySafeUploadAsync(stream, validationContext.GetMimeType(), out var fileId))
         {
             ModelState.AddModelError(nameof(File), "The selected file contains a virus");
             return this.PageWithErrors();

--- a/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
+++ b/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
@@ -985,6 +985,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1273,6 +1274,12 @@
           "Microsoft.Bcl.TimeProvider": "10.0.5",
           "Npgsql": "10.0.2"
         }
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "morelinq": {
         "type": "CentralTransitive",

--- a/src/TeachingRecordSystem.SupportUi/packages.lock.json
+++ b/src/TeachingRecordSystem.SupportUi/packages.lock.json
@@ -916,6 +916,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1204,6 +1205,12 @@
           "Microsoft.Bcl.TimeProvider": "10.0.5",
           "Npgsql": "10.0.2"
         }
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "morelinq": {
         "type": "CentralTransitive",

--- a/src/TeachingRecordSystem.WebCommon/EnableRequestBufferingAttribute.cs
+++ b/src/TeachingRecordSystem.WebCommon/EnableRequestBufferingAttribute.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace TeachingRecordSystem.WebCommon;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class EnableRequestBufferingAttribute : Attribute, IResourceFilter
+{
+    public void OnResourceExecuting(ResourceExecutingContext context)
+    {
+        context.HttpContext.Request.EnableBuffering();
+    }
+
+    public void OnResourceExecuted(ResourceExecutedContext context)
+    {
+    }
+}

--- a/src/TeachingRecordSystem.WebCommon/TeachingRecordSystem.WebCommon.csproj
+++ b/src/TeachingRecordSystem.WebCommon/TeachingRecordSystem.WebCommon.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Hangfire.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Caching.Postgres" />
+    <PackageReference Include="Mime-Detective" />
     <PackageReference Include="prometheus-net.AspNetCore" />
     <PackageReference Include="Sentry.AspNetCore" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/src/TeachingRecordSystem.WebCommon/Validation/ContextKeys.cs
+++ b/src/TeachingRecordSystem.WebCommon/Validation/ContextKeys.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.WebCommon.Validation;
+
+public static class ValidationContextKeys
+{
+    public const string MimeTypeKey = "MimeType";
+}

--- a/src/TeachingRecordSystem.WebCommon/Validation/FileValidationExtensions.cs
+++ b/src/TeachingRecordSystem.WebCommon/Validation/FileValidationExtensions.cs
@@ -1,0 +1,53 @@
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using MimeDetective;
+
+namespace TeachingRecordSystem.WebCommon.Validation;
+
+public static class FileValidationExtensions
+{
+    private static readonly IContentInspector _inspector =
+        new ContentInspectorBuilder
+        {
+            Definitions = MimeDetective.Definitions.DefaultDefinitions.All()
+        }.Build();
+
+    public static IRuleBuilderOptions<T, IFormFile?> PermittedFileType<T>(
+        this IRuleBuilder<T, IFormFile?> ruleBuilder,
+        IReadOnlyCollection<string> permittedMimeTypes)
+    {
+        return ruleBuilder.MustAsync(async (_, file, ctx, _) =>
+        {
+            if (file is null)
+            {
+                return true;
+            }
+
+            await using var stream = file.OpenReadStream();
+            var matchedMimeTypes = _inspector.Inspect(stream).ByMimeType();
+
+            var mimeType = matchedMimeTypes.FirstOrDefault(mt => permittedMimeTypes.Contains(mt.MimeType))?.MimeType;
+
+            if (mimeType is not null)
+            {
+                ctx.RootContextData.Add(ValidationContextKeys.MimeTypeKey, mimeType);
+            }
+
+            return mimeType is not null;
+        });
+    }
+
+    public static IRuleBuilderOptions<T, IFormFile?> MaxFileSize<T>(
+        this IRuleBuilder<T, IFormFile?> ruleBuilder,
+        int maxFileSizeMb)
+    {
+        return ruleBuilder.Must(file => file is null || file.Length <= maxFileSizeMb * 1024 * 1024);
+    }
+
+    public static string GetMimeType(this IValidationContext context)
+    {
+        return context.RootContextData.TryGetValue(ValidationContextKeys.MimeTypeKey, out var value) ?
+            (string)value :
+            throw new InvalidOperationException("MIME type is not set.");
+    }
+}

--- a/src/TeachingRecordSystem.WebCommon/packages.lock.json
+++ b/src/TeachingRecordSystem.WebCommon/packages.lock.json
@@ -86,6 +86,12 @@
         "resolved": "17.14.15",
         "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
       },
+      "Mime-Detective": {
+        "type": "Direct",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
+      },
       "NSign.Client": {
         "type": "Direct",
         "requested": "[1.2.4, )",
@@ -224,7 +230,8 @@
         "resolved": "11.11.0",
         "contentHash": "viTKWaMbL3yJYgGI0DiCeavNbE9UPMWFVK2XS9nYXGbm3NDMd0/L5ER4wBzmTtW3BYh3SrlSXm9RACiKZ6stlA==",
         "dependencies": {
-          "FluentValidation": "11.11.0"
+          "FluentValidation": "11.11.0",
+          "Microsoft.Extensions.Dependencyinjection.Abstractions": "2.1.0"
         }
       },
       "Google.Api.Gax": {
@@ -413,6 +420,11 @@
         "type": "Transitive",
         "resolved": "10.0.8",
         "contentHash": "M3BZ8JH8rB6BE7dO2g9iVbrHLnEz9wMXT6q+tDR6Nq3gyP3KmBj5OTiZGxyF3vesjOQNKanYoPGSNBR4kR2llg=="
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "8/CtASu80UIoyG+r8FstrmZW5GLtXxzoYpjj3jV0FKZCL5CiFgSH3pAmqut/dC68mu7N1bU6v0UtKKL3gCUQGQ=="
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/packages.lock.json
@@ -954,6 +954,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1293,6 +1294,12 @@
           "Microsoft.IdentityModel.Protocols": "8.0.1",
           "System.IdentityModel.Tokens.Jwt": "8.0.1"
         }
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "morelinq": {
         "type": "CentralTransitive",

--- a/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
@@ -1293,6 +1293,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1769,6 +1770,12 @@
           "Microsoft.IdentityModel.Protocols": "8.0.1",
           "System.IdentityModel.Tokens.Jwt": "8.0.1"
         }
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "morelinq": {
         "type": "CentralTransitive",

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
@@ -1159,6 +1159,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1547,6 +1548,12 @@
         "requested": "[3.0.71, )",
         "resolved": "3.0.71",
         "contentHash": "uO0RegM2P5ZZhQDJQ+YSiugXJgNnh4gmjMd3VofeoE9MSu60zYoR3meA9SAm6PVJW2t//SzICXQf4+JtfUTJQA=="
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "Moq": {
         "type": "CentralTransitive",

--- a/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
@@ -1835,6 +1835,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -2423,6 +2424,12 @@
         "requested": "[3.0.71, )",
         "resolved": "3.0.71",
         "contentHash": "uO0RegM2P5ZZhQDJQ+YSiugXJgNnh4gmjMd3VofeoE9MSu60zYoR3meA9SAm6PVJW2t//SzICXQf4+JtfUTJQA=="
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "Moq": {
         "type": "CentralTransitive",

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
@@ -1103,6 +1103,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1500,6 +1501,12 @@
         "requested": "[3.0.71, )",
         "resolved": "3.0.71",
         "contentHash": "uO0RegM2P5ZZhQDJQ+YSiugXJgNnh4gmjMd3VofeoE9MSu60zYoR3meA9SAm6PVJW2t//SzICXQf4+JtfUTJQA=="
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "Moq": {
         "type": "CentralTransitive",

--- a/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
@@ -1105,6 +1105,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1502,6 +1503,12 @@
         "requested": "[3.0.71, )",
         "resolved": "3.0.71",
         "contentHash": "uO0RegM2P5ZZhQDJQ+YSiugXJgNnh4gmjMd3VofeoE9MSu60zYoR3meA9SAm6PVJW2t//SzICXQf4+JtfUTJQA=="
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "morelinq": {
         "type": "CentralTransitive",

--- a/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
+++ b/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
@@ -1061,6 +1061,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1521,6 +1522,12 @@
           "Microsoft.IdentityModel.Protocols": "7.7.1",
           "System.IdentityModel.Tokens.Jwt": "7.7.1"
         }
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "Moq": {
         "type": "CentralTransitive",

--- a/tests/TeachingRecordSystem.WebCommon.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.WebCommon.Tests/packages.lock.json
@@ -877,6 +877,7 @@
           "JetBrains.Annotations": "[2025.2.4, )",
           "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.Extensions.Caching.Postgres": "[1.2.2, )",
+          "Mime-Detective": "[25.8.1, )",
           "NSign.Client": "[1.2.4, )",
           "NSign.SignatureProviders": "[1.2.4, )",
           "OpenIddict.EntityFrameworkCore": "[7.5.0, )",
@@ -1202,6 +1203,12 @@
           "Microsoft.IdentityModel.Protocols": "7.7.1",
           "System.IdentityModel.Tokens.Jwt": "7.7.1"
         }
+      },
+      "Mime-Detective": {
+        "type": "CentralTransitive",
+        "requested": "[25.8.1, )",
+        "resolved": "25.8.1",
+        "contentHash": "PxCKFfrFxc6rdiVliZjmOlYQ246KY45RDNRwyvG7UVhbyYn/W4nX5sOBcyUWuX8F9vRJ2Vy7jmBnvYqvuMSrtw=="
       },
       "morelinq": {
         "type": "CentralTransitive",


### PR DESCRIPTION
This change examines the file contents to determine its type rather than relying on data from the client.

For now this is added to TeacherAuth only; SupportUi changes will follow later.