### PR TITLE
Content changes for routes pages

### DIFF
--- a/src/TeachingRecordSystem.Api/V3/Operations/SetQtls.cs
+++ b/src/TeachingRecordSystem.Api/V3/Operations/SetQtls.cs
@@ -70,6 +70,7 @@ public class SetQtlsHandler(
                     changeReason: null,
                     changeReasonDetail: null,
                     evidenceFile: null,
+                    additionalInformation: null,
                     @event: out var @event);
 
                 dbContext.Qualifications.Add(professionalStatus);
@@ -86,6 +87,7 @@ public class SetQtlsHandler(
                     evidenceFile: null,
                     updatedBy: currentUserId,
                     now: timeProvider.UtcNow,
+                    additionalInformation: null,
                     out var @event);
 
                 if (@event is not null)
@@ -103,6 +105,7 @@ public class SetQtlsHandler(
                 evidenceFile: null,
                 deletedBy: currentUserId,
                 now: timeProvider.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             dbContext.AddEventWithoutBroadcast(@event);

--- a/src/TeachingRecordSystem.Api/V3/Operations/SetRouteToProfessionalStatus.cs
+++ b/src/TeachingRecordSystem.Api/V3/Operations/SetRouteToProfessionalStatus.cs
@@ -209,6 +209,7 @@ public class SetRouteToProfessionalStatusHandler(
                 evidenceFile: null,
                 currentUserId,
                 timeProvider.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             if (@event is not null)
@@ -241,6 +242,7 @@ public class SetRouteToProfessionalStatusHandler(
                 changeReason: null,
                 changeReasonDetail: null,
                 evidenceFile: null,
+                additionalInformation: null,
                 @event: out var @event);
 
             dbContext.RouteToProfessionalStatuses.Add(route);

--- a/src/TeachingRecordSystem.Cli/Commands.CorrectQualificationStartDate.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.CorrectQualificationStartDate.cs
@@ -147,6 +147,7 @@ public static partial class Commands
                         evidenceFile: null,
                         updatedBy: systemUser,
                         now: timeProvider.UtcNow,
+                        additionalInformation: null,
                         out var updateEvent);
 
                     if (updateEvent is null)

--- a/src/TeachingRecordSystem.Cli/Commands.ImportClaimTestData.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.ImportClaimTestData.cs
@@ -162,6 +162,7 @@ public static partial class Commands
                     changeReason: null,
                     changeReasonDetail: null,
                     evidenceFile: null,
+                    additionalInformation: null,
                     @event: out var @event);
 
                 dbContext.Qualifications.Add(professionalStatus);

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/RouteToProfessionalStatus.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/RouteToProfessionalStatus.cs
@@ -64,6 +64,7 @@ public class RouteToProfessionalStatus : Qualification
         string? changeReason,
         string? changeReasonDetail,
         EventModels.File? evidenceFile,
+        string? additionalInformation,
         out RouteToProfessionalStatusCreatedEvent @event)
     {
         Debug.Assert(person.Qualifications is not null);
@@ -145,7 +146,8 @@ public class RouteToProfessionalStatus : Qualification
             OldPersonAttributes = oldPersonAttributes,
             Changes = changes,
             Induction = newInduction,
-            OldInduction = oldInduction
+            OldInduction = oldInduction,
+            AdditionalInformation = additionalInformation
         };
 
         return route;
@@ -159,6 +161,7 @@ public class RouteToProfessionalStatus : Qualification
         EventModels.File? evidenceFile,
         EventModels.RaisedByUserInfo updatedBy,
         DateTime now,
+        string? additionalInformation,
         out RouteToProfessionalStatusUpdatedEvent? @event)
     {
         Debug.Assert(Person is not null);
@@ -236,7 +239,8 @@ public class RouteToProfessionalStatus : Qualification
             OldPersonAttributes = oldPersonAttributes,
             Changes = changes,
             Induction = newInduction,
-            OldInduction = oldInduction
+            OldInduction = oldInduction,
+            AdditionalInformation = additionalInformation
         };
     }
 
@@ -247,6 +251,7 @@ public class RouteToProfessionalStatus : Qualification
         EventModels.File? evidenceFile,
         EventModels.RaisedByUserInfo deletedBy,
         DateTime now,
+        string? additionalInformation,
         out RouteToProfessionalStatusDeletedEvent @event)
     {
         if (DeletedOn is not null)
@@ -312,7 +317,8 @@ public class RouteToProfessionalStatus : Qualification
             EvidenceFile = evidenceFile,
             Changes = changes,
             Induction = newInduction,
-            OldInduction = oldInduction
+            OldInduction = oldInduction,
+            AdditionalInformation = additionalInformation
         };
     }
 

--- a/src/TeachingRecordSystem.Core/Events/Legacy/RouteToProfessionalStatusCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/RouteToProfessionalStatusCreatedEvent.cs
@@ -16,6 +16,7 @@ public record RouteToProfessionalStatusCreatedEvent : EventBase, IEventWithPerso
     public required ProfessionalStatusPersonAttributes OldPersonAttributes { get; init; }
     public required Induction Induction { get; init; }
     public required Induction OldInduction { get; init; }
+    public required string? AdditionalInformation { get; init; }
 }
 
 [Flags]

--- a/src/TeachingRecordSystem.Core/Events/Legacy/RouteToProfessionalStatusDeletedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/RouteToProfessionalStatusDeletedEvent.cs
@@ -15,6 +15,7 @@ public record RouteToProfessionalStatusDeletedEvent : EventBase, IEventWithPerso
     public required ProfessionalStatusPersonAttributes OldPersonAttributes { get; init; }
     public required Induction Induction { get; init; }
     public required Induction OldInduction { get; init; }
+    public required string? AdditionalInformation { get; set; }
 }
 
 [Flags]

--- a/src/TeachingRecordSystem.Core/Events/Legacy/RouteToProfessionalStatusUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/RouteToProfessionalStatusUpdatedEvent.cs
@@ -16,6 +16,7 @@ public record RouteToProfessionalStatusUpdatedEvent : EventBase, IEventWithPerso
     public required ProfessionalStatusPersonAttributes OldPersonAttributes { get; init; }
     public required Induction Induction { get; init; }
     public required Induction OldInduction { get; init; }
+    public required string? AdditionalInformation { get; set; }
 }
 
 [Flags]

--- a/src/TeachingRecordSystem.Core/Jobs/EwcWalesImport/QtsImporter.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/EwcWalesImport/QtsImporter.cs
@@ -133,6 +133,7 @@ public class QtsImporter
                            changeReason: null,
                            changeReasonDetail: null,
                            evidenceFile: null,
+                           additionalInformation: null,
                            out var routeevent);
 
                         _dbContext.AddEventWithoutBroadcast(routeevent);

--- a/src/TeachingRecordSystem.Core/Jobs/SetMissingHasEypsOnPersonsJob.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/SetMissingHasEypsOnPersonsJob.cs
@@ -50,7 +50,8 @@ public class SetMissingHasEypsOnPersonsJob(
                 OldPersonAttributes = oldPersonAttributes,
                 Changes = RouteToProfessionalStatusUpdatedEventChanges.PersonHasEyps,
                 Induction = newInduction,
-                OldInduction = oldInduction
+                OldInduction = oldInduction,
+                AdditionalInformation = null
             });
 
             updatedPersons.Add(person.PersonId);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusCreatedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusCreatedEvent.cshtml
