### PR TITLE
Add person another reason content updates

### DIFF
--- a/src/TeachingRecordSystem.Core/EventHandlers/CreateLegacyPersonEvents.cs
+++ b/src/TeachingRecordSystem.Core/EventHandlers/CreateLegacyPersonEvents.cs
@@ -26,6 +26,7 @@ public class CreateLegacyPersonEvents(TrsDbContext dbContext) :
                 PersonAttributes = @event.Details,
                 CreateReason = changeReason?.Reason,
                 CreateReasonDetail = changeReason?.Details,
+                CreateAdditionalInformation = changeReason?.AdditionalInformation,
                 EvidenceFile = changeReason?.EvidenceFile,
                 TrnRequestMetadata = @event.TrnRequestMetadata
             };

--- a/src/TeachingRecordSystem.Core/Events/ChangeReasons/ChangeReasonWithDetailsAndEvidence.cs
+++ b/src/TeachingRecordSystem.Core/Events/ChangeReasons/ChangeReasonWithDetailsAndEvidence.cs
@@ -5,4 +5,5 @@ public record ChangeReasonWithDetailsAndEvidence : IChangeReasonInfo
     public required string? Reason { get; init; }
     public required string? Details { get; init; }
     public required EventModels.File? EvidenceFile { get; init; }
