### PR TITLE
Change person status additional information content changes

### DIFF
--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Person.cs
@@ -76,6 +76,7 @@ public class Person
         PersonStatus targetStatus,
         string? reason,
         string? reasonDetail,
+        string? additionalInformation,
         EventModels.File? evidenceFile,
         EventModels.RaisedByUserInfo updatedBy,
         DateTime now,
@@ -96,7 +97,8 @@ public class Person
             Reason = reason,
             ReasonDetail = reasonDetail,
             EvidenceFile = evidenceFile,
-            DateOfDeath = null
+            DateOfDeath = null,
+            AdditionalInformation = additionalInformation
         };
     }
 

--- a/src/TeachingRecordSystem.Core/EventHandlers/CreateLegacyPersonEvents.cs
+++ b/src/TeachingRecordSystem.Core/EventHandlers/CreateLegacyPersonEvents.cs
@@ -82,7 +82,8 @@ public class CreateLegacyPersonEvents(TrsDbContext dbContext) :
                 DateOfDeath = @event.DateOfDeath,
                 Reason = changeReason.Reason,
                 ReasonDetail = changeReason.Details,
-                EvidenceFile = changeReason.EvidenceFile
+                EvidenceFile = changeReason.EvidenceFile,
+                AdditionalInformation = changeReason.AdditionalInformation
             };
 
             dbContext.AddEventWithoutBroadcast(legacyEvent);
@@ -147,7 +148,8 @@ public class CreateLegacyPersonEvents(TrsDbContext dbContext) :
                 DateOfDeath = null,
                 Reason = changeReason.Reason,
                 ReasonDetail = changeReason.Details,
-                EvidenceFile = changeReason.EvidenceFile
+                EvidenceFile = changeReason.EvidenceFile,
+                AdditionalInformation = changeReason.AdditionalInformation
             };
 
             dbContext.AddEventWithoutBroadcast(legacyEvent);

--- a/src/TeachingRecordSystem.Core/Events/Legacy/PersonStatusUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/PersonStatusUpdatedEvent.cs
@@ -7,6 +7,7 @@ public record PersonStatusUpdatedEvent : EventBase, IEventWithPersonId
     public required PersonStatus OldStatus { get; init; }
     public required string? Reason { get; init; }
     public required string? ReasonDetail { get; init; }