@@ -140,6 +140,12 @@
                         </value>
                     </row>
                     <row>
+                        <key>Additional information</key>
+                        <value use-empty-fallback data-testid="additional-information">
+                            @Html.ConvertNewlinesToLineBreaks(createdEvent.AdditionalInformation)
+                        </value>
+                    </row>
+                    <row>
                         <key>Evidence</key>
                         <value>
                             <vc:event-evidence-file-link evidence-file="@createdEvent.EvidenceFile" />

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusDeletedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusDeletedEvent.cshtml
@@ -43,6 +43,12 @@
                         </value>
                     </row>
                     <row>
+                        <key>Additional information</key>
+                        <value use-empty-fallback data-testid="additional-information">
+                            @Html.ConvertNewlinesToLineBreaks(deletedEvent.AdditionalInformation)
+                        </value>
+                    </row>
+                    <row>
                         <key>Evidence</key>
                         <value>
                             <vc:event-evidence-file-link evidence-file="@deletedEvent.EvidenceFile" />

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusUpdatedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/RouteToProfessionalStatusUpdatedEvent.cshtml
@@ -174,6 +174,12 @@
                         </value>
                     </row>
                     <row>
+                        <key>Additional information</key>
+                        <value use-empty-fallback data-testid="additional-detail">
+                            @Html.ConvertNewlinesToLineBreaks(updatedEvent.AdditionalInformation)
+                        </value>
+                    </row>
+                    <row>
                         <key>Evidence</key>
                         <value>
                             <vc:event-evidence-file-link evidence-file="@updatedEvent.EvidenceFile" />

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/CheckAnswers.cshtml
@@ -21,12 +21,29 @@
                     <value>@Model.ChangeReason?.GetDisplayName()</value>
                     <row-actions>
                         <action href="@LinkGenerator.RoutesToProfessionalStatus.AddRoute.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
-                                                       visually-hidden-text="reason">Change</action>
+                                visually-hidden-text="reason">Change</action>
+                    </row-actions>
+                </row>
+                <row>
+                    <key>Reason details</key>
+                    <value>
+                        @if (Model.ChangeReasonDetail.ChangeReasonDetail is not null)
+                        {
+                            @Html.ConvertNewlinesToLineBreaks(Model.ChangeReasonDetail.ChangeReasonDetail)
+                        }
+                        else
+                        {
+                            <span use-empty-fallback></span>
+                        }
+                    </value>
+                    <row-actions>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.AddRoute.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                                visually-hidden-text="additional information">Change</action>
                     </row-actions>
                 </row>
                 <row>
                     <key>Additional information</key>
-                    <value use-empty-fallback="true">@Model.ChangeReasonDetail.ChangeReasonDetail</value>
+                    <value use-empty-fallback="true">@Model.ChangeReasonDetail.AdditionalInformation</value>
                     <row-actions>
                         <action href="@LinkGenerator.RoutesToProfessionalStatus.AddRoute.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
                                                        visually-hidden-text="additional information">Change</action>

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/CheckAnswers.cshtml.cs
@@ -110,7 +110,8 @@ public class CheckAnswersModel(
             changeReason: JourneyInstance.State.ChangeReason?.GetDisplayName(),
             changeReasonDetail: JourneyInstance.State.ChangeReasonDetail.ChangeReasonDetail,
             evidenceFile: JourneyInstance.State.ChangeReasonDetail.Evidence.UploadedEvidenceFile?.ToEventModel(),
-            @event: out var @event);
+            @event: out var @event,
+            additionalInformation: JourneyInstance.State.ChangeReasonDetail.AdditionalInformation);
 
         dbContext.Qualifications.Add(professionalStatus);
         dbContext.AddEventWithoutBroadcast(@event);

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/Reason.cshtml
@@ -1,4 +1,5 @@
 @page "/routes/add/reason/{handler?}"
