### PR TITLE
2683 - Validate infra docker image string update

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -41,3 +41,5 @@ jobs:
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
           gcp-wip: ${{ vars.GCP_WIP }}
           gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
+          docker-repo: true
+          service-name: teaching-record-system

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ terraform-init: vendor-modules
 	$(eval export TF_VAR_config=${CONFIG})
 	$(eval export TF_VAR_environment_short_name=$(CONFIG_SHORT))
 	$(eval export TF_VAR_azure_resource_prefix=$(AZURE_RESOURCE_PREFIX))
-	$(eval export TF_VAR_docker_image?=dummy-string)
 
 	[[ "${SP_AUTH}" != "true" ]] && az account set -s $(AZURE_SUBSCRIPTION) || true
 


### PR DESCRIPTION
## Context

Update the validate infra workflow so that docker image strings can be defined differently in different services.

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

## Changes proposed in this pull request

Add docker-repo and service-name values so that the correct docker string is constructed.

## Guidance to review

Run the "Validate Infra" workflow as it already exists for the service. You can point it at the branch but that will always produce a false positive as the docker image will be different for main and the branch but you should see that the structure is correct and it's just the sha that's different. This will produce a workflow Teams message in SD Infra Alerts Teams channel.

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/b2f7861d-33c5-4382-ab95-1b73e580fc86" />

There are 3 jobs in the workflow, AKS infrastructure, Domains infrastructure and Domains environment. The workflow card will show which job to look at in the bottom left corner (Infrastructure in the image above). You can click the Workflow Run button to go to the correct run.
The jobs must show a green tick not a red cross.
You can alter any value in the terraform production.tfvars.json in your branch to check that the terraform plan picks up those changes, remembering that the docker image is a false positive. 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