+    public required string? AdditionalInformation { get; init; }
     public required EventModels.File? EvidenceFile { get; init; }
     public required DateOnly? DateOfDeath { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Jobs/CapitaImportJob.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/CapitaImportJob.cs
@@ -180,7 +180,7 @@ public class CapitaImportJob(
 
                         if (!string.IsNullOrEmpty(row.DateOfDeath) && DateOnly.TryParseExact(row.DateOfDeath, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfDeath))
                         {
-                            newPerson.SetStatus(PersonStatus.Deactivated, "Date of death received from capita import", null, null, SystemUser.Instance.UserId, timeProvider.UtcNow, out var @event);
+                            newPerson.SetStatus(PersonStatus.Deactivated, "Date of death received from capita import", null, "", null, SystemUser.Instance.UserId, timeProvider.UtcNow, out var @event);
                             if (@event is not null)
                             {
                                 dbContext.AddEventWithoutBroadcast(@event);
@@ -227,7 +227,7 @@ public class CapitaImportJob(
                         if (!string.IsNullOrEmpty(row.DateOfDeath) && DateOnly.TryParseExact(row.DateOfDeath, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateOfDeath))
                         {
                             person.DateOfDeath = dateOfDeath;
-                            person.SetStatus(PersonStatus.Deactivated, "Date of death received from capita import", null, null, SystemUser.Instance.UserId, timeProvider.UtcNow, out var @event);
+                            person.SetStatus(PersonStatus.Deactivated, "Date of death received from capita import", null, "", null, SystemUser.Instance.UserId, timeProvider.UtcNow, out var @event);
                             if (@event is not null)
                             {
                                 dbContext.AddEventWithoutBroadcast(@event);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml
@@ -73,9 +73,25 @@
                         <value>@Model.DeactivateReason?.GetDisplayName()</value>
                         <row-actions>
                             <action data-testid="change-deactivate-reason-link"
-                                                           href=@Model.ChangeReasonLink visually-hidden-text="reason">
+                                    href=@Model.ChangeReasonLink visually-hidden-text="reason">
                                 Change
                             </action>
+                        </row-actions>
+                    </row>
+                    <row>
+                        <key>Reason details</key>
+                        <value>
+                            @if (Model.DeactivateReasonDetail is not null)
+                            {
+                                @Html.ConvertNewlinesToLineBreaks(Model.DeactivateReasonDetail)
+                            }
+                            else
+                            {
+                                <span use-empty-fallback></span>
+                            }
+                        </value>
+                        <row-actions>
+                            <action href=@Model.ChangeReasonLink visually-hidden-text="reason details">Change</action>
                         </row-actions>
                     </row>
                     <row>
@@ -83,7 +99,7 @@
                         <value>
                             @if (Model.DeactivateReasonDetail is not null)
                             {
-                                @Html.ConvertNewlinesToLineBreaks(Model.DeactivateReasonDetail)
+                                @Html.ConvertNewlinesToLineBreaks(Model.DeactivateAdditionalInformation)
                             }
                             else
                             {
@@ -104,17 +120,33 @@
                         <value>@Model.ReactivateReason?.GetDisplayName()</value>
                         <row-actions>
                             <action data-testid="change-reactivate-reason-link"
-                                                           href=@Model.ChangeReasonLink visually-hidden-text="reason">
+                                    href=@Model.ChangeReasonLink visually-hidden-text="reason">
                                 Change
                             </action>
                         </row-actions>
                     </row>
                     <row>
-                        <key>Additional information</key>
+                        <key>Reason details</key>
                         <value>
                             @if (Model.ReactivateReasonDetail is not null)
                             {
                                 @Html.ConvertNewlinesToLineBreaks(Model.ReactivateReasonDetail)
+                            }
+                            else
+                            {
+                                <span use-empty-fallback></span>
+                            }
+                        </value>
+                        <row-actions>
+                            <action href=@Model.ChangeReasonLink visually-hidden-text="reason details">Change</action>
+                        </row-actions>
+                    </row>
+                    <row>
+                        <key>Additional information</key>
+                        <value>
+                            @if (Model.ReactivateAdditionalInformation is not null)
+                            {
+                                @Html.ConvertNewlinesToLineBreaks(Model.ReactivateAdditionalInformation)
                             }
                             else
                             {

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml.cs
@@ -19,6 +19,9 @@ public class CheckAnswersModel(
     public string? DeactivateReasonDetail { get; set; }
     public PersonReactivateReason? ReactivateReason { get; set; }
     public string? ReactivateReasonDetail { get; set; }
+    public string? ReactivateAdditionalInformation { get; set; }
+    public string? DeactivateAdditionalInformation { get; set; }
+
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
     public string BackLink => LinkGenerator.Persons.PersonDetail.SetStatus.Reason(PersonId, TargetStatus, JourneyInstance!.InstanceId);
@@ -41,7 +44,7 @@ public class CheckAnswersModel(
                     Reason = DeactivateReason?.GetDisplayName(),
                     Details = DeactivateReasonDetail,
                     EvidenceFile = EvidenceFile?.ToEventModel(),
-                    AdditionalInformation = null
+                    AdditionalInformation = DeactivateAdditionalInformation
                 });
 
             await PersonService.DeactivatePersonAsync(new DeactivatePersonOptions(PersonId, DateOfDeath: null), processContext);
@@ -57,7 +60,7 @@ public class CheckAnswersModel(
                     Reason = ReactivateReason?.GetDisplayName(),
                     Details = ReactivateReasonDetail,
                     EvidenceFile = EvidenceFile?.ToEventModel(),
-                    AdditionalInformation = null
+                    AdditionalInformation = ReactivateAdditionalInformation
                 });
 
             await PersonService.ReactivatePersonAsync(PersonId, processContext);
@@ -87,6 +90,8 @@ public class CheckAnswersModel(
         DeactivateReasonDetail = state.DeactivateReasonDetail;
         ReactivateReason = state.ReactivateReason;
         ReactivateReasonDetail = state.ReactivateReasonDetail;
+        ReactivateAdditionalInformation = state.ReactivateAdditionalInformation;
+        DeactivateAdditionalInformation = state.DeactivateAdditionalInformation;
         EvidenceFile = state.Evidence.UploadedEvidenceFile;
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/Reason.cshtml
@@ -35,6 +35,11 @@
                         </govuk-radios-item>
                         <govuk-radios-item value="@PersonDeactivateReason.AnotherReason">
                             @PersonDeactivateReason.AnotherReason.GetDisplayName()
+                            <govuk-radios-item-conditional data-testid="deactivate-reason-detail">
+                                <govuk-input data-testid="deactivate-reason-detail" for="DeactivateReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                    <govuk-input-label>Enter a reason</govuk-input-label>
+                                </govuk-input>
+                            </govuk-radios-item-conditional>
                         </govuk-radios-item>
                     </govuk-radios-fieldset>
                 </govuk-radios>
@@ -46,8 +51,8 @@
                         </govuk-radios-fieldset-legend>
                         <govuk-radios-item value="@ProvideMoreInformationOption.Yes">
                             @ProvideMoreInformationOption.Yes.GetDisplayName()
-                            <govuk-radios-item-conditional data-testid="deactivate-reason-detail">
-                                <govuk-character-count for="DeactivateReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                            <govuk-radios-item-conditional>
+                                <govuk-character-count for="DeactivateAdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
                                     <govuk-character-count-label>Enter details</govuk-character-count-label>
                                 </govuk-character-count>
                             </govuk-radios-item-conditional>
@@ -70,6 +75,11 @@
                         </govuk-radios-item>
                         <govuk-radios-item value="@PersonReactivateReason.AnotherReason">
                             @PersonReactivateReason.AnotherReason.GetDisplayName()
+                            <govuk-radios-item-conditional>
+                                <govuk-input data-testid="reactivate-reason-detail" for="ReactivateReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                    <govuk-input-label>Enter a reason</govuk-input-label>
+                                </govuk-input>
+                            </govuk-radios-item-conditional>
                         </govuk-radios-item>
                     </govuk-radios-fieldset>
                 </govuk-radios>
@@ -81,8 +91,8 @@
                         </govuk-radios-fieldset-legend>
                         <govuk-radios-item value="@ProvideMoreInformationOption.Yes">
                             @ProvideMoreInformationOption.Yes.GetDisplayName()
-                            <govuk-radios-item-conditional data-testid="reactivate-reason-detail">
-                                <govuk-character-count for="ReactivateReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                            <govuk-radios-item-conditional>
+                                <govuk-character-count for="ReactivateAdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
                                     <govuk-character-count-label>Enter details</govuk-character-count-label>
                                 </govuk-character-count>
                             </govuk-radios-item-conditional>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/Reason.cshtml.cs
@@ -28,8 +28,18 @@ public class ReasonModel(
         v => v.RuleFor(m => m.DeactivateReasonDetail)
             .NotEmpty()
             .WithMessage("Enter a reason")
+            .When(x => x.DeactivateReason ==  PersonDeactivateReason.AnotherReason && x.TargetStatus == PersonStatus.Deactivated),
+
+        v => v.RuleFor(m => m.DeactivateAdditionalInformation)
+            .NotEmpty()
+            .WithMessage("Enter details")
             .When(x => x.ProvideMoreInformation == ProvideMoreInformationOption.Yes && x.TargetStatus == PersonStatus.Deactivated),
 
+        v => v.RuleFor(m => m.DeactivateAdditionalInformation)
+            .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
+            .WithMessage($"Reason details {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}")
+            .When(m => m.TargetStatus == PersonStatus.Deactivated),
+        
         //re-activate rules
         v => v.RuleFor(m => m.ReactivateReason)
             .NotEmpty()
@@ -41,21 +51,27 @@ public class ReasonModel(
             .WithMessage("Select yes if you want to provide more information")
             .When(x=>x.TargetStatus == PersonStatus.Active),
 
+        v => v.RuleFor(m => m.ReactivateAdditionalInformation)
+            .NotEmpty()
+            .WithMessage("Enter details")
+            .When(x => x.ProvideMoreInformation == ProvideMoreInformationOption.Yes && x.TargetStatus == PersonStatus.Active),
+
+        v => v.RuleFor(m => m.ReactivateAdditionalInformation)
+            .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
+                .WithMessage($"Reason details {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}")
+            .When(m => m.TargetStatus == PersonStatus.Active && m.ProvideMoreInformation == ProvideMoreInformationOption.Yes),
+
+        v => v.RuleFor(m => m.ReactivateReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.ReactivateReason == PersonReactivateReason.AnotherReason),
+        
+        // Make sure to take into account evidence models validation rules.
+        v => v.RuleFor(x => x.Evidence).Evidence(),
+
         v => v.RuleFor(m => m.ReactivateReasonDetail)
             .NotEmpty()
             .WithMessage("Enter a reason")
-            .When(x => x.ProvideMoreInformation == ProvideMoreInformationOption.Yes && x.TargetStatus == PersonStatus.Active),
-
-        v => v.RuleFor(m => m.DeactivateReasonDetail)
-            .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
-                .WithMessage($"Reason details {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}")
-            .When(m => m.TargetStatus == PersonStatus.Deactivated),
-        v => v.RuleFor(m => m.ReactivateReasonDetail)
-            .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
-                .WithMessage($"Reason details {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}")
-            .When(m => m.TargetStatus == PersonStatus.Active),
-        // Make sure to take into account evidence models validation rules.
-        v => v.RuleFor(x => x.Evidence).Evidence()
+            .When(x => x.DeactivateReason ==  PersonDeactivateReason.AnotherReason && x.TargetStatus == PersonStatus.Active),
     };
 
     [BindProperty]
@@ -80,12 +96,20 @@ public class ReasonModel(
         ? LinkGenerator.Persons.PersonDetail.SetStatus.CheckAnswers(PersonId, TargetStatus, JourneyInstance!.InstanceId)
         : LinkGenerator.Persons.PersonDetail.Index(PersonId);
 
+    [BindProperty]
+    public string? ReactivateAdditionalInformation { get; set; }
+
+    [BindProperty]
+    public string? DeactivateAdditionalInformation { get; set; }
+
     public void OnGet()
     {
         DeactivateReason = JourneyInstance!.State.DeactivateReason;
         DeactivateReasonDetail = JourneyInstance!.State.DeactivateReasonDetail;
+        DeactivateAdditionalInformation = JourneyInstance!.State.DeactivateAdditionalInformation;
         ReactivateReason = JourneyInstance!.State.ReactivateReason;
         ReactivateReasonDetail = JourneyInstance!.State.ReactivateReasonDetail;
+        ReactivateAdditionalInformation = JourneyInstance!.State.ReactivateAdditionalInformation;
         Evidence = JourneyInstance.State.Evidence;
         ProvideMoreInformation = JourneyInstance!.State.ProvideMoreInformation;
     }
@@ -106,9 +130,11 @@ public class ReasonModel(
         {
             state.ProvideMoreInformation = ProvideMoreInformation;
             state.DeactivateReason = DeactivateReason;
-            state.DeactivateReasonDetail = ProvideMoreInformation is ProvideMoreInformationOption.Yes ? DeactivateReasonDetail : null;
+            state.DeactivateReasonDetail = DeactivateReason is PersonDeactivateReason.AnotherReason ? DeactivateReasonDetail : null;
+            state.DeactivateAdditionalInformation = ProvideMoreInformation is ProvideMoreInformationOption.Yes ? DeactivateAdditionalInformation : null;
             state.ReactivateReason = ReactivateReason;
-            state.ReactivateReasonDetail = ProvideMoreInformation is ProvideMoreInformationOption.Yes ? ReactivateReasonDetail : null;
+            state.ReactivateReasonDetail = ReactivateReason is PersonReactivateReason.AnotherReason ? ReactivateReasonDetail : null;
+            state.ReactivateAdditionalInformation = ProvideMoreInformation is ProvideMoreInformationOption.Yes ? ReactivateAdditionalInformation : null;
             state.Evidence = Evidence;
         });
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/SetStatusState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/SetStatusState.cs
@@ -13,32 +13,45 @@ public class SetStatusState : IRegisterJourney
 
     public PersonDeactivateReason? DeactivateReason { get; set; }
     public string? DeactivateReasonDetail { get; set; }
+    public string? DeactivateAdditionalInformation { get; set; }
+    public string? ReactivateAdditionalInformation { get; set; }
     public PersonReactivateReason? ReactivateReason { get; set; }
     public string? ReactivateReasonDetail { get; set; }
     public EvidenceUploadModel Evidence { get; set; } = new();
-
     public ProvideMoreInformationOption? ProvideMoreInformation { get; set; }
 
     public bool Initialized { get; set; }
 
-    public bool IsComplete =>
-        Evidence.IsComplete &&
-        (
-            (
-                DeactivateReason is not null &&
+    public bool IsComplete
+    {
+        get
+        {
+            var isDeactivate = DeactivateReason is not null;
+            var isReactivate = ReactivateReason is not null;
+
+            var reasonSelected = isDeactivate || isReactivate;
+
+            var reasonDetailComplete =
+                isDeactivate
+                    ? DeactivateReason != PersonDeactivateReason.AnotherReason ||
+                      !string.IsNullOrWhiteSpace(DeactivateReasonDetail)
+                    : isReactivate && (ReactivateReason != PersonReactivateReason.AnotherReason ||
+                                       !string.IsNullOrWhiteSpace(ReactivateReasonDetail));
+
+            var additionalInformationComplete =
+                ProvideMoreInformation != ProvideMoreInformationOption.Yes ||
                 (
-                    ProvideMoreInformation != ProvideMoreInformationOption.Yes ||
-                    DeactivateReasonDetail is not null
-                )
-            ) ||
-            (
-                ReactivateReason is not null &&
-                (
-                    ProvideMoreInformation != ProvideMoreInformationOption.Yes ||
-                    ReactivateReasonDetail is not null
-                )
-            )
-        );
+                    isDeactivate
+                        ? !string.IsNullOrWhiteSpace(DeactivateAdditionalInformation)
+                        : !string.IsNullOrWhiteSpace(ReactivateAdditionalInformation)
+                );
+
+            return Evidence.IsComplete
+                   && reasonSelected
+                   && reasonDetailComplete
+                   && additionalInformationComplete;
+        }
+    }
 
     public void EnsureInitialized()
     {

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonStatusUpdatedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/PersonStatusUpdatedEvent.cshtml
@@ -42,6 +42,19 @@
                         </value>
                     </row>
                     <row>
+                        <key>Additional information</key>
+                        <value>
+                            @if (statusUpdatedEvent.AdditionalInformation is not null)
+                            {
+                                @Html.ConvertNewlinesToLineBreaks(statusUpdatedEvent.AdditionalInformation)
+                            }
+                            else
+                            {
+                                <span use-empty-fallback></span>
+                            }
+                        </value>
+                    </row>
+                    <row>
                         <key>Evidence</key>
                         <value>
                             <vc:event-evidence-file-link evidence-file="@statusUpdatedEvent.EvidenceFile" />

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaImportJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaImportJobTests.cs
@@ -1694,7 +1694,7 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             var selectedPerson = dbContext.Persons.Single(x => x.Trn == trn);
-            selectedPerson.SetStatus(PersonStatus.Deactivated, "de-activate", "de-activated", null, SystemUser.SystemUserId, Clock.UtcNow, out var _);
+            selectedPerson.SetStatus(PersonStatus.Deactivated, "de-activate", "de-activated", "", null, SystemUser.SystemUserId, Clock.UtcNow, out var _);
             await dbContext.SaveChangesAsync();
         });
     }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogSetStatusEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogSetStatusEventTests.cs
@@ -33,6 +33,7 @@ public class ChangeLogSetStatusEventTests : TestBase
 
         var reason = PersonDeactivateReason.AnotherReason.GetDisplayName();
         var reasonDetail = "Reason detail";
+        var additionalInformation = "this is additional information";
         var evidenceFile = new EventModels.File
         {
             FileId = Guid.NewGuid(),
@@ -50,7 +51,8 @@ public class ChangeLogSetStatusEventTests : TestBase
             Reason = reason,
             ReasonDetail = reasonDetail,
             EvidenceFile = evidenceFile,
-            DateOfDeath = null
+            DateOfDeath = null,
+            AdditionalInformation = additionalInformation
         };
 
         await WithDbContextAsync(async dbContext =>
@@ -78,6 +80,7 @@ public class ChangeLogSetStatusEventTests : TestBase
         Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         doc.AssertSummaryListRowValue("change-reason", "Reason", v => Assert.Equal(reason, v.TrimmedText()));
+        doc.AssertSummaryListRowValue("change-reason", "Additional information", v => Assert.Equal(additionalInformation, v.TrimmedText()));
         doc.AssertSummaryListRowValue("change-reason", "Reason details", v => Assert.Equal(reasonDetail, v.TrimmedText()));
         doc.AssertSummaryListRowValue("change-reason", "Evidence", v => Assert.Equal($"{evidenceFile!.Name} (opens in new tab)", v.TrimmedText()));
     }
@@ -91,6 +94,7 @@ public class ChangeLogSetStatusEventTests : TestBase
 
         var reason = PersonReactivateReason.AnotherReason.GetDisplayName();
         var reasonDetail = "Reason detail";
+        var additionalInformation = "this is additional information";
         var evidenceFile = new EventModels.File
         {
             FileId = Guid.NewGuid(),
@@ -108,7 +112,8 @@ public class ChangeLogSetStatusEventTests : TestBase
             Reason = reason,
             ReasonDetail = reasonDetail,
             EvidenceFile = evidenceFile,
-            DateOfDeath = null
+            DateOfDeath = null,
+            AdditionalInformation = additionalInformation
         };
 
         await WithDbContextAsync(async dbContext =>
@@ -136,6 +141,7 @@ public class ChangeLogSetStatusEventTests : TestBase
         Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         doc.AssertSummaryListRowValue("change-reason", "Reason", v => Assert.Equal(reason, v.TrimmedText()));
+        doc.AssertSummaryListRowValue("change-reason", "Additional information", v => Assert.Equal(additionalInformation, v.TrimmedText()));
         doc.AssertSummaryListRowValue("change-reason", "Reason details", v => Assert.Equal(reasonDetail, v.TrimmedText()));
         doc.AssertSummaryListRowValue("change-reason", "Evidence", v => Assert.Equal($"{evidenceFile!.Name} (opens in new tab)", v.TrimmedText()));
     }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/CheckAnswersTests.cs
@@ -21,17 +21,21 @@ public class CheckAnswersTests(HostFixture hostFixture) : SetStatusTestBase(host
 
         var person = await CreatePersonToBecomeStatus(targetStatus);
 
+        var additionalInformation = "this is some additional information";
         var stateBuilder = new SetStatusStateBuilder()
             .WithInitializedState()
             .WithUploadEvidenceChoice(true, evidenceFileId, "evidence.pdf", "1.2 MB");
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, ChangeReasonDetails);
+            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, ChangeReasonDetails)
+                .WithDeactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.Yes, additionalInformation);
         }
         else
         {
-            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, ChangeReasonDetails);
+            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, ChangeReasonDetails)
+                .WithReactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.Yes, additionalInformation);
+
         }
 
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -47,7 +51,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : SetStatusTestBase(host
         var doc = await AssertEx.HtmlResponseAsync(response);
 
         doc.AssertSummaryListRowValue("Reason", v => Assert.Equal("Another reason", v.TrimmedText()));
-        doc.AssertSummaryListRowValue("Additional information", v => Assert.Equal(ChangeReasonDetails, v.TrimmedText()));
+        doc.AssertSummaryListRowValue("Reason details", v => Assert.Equal(ChangeReasonDetails, v.TrimmedText()));
+        doc.AssertSummaryListRowValue("Additional information", v => Assert.Equal(additionalInformation, v.TrimmedText()));
         var urlEncoder = UrlEncoder.Default;
         var expectedBlobStorageFileUrl = urlEncoder.Encode($"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}");
         var expectedFileUrl = $"http://localhost/files/evidence.pdf?fileUrl={expectedBlobStorageFileUrl}";
@@ -77,11 +82,13 @@ public class CheckAnswersTests(HostFixture hostFixture) : SetStatusTestBase(host
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, ChangeReasonDetails);
+            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, ChangeReasonDetails)
+                .WithDeactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.No);
         }
         else
         {
-            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, ChangeReasonDetails);
+            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, ChangeReasonDetails)
+                .WithReactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.No);
         }
 
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -117,11 +124,13 @@ public class CheckAnswersTests(HostFixture hostFixture) : SetStatusTestBase(host
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.RecordHolderDied, ProvideMoreInformationOption.No);
+            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.RecordHolderDied)
+                .WithDeactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.No);
         }
         else
         {
-            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.DeactivatedByMistake, ProvideMoreInformationOption.No);
+            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.DeactivatedByMistake)
+                .WithReactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.No);
         }
 
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -166,11 +175,13 @@ public class CheckAnswersTests(HostFixture hostFixture) : SetStatusTestBase(host
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, ChangeReasonDetails);
+            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, ChangeReasonDetails)
+                .WithDeactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.No);
         }
         else
         {
-            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, ChangeReasonDetails);
+            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, ChangeReasonDetails)
+                .WithDeactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.No);
         }
 
         var journeyInstance = await CreateJourneyInstanceAsync(

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/ReasonTests.cs
@@ -19,7 +19,7 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
         var urlEncoder = UrlEncoder.Default;
         var expectedBlobStorageFileUrl = urlEncoder.Encode($"{TestScopedServices.FakeBlobStorageFileUrlBase}{evidenceFileId}");
         var expectedFileUrl = $"http://localhost/files/evidence.jpg?fileUrl={expectedBlobStorageFileUrl}";
-
+        var expectedAdditionalInformation = "this is some additional information";
         var person = await CreatePersonToBecomeStatus(targetStatus);
 
         var stateBuilder = new SetStatusStateBuilder()
@@ -28,11 +28,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, reasonDetail);
+            stateBuilder.WithDeactivateReasonChoice(PersonDeactivateReason.AnotherReason, reasonDetail)
+                .WithDeactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.Yes, expectedAdditionalInformation);
         }
         else
         {
-            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, reasonDetail);
+            stateBuilder.WithReactivateReasonChoice(PersonReactivateReason.AnotherReason, reasonDetail)
+                .WithReactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption.Yes, expectedAdditionalInformation);
         }
 
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -53,8 +55,11 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
                 .Single(i => i.IsChecked).Value;
             Assert.Equal(PersonDeactivateReason.AnotherReason.ToString(), reasonChoiceSelection);
 