+@using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus
 @model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute.ReasonModel
 @{
     ViewBag.Title = "Why are you adding this route?";
@@ -28,25 +29,30 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@ChangeReasonOption.AnotherReason">
                         @ChangeReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="reason-detail">
+                            <govuk-input data-testid="reason-detail" for="ChangeReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="provide-more-information-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>
                         <h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2>
                     </govuk-radios-fieldset-legend>
-                    <govuk-radios-item value="@true">
-                        Yes
-                        <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="ChangeReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                    <govuk-radios-item value="@ProvideMoreInformationOption.Yes">
+                        @ProvideMoreInformationOption.Yes.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="additional-information-detail">
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
                                 <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
-                    <govuk-radios-item value="@false">
-                        No
+                    <govuk-radios-item value="@ProvideMoreInformationOption.No">
+                        @ProvideMoreInformationOption.No.GetDisplayName()
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/AddRoute/Reason.cshtml.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute;
@@ -11,14 +12,17 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, ReferenceDataCach
     {
         v => v.RuleFor(m => m.ChangeReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
-            .NotNull().WithMessage("Select yes if you want to add more information about why you\u2019re adding this route"),
         v => v.RuleFor(m => m.ChangeReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.ChangeReason == ChangeReasonOption.AnotherReason),
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
+            .NotNull().WithMessage("Select yes if you want to add more information about why you\u2019re adding this route"),
+        v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
-            .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+        v => v.RuleFor(m => m.AdditionalInformation)
+            .NotEmpty().WithMessage("Enter detail")
+            .When(m => m.ProvideAdditionalInformation == ProvideMoreInformationOption.Yes),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -26,18 +30,22 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, ReferenceDataCach
     public ChangeReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
-    public string? ChangeReasonDetail { get; set; }
+    public string? AdditionalInformation { get; set; }
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
 
+    [BindProperty]
+    public string? ChangeReasonDetail { get; set; }
+
     public void OnGet()
     {
         ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance.State.ChangeReasonDetail.HasAdditionalReasonDetail;
+        ProvideAdditionalInformation = JourneyInstance.State.ChangeReasonDetail.ProvideAdditionalInformation;
+        AdditionalInformation = JourneyInstance.State.ChangeReasonDetail.AdditionalInformation;
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail.ChangeReasonDetail;
         Evidence = JourneyInstance.State.ChangeReasonDetail.Evidence;
     }
@@ -55,9 +63,9 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, ReferenceDataCach
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
             state.ChangeReasonDetail.ChangeReasonDetail = ChangeReasonDetail;
-            state.ChangeReasonDetail.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+            state.ChangeReasonDetail.ProvideAdditionalInformation = ProvideAdditionalInformation;
+            state.ChangeReasonDetail.AdditionalInformation = AdditionalInformation;
             state.ChangeReasonDetail.Evidence = Evidence;
         });
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/ChangeReasonDetailsState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/ChangeReasonDetailsState.cs
@@ -1,17 +1,21 @@
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus;
 
 public class ChangeReasonDetailsState
 {
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
 
     public string? ChangeReasonDetail { get; set; }
+
+    public string? AdditionalInformation { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
 
     public bool IsComplete =>
-        ChangeReasonDetail != null ||
-        HasAdditionalReasonDetail != null ||
+
+        (ProvideAdditionalInformation == ProvideMoreInformationOption.No && AdditionalInformation is null) ||
+        (ProvideAdditionalInformation == ProvideMoreInformationOption.Yes && AdditionalInformation is not null) ||
         Evidence.IsComplete;
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml
@@ -26,11 +26,17 @@
                     </row-actions>
                 </row>
                 <row>
-                    <key>Additional information</key>
+                    <key>Reason details</key>
                     <value use-empty-fallback="true">@Model.ChangeReasonDetail.ChangeReasonDetail</value>
                     <row-actions>
-                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
-                                                       visually-hidden-text="additional information">Change</action>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"  visually-hidden-text="additional information">Change</action>
+                    </row-actions>
+                </row>
+                <row>
+                    <key>Additional information</key>
+                    <value use-empty-fallback="true">@Model.ChangeReasonDetail.AdditionalInformation</value>
+                    <row-actions>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"  visually-hidden-text="additional information">Change</action>
                     </row-actions>
                 </row>
                 <row>

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml.cs
@@ -86,7 +86,9 @@ public class CheckAnswersModel(
             ChangeReasonDetail.Evidence.UploadedEvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
-            out var deletedEvent);
+            additionalInformation: ChangeReasonDetail.AdditionalInformation,
+            out var deletedEvent
+            );
         if (deletedEvent is not null)
         {
             dbContext.AddEventWithoutBroadcast(deletedEvent);

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml
@@ -1,4 +1,5 @@
 @page "/routes/{qualificationId}/delete/reason/{handler?}"
+@using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus
 @model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute.ReasonModel
 @{
     ViewBag.Title = "Why are you deleting this route?";
@@ -25,25 +26,30 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@ChangeReasonOption.AnotherReason">
                         @ChangeReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="delete-reason-detail">
+                            <govuk-input data-testid="reason-detail" for="ChangeReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="provide-more-information-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>
                         <h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2>
                     </govuk-radios-fieldset-legend>
-                    <govuk-radios-item value="@true">
-                        Yes
+                    <govuk-radios-item value="@ProvideMoreInformationOption.Yes">
+                        @ProvideMoreInformationOption.Yes.GetDisplayName()
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="ChangeReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details about this change</govuk-character-count-label>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
-                    <govuk-radios-item value="@false">
-                        No
+                    <govuk-radios-item value="@ProvideMoreInformationOption.No">
+                        @ProvideMoreInformationOption.No.GetDisplayName()
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
@@ -14,14 +15,17 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
     {
         v => v.RuleFor(m => m.ChangeReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
-            .NotNull().WithMessage("Select yes if you want to add more information about why you\u2019re deleting this route"),
         v => v.RuleFor(m => m.ChangeReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.ChangeReason == ChangeReasonOption.AnotherReason),
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
+            .NotNull().WithMessage("Select yes if you want to add more information about why you\u2019re deleting this route"),
+        v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
-            .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+        v => v.RuleFor(m => m.AdditionalInformation)
+            .NotEmpty().WithMessage("Enter details")
+            .When(m => m.ProvideAdditionalInformation == ProvideMoreInformationOption.Yes),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -39,13 +43,16 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
     public ChangeReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     public string NextPage => linkGenerator.RoutesToProfessionalStatus.DeleteRoute.CheckAnswers(QualificationId, JourneyInstance!.InstanceId);
 
@@ -65,9 +72,10 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
     public void OnGet()
     {
         ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance.State.ChangeReasonDetail.HasAdditionalReasonDetail;
+        ProvideAdditionalInformation = JourneyInstance.State.ChangeReasonDetail.ProvideAdditionalInformation;
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail.ChangeReasonDetail;
         Evidence = JourneyInstance.State.ChangeReasonDetail.Evidence;
+        AdditionalInformation = JourneyInstance.State.ChangeReasonDetail.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -83,10 +91,10 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
-            state.ChangeReasonDetail.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+            state.ChangeReasonDetail.ProvideAdditionalInformation = ProvideAdditionalInformation;
             state.ChangeReasonDetail.ChangeReasonDetail = ChangeReasonDetail;
             state.ChangeReasonDetail.Evidence = Evidence;
+            state.ChangeReasonDetail.AdditionalInformation = AdditionalInformation;
         });
 
         return Redirect(NextPage);

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckAnswers.cshtml
@@ -26,11 +26,19 @@
                     </row-actions>
                 </row>
                 <row>
-                    <key>Additional information</key>
+                    <key>Reason details</key>
                     <value use-empty-fallback="true">@Model.ChangeReasonDetail.ChangeReasonDetail</value>
                     <row-actions>
                         <action href="@LinkGenerator.RoutesToProfessionalStatus.EditRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
-                                                       visually-hidden-text="additional information">Change</action>
+                                visually-hidden-text="additional information">Change</action>
+                    </row-actions>
+                </row>
+                <row>
+                    <key>Additional information</key>
+                    <value use-empty-fallback="true">@Model.ChangeReasonDetail.AdditionalInformation</value>
+                    <row-actions>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.EditRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                                visually-hidden-text="additional information">Change</action>
                     </row-actions>
                 </row>
                 <row>

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/CheckAnswers.cshtml.cs
@@ -124,7 +124,9 @@ public class CheckYourAnswersModel(
             evidenceFile: ChangeReasonDetail.Evidence.UploadedEvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
-            out var updatedEvent);
+            additionalInformation: ChangeReasonDetail.AdditionalInformation,
+            out var updatedEvent
+            );
 
         if (updatedEvent is not null)
         {

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Reason.cshtml
@@ -1,4 +1,5 @@
 @page "/routes/{qualificationId}/edit/reason/{handler?}"
+@using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus
 @model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute.ReasonModel
 @{
     ViewBag.Title = "Why are you editing this route?";
@@ -28,25 +29,30 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@ChangeReasonOption.AnotherReason">
                         @ChangeReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="delete-reason-detail">
+                            <govuk-input data-testid="reason-detail" for="ChangeReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="provide-more-information-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>
                         <h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2>
                     </govuk-radios-fieldset-legend>
-                    <govuk-radios-item value="@true">
-                        Yes
+                    <govuk-radios-item value="@ProvideMoreInformationOption.Yes">
+                        @ProvideMoreInformationOption.Yes.GetDisplayName()                        
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="ChangeReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details about this change</govuk-character-count-label>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
-                    <govuk-radios-item value="@false">
-                        No
+                    <govuk-radios-item value="@ProvideMoreInformationOption.No">
+                        @ProvideMoreInformationOption.No.GetDisplayName()
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/EditRoute/Reason.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
@@ -14,14 +15,17 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
     {
         v => v.RuleFor(m => m.ChangeReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
-            .NotNull().WithMessage("Select yes if you want to add more information about why you’re editing this route"),
         v => v.RuleFor(m => m.ChangeReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.ChangeReason == ChangeReasonOption.AnotherReason),
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
+            .NotNull().WithMessage("Select yes if you want to add more information about why you’re editing this route"),
+        v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
-            .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+        v => v.RuleFor(m => m.AdditionalInformation)
+            .NotEmpty().WithMessage("Enter details")
+            .When(m => m.ProvideAdditionalInformation == ProvideMoreInformationOption.Yes),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -39,10 +43,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
     public ChangeReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public ProvideMoreInformationOption? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
     public string? ChangeReasonDetail { get; set; }
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
@@ -67,8 +74,9 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
     public void OnGet()
     {
         ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance!.State.ChangeReasonDetail.HasAdditionalReasonDetail;
+        ProvideAdditionalInformation = JourneyInstance!.State.ChangeReasonDetail.ProvideAdditionalInformation;
         ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail.ChangeReasonDetail;
+        AdditionalInformation = JourneyInstance?.State.ChangeReasonDetail.AdditionalInformation;
         Evidence = JourneyInstance!.State.ChangeReasonDetail.Evidence;
     }
 
@@ -84,10 +92,10 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+            state.ChangeReasonDetail.ProvideAdditionalInformation = ProvideAdditionalInformation;
             state.ChangeReasonDetail.ChangeReasonDetail = ChangeReasonDetail;
-            state.ChangeReasonDetail.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
             state.ChangeReasonDetail.Evidence = Evidence;
+            state.ChangeReasonDetail.AdditionalInformation = AdditionalInformation;
         });
 
         return Redirect(NextPage);

--- a/tests/TeachingRecordSystem.Api.UnitTests/V3/SetRouteToProfessionalStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.UnitTests/V3/SetRouteToProfessionalStatusTests.cs
@@ -319,6 +319,7 @@ public class SetRouteToProfessionalStatusTests(OperationTestFixture operationTes
                 changeReason: null,
                 changeReasonDetail: null,
                 evidenceFile: null,
+                additionalInformation: null,
                 @event: out var createdEvent);
 
             dbContext.RouteToProfessionalStatuses.Add(route);

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
@@ -169,6 +169,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
                 evidenceFile: null,
                 deletedBy: SystemUser.SystemUserId,
                 now: Clock.UtcNow,
+                additionalInformation: null,
                 out var deletedEvent);
             dbContext.AddEventWithoutBroadcast(deletedEvent);
             await dbContext.SaveChangesAsync();

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/AddRouteToProfessionalStatusTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/AddRouteToProfessionalStatusTests.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.Persons;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.RoutesToProfessionalStatus;
@@ -69,8 +70,8 @@ public class AddRouteToProfessionalStatusTests(HostFixture hostFixture) : TestBa
         await page.ClickButtonAsync("Continue");
 
         await page.AssertOnRouteAddChangeReasonPage();
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickButtonAsync("Continue");
 
@@ -170,8 +171,8 @@ public class AddRouteToProfessionalStatusTests(HostFixture hostFixture) : TestBa
         await page.ClickButtonAsync("Continue");
 
         await page.AssertOnRouteAddChangeReasonPage();
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "This is an additional reason");
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickButtonAsync("Continue");
 
@@ -216,8 +217,8 @@ public class AddRouteToProfessionalStatusTests(HostFixture hostFixture) : TestBa
         await page.ClickButtonAsync("Continue");
 
         await page.AssertOnRouteAddChangeReasonPage();
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickButtonAsync("Continue");
 
@@ -298,8 +299,9 @@ public class AddRouteToProfessionalStatusTests(HostFixture hostFixture) : TestBa
         await page.ClickButtonAsync("Continue");
 
         await page.AssertOnRouteAddChangeReasonPage();
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "this is the change reason detail");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "This is an additional reason");
+
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickButtonAsync("Continue");
 
@@ -368,8 +370,8 @@ public class AddRouteToProfessionalStatusTests(HostFixture hostFixture) : TestBa
         await page.ClickButtonAsync("Continue");
 
         await page.AssertOnRouteAddChangeReasonPage();
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "some change reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "This is an additional reason");
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickButtonAsync("Continue");
 
@@ -467,8 +469,8 @@ public class AddRouteToProfessionalStatusTests(HostFixture hostFixture) : TestBa
         await page.ClickButtonAsync("Continue");
 
         await page.AssertOnRouteAddChangeReasonPage();
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "reason 1");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickButtonAsync("Continue");
 

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/DeleteRouteToProfessionalStatusTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/DeleteRouteToProfessionalStatusTests.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.Persons;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.RoutesToProfessionalStatus;
@@ -24,7 +25,36 @@ public class DeleteRouteToProfessionalStatusTests(HostFixture hostFixture) : Tes
 
         await page.AssertOnRouteDeleteChangeReasonPage(qualificationId);
         await page.SelectRouteChangeReasonOption(deletionReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
+        await page.SelectUploadEvidenceAsync(false);
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnRouteDeleteCheckYourAnswersPageAsync(qualificationId);
+        await page.ClickButtonAsync("Confirm and delete route");
+
+        await page.AssertOnPersonQualificationsPageAsync(person.PersonId);
+    }
+
+    [Fact]
+    public async Task DeleteRouteToProfessionalStatusProvideAdditionalDetails()
+    {
+        var deletionReason = ChangeReasonOption.AnotherReason;
+        var person = await TestData.CreatePersonAsync(p => p.WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.QualifiedTeacherStatus));
+        var personId = person.PersonId;
+        var qualificationId = person.ProfessionalStatuses.Single().QualificationId;
+
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonQualificationsPageAsync(person.PersonId);
+
+        await page.AssertOnPersonQualificationsPageAsync(person.PersonId);
+
+        await page.ClickLinkForElementWithTestIdAsync($"delete-route-link-{qualificationId}");
+
+        await page.AssertOnRouteDeleteChangeReasonPage(qualificationId);
+        await page.SelectRouteChangeReasonOption(deletionReason.ToString(), "some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "Some additional information");
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/EditRouteToProfessionalStatusTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/EditRouteToProfessionalStatusTests.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.Persons;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.RoutesToProfessionalStatus;
@@ -123,8 +124,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Some change reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -318,8 +319,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Some reason for change");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "some additional reason");
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -381,8 +382,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "some additional reason");
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -452,8 +453,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.Yes, "some additional reason");
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -520,8 +521,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -585,8 +586,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Some reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -875,8 +876,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Some change reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -938,8 +939,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Some change reason");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 
@@ -1067,8 +1068,8 @@ public class EditRouteToProfessionalStatusTests(HostFixture hostFixture) : TestB
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnRouteChangeReasonPageAsync(qualificationId);
-        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString());
-        await page.SelectReasonMoreDetailsAsync(false);
+        await page.SelectRouteChangeReasonOption(ChangeReasonOption.AnotherReason.ToString(), "Reason for change");
+        await page.SelectProvideAdditionalInformationAsync("provide-more-information-options", ProvideMoreInformationOption.No);
         await page.SelectUploadEvidenceAsync(false);
         await page.ClickContinueButtonAsync();
 

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/RoutesToProfessionalStatusPageExtensions.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/RoutesToProfessionalStatus/RoutesToProfessionalStatusPageExtensions.cs
@@ -16,10 +16,14 @@ public static class RoutesToProfessionalStatusPageExtensions
         return radioButton.Locator("xpath=following-sibling::label").ClickAsync();
     }
 
-    public static Task SelectRouteChangeReasonOption(this IPage page, string reason)
+    public static async Task SelectRouteChangeReasonOption(this IPage page, string reason, string? changeReasonDetails = null)
     {
         var radioButton = page.Locator($"input[type='radio'][value='{reason}']");
-        return radioButton.Locator("xpath=following-sibling::label").ClickAsync();
+        await radioButton.Locator("xpath=following-sibling::label").ClickAsync();
+        if (changeReasonDetails != null)
+        {
+            await page.FillAsync($"label{TestBase.TextIsSelector("Enter a reason")}", changeReasonDetails);
+        }
     }
 
     public static Task EnterDegreeTypeAsync(this IPage page, string name) =>

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -189,6 +189,9 @@ public static class PageExtensions
         Assert.Contains($"/persons/{personId}", href);
     }
 
+    public static Task SelectProvideAdditionalInformationsAsync(this IPage page, bool addAdditionalDetail, string? details = null, string labelText = "Enter details") =>
+        page.SelectReasonMoreDetailsAsync(labelText, addAdditionalDetail, details);
+
     public static Task SelectReasonMoreDetailsAsync(this IPage page, bool addAdditionalDetail, string? details = null, string labelText = "Add additional detail") =>
         page.SelectReasonMoreDetailsAsync(labelText, addAdditionalDetail, details);
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
@@ -215,6 +215,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 updatedBy: updatedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             Debug.Assert(@event is not null);
@@ -310,6 +311,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 updatedBy: updatedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
             Debug.Assert(@event is not null && @event.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.Status));
 