+    public required string? AdditionalInformation { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/Legacy/PersonCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/PersonCreatedEvent.cs
@@ -7,6 +7,7 @@ public record PersonCreatedEvent : EventBase, IEventWithPersonId, IEventWithPers
     public EventModels.PersonDetails? OldPersonAttributes => null;
     public required string? CreateReason { get; init; }
     public required string? CreateReasonDetail { get; init; }
+    public required string? CreateAdditionalInformation { get; init; }
     public required EventModels.File? EvidenceFile { get; init; }
     public required EventModels.TrnRequestMetadata? TrnRequestMetadata { get; init; }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AddAlert/CheckAnswers.cshtml.cs
@@ -75,7 +75,8 @@ public class CheckAnswersModel(
             {
                 Reason = AddReason.GetDisplayName()!,
                 Details = AddReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.CreateAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -80,7 +80,8 @@ public class CheckAnswersModel(
             {
                 Reason = ChangeReason.GetDisplayName()!,
                 Details = ChangeReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.UpdateAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
@@ -76,7 +76,8 @@ public class CheckAnswersModel(
             {
                 Reason = DeleteReason.GetDisplayName()!,
                 Details = DeleteReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.DeleteAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
@@ -68,7 +68,8 @@ public class CheckAnswersModel(
             {
                 Reason = ChangeReason.GetDisplayName()!,
                 Details = ChangeReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.UpdateAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
@@ -68,7 +68,8 @@ public class CheckAnswersModel(
             {
                 Reason = ChangeReason.GetDisplayName()!,
                 Details = ChangeReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.UpdateAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
@@ -74,7 +74,8 @@ public class CheckAnswersModel(
             {
                 Reason = ChangeReason.GetDisplayName()!,
                 Details = ChangeReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.UpdateAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
@@ -68,7 +68,8 @@ public class CheckAnswersModel(
             {
                 Reason = ChangeReason.GetDisplayName()!,
                 Details = ChangeReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.UpdateAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
@@ -77,7 +77,8 @@ public class CheckAnswersModel(
             {
                 Reason = ChangeReason.GetDisplayName()!,
                 Details = ChangeReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await alertService.UpdateAlertAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers.cshtml.cs
@@ -77,7 +77,8 @@ public class CheckAnswersModel(
             Details = JourneyInstance.State.ConnectReason == ConnectPersonReason.AnotherReason
                 ? JourneyInstance.State.ReasonDetail
                 : null,
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
 
         var processContext = new ProcessContext(ProcessType.OneLoginUserPersonConnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/AddPersonState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/AddPersonState.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using TeachingRecordSystem.Core.Services.Persons;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.AddPerson;
@@ -23,6 +24,10 @@ public class AddPersonState : IRegisterJourney
     public PersonCreateReason? Reason { get; set; }
     public string? ReasonDetail { get; set; }
     public EvidenceUploadModel Evidence { get; set; } = new();
+
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
+
+    public string? AdditionalInformation { get; set; }
 
     public bool Initialized { get; set; }
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/CheckAnswers.cshtml
@@ -66,11 +66,27 @@
                     </row-actions>
                 </row>
                 <row>
-                    <key>Additional information</key>
+                    <key>Reason details</key>
                     <value>
                         @if (Model.ReasonDetail is not null)
                         {
                             @Html.ConvertNewlinesToLineBreaks(Model.ReasonDetail)
+                        }
+                        else
+                        {
+                            <span use-empty-fallback></span>
+                        }
+                    </value>
+                    <row-actions>
+                        <action href=@Model.ChangeReasonLink visually-hidden-text="reason details">Change</action>
+                    </row-actions>
+                </row>
+                <row>
+                    <key>Additional Information</key>
+                    <value>
+                        @if (Model.AdditionalInformation is not null)
+                        {
+                            @Html.ConvertNewlinesToLineBreaks(Model.AdditionalInformation)
                         }
                         else
                         {

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/CheckAnswers.cshtml.cs
@@ -23,6 +23,7 @@ public class CheckAnswersModel(
     public Gender? Gender { get; set; }
     public PersonCreateReason? Reason { get; set; }
     public string? ReasonDetail { get; set; }
+    public string? AdditionalInformation { get; set; }
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
     public string Name => StringHelper.JoinNonEmpty(' ', FirstName, MiddleName, LastName);
@@ -53,6 +54,7 @@ public class CheckAnswersModel(
         Reason = JourneyInstance.State.Reason;
         ReasonDetail = JourneyInstance.State.ReasonDetail;
         EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
     }
 
     public void OnGet()
@@ -69,7 +71,8 @@ public class CheckAnswersModel(
             {
                 Reason = Reason?.GetDisplayName(),
                 Details = ReasonDetail,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = AdditionalInformation
             });
 
         var person = await personService.CreatePersonAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/Reason.cshtml
@@ -1,5 +1,6 @@
 @page "/persons/add/reason"
 @using TeachingRecordSystem.Core.Services.Persons
+@using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus
 @model TeachingRecordSystem.SupportUi.Pages.Persons.AddPerson.ReasonModel
 @{
     Layout = "_Layout";
@@ -32,14 +33,33 @@
                         @PersonCreateReason.AnotherReason.GetDisplayName()
 
                         <govuk-radios-item-conditional data-testid="create-reason-detail">
-                            <govuk-character-count for="ReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details</govuk-character-count-label>
-                            </govuk-character-count>
+                            <govuk-input data-testid="reason-detail" for="ReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                           </govuk-input>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="provide-more-information-options">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m" data-testid="create-provide-additional-information-legend">
+                        <h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2>
+                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-item value="@ProvideMoreInformationOption.Yes">
+                        @ProvideMoreInformationOption.Yes.GetDisplayName()
+                        <govuk-radios-item-conditional>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
+                            </govuk-character-count>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@ProvideMoreInformationOption.No">
+                        @ProvideMoreInformationOption.No.GetDisplayName()
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+            
             @Html.EditorFor(m => m.Evidence)
 
             <div class="govuk-button-group">

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/AddPerson/Reason.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.Services.Persons;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.AddPerson;
@@ -21,7 +22,13 @@ public class ReasonModel(
         v => v.RuleFor(m => m.ReasonDetail)
             .NotEmpty().WithMessage("Enter a reason")
             .When(m => m.Reason == PersonCreateReason.AnotherReason),
-        v => v.RuleFor(m => m.Evidence).Evidence()
+        v => v.RuleFor(m => m.Evidence).Evidence(),
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
+            .NotNull().WithMessage("Select yes if you want to add more information"),
+        v => v.RuleFor(m => m.AdditionalInformation)
+            .NotNull().WithMessage("Enter details")
+            .MaximumLength(4000).WithMessage("Additional detail must be 4000 characters or less")
+            .When(x => x.ProvideAdditionalInformation == ProvideMoreInformationOption.Yes)
     };
 
     [BindProperty]
@@ -32,6 +39,12 @@ public class ReasonModel(
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
+
+    [BindProperty]
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     public string BackLink => GetPageLink(
         FromCheckAnswers
@@ -56,6 +69,8 @@ public class ReasonModel(
         Reason = JourneyInstance!.State.Reason;
         ReasonDetail = JourneyInstance.State.ReasonDetail;
         Evidence = JourneyInstance.State.Evidence;
+        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -73,6 +88,8 @@ public class ReasonModel(
             state.Reason = Reason;
             state.ReasonDetail = Reason is PersonCreateReason.AnotherReason ? ReasonDetail : null;
             state.Evidence = Evidence;
+            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+            state.AdditionalInformation = ProvideAdditionalInformation == ProvideMoreInformationOption.Yes ? AdditionalInformation : null;
         });
 
         return Redirect(NextPage);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/MergePerson/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/MergePerson/CheckAnswers.cshtml.cs
@@ -132,7 +132,8 @@ public class CheckAnswersModel(
             {
                 Reason = null,
                 Details = Comments,
-                EvidenceFile = EvidenceFile?.ToEventModel()
+                EvidenceFile = EvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await personService.MergePersonsAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml.cs
@@ -77,7 +77,8 @@ public class CheckAnswersModel(
             Details = JourneyInstance.State.ConnectReason == ConnectOneLoginReason.AnotherReason
                 ? JourneyInstance.State.ReasonDetail
                 : null,
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
 
         var processContext = new ProcessContext(ProcessType.PersonOneLoginUserConnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml.cs
@@ -47,7 +47,8 @@ public class CheckAnswers(
             Details = JourneyInstance!.State.DisconnectReason == DisconnectOneLoginReason.AnotherReason
                 ? JourneyInstance.State.Detail
                 : null,
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
         var processContext = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);
         var person = await dbContext.Persons.SingleAsync(x => x.PersonId == PersonId);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/EditDetails/CheckAnswers.cshtml.cs
@@ -62,7 +62,8 @@ public class CheckAnswersModel(
                 NameChangeEvidenceFile = NameChangeEvidenceFile?.ToEventModel(),
                 Reason = OtherDetailsChangeReason?.GetDisplayName(),
                 Details = OtherDetailsChangeReasonDetail,
-                EvidenceFile = OtherDetailsChangeEvidenceFile?.ToEventModel()
+                EvidenceFile = OtherDetailsChangeEvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             });
 
         await PersonService.UpdatePersonDetailsAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml.cs
@@ -40,7 +40,8 @@ public class CheckAnswersModel(
                 {
                     Reason = DeactivateReason?.GetDisplayName(),
                     Details = DeactivateReasonDetail,
-                    EvidenceFile = EvidenceFile?.ToEventModel()
+                    EvidenceFile = EvidenceFile?.ToEventModel(),
+                    AdditionalInformation = null
                 });
 
             await PersonService.DeactivatePersonAsync(new DeactivatePersonOptions(PersonId, DateOfDeath: null), processContext);
@@ -55,7 +56,8 @@ public class CheckAnswersModel(
                 {
                     Reason = ReactivateReason?.GetDisplayName(),
                     Details = ReactivateReasonDetail,
-                    EvidenceFile = EvidenceFile?.ToEventModel()
+                    EvidenceFile = EvidenceFile?.ToEventModel(),
+                    AdditionalInformation = null
                 });
 
             await PersonService.ReactivatePersonAsync(PersonId, processContext);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonCreatedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonCreatedEvent.cshtml
@@ -81,6 +81,19 @@
                             </value>
                         </row>
                         <row>
+                            <key>Additional information</key>
+                            <value>
+                                @if (createdEvent.CreateAdditionalInformation is not null)
+                                {
+                                    @Html.ConvertNewlinesToLineBreaks(createdEvent.CreateAdditionalInformation)
+                                }
+                                else
+                                {
+                                    <span use-empty-fallback></span>
+                                }
+                            </value>
+                        </row>
+                        <row>
                             <key>Evidence</key>
                             <value>
                             <vc:event-evidence-file-link evidence-file="@createdEvent.EvidenceFile" />

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/AddPersonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/AddPersonTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using TeachingRecordSystem.Core.Services.Persons;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.Persons;
 
@@ -20,6 +21,9 @@ public class AddPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         await page.AssertOnAddPersonReasonPageAsync();
         await page.SelectChangeReasonAsync("create-reason-options", PersonCreateReason.MandatoryQualification);
+
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "this is a test");
+
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -48,6 +52,8 @@ public class AddPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnAddPersonReasonPageAsync();
         await page.SelectChangeReasonAsync("create-reason-options", PersonCreateReason.MandatoryQualification);
         await page.SelectUploadEvidenceAsync(false);
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
+
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnAddPersonCheckAnswersPageAsync();
@@ -78,6 +84,7 @@ public class AddPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnAddPersonReasonPageAsync();
         await page.SelectChangeReasonAsync("create-reason-options", PersonCreateReason.MandatoryQualification);
         await page.SelectUploadEvidenceAsync(false);
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnAddPersonCheckAnswersPageAsync();
@@ -114,6 +121,7 @@ public class AddPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnAddPersonReasonPageAsync();
         await page.SelectChangeReasonAsync("create-reason-options", PersonCreateReason.MandatoryQualification);
         await page.SelectUploadEvidenceAsync(false);
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnAddPersonCheckAnswersPageAsync();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/AddPersonPostRequestContentBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/AddPersonPostRequestContentBuilder.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.Core.Services.Persons;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.AddPerson;
 
@@ -16,6 +17,9 @@ public class AddPersonPostRequestContentBuilder : PostRequestContentBuilder
     public string? ReasonDetail { get; set; }
     public TestEvidenceUploadModel Evidence { get; set; } = new();
 
+    public string? AdditionalInformation { get; set; }
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
+
     public AddPersonPostRequestContentBuilder WithFirstName(string? firstName)
     {
         FirstName = firstName;
@@ -25,6 +29,13 @@ public class AddPersonPostRequestContentBuilder : PostRequestContentBuilder
     public AddPersonPostRequestContentBuilder WithMiddleName(string? middleName)
     {
         MiddleName = middleName;
+        return this;
+    }
+
+    public AddPersonPostRequestContentBuilder WithAdditionalInformation(ProvideMoreInformationOption? provideAdditionalInformation, string? additionalInformation = null)
+    {
+        ProvideAdditionalInformation = provideAdditionalInformation;
+        AdditionalInformation = additionalInformation;
         return this;
     }
 
@@ -86,7 +97,7 @@ public class AddPersonPostRequestContentBuilder : PostRequestContentBuilder
         {
             FileId = id,
             FileName = evidenceFileName ?? "filename.jpg",
-            FileSizeDescription = evidenceFileSizeDescription ?? "5 MB"
+            FileSizeDescription = evidenceFileSizeDescription ?? "5 MB",
         };
 
         return this;

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/AddPersonStateBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/AddPersonStateBuilder.cs
@@ -1,5 +1,6 @@
 using TeachingRecordSystem.Core.Services.Persons;
 using TeachingRecordSystem.SupportUi.Pages.Persons.AddPerson;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.AddPerson;
@@ -13,6 +14,9 @@ public class AddPersonStateBuilder
     public string? EmailAddress { get; set; }
     public string? NationalInsuranceNumber { get; set; }
     public Gender? Gender { get; set; }
+
+    public string? AdditionalInformation { get; set; }
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
 
     public PersonCreateReason? Reason { get; set; }
     public string? ReasonDetail { get; set; }
@@ -39,6 +43,13 @@ public class AddPersonStateBuilder
     public AddPersonStateBuilder WithDateOfBirth(DateOnly? dateOfBirth)
     {
         DateOfBirth = dateOfBirth;
+        return this;
+    }
+
+    public AddPersonStateBuilder WithAdditionalInformation(ProvideMoreInformationOption? provideAdditionalInformation, string? additionalInformation)
+    {
+        ProvideAdditionalInformation = provideAdditionalInformation;
+        AdditionalInformation = additionalInformation;
         return this;
     }
 
@@ -100,7 +111,9 @@ public class AddPersonStateBuilder
                 UploadEvidence = UploadEvidence,
                 UploadedEvidenceFile = UploadedEvidenceFile,
             },
-            Initialized = Initialized
+            Initialized = Initialized,
+            ProvideAdditionalInformation = ProvideAdditionalInformation,
+            AdditionalInformation = AdditionalInformation,
         };
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/CheckAnswersTests.cs
@@ -121,7 +121,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var doc = await AssertEx.HtmlResponseAsync(response);
 
         doc.AssertSummaryListRowValue("Reason", v => Assert.Equal("Another reason", v.TrimmedText()));
-        doc.AssertSummaryListRowValue("Additional information", v => Assert.Equal(ChangeReasonDetails, v.TrimmedText()));
+        doc.AssertSummaryListRowValue("Reason details", v => Assert.Equal(ChangeReasonDetails, v.TrimmedText()));
         var urlEncoder = UrlEncoder.Default;
         var expectedBlobStorageFileUrl = urlEncoder.Encode($"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}");
         var expectedFileUrl = $"http://localhost/files/evidence.pdf?fileUrl={expectedBlobStorageFileUrl}";
@@ -156,7 +156,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var doc = await AssertEx.HtmlResponseAsync(response);
 
         doc.AssertSummaryListRowValue("Reason", v => Assert.Equal("They were awarded a mandatory qualification", v.TrimmedText()));
-        doc.AssertSummaryListRowValue("Additional information", v => Assert.Equal("Not provided", v.TrimmedText()));
+        doc.AssertSummaryListRowValue("Reason details", v => Assert.Equal("Not provided", v.TrimmedText()));
         doc.AssertSummaryListRowValues("Evidence", v => Assert.Equal("Not provided", v.TrimmedText()));
     }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/CommonPageTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/CommonPageTests.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.Services.Persons;
 using TeachingRecordSystem.SupportUi.Pages.Persons.AddPerson;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.AddPerson;
 
@@ -148,6 +149,7 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithNationalInsuranceNumber(nationalInsuranceNumber)
                 .WithReason(PersonCreateReason.MandatoryQualification)
                 .WithUploadEvidence(false)
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .BuildFormUrlEncoded()
         };
 
@@ -308,6 +310,7 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithNationalInsuranceNumber(nationalInsuranceNumber)
                 .WithReason(PersonCreateReason.MandatoryQualification)
                 .WithUploadEvidence(false)
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .BuildFormUrlEncoded()
         };
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/ReasonTests.cs
@@ -3,7 +3,9 @@ using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.Services.Persons;
 using TeachingRecordSystem.SupportUi.Pages.Persons.AddPerson;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
+using ReasonModel = TeachingRecordSystem.SupportUi.Pages.Persons.AddPerson.ReasonModel;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.AddPerson;
 
@@ -45,6 +47,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var urlEncoder = UrlEncoder.Default;
         var expectedBlobStorageFileUrl = urlEncoder.Encode($"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}");
         var expectedFileUrl = $"http://localhost/files/evidence.jpg?fileUrl={expectedBlobStorageFileUrl}";
+        var additionalInfo = "this is additional info";
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             new AddPersonStateBuilder()
@@ -53,6 +56,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithDateOfBirth(DateOnly.Parse("5 Jun 1999"))
                 .WithAddPersonReasonChoice(reasonChoice, reasonDetail)
                 .WithUploadEvidenceChoice(true, evidenceFileId, "evidence.jpg", "1.2 KB")
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, additionalInfo)
                 .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Get, GetRequestPath(journeyInstance));
@@ -67,8 +71,13 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             .Single(i => i.IsChecked).Value;
         Assert.Equal(reasonChoice.ToString(), reasonChoiceSelection);
 
-        var additionalDetailTextArea = doc.GetElementByTestId("create-reason-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
-        Assert.Equal(reasonDetail, additionalDetailTextArea!.Value);
+        var reasonDetailTextbox =
+            doc.GetElementById("ReasonDetail") as IHtmlInputElement;
+        Assert.Equal(reasonDetail, reasonDetailTextbox!.Value);
+
+        var additionalInformation =
+            doc.GetElementById("AdditionalInformation") as IHtmlTextAreaElement;
+        Assert.Equal(additionalInfo, additionalInformation!.Value);
 
         var uploadEvidenceChoices = doc.GetChildElementsOfTestId<IHtmlInputElement>("upload-evidence-options", "input[type='radio']")
             .Single(i => i.IsChecked).Value;
@@ -112,6 +121,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             .Select(i => i.Value);
         Assert.Equal(expectedChoices, reasonChoices);
 
+        var provideAdditionalInformationLegnd = doc.GetElementByTestId("create-provide-additional-information-legend");
+        Assert.Equal("Do you want to provide more information?", provideAdditionalInformationLegnd!.TrimmedText());
+        var provideAdditionalInformationChoices = doc.GetElementByTestId("provide-more-information-options")!
+            .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
+            .Where(i => i.IsChecked == false)
+            .Select(i => i.Value);
+        Assert.Equal(["Yes", "No"], provideAdditionalInformationChoices);
+
         var uploadEvidenceChoicesLegend = doc.GetElementByTestId("upload-evidence-options-legend");
         Assert.Equal("Do you want to upload evidence?", uploadEvidenceChoicesLegend!.TrimmedText());
         var uploadEvidenceChoices = doc.GetElementByTestId("upload-evidence-options")!
@@ -132,6 +149,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             new AddPersonStateBuilder()
                 .WithInitializedState()
                 .WithName("Alfred", "The", "Great")
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .WithDateOfBirth(DateOnly.Parse("5 Jun 1999"))
                 .Build());
 
@@ -140,6 +158,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new AddPersonPostRequestContentBuilder()
                 .WithReason(changeReason, changeReasonDetails)
                 .WithUploadEvidence(false)
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .BuildFormUrlEncoded()
         };
 
@@ -199,6 +218,59 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         await AssertEx.HtmlResponseHasErrorAsync(response, nameof(ReasonModel.ReasonDetail), "Enter a reason");
+    }
+
+    [Fact]
+    public async Task Post_ProvideAdditionalInformationNotAnswered_ReturnsError()
+    {
+        // Arrange
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            new AddPersonStateBuilder()
+                .WithInitializedState()
+                .WithName("Alfred", "The", "Great")
+                .WithDateOfBirth(DateOnly.Parse("5 Jun 1999"))
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(journeyInstance))
+        {
+            Content = new AddPersonPostRequestContentBuilder()
+                .WithReason(PersonCreateReason.AnotherReason, null)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(ReasonModel.ProvideAdditionalInformation), "Select yes if you want to add more information");
+    }
+
+
+    [Fact]
+    public async Task Post_ProvideAdditionalInformationYes_AdditionalInformationNotProvided_ReturnsError()
+    {
+        // Arrange
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            new AddPersonStateBuilder()
+                .WithInitializedState()
+                .WithName("Alfred", "The", "Great")
+                .WithDateOfBirth(DateOnly.Parse("5 Jun 1999"))
+                .WithAdditionalInformation(ProvideMoreInformationOption.No, "")
+                .Build());
+
+        var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(journeyInstance))
+        {
+            Content = new AddPersonPostRequestContentBuilder()
+                .WithReason(PersonCreateReason.AnotherReason, null)
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, null)
+                .BuildFormUrlEncoded()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(postRequest);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(response, nameof(ReasonModel.AdditionalInformation), "Enter details");
     }
 
     [Fact]
@@ -405,6 +477,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithInitializedState()
                 .WithName("Alfred", "The", "Great")
                 .WithDateOfBirth(DateOnly.Parse("5 Jun 1999"))
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(journeyInstance))
@@ -412,6 +485,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new AddPersonPostRequestContentBuilder()
                 .WithReason(PersonCreateReason.MandatoryQualification)
                 .WithUploadEvidence(true, (CreateEvidenceFileBinaryContent(new byte[1230]), "evidence.pdf"))
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .BuildMultipartFormData()
         };
 
@@ -436,6 +510,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithInitializedState()
                 .WithName("Alfred", "The", "Great")
                 .WithDateOfBirth(DateOnly.Parse("5 Jun 1999"))
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(journeyInstance))
@@ -443,6 +518,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new AddPersonPostRequestContentBuilder()
                 .WithReason(PersonCreateReason.MandatoryQualification)
                 .WithUploadEvidence(true, (CreateEvidenceFileBinaryContent(), "evidence.pdf"))
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some more information")
                 .BuildMultipartFormData()
         };
 
@@ -465,6 +541,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithInitializedState()
                 .WithName("Alfred", "The", "Great")
                 .WithDateOfBirth(DateOnly.Parse("5 Jun 1999"))
+                .WithAdditionalInformation(ProvideMoreInformationOption.Yes, "this is additional info that should be discarded")
                 .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(journeyInstance))
@@ -472,6 +549,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new AddPersonPostRequestContentBuilder()
                 .WithReason(PersonCreateReason.MandatoryQualification, "A description about why the change typed into the box")
                 .WithUploadEvidence(false, (CreateEvidenceFileBinaryContent(), "evidence.pdf"))
+                .WithAdditionalInformation(ProvideMoreInformationOption.No)
                 .BuildMultipartFormData()
         };
 
@@ -488,6 +566,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Null(journeyInstance.State.ReasonDetail);
         Assert.False(journeyInstance.State.Evidence.UploadEvidence);
         Assert.Null(journeyInstance.State.Evidence.UploadedEvidenceFile);
+        Assert.Null(journeyInstance.State.AdditionalInformation);
     }
 
     private string GetRequestPath(JourneyInstance<AddPersonState> journeyInstance) =>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryAlertProcessTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryAlertProcessTests.cs
@@ -37,7 +37,8 @@ public partial class ChangeHistoryTests
         {
             Reason = "Safeguarding concern",
             Details = "Details about the alert",
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
         var process = await TestData.CreateProcessAsync(ProcessType.AlertCreating, user.UserId, changeReason, @event);
 
@@ -106,7 +107,8 @@ public partial class ChangeHistoryTests
         {
             Reason = "Safeguarding concern",
             Details = "Details about the alert",
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
         var process = await TestData.CreateProcessAsync(ProcessType.AlertCreating, user.UserId, changeReason, @event);
 
@@ -171,7 +173,8 @@ public partial class ChangeHistoryTests
         {
             Reason = "Update required",
             Details = "Updating alert information",
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
         var process = await TestData.CreateProcessAsync(ProcessType.AlertUpdating, user.UserId, changeReason, @event);
 
@@ -257,7 +260,8 @@ public partial class ChangeHistoryTests
         {
             Reason = "Update required",
             Details = "Updating alert information",
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
         var process = await TestData.CreateProcessAsync(ProcessType.AlertUpdating, user.UserId, changeReason, @event);
 
@@ -312,7 +316,8 @@ public partial class ChangeHistoryTests
         {
             Reason = null,
             Details = "Alert no longer applicable",
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
         var process = await TestData.CreateProcessAsync(ProcessType.AlertDeleting, user.UserId, changeReason, @event);
 
@@ -381,7 +386,8 @@ public partial class ChangeHistoryTests
         {
             Reason = null,
             Details = "Alert no longer applicable",
-            EvidenceFile = null
+            EvidenceFile = null,
+            AdditionalInformation = null
         };
         var process = await TestData.CreateProcessAsync(ProcessType.AlertDeleting, user.UserId, changeReason, @event);
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
@@ -61,7 +61,8 @@ public partial class ChangeHistoryTests
         {
             Details = "these are details",
             EvidenceFile = null,
-            Reason = "this is the reason"
+            Reason = "this is the reason",
+            AdditionalInformation = null
         };
         var process = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, Clock.UtcNow, user.UserId, reason);
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogCreateEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogCreateEventTests.cs
@@ -30,6 +30,7 @@ public class ChangeLogCreateEventTests : TestBase
         string? emailAddress = "old@email-address.com";
         string? nationalInsuranceNumber = "AB 12 34 56 D";
         Gender? gender = Gender.Female;
+        var additionalInformation = "some additional information";
 
         var createReason = PersonCreateReason.AnotherReason.GetDisplayName();
         var createReasonDetail = "Reason detail";
@@ -60,7 +61,8 @@ public class ChangeLogCreateEventTests : TestBase
             CreateReason = createReason,
             CreateReasonDetail = createReasonDetail,
             EvidenceFile = evidenceFile,
-            TrnRequestMetadata = null
+            TrnRequestMetadata = null,
+            CreateAdditionalInformation = additionalInformation
         };
 
         await WithDbContextAsync(async dbContext =>
@@ -90,6 +92,7 @@ public class ChangeLogCreateEventTests : TestBase
 
         doc.AssertSummaryListRowValue("create-reason", "Reason", v => Assert.Equal(createReason, v.TrimmedText()));
         doc.AssertSummaryListRowValue("create-reason", "Reason details", v => Assert.Equal(createReasonDetail, v.TrimmedText()));
+        doc.AssertSummaryListRowValue("create-reason", "Additional information", v => Assert.Equal(additionalInformation, v.TrimmedText()));
         doc.AssertSummaryListRowValue("create-reason", "Evidence", v => Assert.Equal($"{evidenceFile!.Name} (opens in new tab)", v.TrimmedText()));
     }
 
@@ -128,7 +131,8 @@ public class ChangeLogCreateEventTests : TestBase
             CreateReason = createReason,
             CreateReasonDetail = null,
             EvidenceFile = null,
-            TrnRequestMetadata = null
+            TrnRequestMetadata = null,
+            CreateAdditionalInformation = null
         };
 
         await WithDbContextAsync(async dbContext =>


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/2?filterQuery=&pane=issue&itemId=174038796&issue=DFE-Digital%7Cteaching-record-team-project-board%7C192

### Changes proposed in this pull request

Add person Content updates for another reason consistency.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally