### PR TITLE
Content changes for MQ's

### DIFF
--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/MandatoryQualification.cs
@@ -34,6 +34,7 @@ public class MandatoryQualification : Qualification
         EventModels.File? evidenceFile,
         EventModels.RaisedByUserInfo createdBy,
         DateTime now,
+        string? additionalInformation,
         out MandatoryQualificationCreatedEvent @event)
     {
         var qualificationId = Guid.NewGuid();
@@ -62,7 +63,8 @@ public class MandatoryQualification : Qualification
                 providerNameHint: MandatoryQualificationProvider.GetById(providerId).Name),
             AddReason = addReason,
             AddReasonDetail = addReasonDetail,
-            EvidenceFile = evidenceFile
+            EvidenceFile = evidenceFile,
+            AdditionalInformation = additionalInformation,
         };
 
         return qualification;
@@ -74,6 +76,7 @@ public class MandatoryQualification : Qualification
         EventModels.File? evidenceFile,
         EventModels.RaisedByUserInfo deletedBy,
         DateTime now,
+        string? additionalInformation,
         out MandatoryQualificationDeletedEvent @event)
     {
         if (DeletedOn is not null)
@@ -93,7 +96,8 @@ public class MandatoryQualification : Qualification
             MandatoryQualification = EventModels.MandatoryQualification.FromModel(this),
             DeletionReason = deletionReason,
             DeletionReasonDetail = deletionReasonDetail,
-            EvidenceFile = evidenceFile
+            EvidenceFile = evidenceFile,
+            AdditionalInformation = additionalInformation
         };
     }
 
@@ -104,6 +108,7 @@ public class MandatoryQualification : Qualification
         EventModels.File? evidenceFile,
         EventModels.RaisedByUserInfo updatedBy,
         DateTime now,
+        string? additionalInformation,
         out MandatoryQualificationUpdatedEvent? @event)
     {
         var oldMqEventModel = EventModels.MandatoryQualification.FromModel(this);
@@ -138,7 +143,8 @@ public class MandatoryQualification : Qualification
             ChangeReason = changeReason,
             ChangeReasonDetail = changeReasonDetail,
             EvidenceFile = evidenceFile,
-            Changes = changes
+            Changes = changes,
+            AdditionalInformation = additionalInformation
         };
     }
 }

--- a/src/TeachingRecordSystem.Core/Events/Legacy/MandatoryQualificationCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/MandatoryQualificationCreatedEvent.cs
@@ -11,4 +11,5 @@ public record MandatoryQualificationCreatedEvent : EventBase, IEventWithPersonId
     public required string? AddReason { get; init; }
     public required string? AddReasonDetail { get; init; }
     public required File? EvidenceFile { get; init; }
+    public required string? AdditionalInformation { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/Legacy/MandatoryQualificationDeletedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/MandatoryQualificationDeletedEvent.cs
@@ -10,4 +10,5 @@ public record MandatoryQualificationDeletedEvent : EventBase, IEventWithPersonId
     public required string? DeletionReason { get; init; }
     public required string? DeletionReasonDetail { get; init; }
     public required File? EvidenceFile { get; init; }
+    public required string? AdditionalInformation { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/Legacy/MandatoryQualificationUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/Legacy/MandatoryQualificationUpdatedEvent.cs
@@ -13,6 +13,7 @@ public record MandatoryQualificationUpdatedEvent : EventBase, IEventWithPersonId
     public required string? ChangeReasonDetail { get; init; }
     public required File? EvidenceFile { get; init; }
     public required MandatoryQualificationUpdatedEventChanges Changes { get; init; }
+    public required string? AdditionalInformation { get; init; }
 }
 
 [Flags]

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqState.cs
@@ -24,11 +24,13 @@ public class AddMqState : IRegisterJourney
 
     public AddMqReasonOption? AddReason { get; set; }
 
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public bool? ProvideAdditionalInformation { get; set; }
 
     public string? AddReasonDetail { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
+
+    public string? AdditionalInformation { get; set; }
 
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(ProviderId), nameof(Specialism), nameof(StartDate), nameof(Status))]
@@ -37,9 +39,13 @@ public class AddMqState : IRegisterJourney
         Specialism.HasValue &&
         StartDate.HasValue &&
         Status.HasValue &&
-        (Status != MandatoryQualificationStatus.Passed || (Status == MandatoryQualificationStatus.Passed && EndDate.HasValue)) &&
+        (Status != MandatoryQualificationStatus.Passed ||
+         (Status == MandatoryQualificationStatus.Passed && EndDate.HasValue)) &&
         AddReason.HasValue &&
-        HasAdditionalReasonDetail is bool hasDetail &&
-        (!hasDetail || AddReasonDetail is not null) &&
-        Evidence.IsComplete;
+        (AddReason == AddMqReasonOption.AnotherReason && !string.IsNullOrEmpty(AddReasonDetail) ||
+         AddReason != AddMqReasonOption.AnotherReason && string.IsNullOrEmpty(AddReasonDetail)) &&
+         ProvideAdditionalInformation is bool proveAdditionalInfo &&
+         (proveAdditionalInfo == true && !string.IsNullOrEmpty(AdditionalInformation) ||
+          proveAdditionalInfo == false && string.IsNullOrEmpty(AdditionalInformation)) &&
+         Evidence.IsComplete;
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
@@ -63,11 +63,27 @@
                     </row-actions>
                 </row>
                 <row>