@@ -393,6 +395,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 updatedBy: updatedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
             Debug.Assert(@event is not null && @event.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.Status));
 
@@ -462,6 +465,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             dbContext.AddEventWithoutBroadcast(@event);
@@ -517,6 +521,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             dbContext.AddEventWithoutBroadcast(@event);
@@ -556,6 +561,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             dbContext.AddEventWithoutBroadcast(@event);
@@ -595,6 +601,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             dbContext.AddEventWithoutBroadcast(@event);
@@ -634,6 +641,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
                 Clock.UtcNow,
+                additionalInformation: null,
                 out var @event);
 
             dbContext.AddEventWithoutBroadcast(@event);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/AddRouteStateBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/AddRouteStateBuilder.cs
@@ -1,3 +1,4 @@
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute;
 
@@ -56,6 +57,12 @@ public class AddRouteStateBuilder()
     public AddRouteStateBuilder WithStatus(RouteToProfessionalStatusStatus status)
     {
         _status = status;
+        return this;
+    }
+
+    public AddRouteStateBuilder WithProvideAdditionalInformation(ProvideMoreInformationOption provideMoreInformationOption, string? additionalInformation)
+    {
+        _changeReasonDetail = new ChangeReasonStateBuilder().WithAdditionalInformation(provideMoreInformationOption, additionalInformation).Build();
         return this;
     }
 
@@ -176,7 +183,7 @@ public class AddRouteStateBuilder()
             IsExemptFromInduction = _isExemptFromInduction,
             DegreeTypeId = _degreeTypeId,
             ChangeReason = _changeReasonOption,
-            ChangeReasonDetail = _changeReasonDetail
+            ChangeReasonDetail = _changeReasonDetail,
         };
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/CheckYourAnswersTests.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.Events.Legacy;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute;
 