-            var additionalDetailTextArea = doc.GetElementByTestId("deactivate-reason-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
-            Assert.Equal(reasonDetail, additionalDetailTextArea!.Value);
+            var reasonDetailTextArea = doc.GetElementById("DeactivateReasonDetail") as IHtmlInputElement;
+            Assert.Equal(reasonDetail, reasonDetailTextArea!.Value);
+
+            var additionalDetailTextArea = doc.GetElementById("DeactivateAdditionalInformation") as IHtmlTextAreaElement;
+            Assert.Equal(expectedAdditionalInformation, additionalDetailTextArea!.Value);
         }
         else
         {
@@ -62,8 +67,11 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
                 .Single(i => i.IsChecked).Value;
             Assert.Equal(PersonDeactivateReason.AnotherReason.ToString(), reasonChoiceSelection);
 
-            var additionalDetailTextArea = doc.GetElementByTestId("reactivate-reason-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
-            Assert.Equal(reasonDetail, additionalDetailTextArea!.Value);
+            var reasonDetailTextArea = doc.GetElementById("ReactivateReasonDetail") as IHtmlInputElement;
+            Assert.Equal(reasonDetail, reasonDetailTextArea!.Value);
+
+            var additionalDetailTextArea = doc.GetElementById("ReactivateAdditionalInformation") as IHtmlTextAreaElement;
+            Assert.Equal(expectedAdditionalInformation, additionalDetailTextArea!.Value);
         }
 
         var uploadEvidenceChoices = doc.GetChildElementsOfTestId<IHtmlInputElement>("upload-evidence-options", "input[type='radio']")
@@ -138,6 +146,7 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
     {
         // Arrange
         var changeReasonDetails = "A description about why the change typed into the box";
+        var additionalInformation = "some additional information about the change";
 
         var person = await CreatePersonToBecomeStatus(targetStatus);
 
@@ -152,11 +161,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, changeReasonDetails);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, changeReasonDetails)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.Yes, additionalInformation);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, changeReasonDetails);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, changeReasonDetails)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.Yes, additionalInformation);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -236,11 +247,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, detail: null)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, detail: null)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -280,11 +293,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.ProblemWithTheRecord, ProvideMoreInformationOption.No);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.ProblemWithTheRecord)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake, ProvideMoreInformationOption.No);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -317,11 +332,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.ProblemWithTheRecord, ProvideMoreInformationOption.No);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.ProblemWithTheRecord)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake, ProvideMoreInformationOption.No);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -355,11 +372,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, detail: null)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, detail: null)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null); ;
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -408,11 +427,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, detail: null)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, detail: null)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null); ;
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -461,11 +482,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, detail: null)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, detail: null)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -502,11 +525,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.AnotherReason, detail: null)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, ProvideMoreInformationOption.Yes, detail: null);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.AnotherReason, detail: null)
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, detail: null);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -541,11 +566,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.RecordHolderDied, ProvideMoreInformationOption.No);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.RecordHolderDied)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No); ;
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake, ProvideMoreInformationOption.No);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -583,11 +610,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.RecordHolderDied, ProvideMoreInformationOption.No);
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.RecordHolderDied)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake, ProvideMoreInformationOption.No);
+            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake)
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))
@@ -623,11 +652,13 @@ public class ReasonTests(HostFixture hostFixture) : SetStatusTestBase(hostFixtur
 
         if (targetStatus == PersonStatus.Deactivated)
         {
-            contentBuilder.WithDeactivateReason(PersonDeactivateReason.RecordHolderDied, ProvideMoreInformationOption.No, "Unneccessary detail");
+            contentBuilder.WithDeactivateReason(PersonDeactivateReason.RecordHolderDied, "Unneccessary detail")
+                .WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, null);
         }
         else
         {
-            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake, ProvideMoreInformationOption.No, "Unneccessary detail");
+            contentBuilder.WithReactivateReason(PersonReactivateReason.DeactivatedByMistake, "Unneccessary detail")
+                .WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption.No, null);
         }
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, GetRequestPath(person, targetStatus, journeyInstance))

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/SetStatusPostRequestContentBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/SetStatusPostRequestContentBuilder.cs
@@ -11,20 +11,33 @@ public class SetStatusPostRequestContentBuilder : PostRequestContentBuilder
     public string? ReactivateReasonDetail { get; set; }
     public TestEvidenceUploadModel Evidence { get; set; } = new();
     public ProvideMoreInformationOption? ProvideMoreInformation { get; set; }