-                    <key>Additional information</key>
-                    <value>
+                    <key>Reason details</key>
+                    <value data-testid="reason-details">
                         @if (Model.AddReasonDetail is not null)
                         {
                             @Html.ConvertNewlinesToLineBreaks(Model.AddReasonDetail)
+                        }
+                        else
+                        {
+                            <span use-empty-fallback></span>
+                        }
+                    </value>
+                    <row-actions>
+                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                    </row-actions>
+                </row>
+                <row>
+                    <key>Additional information</key>
+                    <value data-testid="additional-information">
+                        @if (Model.AdditionalInformation is not null)
+                        {
+                            @Html.ConvertNewlinesToLineBreaks(Model.AdditionalInformation)
                         }
                         else
                         {

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
@@ -37,6 +37,8 @@ public class CheckAnswersModel(
 
     public string? AddReasonDetail { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
     [BindProperty]
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
@@ -54,6 +56,7 @@ public class CheckAnswersModel(
             evidenceFile: EvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
+            additionalInformation: AdditionalInformation,
             out var createdEvent);
 
         dbContext.MandatoryQualifications.Add(qualification);
@@ -92,8 +95,8 @@ public class CheckAnswersModel(
         EndDate = JourneyInstance.State.EndDate;
         AddReason = JourneyInstance.State.AddReason!.Value;
         AddReasonDetail = JourneyInstance.State.AddReasonDetail;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
         EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
-
         await next();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml
@@ -22,11 +22,16 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@AddMqReasonOption.AnotherReason">
                         @AddMqReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="add-reason-detail">
+                            <govuk-input data-testid="reason-detail" for="AddReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="has-additional-reason_detail-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>
                         <h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2>
@@ -34,7 +39,7 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="AddReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
                                 <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml.cs
@@ -14,14 +14,17 @@ public class ReasonModel(
     {
         v => v.RuleFor(m => m.AddReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
-            .NotNull().WithMessage("Select yes if you want to add more information about why you’re adding this mandatory qualification"),
         v => v.RuleFor(m => m.AddReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.AddReason == AddMqReasonOption.AnotherReason),
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
+            .NotNull().WithMessage("Select yes if you want to add more information about why you’re adding this mandatory qualification"),
+        v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.AddReasonDetail)
+        v => v.RuleFor(m => m.AdditionalInformation)
             .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+            .When(m => m.ProvideAdditionalInformation == true),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -39,7 +42,7 @@ public class ReasonModel(
     public AddMqReasonOption? AddReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public bool? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
     public string? AddReasonDetail { get; set; }
@@ -47,12 +50,16 @@ public class ReasonModel(
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
 
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
+
     public void OnGet()
     {
         AddReason = JourneyInstance!.State.AddReason;
-        HasAdditionalReasonDetail = JourneyInstance.State.HasAdditionalReasonDetail;
+        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
         AddReasonDetail = JourneyInstance.State.AddReasonDetail;
         Evidence = JourneyInstance.State.Evidence;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -68,9 +75,10 @@ public class ReasonModel(
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.AddReason = AddReason;
-            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
-            state.AddReasonDetail = AddReasonDetail;
+            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+            state.AddReasonDetail = AddReason == AddMqReasonOption.AnotherReason ? AddReasonDetail : null;
             state.Evidence = Evidence;
+            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
         });
 
         return Redirect(linkGenerator.Mqs.AddMq.CheckAnswers(PersonId, JourneyInstance.InstanceId));

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml
@@ -43,9 +43,15 @@
                     <value data-testid="deletion-reason">@Model.DeletionReason!.GetDisplayName()</value>
                 </row>
                 <row>
-                    <key>Additional information</key>
+                    <key>Reason details</key>
                     <value data-testid="deletion-reason-detail">
                         @Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.DeletionReasonDetail) ? Model.DeletionReasonDetail : "None")
+                    </value>
+                </row>
+                <row>
+                    <key>Additional information</key>
+                    <value data-testid="additional-information">
+                        @Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.AdditionalInformation) ? Model.AdditionalInformation : "None")
                     </value>
                 </row>
                 <row>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml.cs
@@ -38,6 +38,8 @@ public class CheckAnswersModel(
 
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (!JourneyInstance!.State.IsComplete)
@@ -59,6 +61,7 @@ public class CheckAnswersModel(
         DeletionReason = JourneyInstance.State.DeletionReason;
         DeletionReasonDetail = JourneyInstance.State.DeletionReasonDetail;
         EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -71,6 +74,7 @@ public class CheckAnswersModel(
             EvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
+            additionalInformation: AdditionalInformation,
             out var deletedEvent);
 
         dbContext.AddEventWithoutBroadcast(deletedEvent);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
@@ -18,10 +18,17 @@ public class DeleteMqState : IRegisterJourney
 
     public string? DeletionReasonDetail { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
+    public bool? ProvideAdditionalInformation { get; set; }
+
     public EvidenceUploadModel Evidence { get; set; } = new();
 
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(DeletionReason))]
 
-    public bool IsComplete => DeletionReason.HasValue && Evidence.IsComplete;
+    public bool IsComplete => DeletionReason.HasValue &&
+        (DeletionReason == MqDeletionReasonOption.AnotherReason && !string.IsNullOrEmpty(DeletionReasonDetail) || DeletionReason != MqDeletionReasonOption.AnotherReason && string.IsNullOrEmpty(DeletionReasonDetail)) &&
+        (ProvideAdditionalInformation == true && !string.IsNullOrEmpty(AdditionalInformation) || ProvideAdditionalInformation == false && string.IsNullOrEmpty(AdditionalInformation)) &&
+        Evidence.IsComplete;
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
@@ -24,18 +24,23 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@MqDeletionReasonOption.AnotherReason">
                         @MqDeletionReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="delete-reason-detail">
+                            <govuk-input data-testid="reason-detail" for="DeletionReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="has-additional-reason_detail-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m">Do you want to provide more information?</govuk-radios-fieldset-legend>
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="DeletionReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details about this change</govuk-character-count-label>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
@@ -12,14 +12,17 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
     {
         v => v.RuleFor(m => m.DeletionReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
             .NotNull().WithMessage("Select yes if you want to add more information"),
         v => v.RuleFor(m => m.DeletionReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.DeletionReason == MqDeletionReasonOption.AnotherReason),
+        v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.DeletionReasonDetail)
+        v => v.RuleFor(m => m.AdditionalInformation)
             .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+            .When(m => m.ProvideAdditionalInformation == true),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -38,7 +41,10 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
     public MqDeletionReasonOption? DeletionReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public bool? ProvideAdditionalInformation { get; set; }
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     [BindProperty]
     public string? DeletionReasonDetail { get; set; }
@@ -59,8 +65,10 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
     public void OnGet()
     {
         DeletionReason = JourneyInstance!.State.DeletionReason;
-        DeletionReasonDetail = JourneyInstance.State.DeletionReasonDetail;
+        DeletionReasonDetail = DeletionReason == MqDeletionReasonOption.AnotherReason ? JourneyInstance.State.DeletionReasonDetail : null;
         Evidence = JourneyInstance.State.Evidence;
+        AdditionalInformation = ProvideAdditionalInformation == true ? JourneyInstance.State.AdditionalInformation : null;
+        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -78,6 +86,8 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
             state.DeletionReason = DeletionReason;
             state.DeletionReasonDetail = DeletionReasonDetail;
             state.Evidence = Evidence;
+            state.AdditionalInformation = AdditionalInformation;
+            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
         });
 
         return Redirect(linkGenerator.Mqs.DeleteMq.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml
@@ -31,8 +31,14 @@
                     <value data-testid="change-reason">@Model.ChangeReason!.GetDisplayName()</value>
                 </row>
                 <row>
-                    <key>More details</key>
+                    <key>Reason details</key>
                     <value data-testid="change-reason-detail">@Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.ChangeReasonDetail) ? Model.ChangeReasonDetail : "None")</value>
+                </row>
+                <row>
+                    <key>Additional information</key>
+                    <value data-testid="additional-information">
+                        @Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.AdditionalInformation) ? Model.AdditionalInformation : "None")
+                    </value>
                 </row>
                 <row>
                     <key>Evidence</key>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml.cs
@@ -35,6 +35,8 @@ public class CheckAnswersModel(
 
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
     public void OnGet() { }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -56,6 +58,7 @@ public class CheckAnswersModel(
         ChangeReason = JourneyInstance.State.ChangeReason!.Value;
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -69,6 +72,7 @@ public class CheckAnswersModel(
             evidenceFile: EvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
+            additionalInformation: AdditionalInformation,
             out var updatedEvent);
 
         if (updatedEvent is not null)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderState.cs
@@ -24,11 +24,17 @@ public class EditMqProviderState : IRegisterJourney
 
     public EvidenceUploadModel Evidence { get; set; } = new();
 
+    public string? AdditionalInformation { get; set; }
+
+    public bool? ProvideAdditionalInformation { get; set; }
+
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(ProviderId), nameof(ChangeReason))]
     public bool IsComplete =>
         ProviderId.HasValue &&
         ChangeReason.HasValue &&
+        (ChangeReason == MqChangeProviderReasonOption.AnotherReason && !string.IsNullOrEmpty(ChangeReasonDetail) || (ChangeReason != MqChangeProviderReasonOption.AnotherReason && string.IsNullOrEmpty(ChangeReasonDetail))) &&
+        (ProvideAdditionalInformation == true && !string.IsNullOrEmpty(AdditionalInformation) || (ProvideAdditionalInformation != true && string.IsNullOrEmpty(AdditionalInformation))) &&
         Evidence.IsComplete;
 
     public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml
@@ -24,18 +24,23 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@MqChangeProviderReasonOption.AnotherReason">
                         @MqChangeProviderReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="provider-reason-detail">
+                            <govuk-input data-testid="reason-detail" for="ChangeReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="has-additional-reason_detail-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend><h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2></govuk-radios-fieldset-legend>
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="ChangeReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details about this change</govuk-character-count-label>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml.cs
@@ -12,14 +12,17 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     {
         v => v.RuleFor(m => m.ChangeReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
+        v => v.RuleFor(m => m.ChangeReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.ChangeReason == MqChangeProviderReasonOption.AnotherReason),
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
             .NotNull().WithMessage("Select yes if you want to add more information"),
         v => v.RuleFor(m => m.ChangeReasonDetail)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
+        v => v.RuleFor(m => m.AdditionalInformation)
             .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+            .When(m => m.ProvideAdditionalInformation == true),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -36,10 +39,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     public MqChangeProviderReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public bool? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
     public string? ChangeReasonDetail { get; set; }
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
@@ -61,8 +67,10 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     public void OnGet()
     {
         ChangeReason = JourneyInstance!.State.ChangeReason;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
+        ChangeReasonDetail = ChangeReason == MqChangeProviderReasonOption.AnotherReason ? JourneyInstance.State.ChangeReasonDetail : null;
         Evidence = JourneyInstance.State.Evidence;
+        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
+        AdditionalInformation = ProvideAdditionalInformation == true ? JourneyInstance.State.AdditionalInformation : null;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -78,8 +86,10 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail = ChangeReasonDetail;
+            state.ChangeReasonDetail = ChangeReason == MqChangeProviderReasonOption.AnotherReason ? ChangeReasonDetail : null;
             state.Evidence = Evidence;
+            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
         });
 
         return Redirect(linkGenerator.Mqs.EditMq.Provider.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml
@@ -35,6 +35,10 @@
                     <value data-testid="change-reason-detail">@Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.ChangeReasonDetail) ? Model.ChangeReasonDetail : "None")</value>
                 </row>
                 <row>
+                    <key>Additional information</key>
+                    <value data-testid="additional-information">@Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.AdditionalInformation) ? Model.AdditionalInformation : "None")</value>
+                </row>
+                <row>
                     <key>Evidence</key>
                     <value data-testid="evidence">
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml.cs
@@ -30,6 +30,8 @@ public class CheckAnswersModel(
 
     public string? ChangeReasonDetail { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -48,6 +50,7 @@ public class CheckAnswersModel(
         NewSpecialism = JourneyInstance.State.Specialism;
         ChangeReason = JourneyInstance.State.ChangeReason!.Value;
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
         EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
     }
 
@@ -62,6 +65,7 @@ public class CheckAnswersModel(
             evidenceFile: EvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
+            additionalInformation: AdditionalInformation,
             out var updatedEvent);
 
         if (updatedEvent is not null)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
@@ -24,10 +24,15 @@ public class EditMqSpecialismState : IRegisterJourney
 
     public EvidenceUploadModel Evidence { get; set; } = new();
 
+    public string? AdditionalInformation { get; set; }
+
+    public bool? ProvideAdditionalInformation { get; set; }
+
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(Specialism), nameof(ChangeReason))]
     public bool IsComplete => Specialism is not null &&
-        ChangeReason.HasValue &&
+                              (ChangeReason == MqChangeSpecialismReasonOption.AnotherReason && !string.IsNullOrEmpty(ChangeReasonDetail) || ChangeReason != MqChangeSpecialismReasonOption.AnotherReason && string.IsNullOrEmpty(ChangeReasonDetail)) &&
+                              (ProvideAdditionalInformation == true && !string.IsNullOrWhiteSpace(AdditionalInformation) || ProvideAdditionalInformation != true && string.IsNullOrWhiteSpace(AdditionalInformation)) &&
         Evidence.IsComplete;
 
     public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml
@@ -24,18 +24,23 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@MqChangeSpecialismReasonOption.AnotherReason">
                         @MqChangeSpecialismReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="specialism-reason-detail">
+                            <govuk-input data-testid="reason-detail" for="ChangeReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="has-additional-reason_detail-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend><h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2></govuk-radios-fieldset-legend>
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="ChangeReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details about this change</govuk-character-count-label>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml.cs
@@ -12,14 +12,14 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     {
         v => v.RuleFor(m => m.ChangeReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
             .NotNull().WithMessage("Select yes if you want to add more information"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
+        v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
+        v => v.RuleFor(m => m.AdditionalInformation)
             .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+            .When(m => m.ProvideAdditionalInformation == true),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -36,13 +36,16 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     public MqChangeSpecialismReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public bool? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
@@ -63,6 +66,9 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         ChangeReason = JourneyInstance!.State.ChangeReason;
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         Evidence = JourneyInstance.State.Evidence;
+        ChangeReasonDetail = ChangeReason == MqChangeSpecialismReasonOption.AnotherReason ? JourneyInstance.State.ChangeReasonDetail : null;
+        AdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation == true ? JourneyInstance.State.AdditionalInformation : null;
+        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -78,8 +84,10 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail = ChangeReasonDetail;
+            state.ChangeReasonDetail = ChangeReason == MqChangeSpecialismReasonOption.AnotherReason ? ChangeReasonDetail : null;
             state.Evidence = Evidence;
+            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
         });
 
         return Redirect(linkGenerator.Mqs.EditMq.Specialism.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml
@@ -35,6 +35,10 @@
                     <value data-testid="change-reason-detail">@Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.ChangeReasonDetail) ? Model.ChangeReasonDetail : "None")</value>
                 </row>
                 <row>
+                    <key>Additional information</key>
+                    <value data-testid="additional-information">@Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.AdditionalInformation) ? Model.AdditionalInformation : "None")</value>
+                </row>
+                <row>
                     <key>Evidence</key>
                     <value data-testid="evidence">
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml.cs
@@ -32,6 +32,8 @@ public class CheckAnswersModel(
 
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (!JourneyInstance!.State.IsComplete)
@@ -49,6 +51,7 @@ public class CheckAnswersModel(
         ChangeReason = JourneyInstance.State.ChangeReason!.Value;
         ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
         EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -62,6 +65,7 @@ public class CheckAnswersModel(
             evidenceFile: EvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
+            additionalInformation: AdditionalInformation,
             out var updatedEvent);
 
         if (updatedEvent is not null)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateState.cs
@@ -22,12 +22,18 @@ public class EditMqStartDateState : IRegisterJourney
 
     public string? ChangeReasonDetail { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
+    public bool? ProvideAdditionalInformation { get; set; }
+
     public EvidenceUploadModel Evidence { get; set; } = new();
 
     [JsonIgnore]
     [MemberNotNullWhen(true, nameof(StartDate), nameof(ChangeReason))]
     public bool IsComplete => StartDate is not null &&
         ChangeReason.HasValue &&
+        (ProvideAdditionalInformation == true && !string.IsNullOrWhiteSpace(AdditionalInformation) || (ProvideAdditionalInformation == false && string.IsNullOrWhiteSpace(AdditionalInformation))) &&
+        (ChangeReason == MqChangeStartDateReasonOption.AnotherReason && !string.IsNullOrWhiteSpace(ChangeReasonDetail) || (ChangeReason != MqChangeStartDateReasonOption.AnotherReason && string.IsNullOrWhiteSpace(ChangeReasonDetail))) &&
         Evidence.IsComplete;
 
     public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml
@@ -27,18 +27,23 @@
                     </govuk-radios-item>
                     <govuk-radios-item value="@MqChangeStartDateReasonOption.AnotherReason">
                         @MqChangeStartDateReasonOption.AnotherReason.GetDisplayName()
+                        <govuk-radios-item-conditional data-testid="start-date-reason-detail">
+                            <govuk-input data-testid="reason-detail" for="ChangeReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                <govuk-input-label>Enter a reason</govuk-input-label>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="has-additional-reason_detail-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend><h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2></govuk-radios-fieldset-legend>
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="ChangeReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details about this change</govuk-character-count-label>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml.cs
@@ -12,14 +12,17 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     {
         v => v.RuleFor(m => m.ChangeReason)
             .NotNull().WithMessage("Select a reason"),
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
+        v => v.RuleFor(m => m.ChangeReasonDetail)
+            .NotEmpty().WithMessage("Enter a reason")
+            .When(m => m.ChangeReason == MqChangeStartDateReasonOption.AnotherReason),
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
             .NotNull().WithMessage("Select yes if you want to add more information"),
         v => v.RuleFor(m => m.ChangeReasonDetail)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
+        v => v.RuleFor(m => m.AdditionalInformation)
             .NotEmpty().WithMessage("Enter additional detail")
-            .When(m => m.HasAdditionalReasonDetail == true),
+            .When(m => m.ProvideAdditionalInformation == true),
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
@@ -36,13 +39,16 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     public MqChangeStartDateReasonOption? ChangeReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public bool? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
@@ -61,8 +67,10 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     public void OnGet()
     {
         ChangeReason = JourneyInstance!.State.ChangeReason;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
+        ChangeReasonDetail = ChangeReason == MqChangeStartDateReasonOption.AnotherReason ? JourneyInstance.State.ChangeReasonDetail : null;
         Evidence = JourneyInstance.State.Evidence;
+        AdditionalInformation = JourneyInstance!.State.ProvideAdditionalInformation == true ? JourneyInstance!.State.AdditionalInformation : null;
+        ProvideAdditionalInformation = JourneyInstance!.State.ProvideAdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -78,8 +86,11 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         await JourneyInstance!.UpdateStateAsync(state =>
         {
             state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail = ChangeReasonDetail;
+            state.ChangeReasonDetail = ChangeReason == MqChangeStartDateReasonOption.AnotherReason ? ChangeReasonDetail : null;
             state.Evidence = Evidence;
+            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+
         });
 
         return Redirect(linkGenerator.Mqs.EditMq.StartDate.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/CheckAnswers.cshtml
@@ -56,6 +56,10 @@
                     <value data-testid="change-reason-detail">@Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.ChangeReasonDetail) ? Model.ChangeReasonDetail : "None")</value>
                 </row>
                 <row>
+                    <key>Additional information</key>
+                    <value data-testid="additional-information">@Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(Model.AdditionalInformation) ? Model.AdditionalInformation : "None")</value>
+                </row>
+                <row>
                     <key>Evidence</key>
                     <value data-testid="evidence">
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/CheckAnswers.cshtml.cs
@@ -42,6 +42,8 @@ public class CheckAnswersModel(
 
     public bool IsStatusChange { get; set; }
 
+    public string? AdditionalInformation { get; set; }
+
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (!JourneyInstance!.State.IsComplete)
@@ -64,6 +66,7 @@ public class CheckAnswersModel(
         EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
         IsEndDateChange = JourneyInstance.State.IsEndDateChange;
         IsStatusChange = JourneyInstance.State.IsStatusChange;
+        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -81,6 +84,7 @@ public class CheckAnswersModel(
             evidenceFile: EvidenceFile?.ToEventModel(),
             User.GetUserId(),
             timeProvider.UtcNow,
+            additionalInformation: AdditionalInformation,
             out var updatedEvent);
 
         if (updatedEvent is not null)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqStatusState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/EditMqStatusState.cs
@@ -35,6 +35,8 @@ public class EditMqStatusState : IRegisterJourney
     [JsonIgnore]
     public bool IsStatusChange => Status != CurrentStatus;
 
+    public string? AdditionalInformation { get; set; }
+
     [JsonIgnore]
     public bool IsComplete => Status.HasValue &&
         (Status != MandatoryQualificationStatus.Passed || Status == MandatoryQualificationStatus.Passed && EndDate.HasValue) &&

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Reason.cshtml
@@ -28,6 +28,11 @@
                         </govuk-radios-item>
                         <govuk-radios-item value="@MqChangeEndDateReasonOption.AnotherReason">
                             @MqChangeEndDateReasonOption.AnotherReason.GetDisplayName()
+                            <govuk-radios-item-conditional data-testid="status-reason-detail">
+                                <govuk-input data-testid="reason-detail" for="ChangeReasonDetail" input-class="govuk-input--width-20 govuk-input--extra-letter-spacing" spellcheck="false">
+                                    <govuk-input-label>Enter a reason</govuk-input-label>
+                                </govuk-input>
+                            </govuk-radios-item-conditional>
                         </govuk-radios-item>
                     </govuk-radios-fieldset>
                 </govuk-radios>
@@ -50,7 +55,7 @@
                 </govuk-radios>
             }
 
-            <govuk-radios for="HasAdditionalReasonDetail" data-testid="has-additional-reason_detail-options">
+            <govuk-radios for="ProvideAdditionalInformation" data-testid="has-additional-reason_detail-options">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>
                         <h2 class="govuk-fieldset__legend--m">Do you want to provide more information?</h2>
@@ -58,8 +63,8 @@
                     <govuk-radios-item value="@true">
                         Yes
                         <govuk-radios-item-conditional data-testid="additional-detail">
-                            <govuk-character-count for="ChangeReasonDetail" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
-                                <govuk-character-count-label>Enter details about this change</govuk-character-count-label>
+                            <govuk-character-count for="AdditionalInformation" max-length="UiDefaults.ReasonDetailsMaxCharacterCount" rows="UiDefaults.ReasonDetailsRows">
+                                <govuk-character-count-label>Enter details</govuk-character-count-label>
                             </govuk-character-count>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Status/Reason.cshtml.cs
@@ -10,9 +10,9 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
-        v => v.RuleFor(m => m.HasAdditionalReasonDetail)
+        v => v.RuleFor(m => m.ProvideAdditionalInformation)
             .NotNull().WithMessage("Select yes if you want to add more information"),
-        v => v.RuleFor(m => m.ChangeReasonDetail)
+        v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
         v => v.RuleFor(m => m.Evidence).Evidence()
@@ -34,10 +34,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
     public MqChangeEndDateReasonOption? EndDateChangeReason { get; set; }
 
     [BindProperty]
-    public bool? HasAdditionalReasonDetail { get; set; }
+    public bool? ProvideAdditionalInformation { get; set; }
 
     [BindProperty]
     public string? ChangeReasonDetail { get; set; }
+
+    [BindProperty]
+    public string? AdditionalInformation { get; set; }
 
     [BindProperty]
     public EvidenceUploadModel Evidence { get; set; } = new();

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationCreatedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationCreatedEvent.cshtml
@@ -47,9 +47,29 @@
                         <value data-testid="reason" use-empty-fallback>@createdEvent.AddReason</value>
                     </row>
                     <row>
+                        <key>Reason details</key>
+                        <value data-testid="reason-detail">
+                            @if (createdEvent.AddReasonDetail is not null)
+                            {
+                                @Html.ConvertNewlinesToLineBreaks(createdEvent.AddReasonDetail)
+                            }
+                            else
+                            {
+                                <span use-empty-fallback></span>
+                            }
+                        </value>
+                    </row>
+                    <row>
                         <key>Additional information</key>
-                        <value data-testid="reason-detail" use-empty-fallback>
-                            @Html.ConvertNewlinesToLineBreaks(createdEvent.AddReasonDetail)
+                        <value data-testid="additional-information">
+                            @if (createdEvent.AdditionalInformation is not null)
+                            {
+                                @Html.ConvertNewlinesToLineBreaks(createdEvent.AdditionalInformation)
+                            }
+                            else
+                            {
+                                <span use-empty-fallback></span>
+                            }
                         </value>
                     </row>
                     <row>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDeletedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationDeletedEvent.cshtml
@@ -27,9 +27,11 @@
                     </row>
                     <row>
                         <key>More detail</key>
-                        <value data-testid="deletion-reason-detail">
-                            @Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(deletedEvent.DeletionReasonDetail) ? deletedEvent.DeletionReasonDetail : "None")
-                        </value>
+                        <value data-testid="deletion-reason-detail">@(!string.IsNullOrEmpty(deletedEvent.DeletionReasonDetail) ? deletedEvent.DeletionReasonDetail : "None")</value>
+                    </row>
+                    <row>
+                        <key>Additional information</key>
+                        <value data-testid="additional-information">@(!string.IsNullOrEmpty(deletedEvent.AdditionalInformation) ? deletedEvent.AdditionalInformation : "None")</value>
                     </row>
                     @if (evidenceFileUrl is not null)
                     {

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationUpdatedEvent.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Timeline/Events/MandatoryQualificationUpdatedEvent.cshtml
@@ -32,7 +32,27 @@
                         <row>
                             <key>More detail</key>
                             <value data-testid="change-reason-detail">
-                                @Html.ConvertNewlinesToLineBreaks(!string.IsNullOrEmpty(updatedEvent.ChangeReasonDetail) ? updatedEvent.ChangeReasonDetail : "None")
+                                @if (updatedEvent.ChangeReasonDetail is not null)
+                                {
+                                    @Html.ConvertNewlinesToLineBreaks(updatedEvent.ChangeReasonDetail)
+                                }
+                                else
+                                {
+                                    <span use-empty-fallback></span>
+                                }
+                            </value>
+                        </row>
+                        <row>
+                            <key>Additional information</key>
+                            <value data-testid="additional-information">
+                                @if (updatedEvent.AdditionalInformation is not null)
+                                {
+                                    @Html.ConvertNewlinesToLineBreaks(updatedEvent.AdditionalInformation)
+                                }
+                                else
+                                {
+                                    <span use-empty-fallback></span>
+                                }
                             </value>
                         </row>
                         @if (evidenceFileUrl is not null)

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Qualifications/MqTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Qualifications/MqTests.cs
@@ -118,7 +118,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnEditMqProviderReasonPageAsync(qualificationId);
 
         await page.CheckAsync($"label{TextIsSelector(changeReason.GetDisplayName())}");
-        await page.SelectReasonMoreDetailsAsync("Enter details about this change", true, changeReasonDetail);
+        await page.SelectReasonMoreDetailsAsync("Enter details", true, changeReasonDetail);
         await page.SelectUploadEvidenceAsync(true, "evidence.jpg");
         await page.ClickContinueButtonAsync();
 
@@ -162,7 +162,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnEditMqSpecialismReasonPageAsync(qualificationId);
 
         await page.CheckAsync($"label{TextIsSelector(changeReason.GetDisplayName())}");
-        await page.SelectReasonMoreDetailsAsync("Enter details about this change", true, changeReasonDetail);
+        await page.SelectReasonMoreDetailsAsync("Enter details", true, changeReasonDetail);
         await page.SelectUploadEvidenceAsync(true, "evidence.jpg");
         await page.ClickContinueButtonAsync();
 
@@ -204,7 +204,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnEditMqStartDateReasonPageAsync(qualificationId);
 
         await page.CheckAsync($"label{TextIsSelector(changeReason.GetDisplayName())}");
-        await page.SelectReasonMoreDetailsAsync("Enter details about this change", true, changeReasonDetail);
+        await page.SelectReasonMoreDetailsAsync("Enter details", true, changeReasonDetail);
         await page.SelectUploadEvidenceAsync(true, "evidence.jpg");
         await page.ClickContinueButtonAsync();
 
@@ -292,7 +292,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnEditMqStatusReasonPageAsync(qualificationId);
 
         await page.CheckAsync($"label{TextIsSelector(changeReason)}");
-        await page.SelectReasonMoreDetailsAsync("Enter details about this change", true, changeReasonDetail);
+        await page.SelectReasonMoreDetailsAsync("Enter details", true, changeReasonDetail);
         await page.SelectUploadEvidenceAsync(true, "evidence.jpg");
         await page.ClickContinueButtonAsync();
 
@@ -326,7 +326,7 @@ public class MqTests(HostFixture hostFixture) : TestBase(hostFixture)
         await page.AssertOnDeleteMqPageAsync(qualificationId);
 
         await page.CheckAsync($"label{TextIsSelector(deletionReason.GetDisplayName())}");
-        await page.SelectReasonMoreDetailsAsync("Enter details about this change", true, deletionReasonDetail);
+        await page.SelectReasonMoreDetailsAsync("Enter details", true, deletionReasonDetail);
         await page.SelectUploadEvidenceAsync(true, "evidence.jpg");
         await page.ClickContinueButtonAsync();
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -35,7 +35,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var status = MandatoryQualificationStatus.Passed;
         DateOnly? endDate = new DateOnly(2021, 11, 5);
         var addReason = AddMqReasonOption.NewInformationReceived;
-        var addReasonDetail = "More details about the MQ";
+        var additionalInformation = "More details about the MQ";
         var evidence = new EvidenceUploadModel
         {
             UploadEvidence = true,
@@ -57,9 +57,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Status = status,
                 EndDate = endDate,
                 AddReason = addReason,
-                HasAdditionalReasonDetail = true,
-                AddReasonDetail = addReasonDetail,
-                Evidence = evidence
+                ProvideAdditionalInformation = true,
+                AddReasonDetail = null,
+                Evidence = evidence,
+                AdditionalInformation = additionalInformation
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/check-answers?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -83,8 +84,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
         DateOnly? endDate = status == MandatoryQualificationStatus.Passed ? new DateOnly(2021, 11, 5) : null;
-        var addReason = AddMqReasonOption.NewInformationReceived;
+        var addReason = AddMqReasonOption.AnotherReason;
         var addReasonDetail = "More details about the MQ";
+        var additionalInformation = "some additional info";
         var evidence = new EvidenceUploadModel
         {
             UploadEvidence = true,
@@ -106,7 +108,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Status = status,
                 EndDate = endDate,
                 AddReason = addReason,
-                HasAdditionalReasonDetail = true,
+                ProvideAdditionalInformation = true,
+                AdditionalInformation = additionalInformation,
                 AddReasonDetail = addReasonDetail,
                 Evidence = evidence
             });
@@ -122,6 +125,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(specialism.GetTitle(), doc.GetElementByTestId("specialism")!.TrimmedText());
         Assert.Equal(startDate.ToString(WebConstants.DateDisplayFormat), doc.GetElementByTestId("start-date")!.TrimmedText());
         Assert.Equal(status.GetTitle(), doc.GetElementByTestId("status")!.TrimmedText());
+        Assert.Equal(addReasonDetail, doc.GetElementByTestId("reason-details")!.TrimmedText());
+        Assert.Equal(additionalInformation, doc.GetElementByTestId("additional-information")!.TrimmedText());
         if (status == MandatoryQualificationStatus.Passed)
         {
             Assert.Equal(endDate!.Value.ToString(WebConstants.DateDisplayFormat), doc.GetElementByTestId("end-date")!.TrimmedText());
@@ -164,7 +169,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var specialism = MandatoryQualificationSpecialism.Hearing;
         var startDate = new DateOnly(2021, 3, 1);
         DateOnly? endDate = status == MandatoryQualificationStatus.Passed ? new DateOnly(2021, 11, 5) : null;
-        var addReason = AddMqReasonOption.NewInformationReceived;
+        var addReason = AddMqReasonOption.AnotherReason;
         var addReasonDetail = "More details about the MQ";
         var evidence = new EvidenceUploadModel
         {
@@ -187,9 +192,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Status = status,
                 EndDate = endDate,
                 AddReason = addReason,
-                HasAdditionalReasonDetail = true,
+                ProvideAdditionalInformation = false,
                 AddReasonDetail = addReasonDetail,
-                Evidence = evidence
+                Evidence = evidence,
+                AdditionalInformation = null
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/check-answers?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -247,7 +253,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 },
                 AddReason = addReason.GetDisplayName(),
                 AddReasonDetail = addReasonDetail,
-                EvidenceFile = evidence.UploadedEvidenceFile?.ToEventModel()
+                EvidenceFile = evidence.UploadedEvidenceFile?.ToEventModel(),
+                AdditionalInformation = null
             };
 
             var actualMqCreatedEvent = Assert.IsType<MandatoryQualificationCreatedEvent>(e);
@@ -266,7 +273,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var status = MandatoryQualificationStatus.Passed;
         DateOnly? endDate = new DateOnly(2021, 11, 5);
         var addReason = AddMqReasonOption.NewInformationReceived;
-        var addReasonDetail = "More details about the MQ";
+        var additionalInformation = "More details about the MQ";
         var evidence = new EvidenceUploadModel
         {
             UploadEvidence = true,
@@ -288,8 +295,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Status = status,
                 EndDate = endDate,
                 AddReason = addReason,
-                HasAdditionalReasonDetail = true,
-                AddReasonDetail = addReasonDetail,
+                ProvideAdditionalInformation = true,
+                AddReasonDetail = null,
+                AdditionalInformation = additionalInformation,
                 Evidence = evidence
             });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ReasonTests.cs
@@ -1,3 +1,4 @@
+using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
@@ -66,9 +67,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.PersonId,
             state =>
             {
-                state.HasAdditionalReasonDetail = true;
-                state.AddReason = AddMqReasonOption.NewInformationReceived;
-                state.AddReasonDetail = "Some additional details";
+                state.ProvideAdditionalInformation = true;
+                state.AddReason = AddMqReasonOption.AnotherReason;
+                state.AddReasonDetail = "Some reason";
                 state.Evidence = new EvidenceUploadModel
                 {
                     UploadEvidence = true,
@@ -79,6 +80,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                         FileSizeDescription = "5MB"
                     }
                 };
+                state.AdditionalInformation = "Additional information";
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/reason?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -90,9 +92,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var doc = await AssertEx.HtmlResponseAsync(response);
 
         AssertCheckedRadioOption("AddReason", journeyInstance.State.AddReason!.ToString()!);
-        AssertCheckedRadioOption("HasAdditionalReasonDetail", bool.TrueString);
-        Assert.Equal(journeyInstance.State.AddReasonDetail, doc.GetElementsByName("AddReasonDetail")[0].TrimmedText());
+        AssertCheckedRadioOption("ProvideAdditionalInformation", bool.TrueString);
+        var reasonDetailTextbox =
+            doc.GetElementById("AddReasonDetail") as IHtmlInputElement;
+        Assert.Equal(journeyInstance.State.AddReasonDetail, reasonDetailTextbox!.Value);
         AssertCheckedRadioOption("Evidence.UploadEvidence", bool.TrueString);
+        var additionalInformation =
+            doc.GetElementById("AdditionalInformation") as IHtmlTextAreaElement;
+        Assert.Equal(journeyInstance.State.AdditionalInformation, additionalInformation!.Value);
 
         var uploadedEvidenceLink = doc.GetElementByTestId("uploaded-evidence-file-link");
         Assert.NotNull(uploadedEvidenceLink);
@@ -174,7 +181,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         {
             Content = new MultipartFormDataContentBuilder
             {
-                { "AddReason", AddMqReasonOption.NewInformationReceived.ToString() },
+                { "AddReason", AddMqReasonOption.AnotherReason.ToString() },
                 { "Evidence.UploadEvidence", "false" }
             }
         };
@@ -183,7 +190,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "HasAdditionalReasonDetail", "Select yes if you want to add more information about why you’re adding this mandatory qualification");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "ProvideAdditionalInformation", "Select yes if you want to add more information about why you’re adding this mandatory qualification");
     }
 
     [Fact]