@@ -671,7 +672,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 ChangeReason = ChangeReasonOption.AnotherReason,
                 ChangeReasonDetail = new ChangeReasonDetailsState
                 {
-                    HasAdditionalReasonDetail = false,
+                    ProvideAdditionalInformation = ProvideMoreInformationOption.No,
                     Evidence = new()
                     {
                         UploadEvidence = false
@@ -697,7 +698,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 ChangeReason = ChangeReasonOption.AnotherReason,
                 ChangeReasonDetail = new ChangeReasonDetailsState
                 {
-                    HasAdditionalReasonDetail = false,
+                    ProvideAdditionalInformation = ProvideMoreInformationOption.No,
                     Evidence = new()
                     {
                         UploadEvidence = false
@@ -723,7 +724,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 ChangeReason = ChangeReasonOption.AnotherReason,
                 ChangeReasonDetail = new ChangeReasonDetailsState
                 {
-                    HasAdditionalReasonDetail = false,
+                    ProvideAdditionalInformation = ProvideMoreInformationOption.No,
                     Evidence = new()
                     {
                         UploadEvidence = false
@@ -749,7 +750,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 ChangeReason = ChangeReasonOption.AnotherReason,
                 ChangeReasonDetail = new ChangeReasonDetailsState
                 {
-                    HasAdditionalReasonDetail = false,
+                    ProvideAdditionalInformation = ProvideMoreInformationOption.No,
                     Evidence = new()
                     {
                         UploadEvidence = false

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/ReasonTests.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.AddRoute;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.AddRoute;
@@ -10,6 +11,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithPreviouslyStoredChoices_ShowsChoices()
     {
         // Arrange
+        var reasonDetail = "A description about why the change typed into the box";
+        var additionalInfo = "this is additional info";
+
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
         var person = await TestData.CreatePersonAsync(p => p
             .WithRouteToProfessionalStatus(r => r
@@ -20,7 +24,12 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusTypeId)
             .WithStatus(RouteToProfessionalStatusStatus.Deferred)
             .WithValidChangeReasonOption()
-            .WithDefaultChangeReasonNoUploadFileDetail()
+            .WithChangeReasonDetail(x =>
+                {
+                    x.WithAdditionalInformation(ProvideMoreInformationOption.Yes, additionalInfo);
+                    x.WithChangeReasonDetail(reasonDetail);
+                    x.WithFileUploadChoice(false);
+                })
             .Build();
         var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId, addRouteState);
 
@@ -37,18 +46,23 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             .Single(i => i.IsChecked).Value;
         Assert.Equal(addRouteState.ChangeReason.ToString(), reasonChoiceSelection);
 
-        var additionalDetailChoices = doc.GetElementByTestId("has-additional-reason_detail-options")!
+        var reasonDetailTextbox =
+            doc.GetElementById("ChangeReasonDetail") as IHtmlInputElement;
+        Assert.Equal(reasonDetail, reasonDetailTextbox!.Value);
+
+        var additionalInformation =
+            doc.GetElementById("AdditionalInformation") as IHtmlTextAreaElement;
+        Assert.Equal(additionalInfo, additionalInformation!.Value);
+
+        var additionalDetailChoices = doc.GetElementByTestId("provide-more-information-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Single(i => i.IsChecked).Value;
-        Assert.Equal(true.ToString(), additionalDetailChoices);
+        Assert.Equal(ProvideMoreInformationOption.Yes.ToString(), additionalDetailChoices);
 
         var uploadEvidenceChoices = doc.GetElementByTestId("upload-evidence-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Single(i => i.IsChecked).Value;
         Assert.Equal(false.ToString(), uploadEvidenceChoices);
-
-        var additionalDetailTextArea = doc.GetElementByTestId("additional-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
-        Assert.Equal(addRouteState.ChangeReasonDetail.ChangeReasonDetail, additionalDetailTextArea!.Value);
     }
 
     [Fact]
@@ -86,10 +100,10 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
              .Select(i => i.Value);
         Assert.Equal(expectedChoices, reasonChoices);
 
-        var additionalDetailChoices = doc.GetElementByTestId("has-additional-reason_detail-options")!
+        var additionalDetailChoices = doc.GetElementByTestId("provide-more-information-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Select(i => i.Value);
-        Assert.Equal(["True", "False"], additionalDetailChoices);
+        Assert.Equal([ProvideMoreInformationOption.Yes.ToString(), ProvideMoreInformationOption.No.ToString()], additionalDetailChoices);
 
         var uploadEvidenceChoices = doc.GetElementByTestId("upload-evidence-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
@@ -101,8 +115,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SetValidChangeReasonDetails_PersistsDetailsAndRedirects()
     {
         // Arrange
-        var changeReason = ChangeReasonOption.AddedForApplyQts;
+        var changeReason = ChangeReasonOption.AnotherReason;
         var changeReasonDetails = "A description about why the change typed into the box";
+        var additionalInformation = "this is some additional information";
 
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
         var person = await TestData.CreatePersonAsync(p => p
@@ -121,8 +136,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", true },
+                { "ProvideAdditionalInformation", ProvideMoreInformationOption.Yes },
                 { "ChangeReasonDetail", changeReasonDetails },
+                { "AdditionalInformation", additionalInformation },
                 { "Evidence.UploadEvidence", false  }
             }
         };
@@ -134,6 +150,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(changeReason.GetDisplayName(), journeyInstance.State.ChangeReason?.GetDisplayName());
         Assert.Equal(changeReasonDetails, journeyInstance.State.ChangeReasonDetail.ChangeReasonDetail);
+        Assert.Equal(ProvideMoreInformationOption.Yes, journeyInstance.State.ChangeReasonDetail.ProvideAdditionalInformation);
+        Assert.Equal(additionalInformation, journeyInstance.State.ChangeReasonDetail.AdditionalInformation);
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/routes/add/check-answers?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
@@ -167,7 +185,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReason", "Select a reason");
-        await AssertEx.HtmlResponseHasErrorAsync(response, "HasAdditionalReasonDetail", "Select yes if you want to add more information about why you’re adding this route");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "ProvideAdditionalInformation", "Select yes if you want to add more information about why you’re adding this route");
         await AssertEx.HtmlResponseHasErrorAsync(response, "Evidence.UploadEvidence", "Select yes if you want to upload evidence");
     }
 
@@ -200,7 +218,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReasonDetail", "Enter additional detail");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReasonDetail", "Enter a reason");
     }
 
     [Fact]
@@ -267,7 +285,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", false },
+                { "ProvideAdditionalInformation", ProvideMoreInformationOption.No },
                 { "Evidence.UploadEvidence", true },
                 { "Evidence.EvidenceFile", (CreateEvidenceFileBinaryContent(), evidenceFileName) }
             }
@@ -279,6 +297,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.True(journeyInstance.State.ChangeReasonDetail.Evidence.UploadEvidence);
+        Assert.Equal(ProvideMoreInformationOption.No, journeyInstance.State.ChangeReasonDetail.ProvideAdditionalInformation);
         Assert.Equal(evidenceFileName, journeyInstance.State.ChangeReasonDetail.Evidence.UploadedEvidenceFile!.FileName);
     }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/ChangeReasonStateBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/ChangeReasonStateBuilder.cs
@@ -1,3 +1,4 @@
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
@@ -7,8 +8,9 @@ public class ChangeReasonStateBuilder
 {
     private string? _changeReasonDetail;
     private readonly EvidenceUploadModel _evidence = new();
+    private string? _additionalInormation;
 
-    private bool? _hasAdditionalReasonDetail;
+    private ProvideMoreInformationOption? _provideAdditionalInformation;
 
     public ChangeReasonStateBuilder WithChangeReasonDetail(string detail)
     {
@@ -16,11 +18,19 @@ public class ChangeReasonStateBuilder
         return this;
     }
 
+    public ChangeReasonStateBuilder WithAdditionalInformation(ProvideMoreInformationOption provideAdditionalInformation, string? additionalInformation)
+    {
+        _provideAdditionalInformation = provideAdditionalInformation;
+        _additionalInormation = additionalInformation;
+        return this;
+    }
+
     public ChangeReasonStateBuilder WithValidChangeReasonDetail()
     {
-        _hasAdditionalReasonDetail = true;
+        _provideAdditionalInformation = ProvideMoreInformationOption.Yes;
         _changeReasonDetail = "Some free text reason detail";
         _evidence.UploadEvidence = false;
+        _additionalInormation = "some additional information";
         return this;
     }
 
@@ -44,8 +54,9 @@ public class ChangeReasonStateBuilder
         return new ChangeReasonDetailsState
         {
             ChangeReasonDetail = _changeReasonDetail,
-            HasAdditionalReasonDetail = _hasAdditionalReasonDetail,
-            Evidence = _evidence
+            ProvideAdditionalInformation = _provideAdditionalInformation,
+            Evidence = _evidence,
+            AdditionalInformation = _additionalInormation,
         };
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
@@ -176,7 +176,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var doc = await AssertEx.HtmlResponseAsync(response);
 
         doc.AssertSummaryListRowValueContentMatches("Reason", deleteRouteState.ChangeReason!.GetDisplayName()!);
-        doc.AssertSummaryListRowValueContentMatches("Additional information", deleteRouteState.ChangeReasonDetail!.ChangeReasonDetail!);
+        doc.AssertSummaryListRowValueContentMatches("Reason details", deleteRouteState.ChangeReasonDetail!.ChangeReasonDetail!);
+        doc.AssertSummaryListRowValueContentMatches("Additional information", deleteRouteState.ChangeReasonDetail!.AdditionalInformation!);
         doc.AssertSummaryListRowValueContentMatches("Evidence", "Not provided");
     }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/ReasonTests.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.DeleteRoute;
@@ -41,18 +42,22 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             .Single(i => i.IsChecked).Value;
         Assert.Equal(deleteRouteState.ChangeReason.ToString(), reasonChoiceSelection);
 
-        var additionalDetailChoices = doc.GetElementByTestId("has-additional-reason_detail-options")!
+        var additionalDetailChoices = doc.GetElementByTestId("provide-more-information-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Single(i => i.IsChecked).Value;
-        Assert.Equal(true.ToString(), additionalDetailChoices);
+        Assert.Equal(ProvideMoreInformationOption.Yes.ToString(), additionalDetailChoices);
 
         var uploadEvidenceChoices = doc.GetElementByTestId("upload-evidence-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Single(i => i.IsChecked).Value;
         Assert.Equal(false.ToString(), uploadEvidenceChoices);
 
+        var reasonDetailTextbox =
+            doc.GetElementById("ChangeReasonDetail") as IHtmlInputElement;
+        Assert.Equal(deleteRouteState.ChangeReasonDetail.ChangeReasonDetail, reasonDetailTextbox!.Value);
+
         var additionalDetailTextArea = doc.GetElementByTestId("additional-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
-        Assert.Equal(deleteRouteState.ChangeReasonDetail.ChangeReasonDetail, additionalDetailTextArea!.Value);
+        Assert.Equal(deleteRouteState.ChangeReasonDetail.AdditionalInformation, additionalDetailTextArea!.Value);
     }
 
     [Fact]
@@ -95,10 +100,10 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
              .Select(i => i.Value);
         Assert.Equal(expectedChoices, reasonChoices);
 
-        var additionalDetailChoices = doc.GetElementByTestId("has-additional-reason_detail-options")!
+        var additionalDetailChoices = doc.GetElementByTestId("provide-more-information-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Select(i => i.Value);
-        Assert.Equal(["True", "False"], additionalDetailChoices);
+        Assert.Equal([ProvideMoreInformationOption.Yes.ToString(), ProvideMoreInformationOption.No.ToString()], additionalDetailChoices);
 
         var uploadEvidenceChoices = doc.GetElementByTestId("upload-evidence-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
@@ -110,7 +115,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SetValidChangeReasonDetails_PersistsDetailsAndRedirects()
     {
         // Arrange
-        var changeReason = ChangeReasonOption.CreatedInError;
+        var changeReason = ChangeReasonOption.AnotherReason;
         var changeReasonDetails = "A description about why the deletion typed into the box";
 
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
@@ -130,7 +135,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", true },
+                { "ProvideAdditionalInformation", ProvideMoreInformationOption.No },
                 { "ChangeReasonDetail", changeReasonDetails },
                 { "Evidence.UploadEvidence", false }
             }
@@ -176,7 +181,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReason", "Select a reason");
-        await AssertEx.HtmlResponseHasErrorAsync(response, "HasAdditionalReasonDetail", "Select yes if you want to add more information about why you’re deleting this route");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "ProvideAdditionalInformation", "Select yes if you want to add more information about why you’re deleting this route");
         await AssertEx.HtmlResponseHasErrorAsync(response, "Evidence.UploadEvidence", "Select yes if you want to upload evidence");
     }
 
@@ -201,7 +206,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", true },
+                { "ProvideAdditionalInformation", ProvideMoreInformationOption.Yes },
                 { "Evidence.UploadEvidence", false }
             }
         };
@@ -210,7 +215,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReasonDetail", "Enter additional detail");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "AdditionalInformation", "Enter details");
     }
 
     [Fact]
@@ -236,7 +241,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", false },
+                { "ProvideAdditionalInformation", ProvideMoreInformationOption.No },
                 { "Evidence.UploadEvidence", true }
             }
         };
@@ -271,7 +276,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", false },
+                { "ProvideAdditionalInformation", ProvideMoreInformationOption.No },
                 { "Evidence.UploadEvidence", true },
                 { "Evidence.EvidenceFile", (CreateEvidenceFileBinaryContent(), evidenceFileName) }
             }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/CheckYourAnswersTests.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events.Legacy;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
@@ -396,8 +397,12 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusTypeId)
             .WithStatus(RouteToProfessionalStatusStatus.Deferred)
             .WithTrainingCountryId(_countryCode)
-            .WithValidChangeReasonOption()
-            .WithDefaultChangeReasonNoUploadFileDetail()
+            .WithChangeReasonOption(ChangeReasonOption.AnotherReason)
+            .WithChangeReasonDetail(x =>
+            {
+                x.WithAdditionalInformation(ProvideMoreInformationOption.Yes, "Some additional information");
+                x.WithChangeReasonDetail("Some reason");
+            })
             .Build();
 
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -414,7 +419,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var doc = await AssertEx.HtmlResponseAsync(response);
 
         doc.AssertSummaryListRowValueContentMatches("Reason", editRouteState.ChangeReason!.GetDisplayName()!);
-        doc.AssertSummaryListRowValueContentMatches("Additional information", editRouteState.ChangeReasonDetail!.ChangeReasonDetail!);
+        doc.AssertSummaryListRowValueContentMatches("Additional information", editRouteState.ChangeReasonDetail!.AdditionalInformation!);
+        doc.AssertSummaryListRowValueContentMatches("Reason details", editRouteState.ChangeReasonDetail!.ChangeReasonDetail!);
         doc.AssertSummaryListRowValueContentMatches("Evidence", "Not provided");
     }
 
@@ -670,10 +676,12 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         editRouteState.EnsureInitialized(qualification);
         action(editRouteState);
         editRouteState.ChangeReason = ChangeReasonOption.AnotherReason;
+
         editRouteState.ChangeReasonDetail = new ChangeReasonDetailsState
         {
-            HasAdditionalReasonDetail = false,
-            ChangeReasonDetail = null
+            ProvideAdditionalInformation = ProvideMoreInformationOption.No,
+            ChangeReasonDetail = "this is the change Reason",
+            AdditionalInformation = null
         };
 
         return CreateJourneyInstanceAsync(qualification.QualificationId, editRouteState);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRoutePostRequestBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRoutePostRequestBuilder.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.EditRoute;
@@ -10,9 +11,11 @@ public class EditRoutePostRequestBuilder
     private RouteToProfessionalStatusStatus? RouteStatus { get; set; }
     private Guid[]? ExemptionReasonIds { get; set; }
     private ChangeReasonOption? ChangeReason { get; set; }
-    private bool? HasAdditionalReasonDetail { get; set; }
+    private ProvideMoreInformationOption ProvideAdditionalInformation { get; set; }
     private string? ChangeReasonDetail { get; set; }
     private bool? UploadEvidence { get; set; }
+    private string? AdditionalInformation { get; set; }
+
 
     private string? _evidenceFileName;
     private HttpContent? _evidenceFileContent;
@@ -47,10 +50,16 @@ public class EditRoutePostRequestBuilder
         return this;
     }
 
