### PR TITLE
Use IncrementalAppendDeduped Airbyte sync mode

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,8 +18,8 @@
     <PackageVersion Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="dbup-sqlserver" Version="5.0.37" />
-    <PackageVersion Include="DfeAnalytics.AspNetCore" Version="0.4.3-alpha.0.3" />
-    <PackageVersion Include="DfeAnalytics.EFCore" Version="0.4.3-alpha.0.3" />
+    <PackageVersion Include="DfeAnalytics.AspNetCore" Version="0.5.1" />
+    <PackageVersion Include="DfeAnalytics.EFCore" Version="0.5.1" />
     <PackageVersion Include="EFCore.BulkExtensions.PostgreSql" Version="10.0.1" />
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.0" />
     <PackageVersion Include="EntityFrameworkCore.Projectables" Version="6.0.4" />

--- a/nuget.config
+++ b/nuget.config
@@ -8,7 +8,6 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="lib">
-      <package pattern="DfeAnalytics*" />
       <package pattern="GovUk.Questions.AspNetCore*" />
     </packageSource>
   </packageSourceMapping>

--- a/src/TeachingRecordSystem.Api/packages.lock.json
+++ b/src/TeachingRecordSystem.Api/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -700,7 +700,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -852,11 +852,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
+++ b/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "DfeAnalytics.AspNetCore": {
         "type": "Direct",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "u1umW2w5yId8rQMFD4tew44UmMEbGZtefGzjCdT/cMJSIjliVMxiWwhdLRIaxtgt2KJklMBx01OoEMsy8pwYtg==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "GKtS7ebDfODG3jdvG0PJKLiySGR0ce4t9flX4RXjpNud6eoOpt7I73pH0+9wwzPHFOseC3KdKGrKelQjYK1chA==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3"
+          "DfeAnalytics.Core": "0.5.1"
         }
       },
       "GovUk.Frontend.AspNetCore": {
@@ -167,8 +167,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -938,7 +938,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1084,11 +1084,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/src/TeachingRecordSystem.Cli/packages.lock.json
+++ b/src/TeachingRecordSystem.Cli/packages.lock.json
@@ -70,8 +70,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -778,7 +778,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -882,11 +882,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/TrsDbContext.cs
@@ -1,4 +1,6 @@
 using System.Data.Common;
+using Dfe.Analytics.EFCore;
+using Dfe.Analytics.EFCore.Description;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Npgsql;
@@ -186,6 +188,8 @@ public partial class TrsDbContext(DbContextOptions<TrsDbContext> options) : DbCo
                 });
             }
         }
+
+        modelBuilder.ConfigureAnalyticsSync(AirbyteSyncMode.IncrementalAppendDeduped);
     }
 
     private static DbContextOptions<TrsDbContext> CreateOptions(string? connectionString, int? commandTimeout)

--- a/src/TeachingRecordSystem.Core/packages.lock.json
+++ b/src/TeachingRecordSystem.Core/packages.lock.json
@@ -63,11 +63,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "Direct",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",
@@ -543,8 +543,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",

--- a/src/TeachingRecordSystem.SupportUi/packages.lock.json
+++ b/src/TeachingRecordSystem.SupportUi/packages.lock.json
@@ -166,8 +166,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -869,7 +869,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1015,11 +1015,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/src/TeachingRecordSystem.WebCommon/packages.lock.json
+++ b/src/TeachingRecordSystem.WebCommon/packages.lock.json
@@ -203,8 +203,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -720,7 +720,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -816,11 +816,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/src/TeachingRecordSystem.Worker/packages.lock.json
+++ b/src/TeachingRecordSystem.Worker/packages.lock.json
@@ -100,8 +100,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -822,7 +822,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -926,11 +926,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -892,7 +892,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1048,11 +1048,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.Api.UnitTests/packages.lock.json
@@ -118,8 +118,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -1223,7 +1223,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1403,11 +1403,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
@@ -105,8 +105,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -1065,7 +1065,7 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.SassCompiler": "[1.99.0, )",
-          "DfeAnalytics.AspNetCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.AspNetCore": "[0.5.1, )",
           "GovUk.Frontend.AspNetCore": "[4.1.1, )",
           "GovUk.OneLogin.AspNetCore": "[0.4.3, )",
           "GovUk.Questions.AspNetCore": "[0.1.0-alpha.0.94, )",
@@ -1090,7 +1090,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1270,20 +1270,20 @@
       },
       "DfeAnalytics.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "u1umW2w5yId8rQMFD4tew44UmMEbGZtefGzjCdT/cMJSIjliVMxiWwhdLRIaxtgt2KJklMBx01OoEMsy8pwYtg==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "GKtS7ebDfODG3jdvG0PJKLiySGR0ce4t9flX4RXjpNud6eoOpt7I73pH0+9wwzPHFOseC3KdKGrKelQjYK1chA==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3"
+          "DfeAnalytics.Core": "0.5.1"
         }
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/tests/TeachingRecordSystem.Cli.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.Cli.Tests/packages.lock.json
@@ -88,8 +88,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -991,7 +991,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1126,11 +1126,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/tests/TeachingRecordSystem.Core.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.Core.Tests/packages.lock.json
@@ -120,8 +120,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -1028,7 +1028,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1155,11 +1155,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
@@ -135,8 +135,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -1722,7 +1722,7 @@
         "type": "Project",
         "dependencies": {
           "AspNetCore.SassCompiler": "[1.99.0, )",
-          "DfeAnalytics.AspNetCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.AspNetCore": "[0.5.1, )",
           "GovUk.Frontend.AspNetCore": "[4.1.1, )",
           "GovUk.OneLogin.AspNetCore": "[0.4.3, )",
           "GovUk.Questions.AspNetCore": "[0.1.0-alpha.0.94, )",
@@ -1747,7 +1747,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1957,20 +1957,20 @@
       },
       "DfeAnalytics.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "u1umW2w5yId8rQMFD4tew44UmMEbGZtefGzjCdT/cMJSIjliVMxiWwhdLRIaxtgt2KJklMBx01OoEMsy8pwYtg==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "GKtS7ebDfODG3jdvG0PJKLiySGR0ce4t9flX4RXjpNud6eoOpt7I73pH0+9wwzPHFOseC3KdKGrKelQjYK1chA==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3"
+          "DfeAnalytics.Core": "0.5.1"
         }
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
@@ -122,8 +122,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -1024,7 +1024,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1214,11 +1214,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -1018,7 +1018,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1216,11 +1216,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"

--- a/tests/TeachingRecordSystem.TestCommon/packages.lock.json
+++ b/tests/TeachingRecordSystem.TestCommon/packages.lock.json
@@ -123,8 +123,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -926,7 +926,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1039,11 +1039,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
+++ b/tests/TeachingRecordSystem.UiTestCommon/packages.lock.json
@@ -69,8 +69,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)",
@@ -992,7 +992,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -1172,11 +1172,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "Microsoft.Extensions.Http": "8.0.0",

--- a/tests/TeachingRecordSystem.WebCommon.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.WebCommon.Tests/packages.lock.json
@@ -105,8 +105,8 @@
       },
       "DfeAnalytics.Core": {
         "type": "Transitive",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "+CFRCwVIUzXgu796NLyyLgdoggbJxYZ8TYfm+rBNqUcOFy26ofRVk7t7sJ97+mQSZCfZecKS5iS1GgugvreCEg==",
+        "resolved": "0.5.1",
+        "contentHash": "x4Sh//vMpyzSUGxEhQqMghZpo6sKbdVZKAoAG9rPQQkGKkvXaPazxMT2s/ZEQrhw3VCX40LDm3sqfE08JJbNsQ==",
         "dependencies": {
           "Google.Apis.Auth": "1.71.0",
           "Google.Cloud.BigQuery.V2": "[3.0.0, 4.0.0)"
@@ -816,7 +816,7 @@
           "CloudNative.CloudEvents": "[2.8.0, )",
           "CloudNative.CloudEvents.SystemTextJson": "[2.8.0, )",
           "CsvHelper": "[33.1.0, )",
-          "DfeAnalytics.EFCore": "[0.4.3-alpha.0.3, )",
+          "DfeAnalytics.EFCore": "[0.5.1, )",
           "EFCore.BulkExtensions.PostgreSql": "[10.0.1, )",
           "EFCore.NamingConventions": "[10.0.0, )",
           "EntityFrameworkCore.Projectables": "[6.0.4, )",
@@ -982,11 +982,11 @@
       },
       "DfeAnalytics.EFCore": {
         "type": "CentralTransitive",
-        "requested": "[0.4.3-alpha.0.3, )",
-        "resolved": "0.4.3-alpha.0.3",
-        "contentHash": "BHGUdAbvgx6ffEbe+Ov4SWEy8nJ/WPXqgSjZIGXebERh0FMZzaAQi/b1pSe4cEA+igkr7OraYtD2B12dqpCX1g==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "NWXWb4Wi5+huVLsei1uoI4v5ZbQ/lcGi4GvhJkcfQIWg5seb8HGGgJ/z+lV45wL1V3X0oDH25D1pdO0wlygoaQ==",
         "dependencies": {
-          "DfeAnalytics.Core": "0.4.3-alpha.0.3",
+          "DfeAnalytics.Core": "0.5.1",
           "Microsoft.EntityFrameworkCore": "10.0.0",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "10.0.0",
           "System.CommandLine": "2.0.0"


### PR DESCRIPTION
This prevents us getting duplicate rows in BQ when a full sync is done (e.g. after recovering from monthly maintenance when the replication slot is dropped).