@@ -197,8 +204,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         {
             Content = new MultipartFormDataContentBuilder
             {
-                { "AddReason", AddMqReasonOption.NewInformationReceived.ToString() },
-                { "HasAdditionalReasonDetail", "true" },
+                { "AddReason", AddMqReasonOption.AnotherReason.ToString() },
+                { "ProvideAdditionalInformation", "true" },
+                { "AdditionalInformation", "some additional information" },
                 { "AddReasonDetail", "" },
                 { "Evidence.UploadEvidence", "false" }
             }
@@ -208,7 +216,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "AddReasonDetail", "Enter additional detail");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "AddReasonDetail", "Enter a reason");
     }
 
     [Fact]
@@ -296,8 +304,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "AddReason", AddMqReasonOption.NewInformationReceived.ToString() },
-                { "HasAdditionalReasonDetail", "true" },
-                { "AddReasonDetail", new string('a', 4001) },
+                { "ProvideAdditionalInformation", "true" },
+                { "AddReasonDetail", "true" },
+                { "AdditionalInformation", new string('a', 4001) },
                 { "Evidence.UploadEvidence", "false" }
             }
         };
@@ -306,7 +315,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "AddReasonDetail", "Additional detail must be 4000 characters or less");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "AdditionalInformation", "Additional detail must be 4000 characters or less");
     }
 
     [Fact]
@@ -316,16 +325,18 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId);
 
-        var addReason = AddMqReasonOption.NewInformationReceived;
+        var addReason = AddMqReasonOption.AnotherReason;
         var hasAdditionalReasonDetail = true;
         var addReasonDetail = "More details";
+        var additionalInformation = "Additional information";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/reason?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new MultipartFormDataContentBuilder
             {
                 { "AddReason", addReason.ToString() },
-                { "HasAdditionalReasonDetail", hasAdditionalReasonDetail.ToString() },
+                { "ProvideAdditionalInformation", hasAdditionalReasonDetail.ToString() },
+                { "AdditionalInformation", additionalInformation},
                 { "AddReasonDetail", addReasonDetail },
                 { "Evidence.UploadEvidence", "false" }
             }
@@ -340,9 +351,10 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(addReason, journeyInstance.State.AddReason);
-        Assert.Equal(hasAdditionalReasonDetail, journeyInstance.State.HasAdditionalReasonDetail);
+        Assert.Equal(hasAdditionalReasonDetail, journeyInstance.State.ProvideAdditionalInformation);
         Assert.Equal(addReasonDetail, journeyInstance.State.AddReasonDetail);
         Assert.Null(journeyInstance.State.Evidence.UploadedEvidenceFile);
+        Assert.Equal(additionalInformation, journeyInstance.State.AdditionalInformation);
     }
 
     [Fact]
@@ -360,7 +372,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new MultipartFormDataContentBuilder
             {
                 { "AddReason", addReason.ToString() },
-                { "HasAdditionalReasonDetail", hasAdditionalReasonDetail.ToString() },
+                { "AdditionalInformation", addReason.ToString() },
+                { "ProvideAdditionalInformation", hasAdditionalReasonDetail.ToString() },
                 { "Evidence.UploadEvidence", "true" },
                 { "Evidence.EvidenceFile", (CreateEvidenceFileBinaryContent(), evidenceFileName) }
             }
@@ -375,7 +388,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(addReason, journeyInstance.State.AddReason);
-        Assert.False(journeyInstance.State.HasAdditionalReasonDetail);
+        Assert.False(journeyInstance.State.ProvideAdditionalInformation);
         Assert.Null(journeyInstance.State.AddReasonDetail);
         Assert.NotNull(journeyInstance.State.Evidence.UploadedEvidenceFile);
         Assert.Equal(evidenceFileName, journeyInstance.State.Evidence.UploadedEvidenceFile!.FileName);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
@@ -30,9 +30,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Theory]
-    [InlineData("University of Leeds", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Passed, "2021-11-05", MqDeletionReasonOption.ProviderRequest, "Some details about the deletion reason", true)]
-    [InlineData("University of Leeds", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Deferred, null, MqDeletionReasonOption.ProviderRequest, null, false)]
-    [InlineData(null, null, null, null, null, MqDeletionReasonOption.AnotherReason, null, false)]
+    [InlineData("University of Leeds", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Passed, "2021-11-05", MqDeletionReasonOption.AnotherReason, "Some details about the deletion reason", true, "additional info", true)]
+    [InlineData("University of Leeds", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Deferred, null, MqDeletionReasonOption.ProviderRequest, null, false, "additional info", true)]
+    [InlineData(null, null, null, null, null, MqDeletionReasonOption.AddedInError, null, false, "additional info", true)]
+    [InlineData(null, null, null, null, null, MqDeletionReasonOption.AddedInError, null, false, null, false)]
     public async Task Get_ValidRequest_DisplaysContentAsExpected(
         string? providerName,
         MandatoryQualificationSpecialism? specialism,
@@ -41,7 +42,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         string? endDateString,
         MqDeletionReasonOption deletionReason,
         string? deletionReasonDetail,
-        bool uploadEvidence)
+        bool uploadEvidence,
+        string? additionalInformation,
+        bool provideAdditionalInformation)
     {
         // Arrange
         var provider = providerName is not null ? MandatoryQualificationProvider.All.Single(p => p.Name == providerName) : null;
@@ -52,7 +55,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             .WithProvider(provider?.MandatoryQualificationProviderId)
             .WithSpecialism(specialism)
             .WithStartDate(startDate)
-            .WithStatus(status, endDate)));
+            .WithStatus(status, endDate)
+            .WithAdditionalInformation("additional information")));
         var qualification = person.MandatoryQualifications.Single();
         var journeyInstance = await CreateJourneyInstanceAsync(
             qualification.QualificationId,
@@ -70,7 +74,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                         FileName = "test.pdf",
                         FileSizeDescription = "1MB"
                     } : null
-                }
+                },
+                ProvideAdditionalInformation = provideAdditionalInformation,
+                AdditionalInformation = additionalInformation
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualification.QualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -92,6 +98,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.NotNull(deletionReasonSummary);
         Assert.Equal(deletionReason.GetDisplayName(), deletionReasonSummary.GetElementByTestId("deletion-reason")!.TrimmedText());
         Assert.Equal(!string.IsNullOrEmpty(deletionReasonDetail) ? deletionReasonDetail : "None", deletionReasonSummary.GetElementByTestId("deletion-reason-detail")!.TrimmedText());
+        Assert.Equal(provideAdditionalInformation ? additionalInformation : "None", deletionReasonSummary.GetElementByTestId("additional-information")!.TrimmedText());
         var uploadedEvidenceLink = deletionReasonSummary.GetElementByTestId("uploaded-evidence-file-link");
         if (uploadEvidence)
         {
@@ -138,8 +145,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var status = MandatoryQualificationStatus.Passed;
         var startDate = new DateOnly(2023, 09, 01);
         var endDate = new DateOnly(2023, 11, 05);
-        var deletionReason = MqDeletionReasonOption.ProviderRequest;
+        var deletionReason = MqDeletionReasonOption.AnotherReason;
         var deletionReasonDetail = "Some details about the deletion reason";
+        var additionalInformation = "this is some additional info";
         var evidenceFileId = Guid.NewGuid();
         var evidenceFileName = "test.pdf";
 
@@ -169,7 +177,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                         FileName = evidenceFileName,
                         FileSizeDescription = "1MB"
                     }
-                }
+                },
+                AdditionalInformation = additionalInformation,
+                ProvideAdditionalInformation = true
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -215,7 +225,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 {
                     FileId = evidenceFileId,
                     Name = evidenceFileName
-                }
+                },
+                AdditionalInformation = additionalInformation
             };
 
             var actualMqDeletedEvent = Assert.IsType<MandatoryQualificationDeletedEvent>(e);
@@ -237,12 +248,14 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             new DeleteMqState
             {
                 Initialized = true,
-                DeletionReason = MqDeletionReasonOption.ProviderRequest,
+                DeletionReason = MqDeletionReasonOption.AnotherReason,
                 DeletionReasonDetail = "Some details about the deletion reason",
                 Evidence = new()
                 {
                     UploadEvidence = false
-                }
+                },
+                ProvideAdditionalInformation = false,
+                AdditionalInformation = null
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -271,7 +284,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var startDate = new DateOnly(2023, 09, 01);
         var endDate = new DateOnly(2023, 11, 05);
         var deletionReason = MqDeletionReasonOption.ProviderRequest;
-        var deletionReasonDetail = "Some details about the deletion reason";
         var evidenceFileId = Guid.NewGuid();
         var evidenceFileName = "test.pdf";
 
@@ -295,7 +307,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 Initialized = true,
                 DeletionReason = deletionReason,
-                DeletionReasonDetail = deletionReasonDetail,
+                DeletionReasonDetail = null,
                 Evidence = new()
                 {
                     UploadEvidence = true,
@@ -305,7 +317,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                         FileName = evidenceFileName,
                         FileSizeDescription = "1MB"
                     }
-                }
+                },
+                ProvideAdditionalInformation = false,
+                AdditionalInformation = null
             });
 
         var request = new HttpRequestMessage(httpMethod, $"/mqs/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/IndexTests.cs
@@ -203,7 +203,8 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var multipartContent = CreateFormFileUpload(".png");
         multipartContent.Add(new StringContent(MqDeletionReasonOption.ProviderRequest.ToString()), "DeletionReason");
-        multipartContent.Add(new StringContent("True"), "HasAdditionalReasonDetail");
+        multipartContent.Add(new StringContent("True"), "ProvideAdditionalInformation");
+        multipartContent.Add(new StringContent("This is some additional information"), "AdditionalInformation");
         multipartContent.Add(new StringContent("My deletion reason detail"), "DeletionReasonDetail");
         multipartContent.Add(new StringContent("True"), "Evidence.UploadEvidence");
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
@@ -30,18 +30,20 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Theory]
-    [InlineData(null, false)]
-    [InlineData("Some reason", true)]
+    [InlineData(MqChangeProviderReasonOption.ChangeOfTrainingProvider, null, false, true, "Additional info")]
+    [InlineData(MqChangeProviderReasonOption.AnotherReason, "Some reason", true, false, null)]
     public async Task Get_ValidRequest_DisplaysContentAsExpected(
+        MqChangeProviderReasonOption changeReason,
         string? changeReasonDetail,
-        bool uploadEvidence)
+        bool uploadEvidence,
+        bool provideAdditionalInformation,
+        string? additionalInformation)
     {
         // Arrange
         var oldProvider = MandatoryQualificationProvider.All.Single(p => p.Name == "University of Birmingham");
         var newProvider = MandatoryQualificationProvider.All.Single(p => p.Name == "University of Leeds");
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithProvider(oldProvider.MandatoryQualificationProviderId)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var changeReason = MqChangeProviderReasonOption.ChangeOfTrainingProvider;
         var journeyInstance = await CreateJourneyInstanceAsync(
             qualificationId,
             new EditMqProviderState
@@ -60,7 +62,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                         FileName = "test.pdf",
                         FileSizeDescription = "1MB"
                     } : null
-                }
+                },
+                ProvideAdditionalInformation = provideAdditionalInformation,
+                AdditionalInformation = additionalInformation
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/provider/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -136,13 +140,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Initialized = true,
                 ProviderId = newProvider.MandatoryQualificationProviderId,
                 CurrentProviderId = oldProvider.MandatoryQualificationProviderId,
-                ChangeReason = MqChangeProviderReasonOption.ChangeOfTrainingProvider,
+                ChangeReason = MqChangeProviderReasonOption.AnotherReason,
                 ChangeReasonDetail = "Some reason",
                 Evidence = new()
                 {
                     UploadEvidence = false
 
-                }
+                },
+                ProvideAdditionalInformation = true,
+                AdditionalInformation = "some Additional reason"
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -206,10 +212,11 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                     StartDate = qualification.StartDate,
                     EndDate = qualification.EndDate
                 },
-                ChangeReason = MqChangeProviderReasonOption.ChangeOfTrainingProvider.GetDisplayName(),
+                ChangeReason = MqChangeProviderReasonOption.AnotherReason.GetDisplayName(),
                 ChangeReasonDetail = "Some reason",
                 EvidenceFile = null,
-                Changes = MandatoryQualificationUpdatedEventChanges.Provider
+                Changes = MandatoryQualificationUpdatedEventChanges.Provider,
+                AdditionalInformation = "some Additional reason"
             };
 
             var actualMqUpdatedEvent = Assert.IsType<MandatoryQualificationUpdatedEvent>(e);
@@ -233,11 +240,13 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 ProviderId = newProvider.MandatoryQualificationProviderId,
                 CurrentProviderId = oldProvider.MandatoryQualificationProviderId,
                 ChangeReason = MqChangeProviderReasonOption.ChangeOfTrainingProvider,
-                ChangeReasonDetail = "Some reason",
+                ChangeReasonDetail = null,
                 Evidence = new()
                 {
                     UploadEvidence = false
-                }
+                },
+                ProvideAdditionalInformation = false,
+                AdditionalInformation = null,
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ReasonTests.cs
@@ -231,7 +231,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var multipartContent = CreateFormFileUpload(".png");
         multipartContent.Add(new StringContent(MqChangeProviderReasonOption.ChangeOfTrainingProvider.ToString()), "ChangeReason");
-        multipartContent.Add(new StringContent("True"), "HasAdditionalReasonDetail");
+        multipartContent.Add(new StringContent("True"), "ProvideAdditionalInformation");
+        multipartContent.Add(new StringContent("AdditionalInformation"), "AdditionalInformation");
         multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
         multipartContent.Add(new StringContent("True"), "Evidence.UploadEvidence");
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
@@ -30,9 +30,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Theory]
-    [InlineData(null, false)]
-    [InlineData("Some reason", true)]
+    [InlineData(MqChangeSpecialismReasonOption.ChangeOfSpecialism, null, false)]
+    [InlineData(MqChangeSpecialismReasonOption.AnotherReason, "Some reason", true)]
     public async Task Get_ValidRequest_DisplaysContentAsExpected(
+        MqChangeSpecialismReasonOption changeReason,
         string? changeReasonDetail,
         bool uploadEvidence)
     {
@@ -41,7 +42,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var newMqSpecialism = MandatoryQualificationSpecialism.Visual;
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithSpecialism(oldMqSpecialism)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var changeReason = MqChangeSpecialismReasonOption.ChangeOfSpecialism;
         var journeyInstance = await CreateJourneyInstanceAsync(
             qualificationId,
             new EditMqSpecialismState
@@ -51,6 +51,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 CurrentSpecialism = oldMqSpecialism,
                 ChangeReason = changeReason,
                 ChangeReasonDetail = changeReasonDetail,
+                ProvideAdditionalInformation = false,
                 Evidence = new()
                 {
                     UploadEvidence = uploadEvidence,
@@ -126,7 +127,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualification = person.MandatoryQualifications.First();
         var qualificationId = qualification.QualificationId;
         var provider = MandatoryQualificationProvider.GetById(qualification.ProviderId!.Value);
-        var changeReason = MqChangeSpecialismReasonOption.ChangeOfSpecialism;
+        var changeReason = MqChangeSpecialismReasonOption.AnotherReason;
         var changeReasonDetail = "Some reason";
 
         EventObserver.Clear();
@@ -140,6 +141,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 CurrentSpecialism = oldMqSpecialism,
                 ChangeReason = changeReason,
                 ChangeReasonDetail = changeReasonDetail,
+                ProvideAdditionalInformation = false,
+                AdditionalInformation = null,
                 Evidence = new()
                 {
                     UploadEvidence = false
@@ -210,7 +213,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 ChangeReason = changeReason.GetDisplayName(),
                 ChangeReasonDetail = changeReasonDetail,
                 EvidenceFile = null,
-                Changes = MandatoryQualificationUpdatedEventChanges.Specialism
+                Changes = MandatoryQualificationUpdatedEventChanges.Specialism,
+                AdditionalInformation = null
             };
 
             var actualMqUpdatedEvent = Assert.IsType<MandatoryQualificationUpdatedEvent>(e);
@@ -233,7 +237,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Initialized = true,
                 Specialism = newMqSpecialism,
                 ChangeReason = MqChangeSpecialismReasonOption.ChangeOfSpecialism,
-                ChangeReasonDetail = "Some reason",
+                ChangeReasonDetail = null,
+                ProvideAdditionalInformation = false,
                 Evidence = new()
                 {
                     UploadEvidence = false

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ReasonTests.cs
@@ -229,7 +229,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var multipartContent = CreateFormFileUpload(".png");
         multipartContent.Add(new StringContent(MqChangeSpecialismReasonOption.ChangeOfSpecialism.ToString()), "ChangeReason");
-        multipartContent.Add(new StringContent("True"), "HasAdditionalReasonDetail");
+        multipartContent.Add(new StringContent("True"), "ProvideAdditionalInformation");
+        multipartContent.Add(new StringContent("More reasons"), "AdditionalInformation");
         multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
         multipartContent.Add(new StringContent("True"), "Evidence.UploadEvidence");
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
@@ -30,18 +30,20 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Theory]
-    [InlineData(null, false)]
-    [InlineData("Some reason", true)]
+    [InlineData(MqChangeStartDateReasonOption.IncorrectStartDate, null, false, true, "additional information")]
+    [InlineData(MqChangeStartDateReasonOption.AnotherReason, "Some reason", true, false, null)]
     public async Task Get_ValidRequest_DisplaysContentAsExpected(
+        MqChangeStartDateReasonOption changeReason,
         string? changeReasonDetail,
-        bool uploadEvidence)
+        bool uploadEvidence,
+        bool provideAdditionalInformation,
+        string? additionalInformation)
     {
         // Arrange
         var oldStartDate = new DateOnly(2021, 10, 5);
         var newStartDate = new DateOnly(2021, 10, 6);
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithStartDate(oldStartDate)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var changeReason = MqChangeStartDateReasonOption.IncorrectStartDate;
         var journeyInstance = await CreateJourneyInstanceAsync(
             qualificationId,
             new EditMqStartDateState
@@ -60,7 +62,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                         FileName = "test.pdf",
                         FileSizeDescription = "1MB"
                     } : null
-                }
+                },
+                ProvideAdditionalInformation = provideAdditionalInformation,
+                AdditionalInformation = additionalInformation
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -78,6 +82,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.NotNull(changeReasonSummary);
         Assert.Equal(changeReason.GetDisplayName(), changeReasonSummary.GetElementByTestId("change-reason")!.TrimmedText());
         Assert.Equal(!string.IsNullOrEmpty(changeReasonDetail) ? changeReasonDetail : "None", changeReasonSummary.GetElementByTestId("change-reason-detail")!.TrimmedText());
+        Assert.Equal(provideAdditionalInformation == true ? additionalInformation : "None", changeReasonSummary.GetElementByTestId("additional-information")!.TrimmedText());
         var uploadedEvidenceLink = changeReasonSummary.GetElementByTestId("uploaded-evidence-file-link");
         if (uploadEvidence)
         {
@@ -126,7 +131,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualification = person.MandatoryQualifications.First();
         var qualificationId = qualification.QualificationId;
         var provider = MandatoryQualificationProvider.GetById(qualification.ProviderId!.Value);
-        var changeReason = MqChangeStartDateReasonOption.IncorrectStartDate;
+        var changeReason = MqChangeStartDateReasonOption.AnotherReason;
         var changeReasonDetail = "Some reason";
 
         EventObserver.Clear();
@@ -143,7 +148,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Evidence = new()
                 {
                     UploadEvidence = false
-                }
+                },
+                ProvideAdditionalInformation = false,
+                AdditionalInformation = null
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -210,7 +217,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 ChangeReason = changeReason.GetDisplayName(),
                 ChangeReasonDetail = changeReasonDetail,
                 EvidenceFile = null,
-                Changes = MandatoryQualificationUpdatedEventChanges.StartDate
+                Changes = MandatoryQualificationUpdatedEventChanges.StartDate,
+                AdditionalInformation = null
             };
 
             var actualMqUpdatedEvent = Assert.IsType<MandatoryQualificationUpdatedEvent>(e);