+    public string? DeactivateAdditionalInformation { get; set; }
+    public string? ReactivateAdditionalInformation { get; set; }
 
-
-    public SetStatusPostRequestContentBuilder WithDeactivateReason(PersonDeactivateReason deactivateReason, ProvideMoreInformationOption provideAdditionalInformation, string? detail = null)
+    public SetStatusPostRequestContentBuilder WithDeactivateReason(PersonDeactivateReason deactivateReason, string? detail = null)
     {
         DeactivateReason = deactivateReason;
         DeactivateReasonDetail = detail;
+        return this;
+    }
+
+    public SetStatusPostRequestContentBuilder WithReactivateReason(PersonReactivateReason reactivateReason, string? detail = null)
+    {
+        ReactivateReason = reactivateReason;
+        ReactivateReasonDetail = detail;
+        return this;
+    }
+
+    public SetStatusPostRequestContentBuilder WithDeactivateProvideAdditionalInformation(ProvideMoreInformationOption provideAdditionalInformation, string? detail = null)
+    {
+        DeactivateAdditionalInformation = detail;
         ProvideMoreInformation = provideAdditionalInformation;
         return this;
     }
 
-    public SetStatusPostRequestContentBuilder WithReactivateReason(PersonReactivateReason reactivateReason, ProvideMoreInformationOption provideAdditionalInformation, string? detail = null)
+    public SetStatusPostRequestContentBuilder WithReactivateProvideAdditionalInformation(ProvideMoreInformationOption provideAdditionalInformation, string? detail = null)
     {
-        ReactivateReason = reactivateReason;
-        ReactivateReasonDetail = detail;
+        ReactivateAdditionalInformation = detail;
         ProvideMoreInformation = provideAdditionalInformation;
         return this;
     }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/SetStatusStateBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/SetStatusStateBuilder.cs