-    public EditRoutePostRequestBuilder WithChangeReasonDetailSelections(bool? hasAdditionalDetail, string? detail = null)
+    public EditRoutePostRequestBuilder WithChangeReasonDetailSelections(string? detail = null)
     {
-        HasAdditionalReasonDetail = hasAdditionalDetail;
         ChangeReasonDetail = detail;
+        return this;
+    }
+
+    public EditRoutePostRequestBuilder WithAdditionalInformation(ProvideMoreInformationOption provideAdditionalInformation, string? detail = null)
+    {
+        ProvideAdditionalInformation = provideAdditionalInformation;
+        AdditionalInformation = detail;
         return this;
     }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRouteStateBuilder.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/EditRouteStateBuilder.cs
@@ -209,8 +209,9 @@ public class EditRouteStateBuilder()
             ChangeReasonDetail = new ChangeReasonDetailsState
             {
                 ChangeReasonDetail = _changeReasonDetail.ChangeReasonDetail,
-                HasAdditionalReasonDetail = _changeReasonDetail.HasAdditionalReasonDetail,
-                Evidence = _changeReasonDetail.Evidence
+                ProvideAdditionalInformation = _changeReasonDetail.ProvideAdditionalInformation,
+                Evidence = _changeReasonDetail.Evidence,
+                AdditionalInformation = _changeReasonDetail.AdditionalInformation,
             },
             EditStatusState = _editRouteStatusState
         };

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/ReasonTests.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.EditRoute;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.EditRoute;
@@ -39,18 +40,22 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             .Single(i => i.IsChecked).Value;
         Assert.Equal(editRouteState.ChangeReason.ToString(), reasonChoiceSelection);
 
-        var additionalDetailChoices = doc.GetElementByTestId("has-additional-reason_detail-options")!
+        var additionalDetailChoices = doc.GetElementByTestId("provide-more-information-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Single(i => i.IsChecked).Value;
-        Assert.Equal(true.ToString(), additionalDetailChoices);
+        Assert.Equal(ProvideMoreInformationOption.Yes.ToString(), additionalDetailChoices);
 
         var uploadEvidenceChoices = doc.GetElementByTestId("upload-evidence-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Single(i => i.IsChecked).Value;
         Assert.Equal(false.ToString(), uploadEvidenceChoices);
 
+        var reasonDetailTextbox =
+            doc.GetElementById("ChangeReasonDetail") as IHtmlInputElement;
+        Assert.Equal(editRouteState.ChangeReasonDetail.ChangeReasonDetail, reasonDetailTextbox!.Value);
+
         var additionalDetailTextArea = doc.GetElementByTestId("additional-detail")!.GetElementsByTagName("textarea").Single() as IHtmlTextAreaElement;
-        Assert.Equal(editRouteState.ChangeReasonDetail.ChangeReasonDetail, additionalDetailTextArea!.Value);
+        Assert.Equal(editRouteState.ChangeReasonDetail.AdditionalInformation, additionalDetailTextArea!.Value);
     }
 
     [Fact]
@@ -91,10 +96,10 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
              .Select(i => i.Value);
         Assert.Equal(expectedChoices, reasonChoices);
 
-        var additionalDetailChoices = doc.GetElementByTestId("has-additional-reason_detail-options")!
+        var additionalDetailChoices = doc.GetElementByTestId("provide-more-information-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
             .Select(i => i.Value);
-        Assert.Equal(["True", "False"], additionalDetailChoices);
+        Assert.Equal([ProvideMoreInformationOption.Yes.ToString(), ProvideMoreInformationOption.No.ToString()], additionalDetailChoices);
 
         var uploadEvidenceChoices = doc.GetElementByTestId("upload-evidence-options")!
             .QuerySelectorAll<IHtmlInputElement>("input[type='radio']")
@@ -106,8 +111,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SetValidChangeReasonDetails_PersistsDetailsAndRedirects()
     {
         // Arrange
-        var changeReason = ChangeReasonOption.NewInformation;
+        var changeReason = ChangeReasonOption.AnotherReason;
         var changeReasonDetails = "A description about why the change typed into the box";
+        var additionalInformation = "More information related to change";
 
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
         var person = await TestData.CreatePersonAsync(p => p
@@ -129,7 +135,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new FormUrlEncodedContent(
                 new EditRoutePostRequestBuilder()
                     .WithChangeReason(changeReason)
-                    .WithChangeReasonDetailSelections(true, changeReasonDetails)
+                    .WithAdditionalInformation(ProvideMoreInformationOption.Yes, additionalInformation)
+                    .WithChangeReasonDetailSelections(changeReasonDetails)
                     .WithNoFileUploadSelection()
                     .Build())
         };
@@ -141,6 +148,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(changeReason.GetDisplayName(), journeyInstance.State.ChangeReason!.GetDisplayName());
         Assert.Equal(changeReasonDetails, journeyInstance.State.ChangeReasonDetail.ChangeReasonDetail);
+        Assert.Equal(additionalInformation, journeyInstance.State.ChangeReasonDetail.AdditionalInformation);
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/routes/{qualificationId}/edit/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
@@ -177,7 +185,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReason", "Select a reason");
-        await AssertEx.HtmlResponseHasErrorAsync(response, "HasAdditionalReasonDetail", "Select yes if you want to add more information about why you’re editing this route");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "ProvideAdditionalInformation", "Select yes if you want to add more information about why you’re editing this route");
         await AssertEx.HtmlResponseHasErrorAsync(response, "Evidence.UploadEvidence", "Select yes if you want to upload evidence");
     }
 
@@ -204,7 +212,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new FormUrlEncodedContent(
                 new EditRoutePostRequestBuilder()
                     .WithChangeReason(ChangeReasonOption.AnotherReason)
-                    .WithChangeReasonDetailSelections(true, null)
+                    .WithAdditionalInformation(ProvideMoreInformationOption.Yes, null)
                     .Build())
         };
 
@@ -212,14 +220,15 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReasonDetail", "Enter additional detail");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "ChangeReasonDetail", "Enter a reason");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "AdditionalInformation", "Enter details");
     }
 
     [Fact]
     public async Task Post_FileUploadYes_NoFileUploaded_ReturnsError()
     {
         // Arrange
-        var changeReason = ChangeReasonOption.NewInformation;
+        var changeReason = ChangeReasonOption.AnotherReason;
         var changeReasonDetails = "A description about why the change typed into the box";
 
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
@@ -244,7 +253,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", false },
+                { "ChangeReasonDetail", changeReasonDetails },
+                { "AdditionalInformation", ProvideMoreInformationOption.No },
                 { "Evidence.UploadEvidence", true }
             }
         };
@@ -260,7 +270,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SetValidFileUpload_PersistsDetails()
     {
         // Arrange
-        var changeReason = ChangeReasonOption.NewInformation;
+        var changeReason = ChangeReasonOption.AnotherReason;
         var changeReasonDetails = "A description about why the change typed into the box";
         var evidenceFileName = "evidence.pdf";
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
@@ -285,7 +295,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "ChangeReason", changeReason },
-                { "HasAdditionalReasonDetail", false },
+                { "ProvideAdditionalInformation", ProvideMoreInformationOption.No},
+                { "ChangeReasonDetail", changeReasonDetails },
                 { "Evidence.UploadEvidence", true },
                 { "Evidence.EvidenceFile", (CreateEvidenceFileBinaryContent(), evidenceFileName) }
             }

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonRouteToProfessionalStatusBuilder.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreatePersonRouteToProfessionalStatusBuilder.cs
@@ -179,6 +179,7 @@ public partial class TestData
                 changeReason: _changeReason,
                 changeReasonDetail: _changeReasonDetail,
                 evidenceFile: _evidenceFile,
+                additionalInformation: null,
                 @event: out var createdEvent);
 
             dbContext.RouteToProfessionalStatuses.Add(professionalStatus);


### PR DESCRIPTION
### Context

https://github.com.mcas.ms/orgs/DFE-Digital/projects/85/views/2?filterQuery=&pane=issue&itemId=174038796&issue=DFE-Digital%7Cteaching-record-team-project-board%7C192

### Changes proposed in this pull request
Reason pages are being made consistent across all pages in TRS to have a Reason detail & additional information option.

Content changes for
- Add Route
- Edit Route
- Delete Route
- Fix for De-serializing json object events that do not have the additionalinformation property (events created before new property has been introduced). 

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally