### PR TITLE
Remove NPQ application user from DB seeding

### DIFF
--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/User.cs
@@ -50,7 +50,6 @@ public class ApplicationUser : UserBase
     public const string OneLoginAuthenticationSchemeNameUniqueIndexName = "ix_users_one_login_authentication_scheme_name";
     public const int ShortNameMaxLength = 25;
 
-    public static Guid NpqApplicationUserGuid { get; } = new("0F18F1EC-A102-4023-843F-1CADEF3E6E14");
     public static Guid CapitaTpsImportGuid { get; } = new("14e1fa20-b364-446d-805d-699525671111");
 
     public string[]? ApiRoles { get; set; }
@@ -140,13 +139,6 @@ public class ApplicationUser : UserBase
 
         static string CreateJsonArray(params string[] values) => JsonSerializer.Serialize(values);
     }
-
-    public static ApplicationUser NpqApplicationUser { get; } = new()
-    {
-        UserId = NpqApplicationUserGuid,
-        Name = "NPQ",
-        Active = true
-    };
 
     public static ApplicationUser CapitaTpsImportUser { get; } = new()
     {

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.Seeding.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.Seeding.cs
@@ -19,7 +19,6 @@ public partial class TrsDbContext
         this.BulkInsertOrUpdate(GetRouteToProfessionalStatusTypes());
         this.BulkInsertOrUpdate(GetTpsEstablishmentTypes());
         this.BulkInsertOrUpdate(GetTrainingSubjects());
-        this.BulkInsertOrUpdate(GetApplicationUsers());
         this.BulkInsertOrUpdate(GetSystemUsers());
         this.BulkInsertOrUpdate(GetEstablishments());
     }
@@ -38,7 +37,6 @@ public partial class TrsDbContext
         await this.BulkInsertOrUpdateAsync(GetRouteToProfessionalStatusTypes(), cancellationToken: cancellationToken);
         await this.BulkInsertOrUpdateAsync(GetTpsEstablishmentTypes(), cancellationToken: cancellationToken);
         await this.BulkInsertOrUpdateAsync(GetTrainingSubjects(), cancellationToken: cancellationToken);
-        await this.BulkInsertOrUpdateAsync(GetApplicationUsers(), cancellationToken: cancellationToken);
         await this.BulkInsertOrUpdateAsync(GetSystemUsers(), cancellationToken: cancellationToken);
         await this.BulkInsertOrUpdateAsync(GetEstablishments(), cancellationToken: cancellationToken);
     }
@@ -2403,14 +2401,6 @@ public partial class TrsDbContext
             new TrainingSubject { TrainingSubjectId = new("0e1cfcf8-d7ae-40a9-a09b-61f369648b9e"), Reference = "H990", Name = "Engineering (Diploma)", IsActive = false },
             new TrainingSubject { TrainingSubjectId = new("94e13788-d55d-4d0a-8c7a-ef6b0c94257b"), Reference = "B990", Name = "Hair and Beauty", IsActive = false },
             new TrainingSubject { TrainingSubjectId = new("13a673ca-3bc4-4e7e-a8cc-0ca0da648a81"), Reference = "N900", Name = "Retail Business", IsActive = false }
-        ];
-    }
-
-    private static List<ApplicationUser> GetApplicationUsers()
-    {
-        return
-        [
-            new ApplicationUser { UserId = ApplicationUser.NpqApplicationUserGuid, Name = "NPQ", Active = true }
         ];
     }
 

--- a/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
+++ b/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
@@ -186,7 +186,6 @@ public sealed class DbHelper : IAsyncDisposable
         }
 
         AddUserIfNotExists(SystemUser.Instance);
-        AddUserIfNotExists(ApplicationUser.NpqApplicationUser);
         AddUserIfNotExists(ApplicationUser.CapitaTpsImportUser);
 
         if (!await dbContext.Set<TrnRange>().AnyAsync())


### PR DESCRIPTION
Every time we deploy we're clearing out One Login information due to this user being in the DB seeding.