@@ -14,6 +14,8 @@ public class SetStatusStateBuilder
 
     private bool Initialized { get; set; }
     public ProvideMoreInformationOption ProvideMoreInformation { get; set; }
+    public string? DeactivateAdditionalInformation { get; set; }
+    public string? ReactivateAdditionalInformation { get; set; }
 
     public SetStatusStateBuilder WithInitializedState()
     {
@@ -22,19 +24,31 @@ public class SetStatusStateBuilder
         return this;
     }
 
-    public SetStatusStateBuilder WithDeactivateReasonChoice(PersonDeactivateReason option, ProvideMoreInformationOption provideAdditionalInformation, string? detailText = null)
+    public SetStatusStateBuilder WithDeactivateReasonChoice(PersonDeactivateReason option, string? detailText = null)
     {
-        ProvideMoreInformation = provideAdditionalInformation;
         DeactivateReason = option;
         DeactivateReasonDetail = detailText;
         return this;
     }
 
-    public SetStatusStateBuilder WithReactivateReasonChoice(PersonReactivateReason option, ProvideMoreInformationOption provideAdditionalInformation, string? detailText = null)
+    public SetStatusStateBuilder WithReactivateReasonChoice(PersonReactivateReason option, string? detailText = null)
     {
-        ProvideMoreInformation = provideAdditionalInformation;
         ReactivateReason = option;
         ReactivateReasonDetail = detailText;
+        return this;
+    }
+
+    public SetStatusStateBuilder WithDeactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption provideAdditionalInformation, string? detailText = null)
+    {
+        ProvideMoreInformation = provideAdditionalInformation;
+        DeactivateAdditionalInformation = detailText;
+        return this;
+    }
+
+    public SetStatusStateBuilder WithReactivateProvideAdditionalInformationChoice(ProvideMoreInformationOption provideAdditionalInformation, string? detailText = null)
+    {
+        ProvideMoreInformation = provideAdditionalInformation;
+        ReactivateAdditionalInformation = detailText;
         return this;
     }
 
@@ -63,7 +77,9 @@ public class SetStatusStateBuilder
             ReactivateReasonDetail = ReactivateReasonDetail,
             ProvideMoreInformation = ProvideMoreInformation,
             Evidence = Evidence,
-            Initialized = Initialized
+            Initialized = Initialized,
+            ReactivateAdditionalInformation = ReactivateAdditionalInformation,
+            DeactivateAdditionalInformation = DeactivateAdditionalInformation,
         };
     }
 }


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/2?filterQuery=&pane=issue&itemId=174038796&issue=DFE-Digital%7Cteaching-record-team-project-board%7C192

### Changes proposed in this pull request

Update content for set person status to make reason detail, additional information consistent across pages.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally