### PR TITLE
Additional information missing Not provided

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/SetStatus/CheckAnswers.cshtml
@@ -97,7 +97,7 @@
                     <row>
                         <key>Additional information</key>
                         <value>
-                            @if (Model.DeactivateReasonDetail is not null)
+                            @if (Model.DeactivateAdditionalInformation is not null)
                             {
                                 @Html.ConvertNewlinesToLineBreaks(Model.DeactivateAdditionalInformation)
                             }


### PR DESCRIPTION
Bug fix for missing not provided label not showing when additional information is not provided on CYA page.