@@ -234,11 +242,13 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate,
                 ChangeReason = MqChangeStartDateReasonOption.IncorrectStartDate,
-                ChangeReasonDetail = "Some reason",
+                ChangeReasonDetail = null,
                 Evidence = new()
                 {
                     UploadEvidence = false
-                }
+                },
+                ProvideAdditionalInformation = false,
+                AdditionalInformation = null
             });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ReasonTests.cs
@@ -235,7 +235,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var multipartContent = CreateFormFileUpload(".png");
         multipartContent.Add(new StringContent(MqChangeStartDateReasonOption.ChangeOfStartDate.ToString()), "ChangeReason");
-        multipartContent.Add(new StringContent("True"), "HasAdditionalReasonDetail");
+        multipartContent.Add(new StringContent("True"), "ProvideAdditionalInformation");
+        multipartContent.Add(new StringContent("More details for edit"), "AdditionalInformation");
         multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
         multipartContent.Add(new StringContent("True"), "Evidence.UploadEvidence");
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/CheckAnswersTests.cs
@@ -338,7 +338,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                         Name = evidenceFileName
                     } :
                     null,
-                Changes = changes
+                Changes = changes,
+                AdditionalInformation = null
             };
 
             var actualMqUpdatedEvent = Assert.IsType<MandatoryQualificationUpdatedEvent>(e);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/ReasonTests.cs
@@ -326,7 +326,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var multipartContent = CreateFormFileUpload(".png");
         multipartContent.Add(new StringContent(changeReason), changeReasonKey);
-        multipartContent.Add(new StringContent("True"), "HasAdditionalReasonDetail");
+        multipartContent.Add(new StringContent("True"), "ProvideAdditionalInformation");
+        multipartContent.Add(new StringContent("Some more details"), "AdditionalInformation");
         multipartContent.Add(new StringContent("My change reason detail"), "ChangeReasonDetail");
         multipartContent.Add(new StringContent("True"), "Evidence.UploadEvidence");
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMandatoryQualificationEventsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMandatoryQualificationEventsTests.cs
@@ -21,17 +21,18 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task Person_WithMandatoryQualificationCreatedEvent_RendersExpectedContent(bool populateOptional)
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public async Task Person_WithMandatoryQualificationCreatedEvent_RendersExpectedContent(bool populateReasonDetail, bool provideAdditionalInformation)
     {
         // Arrange
         var createdByUser = await TestData.CreateUserAsync();
-        var status = populateOptional ? MandatoryQualificationStatus.Passed : MandatoryQualificationStatus.InProgress;
-        AddMqReasonOption? addReason = populateOptional ? AddMqReasonOption.NewInformationReceived : null;
-        var addReasonDetail = populateOptional ? "More information" : null;
-        (Guid FileId, string Name)? evidenceFile = populateOptional ? (FileId: Guid.NewGuid(), Name: "evidence.jpeg") : null;
-        var (personId, mq) = await CreateFullyPopulatedMq(createdByUser.UserId, status, addReason, addReasonDetail, evidenceFile);
+        var status = populateReasonDetail ? MandatoryQualificationStatus.Passed : MandatoryQualificationStatus.InProgress;
+        AddMqReasonOption? addReason = populateReasonDetail ? AddMqReasonOption.AnotherReason : null;
+        var addReasonDetail = populateReasonDetail ? "More information" : null;
+        var additionalInformation = provideAdditionalInformation ? "Some additional information" : null;
+        (Guid FileId, string Name)? evidenceFile = populateReasonDetail ? (FileId: Guid.NewGuid(), Name: "evidence.jpeg") : null;
+        var (personId, mq) = await CreateFullyPopulatedMq(createdByUser.UserId, status, addReason, addReasonDetail, evidenceFile, additionalInformation);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{personId}/change-history");
 
@@ -51,7 +52,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 Assert.Equal(mq.Specialism!.Value.GetTitle(), item.GetElementByTestId("specialism")?.TrimmedText());
                 Assert.Equal(mq.StartDate!.Value.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("start-date")?.TrimmedText());
                 Assert.Equal(mq.Status!.Value.GetTitle(), item.GetElementByTestId("status")?.TrimmedText());
-                if (populateOptional)
+                if (populateReasonDetail)
                 {
                     Assert.Equal(mq.EndDate!.Value.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("end-date")?.TrimmedText());
                     Assert.Equal(addReason?.GetDisplayName(), item.GetElementByTestId("reason")?.TrimmedText());
@@ -64,6 +65,15 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                     Assert.Equal(WebConstants.EmptyFallbackContent, item.GetElementByTestId("reason")?.TrimmedText());
                     Assert.Equal(WebConstants.EmptyFallbackContent, item.GetElementByTestId("reason-detail")?.TrimmedText());
                     Assert.Equal(WebConstants.EmptyFallbackContent, item.GetElementByTestId("evidence")?.TrimmedText());
+                }
+
+                if (provideAdditionalInformation)
+                {
+                    Assert.Equal(additionalInformation, item.GetElementByTestId("additional-information")?.TrimmedText());
+                }
+                else
+                {
+                    Assert.Equal(WebConstants.EmptyFallbackContent, item.GetElementByTestId("additional-information")?.TrimmedText());
                 }
             });
     }
@@ -154,6 +164,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 Assert.Equal("None", item.GetElementByTestId("start-date")?.TrimmedText());
                 Assert.Equal("None", item.GetElementByTestId("status")?.TrimmedText());
                 Assert.Equal("None", item.GetElementByTestId("end-date")?.TrimmedText());
+                Assert.Equal("None", item.GetElementByTestId("additional-information")?.TrimmedText());
             });
     }
 
@@ -913,13 +924,15 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
         MandatoryQualificationStatus? status = null,
         AddMqReasonOption? reason = null,
         string? reasonDetail = null,
-        (Guid FileId, string Name)? evidenceFile = null)
+        (Guid FileId, string Name)? evidenceFile = null,
+        string? additionalInformation = null)
     {
         var person = await TestData.CreatePersonAsync(b => b
             .WithMandatoryQualification(q =>
             {
                 q.WithStatus(status ?? MandatoryQualificationStatus.Passed);
                 q.WithAddReason(reason?.GetDisplayName(), reasonDetail, evidenceFile);
+                q.WithAdditionalInformation(additionalInformation);
 
                 if (createdByUser is not null)
                 {
@@ -1124,6 +1137,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
                 OldMandatoryQualification = oldMq,
                 ChangeReason = changeReason,
                 ChangeReasonDetail = changeReasonDetail,
+                AdditionalInformation = null,
                 EvidenceFile = evidenceFile is not null ?
                     new EventModels.File
                     {

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreatePerson.cs
@@ -710,6 +710,7 @@ public partial class TestData
         private Option<DateOnly?> _startDate;
         private Option<DateOnly?> _endDate;
         private Option<string?> _reason;
+        private Option<string?> _additionalInformation;
         private Option<string?> _reasonDetail;
         private Option<(Guid FileId, string Name)?> _evidenceFile;
         private Option<DateTime?> _createdUtc;
@@ -782,6 +783,12 @@ public partial class TestData
             return this;
         }
 
+        public CreatePersonMandatoryQualificationBuilder WithAdditionalInformation(string? additionalInformation)
+        {
+            _additionalInformation = Option.Some(additionalInformation);
+            return this;
+        }
+
         public CreatePersonMandatoryQualificationBuilder WithCreatedUtc(DateTime? createdUtc)
         {
             _createdUtc = Option.Some(createdUtc);
@@ -831,6 +838,7 @@ public partial class TestData
             var reasonDetail = _reasonDetail.ValueOrDefault();
             var evidenceFile = _evidenceFile.ValueOrDefault();
             var createdUtc = _createdUtc.ValueOr(testData.TimeProvider.UtcNow);
+            var additionalInformation = _additionalInformation.ValueOrDefault();
 
             var provider = providerId.HasValue ?
                 await dbContext.MandatoryQualificationProviders.SingleAsync(p => p.MandatoryQualificationProviderId == providerId) :
@@ -918,6 +926,7 @@ public partial class TestData
                             Name = evidenceFile.Value.Name
                         } :
                         null,
+                    AdditionalInformation = additionalInformation
                 };
 
                 dbContext.AddEventWithoutBroadcast(createdEvent);

--- a/tests/TeachingRecordSystem.TestCommon/TestData.DeleteMandatoryQualification.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.DeleteMandatoryQualification.cs
@@ -59,7 +59,8 @@ public partial class TestData
                         FileId = FileId,
                         Name = Name
                     } :
-                    null
+                    null,
+                AdditionalInformation = null
             };
             dbContext.AddEventWithoutBroadcast(deletedEvent);
 


### PR DESCRIPTION
### Context

MQ's Content design updates: 'another reason'

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/192

### Changes proposed in this pull request

'another reason' is being standardised across pages in TRS. This PR updatesQ pages to show a reason textbox when selecting another reason.

- Update MQ pages
- Update Integration tests
- Update Unit Tests

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally