### PR TITLE
Move AppContent out of state

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -18,11 +18,12 @@ public class OneLoginService(
     IBackgroundJobScheduler backgroundJobScheduler,
     TimeProvider timeProvider)
 {
-    // ID's database has a user_id column to indicate that a TRN token has been used already.
-    // This sentinel value indicates the token has been used by us, rather than a teacher ID user.
-    private static readonly Guid _teacherAuthIdUserIdSentinel = Guid.Empty;
-
-    public async Task EnqueueNotVerifiedEmailAsync(string emailAddress, string personName, string reason, ProcessContext processContext, string? templateId = null)
+    public async Task EnqueueNotVerifiedEmailAsync(
+        string emailAddress,
+        string personName,
+        string reason,
+        string? templateId,
+        ProcessContext processContext)
     {
         var email = new Email
         {
@@ -38,7 +39,11 @@ public class OneLoginService(
         await backgroundJobScheduler.EnqueueAsync<SendEmailJob>(j => j.ExecuteAsync(email.EmailId, processContext.ProcessId));
     }
 
-    public async Task EnqueueRecordNotFoundEmailAsync(string emailAddress, string personName, ProcessContext processContext, string? templateId = null, string? emailReplyToId = null)
+    public async Task EnqueueRecordNotFoundEmailAsync(string emailAddress,
+        string personName,
+        string? templateId,
+        string? emailReplyToId,
+        ProcessContext processContext)
     {
         var email = new Email
         {
@@ -55,7 +60,11 @@ public class OneLoginService(
         await backgroundJobScheduler.EnqueueAsync<SendEmailJob>(j => j.ExecuteAsync(email.EmailId, processContext.ProcessId));
     }
 
-    public async Task EnqueueRecordMatchedEmailAsync(string emailAddress, string personName, ProcessContext processContext, string? templateId = null, string? emailReplyToId = null)
+    public async Task EnqueueRecordMatchedEmailAsync(string emailAddress,
+        string personName,
+        string? templateId,
+        string? emailReplyToId,
+        ProcessContext processContext)
     {
         var personalization = new Dictionary<string, string>
         {
@@ -77,7 +86,11 @@ public class OneLoginService(
         await backgroundJobScheduler.EnqueueAsync<SendEmailJob>(j => j.ExecuteAsync(email.EmailId, processContext.ProcessId));
     }
 
-    public async Task EnqueueNotConnectedEmailAsync(string emailAddress, string personName, string reason, ProcessContext processContext, string? templateId = null)
+    public async Task EnqueueNotConnectedEmailAsync(string emailAddress,
+        string personName,
+        string reason,
+        string? templateId,
+        ProcessContext processContext)
     {
         var email = new Email
         {
@@ -130,7 +143,6 @@ public class OneLoginService(
 
     public async Task SetUserUnmatchedAsync(string oneLoginSubject, ProcessContext processContext)
     {
-
         var user = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginSubject);
         await using var eventScope = eventPublisher.GetOrCreateEventScope(processContext);
 
@@ -138,7 +150,6 @@ public class OneLoginService(
         user.SetUnmatched();
         var oneLoginUserEventModel = EventModels.OneLoginUser.FromModel(user);
         await dbContext.SaveChangesAsync();
-
 
         var updatedEvent = new OneLoginUserUpdatedEvent
         {

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/ConnectedOutcomeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/ConnectedOutcomeOptions.cs
@@ -8,6 +8,4 @@ public record ConnectedOutcomeOptions
     public required Guid MatchedPersonId { get; init; }
     public required string Trn { get; init; }
     public required IEnumerable<KeyValuePair<PersonMatchedAttribute, string>> MatchedAttributes { get; init; }
-    public required string? EmailTemplateId { get; init; }
-    public required string? EmailReplyToId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/NoMatchesOutcomeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/NoMatchesOutcomeOptions.cs
@@ -5,6 +5,4 @@ namespace TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 public record NoMatchesOutcomeOptions
 {
     public required SupportTask SupportTask { get; init; }
-    public required string? EmailTemplateId { get; init; }
-    public required string? EmailReplyToId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/NotConnectingOutcomeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/NotConnectingOutcomeOptions.cs
@@ -8,6 +8,4 @@ public record NotConnectingOutcomeOptions
     public required SupportTask SupportTask { get; init; }
     public required OneLoginUserNotConnectingReason NotConnectingReason { get; init; }
     public required string? NotConnectingAdditionalDetails { get; init; }
-    public required RecordMatchingPolicy RecordMatchingPolicy { get; init; }
-    public required string? EmailTemplateId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/NotVerifiedOutcomeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/NotVerifiedOutcomeOptions.cs
@@ -8,5 +8,4 @@ public record NotVerifiedOutcomeOptions
     public required SupportTask SupportTask { get; init; }
     public required OneLoginIdVerificationRejectReason RejectReason { get; init; }
     public required string? RejectionAdditionalDetails { get; init; }
-    public required string? EmailTemplateId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.IdVerification.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.IdVerification.cs
@@ -43,6 +43,8 @@ public partial class OneLoginUserMatchingSupportTaskService
 
         var data = supportTask.GetData<OneLoginUserIdVerificationData>();
 
+        var appContent = await GetAppContentAsync(data.ClientApplicationUserId);
+
         await supportTaskService.UpdateSupportTaskAsync(
             new UpdateSupportTaskOptions<OneLoginUserIdVerificationData>
             {
@@ -62,7 +64,13 @@ public partial class OneLoginUserMatchingSupportTaskService
         var reason = options.RejectReason is OneLoginIdVerificationRejectReason.AnotherReason
             ? options.RejectionAdditionalDetails!
             : options.RejectReason.GetDisplayName()!;
-        await oneLoginService.EnqueueNotVerifiedEmailAsync(supportTask.OneLoginUser!.EmailAddress!, name, reason, processContext, options.EmailTemplateId);
+
+        await oneLoginService.EnqueueNotVerifiedEmailAsync(
+            supportTask.OneLoginUser!.EmailAddress!,
+            name,
+            reason,
+            appContent?.OneLoginNotVerifiedEmailTemplateId,
+            processContext);
     }
 
     public async Task ResolveVerificationSupportTaskAsync(VerifiedOnlyWithMatchesOutcomeOptions options, ProcessContext processContext)
@@ -71,6 +79,10 @@ public partial class OneLoginUserMatchingSupportTaskService
         ThrowIfSupportTaskIsClosed(supportTask);
 
         var data = supportTask.GetData<OneLoginUserIdVerificationData>();
+
+        var applicationUser = await GetApplicationUserAsync(supportTask);
+        var recordMatchingPolicy = applicationUser.RecordMatchingPolicy;
+        var appContent = applicationUser.AppContent;
 
         await oneLoginService.SetUserVerifiedAsync(
             new SetUserVerifiedOptions
@@ -83,13 +95,19 @@ public partial class OneLoginUserMatchingSupportTaskService
             },
             processContext);
 
-        if (options.RecordMatchingPolicy == RecordMatchingPolicy.Deferred && options.EmailTemplateId is not null)
+        if (recordMatchingPolicy == RecordMatchingPolicy.Deferred && appContent?.OneLoginNotConnectedEmailTemplateId is { } templateId)
         {
             var name = $"{data.StatedFirstName} {data.StatedLastName}";
             var reason = options.NotConnectingReason is OneLoginUserNotConnectingReason.AnotherReason
                 ? options.NotConnectingAdditionalDetails!
                 : options.NotConnectingReason.GetDisplayName()!;
-            await oneLoginService.EnqueueNotConnectedEmailAsync(supportTask.OneLoginUser!.EmailAddress!, name, reason, processContext, options.EmailTemplateId);
+
+            await oneLoginService.EnqueueNotConnectedEmailAsync(
+                supportTask.OneLoginUser!.EmailAddress!,
+                name,
+                reason,
+                templateId,
+                processContext);
         }
 
         await supportTaskService.UpdateSupportTaskAsync(
@@ -114,6 +132,8 @@ public partial class OneLoginUserMatchingSupportTaskService
         ThrowIfSupportTaskIsClosed(supportTask);
 
         var data = supportTask.GetData<OneLoginUserIdVerificationData>();
+
+        var appContent = await GetAppContentAsync(data.ClientApplicationUserId);
 
         await oneLoginService.SetUserVerifiedAsync(
             new SetUserVerifiedOptions
@@ -140,7 +160,13 @@ public partial class OneLoginUserMatchingSupportTaskService
             processContext);
 
         var name = $"{data.StatedFirstName} {data.StatedLastName}";
-        await oneLoginService.EnqueueRecordNotFoundEmailAsync(supportTask.OneLoginUser!.EmailAddress!, name, processContext, options.EmailTemplateId, options.EmailReplyToId);
+
+        await oneLoginService.EnqueueRecordNotFoundEmailAsync(
+            supportTask.OneLoginUser!.EmailAddress!,
+            name,
+            appContent?.OneLoginCannotFindRecordEmailTemplateId,
+            appContent?.SupportEmailAddressNotifyId,
+            processContext);
     }
 
     public async Task ResolveVerificationSupportTaskAsync(VerifiedAndConnectedOutcomeOptions options, ProcessContext processContext)
@@ -149,6 +175,8 @@ public partial class OneLoginUserMatchingSupportTaskService
         ThrowIfSupportTaskIsClosed(supportTask);
 
         var data = supportTask.GetData<OneLoginUserIdVerificationData>();
+
+        var appContent = await GetAppContentAsync(data.ClientApplicationUserId);
 
         await oneLoginService.SetUserVerifiedAndMatchedAsync(
             new SetUserVerifiedAndMatchedOptions
@@ -165,7 +193,11 @@ public partial class OneLoginUserMatchingSupportTaskService
             processContext);
 
         var name = $"{data.StatedFirstName} {data.StatedLastName}";
-        await oneLoginService.EnqueueRecordMatchedEmailAsync(supportTask.OneLoginUser!.EmailAddress!, name, processContext, options.EmailTemplateId, options.EmailReplyToId);
+        await oneLoginService.EnqueueRecordMatchedEmailAsync(
+            supportTask.OneLoginUser!.EmailAddress!,
+            name,
+            appContent?.OneLoginRecordMatchedEmailTemplateId,
+            appContent?.SupportEmailAddressNotifyId, processContext);
 
         await supportTaskService.UpdateSupportTaskAsync(
             new UpdateSupportTaskOptions<OneLoginUserIdVerificationData>

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.RecordMatching.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.RecordMatching.cs
@@ -38,21 +38,37 @@ public partial class OneLoginUserMatchingSupportTaskService
         return supportTask;
     }
 
-    public async Task ResolveRecordMatchingSupportTaskAsync(NotConnectingOutcomeOptions options, ProcessContext processContext)
+    public async Task<ResolveRecordMatchingSupportTaskResult> ResolveRecordMatchingSupportTaskAsync(
+        NotConnectingOutcomeOptions options,
+        ProcessContext processContext)
     {
         var supportTask = options.SupportTask;
         ThrowIfSupportTaskIsClosed(supportTask);
 
         var data = supportTask.GetData<OneLoginUserRecordMatchingData>();
 
-        if (options.RecordMatchingPolicy == RecordMatchingPolicy.Deferred && options.EmailTemplateId is not null)
+        var applicationUser = await GetApplicationUserAsync(supportTask);
+        var appContent = applicationUser.AppContent;
+        var recordMatchingPolicy = applicationUser.RecordMatchingPolicy;
+
+        bool emailSent = false;
+
+        if (recordMatchingPolicy == RecordMatchingPolicy.Deferred && appContent?.OneLoginNotConnectedEmailTemplateId is { } templateId)
         {
             var firstVerifiedOrStatedName = data.VerifiedOrStatedNames!.First();
             var name = $"{firstVerifiedOrStatedName.First()} {firstVerifiedOrStatedName.LastOrDefault()}";
             var reason = options.NotConnectingReason is OneLoginUserNotConnectingReason.AnotherReason
                 ? options.NotConnectingAdditionalDetails!
                 : options.NotConnectingReason.GetDisplayName()!;
-            await oneLoginService.EnqueueNotConnectedEmailAsync(supportTask.OneLoginUser!.EmailAddress!, name, reason, processContext, options.EmailTemplateId);
+
+            await oneLoginService.EnqueueNotConnectedEmailAsync(
+                supportTask.OneLoginUser!.EmailAddress!,
+                name,
+                reason,
+                templateId,
+                processContext);
+
+            emailSent = true;
         }
 
         await supportTaskService.UpdateSupportTaskAsync(
@@ -68,14 +84,19 @@ public partial class OneLoginUserMatchingSupportTaskService
                 Status = SupportTaskStatus.Closed
             },
             processContext);
+
+        return new() { EmailSent = emailSent };
     }
 
-    public async Task ResolveRecordMatchingSupportTaskAsync(NoMatchesOutcomeOptions options, ProcessContext processContext)
+    public async Task<ResolveRecordMatchingSupportTaskResult> ResolveRecordMatchingSupportTaskAsync(NoMatchesOutcomeOptions options, ProcessContext processContext)
     {
         var supportTask = options.SupportTask;
         ThrowIfSupportTaskIsClosed(supportTask);
 
         var data = supportTask.GetData<OneLoginUserRecordMatchingData>();
+
+        var applicationUser = await dbContext.ApplicationUsers.SingleAsync(u => u.UserId == data.ClientApplicationUserId);
+        var appContent = applicationUser.AppContent;
 
         await supportTaskService.UpdateSupportTaskAsync(
             new UpdateSupportTaskOptions<OneLoginUserRecordMatchingData>
@@ -89,7 +110,11 @@ public partial class OneLoginUserMatchingSupportTaskService
             },
             processContext);
 
-        if (options.EmailTemplateId is not null)
+        var emailTemplateId = applicationUser.RecordMatchingPolicy is RecordMatchingPolicy.Deferred
+            ? null
+            : appContent?.OneLoginCannotFindRecordEmailTemplateId;
+
+        if (emailTemplateId is not null)
         {
             var firstVerifiedOrStatedName = data.VerifiedOrStatedNames!.First();
             var name = $"{firstVerifiedOrStatedName.First()} {firstVerifiedOrStatedName.LastOrDefault()}";
@@ -97,10 +122,14 @@ public partial class OneLoginUserMatchingSupportTaskService
             await oneLoginService.EnqueueRecordNotFoundEmailAsync(
                 supportTask.OneLoginUser!.EmailAddress!,
                 name,
-                processContext,
-                options.EmailTemplateId,
-                options.EmailReplyToId);
+                emailTemplateId,
+                appContent?.SupportEmailAddressNotifyId,
+                processContext);
+
+            return new() { EmailSent = true };
         }
+
+        return new() { EmailSent = false };
     }
 
     public async Task ResolveRecordMatchingSupportTaskAsync(ConnectedOutcomeOptions options, ProcessContext processContext)
@@ -144,15 +173,16 @@ public partial class OneLoginUserMatchingSupportTaskService
         }
         else
         {
+            var appContent = await GetAppContentAsync(data.ClientApplicationUserId);
+
             var firstVerifiedOrStatedName = data.VerifiedOrStatedNames!.First();
             var name = $"{firstVerifiedOrStatedName.First()} {firstVerifiedOrStatedName.LastOrDefault()}";
 
             await oneLoginService.EnqueueRecordMatchedEmailAsync(
                 supportTask.OneLoginUser!.EmailAddress!,
                 name,
-                processContext,
-                options.EmailTemplateId,
-                options.EmailReplyToId);
+                appContent?.OneLoginRecordMatchedEmailTemplateId,
+                appContent?.SupportEmailAddressNotifyId, processContext);
         }
     }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.cs
@@ -1,3 +1,6 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 
@@ -6,4 +9,39 @@ namespace TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 public partial class OneLoginUserMatchingSupportTaskService(
     SupportTaskService supportTaskService,
     OneLoginService oneLoginService,
-    TrnRequestService trnRequestService);
+    TrnRequestService trnRequestService,
+    TrsDbContext dbContext)
+{
+    public Task<ApplicationUser> GetApplicationUserAsync(SupportTask supportTask)
+    {
+        var applicationUserId = supportTask.Data switch
+        {
+            OneLoginUserIdVerificationData verificationData => verificationData.ClientApplicationUserId,
+            OneLoginUserRecordMatchingData matchingData => matchingData.ClientApplicationUserId,
+            _ => throw new ArgumentException($"Unknown task type: '{supportTask.SupportTaskType}'.")
+        };
+
+        return dbContext.ApplicationUsers.SingleAsync(u => u.UserId == applicationUserId);
+    }
+
+    public Task<AppContent?> GetAppContentAsync(SupportTask supportTask)
+    {
+        var applicationUserId = supportTask.Data switch
+        {
+            OneLoginUserIdVerificationData verificationData => verificationData.ClientApplicationUserId,
+            OneLoginUserRecordMatchingData matchingData => matchingData.ClientApplicationUserId,
+            _ => throw new ArgumentException($"Unknown task type: '{supportTask.SupportTaskType}'.")
+        };
+
+        return dbContext.ApplicationUsers
+            .Where(u => u.UserId == applicationUserId)
+            .Select(u => u.AppContent)
+            .SingleAsync();
+    }
+
+    public Task<AppContent?> GetAppContentAsync(Guid applicationUserId) =>
+        dbContext.ApplicationUsers
+            .Where(u => u.UserId == applicationUserId)
+            .Select(u => u.AppContent)
+            .SingleAsync();
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/ResolveRecordMatchingSupportTaskResult.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/ResolveRecordMatchingSupportTaskResult.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
+
+public record ResolveRecordMatchingSupportTaskResult
+{
+    public required bool EmailSent { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/VerifiedAndConnectedOutcomeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/VerifiedAndConnectedOutcomeOptions.cs
@@ -7,6 +7,4 @@ public record VerifiedAndConnectedOutcomeOptions
     public required SupportTask SupportTask { get; init; }
     public required Guid MatchedPersonId { get; init; }
     public required IEnumerable<KeyValuePair<PersonMatchedAttribute, string>> MatchedAttributes { get; init; }
-    public required string? EmailTemplateId { get; init; }
-    public required string? EmailReplyToId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/VerifiedOnlyWithMatchesOutcomeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/VerifiedOnlyWithMatchesOutcomeOptions.cs
@@ -8,6 +8,4 @@ public record VerifiedOnlyWithMatchesOutcomeOptions
     public required SupportTask SupportTask { get; init; }
     public required OneLoginUserNotConnectingReason NotConnectingReason { get; init; }
     public required string? NotConnectingAdditionalDetails { get; init; }
-    public required RecordMatchingPolicy RecordMatchingPolicy { get; init; }
-    public required string? EmailTemplateId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/VerifiedOnlyWithoutMatchesOutcomeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/VerifiedOnlyWithoutMatchesOutcomeOptions.cs
@@ -5,6 +5,4 @@ namespace TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 public record VerifiedOnlyWithoutMatchesOutcomeOptions
 {
     public required SupportTask SupportTask { get; init; }
-    public required string? EmailTemplateId { get; init; }
-    public required string? EmailReplyToId { get; init; }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
-using TeachingRecordSystem.SupportUi;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
@@ -68,9 +67,7 @@ public class ConfirmConnect(
                 {
                     SupportTask = _supportTask!,
                     MatchedPersonId = MatchedPersonId,
-                    MatchedAttributes = matchedPerson.MatchedAttributes,
-                    EmailTemplateId = JourneyInstance.State.AppContent?.OneLoginRecordMatchedEmailTemplateId,
-                    EmailReplyToId = JourneyInstance.State.AppContent?.SupportEmailAddressNotifyId
+                    MatchedAttributes = matchedPerson.MatchedAttributes
                 },
                 processContext);
         }
@@ -84,9 +81,7 @@ public class ConfirmConnect(
                     SupportTask = _supportTask!,
                     MatchedPersonId = MatchedPersonId,
                     Trn = matchedPerson.Trn,
-                    MatchedAttributes = matchedPerson.MatchedAttributes,
-                    EmailTemplateId = JourneyInstance.State.AppContent?.OneLoginRecordMatchedEmailTemplateId,
-                    EmailReplyToId = JourneyInstance.State.AppContent?.SupportEmailAddressNotifyId
+                    MatchedAttributes = matchedPerson.MatchedAttributes
                 },
                 processContext);
         }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml.cs
@@ -44,6 +44,8 @@ public class ConfirmNotConnecting(
             return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
         }
 
+        bool emailSent = false;
+
         if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
         {
             var processContext = new ProcessContext(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, timeProvider.UtcNow, User.GetUserId());
@@ -53,9 +55,7 @@ public class ConfirmNotConnecting(
                 {
                     SupportTask = _supportTask!,
                     NotConnectingReason = JourneyInstance.State.NotConnectingReason!.Value,
-                    NotConnectingAdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails,
-                    RecordMatchingPolicy = JourneyInstance.State.RecordMatchingPolicy!.Value,
-                    EmailTemplateId = JourneyInstance.State.AppContent?.OneLoginNotConnectedEmailTemplateId
+                    NotConnectingAdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails
                 },
                 processContext);
         }
@@ -63,16 +63,16 @@ public class ConfirmNotConnecting(
         {
             var processContext = new ProcessContext(ProcessType.OneLoginUserRecordMatchingSupportTaskCompleting, timeProvider.UtcNow, User.GetUserId());
 
-            await supportTaskService.ResolveRecordMatchingSupportTaskAsync(
+            var resolveResult = await supportTaskService.ResolveRecordMatchingSupportTaskAsync(
                 new NotConnectingOutcomeOptions
                 {
                     SupportTask = _supportTask!,
                     NotConnectingReason = JourneyInstance.State.NotConnectingReason!.Value,
-                    NotConnectingAdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails,
-                    RecordMatchingPolicy = JourneyInstance.State.RecordMatchingPolicy!.Value,
-                    EmailTemplateId = JourneyInstance.State.AppContent?.OneLoginNotConnectedEmailTemplateId
+                    NotConnectingAdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails
                 },
                 processContext);
+
+            emailSent = resolveResult.EmailSent;
         }
 
         await JourneyInstance.DeleteAsync();
@@ -81,15 +81,15 @@ public class ConfirmNotConnecting(
         var firstVerifiedOrStatedName = data.VerifiedOrStatedNames!.First();
         var personName = $"{firstVerifiedOrStatedName.First()} {firstVerifiedOrStatedName.LastOrDefault()}";
 
-        var emailSent = JourneyInstance.State.RecordMatchingPolicy == RecordMatchingPolicy.Deferred;
+        var appContent = await supportTaskService.GetAppContentAsync(_supportTask);
 
-        var emailSentMessage = JourneyInstance.State.AppContent?.OneLoginNotConnectedEmailSentFlashMessage is not null
-            ? string.Format(JourneyInstance.State.AppContent.OneLoginNotConnectedEmailSentFlashMessage, personName)
+        var emailSentMessage = appContent?.OneLoginNotConnectedEmailSentFlashMessage is not null
+            ? string.Format(appContent.OneLoginNotConnectedEmailSentFlashMessage, personName)
             : $"Request closed for {personName}. We’ve sent them an email confirming their GOV.UK One Login is not connected to a teaching record.";
 
         TempData.SetFlashNotificationBanner(
-            emailSent ? "Email sent" : "GOV.UK One Login not connected to a record",
-            emailSent ? emailSentMessage : $"Request closed for {personName}.",
+            heading: emailSent ? "Email sent" : "GOV.UK One Login not connected to a record",
+            messageText: emailSent ? emailSentMessage : $"Request closed for {personName}.",
             notificationBannerType: NotificationBannerType.Default);
 
         if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml.cs
@@ -45,8 +45,7 @@ public class ConfirmReject(OneLoginUserMatchingSupportTaskService supportTaskSer
             {
                 SupportTask = _supportTask!,
                 RejectReason = JourneyInstance.State.RejectReason!.Value,
-                RejectionAdditionalDetails = JourneyInstance.State.RejectionAdditionalDetails,
-                EmailTemplateId = JourneyInstance.State.AppContent?.OneLoginNotVerifiedEmailTemplateId
+                RejectionAdditionalDetails = JourneyInstance.State.RejectionAdditionalDetails
             },
             processContext);
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml.cs
@@ -41,6 +41,8 @@ public class NoMatches(
                 linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
         }
 
+        bool emailSent;
+
         if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
         {
             var processContext = new ProcessContext(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, timeProvider.UtcNow, User.GetUserId());
@@ -48,42 +50,37 @@ public class NoMatches(
             await supportTaskService.ResolveVerificationSupportTaskAsync(
                 new VerifiedOnlyWithoutMatchesOutcomeOptions
                 {
-                    SupportTask = _supportTask!,
-                    EmailTemplateId = JourneyInstance.State.AppContent?.OneLoginCannotFindRecordEmailTemplateId ?? EmailTemplateIds.OneLoginCannotFindRecord,
-                    EmailReplyToId = JourneyInstance.State.AppContent?.SupportEmailAddressNotifyId ?? null
+                    SupportTask = _supportTask!
                 },
                 processContext);
+
+            emailSent = true;
         }
         else
         {
             var processContext = new ProcessContext(ProcessType.OneLoginUserRecordMatchingSupportTaskCompleting, timeProvider.UtcNow, User.GetUserId());
 
-            var emailTemplateId = JourneyInstance.State.RecordMatchingPolicy == RecordMatchingPolicy.Deferred
-                ? null
-                : JourneyInstance.State.AppContent?.OneLoginCannotFindRecordEmailTemplateId ?? EmailTemplateIds.OneLoginCannotFindRecord;
-
-            await supportTaskService.ResolveRecordMatchingSupportTaskAsync(
+            var resolveResult = await supportTaskService.ResolveRecordMatchingSupportTaskAsync(
                 new NoMatchesOutcomeOptions
                 {
-                    SupportTask = _supportTask!,
-                    EmailTemplateId = emailTemplateId,
-                    EmailReplyToId = JourneyInstance.State.AppContent?.SupportEmailAddressNotifyId ?? null
+                    SupportTask = _supportTask!
                 },
                 processContext);
+
+            emailSent = resolveResult.EmailSent;
         }
 
         await JourneyInstance.DeleteAsync();
 
-        var emailSent = _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification ||
-            JourneyInstance.State.RecordMatchingPolicy != RecordMatchingPolicy.Deferred;
+        var appContent = await supportTaskService.GetAppContentAsync(_supportTask);
 
-        var emailSentMessage = JourneyInstance.State.AppContent?.OneLoginNoMatchesEmailSentFlashMessage is not null
-            ? string.Format(JourneyInstance.State.AppContent.OneLoginNoMatchesEmailSentFlashMessage, Name)
+        var emailSentMessage = appContent?.OneLoginNoMatchesEmailSentFlashMessage is not null
+            ? string.Format(appContent.OneLoginNoMatchesEmailSentFlashMessage, Name)
             : $"Request closed for {Name}. We’ve sent them an email confirming we could not find a teaching record matching their GOV.UK One Login.";
 
         TempData.SetFlashNotificationBanner(
-            emailSent ? "Email sent" : "Request closed",
-            emailSent ? emailSentMessage : $"Request closed for {Name}.",
+            heading: emailSent ? "Email sent" : "Request closed",
+            messageText: emailSent ? emailSentMessage : $"Request closed for {Name}.",
             notificationBannerType: NotificationBannerType.Default);
 
         return Redirect(_supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
@@ -113,7 +110,8 @@ public class NoMatches(
         var firstVerifiedOrStatedName = data.VerifiedOrStatedNames!.First();
         Name = $"{firstVerifiedOrStatedName.First()} {firstVerifiedOrStatedName.LastOrDefault()}";
 
-        NoMatchesPageContent = JourneyInstance.State.AppContent?.OneLoginNoMatchesPageContentHtml;
+        var appContent = await supportTaskService.GetAppContentAsync(_supportTask);
+        NoMatchesPageContent = appContent?.OneLoginNoMatchesPageContentHtml;
 
         await base.OnPageHandlerExecutionAsync(context, next);
     }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
@@ -31,16 +30,11 @@ public record ResolveOneLoginUserMatchingState : IRegisterJourney, IJourneyWithS
     public OneLoginUserNotConnectingReason? NotConnectingReason { get; set; }
 
     public string? NotConnectingAdditionalDetails { get; set; }
-
-    public AppContent? AppContent { get; set; }
-
-    public RecordMatchingPolicy? RecordMatchingPolicy { get; set; }
 }
 
 [UsedImplicitly]
 public class ResolveOneLoginUserMatchingStateFactory(
-    OneLoginService oneLoginService,
-    TrsDbContext dbContext) :
+    OneLoginService oneLoginService) :
     IJourneyStateFactory<ResolveOneLoginUserMatchingState>
 {
     public Task<ResolveOneLoginUserMatchingState> CreateAsync(CreateJourneyStateContext context)
@@ -78,40 +72,16 @@ public class ResolveOneLoginUserMatchingStateFactory(
             }
         }
 
-        AppContent? appContent = null;
-        RecordMatchingPolicy? recordMatchingPolicy = null;
-        Guid clientApplicationUserId = requestData switch
-        {
-            OneLoginUserIdVerificationData idVerificationData => idVerificationData.ClientApplicationUserId,
-            OneLoginUserRecordMatchingData recordMatchingData => recordMatchingData.ClientApplicationUserId,
-            _ => Guid.Empty
-        };
-
-        if (clientApplicationUserId != Guid.Empty)
-        {
-            var applicationUser = await dbContext.ApplicationUsers
-                .Where(u => u.UserId == clientApplicationUserId)
-                .Select(u => new { u.AppContent, u.RecordMatchingPolicy })
-                .SingleOrDefaultAsync();
-
-            appContent = applicationUser?.AppContent;
-            recordMatchingPolicy = applicationUser?.RecordMatchingPolicy;
-        }
-
         return supportTask.ResolveJourneySavedState?.GetState<ResolveOneLoginUserMatchingState>() is { } existingState ?
             existingState with
             {
                 MatchedPersons = suggestedMatches,
-                AppContent = appContent,
-                RecordMatchingPolicy = recordMatchingPolicy,
                 SavedJourneyState = supportTask.ResolveJourneySavedState
             } :
             new ResolveOneLoginUserMatchingState
             {
                 MatchedPersons = suggestedMatches,
-                Verified = supportTask.SupportTaskType is SupportTaskType.OneLoginUserRecordMatching ? true : null,
-                AppContent = appContent,
-                RecordMatchingPolicy = recordMatchingPolicy
+                Verified = supportTask.SupportTaskType is SupportTaskType.OneLoginUserRecordMatching ? true : null
             };
     }
 }

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskServiceTests_IdVerification.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskServiceTests_IdVerification.cs
@@ -76,8 +76,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
         {
             SupportTask = supportTask,
             RejectReason = rejectReason,
-            RejectionAdditionalDetails = rejectionAdditionalDetails,
-            EmailTemplateId = null
+            RejectionAdditionalDetails = rejectionAdditionalDetails
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -136,8 +135,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
         {
             SupportTask = supportTask,
             RejectReason = reason,
-            RejectionAdditionalDetails = rejectionAdditionalDetails,
-            EmailTemplateId = null
+            RejectionAdditionalDetails = rejectionAdditionalDetails
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -165,8 +163,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
         {
             SupportTask = supportTask,
             RejectReason = OneLoginIdVerificationRejectReason.AnotherReason,
-            RejectionAdditionalDetails = rejectionAdditionalDetails,
-            EmailTemplateId = null
+            RejectionAdditionalDetails = rejectionAdditionalDetails
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -186,16 +183,19 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
 
         var customTemplateId = "custom-template-id";
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            appContent: new AppContent { OneLoginNotVerifiedEmailTemplateId = customTemplateId });
+
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new NotVerifiedOutcomeOptions
         {
             SupportTask = supportTask,
             RejectReason = OneLoginIdVerificationRejectReason.ProofDoesNotMatchRequest,
-            RejectionAdditionalDetails = null,
-            EmailTemplateId = customTemplateId
+            RejectionAdditionalDetails = null
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -226,9 +226,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
         {
             SupportTask = supportTask,
             NotConnectingReason = notConnectingReason,
-            NotConnectingAdditionalDetails = notConnectingAdditionalDetails,
-            RecordMatchingPolicy = RecordMatchingPolicy.Required,
-            EmailTemplateId = null
+            NotConnectingAdditionalDetails = notConnectingAdditionalDetails
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -270,18 +268,22 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
 
         var customTemplateId = "custom-template-id";
         var notConnectingReason = OneLoginUserNotConnectingReason.NoMatchingRecord;
+
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Deferred,
+            appContent: new AppContent { OneLoginNotConnectedEmailTemplateId = customTemplateId });
+
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new VerifiedOnlyWithMatchesOutcomeOptions
         {
             SupportTask = supportTask,
             NotConnectingReason = notConnectingReason,
-            NotConnectingAdditionalDetails = null,
-            RecordMatchingPolicy = RecordMatchingPolicy.Deferred,
-            EmailTemplateId = customTemplateId
+            NotConnectingAdditionalDetails = null
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -305,18 +307,22 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
 
         var customTemplateId = "custom-template-id";
         var notConnectingAdditionalDetails = Faker.Lorem.Paragraph();
+
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Deferred,
+            appContent: new AppContent { OneLoginNotConnectedEmailTemplateId = customTemplateId });
+
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new VerifiedOnlyWithMatchesOutcomeOptions
         {
             SupportTask = supportTask,
             NotConnectingReason = OneLoginUserNotConnectingReason.AnotherReason,
-            NotConnectingAdditionalDetails = notConnectingAdditionalDetails,
-            RecordMatchingPolicy = RecordMatchingPolicy.Deferred,
-            EmailTemplateId = customTemplateId
+            NotConnectingAdditionalDetails = notConnectingAdditionalDetails
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -340,15 +346,19 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
+
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Required,
+            appContent: new AppContent { OneLoginNotConnectedEmailTemplateId = "custom-template-id" });
+
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new VerifiedOnlyWithMatchesOutcomeOptions
         {
             SupportTask = supportTask,
             NotConnectingReason = OneLoginUserNotConnectingReason.AnotherReason,
-            NotConnectingAdditionalDetails = Faker.Lorem.Paragraph(),
-            RecordMatchingPolicy = RecordMatchingPolicy.Required,
-            EmailTemplateId = "custom-template-id"
+            NotConnectingAdditionalDetails = Faker.Lorem.Paragraph()
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -373,9 +383,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
 
         var options = new VerifiedOnlyWithoutMatchesOutcomeOptions
         {
-            SupportTask = supportTask,
-            EmailTemplateId = null,
-            EmailReplyToId = null
+            SupportTask = supportTask
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -420,15 +428,17 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
 
         var customReplyToId = "custom-reply-to-id";
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            appContent: new AppContent { SupportEmailAddressNotifyId = customReplyToId });
+
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new VerifiedOnlyWithoutMatchesOutcomeOptions
         {
-            SupportTask = supportTask,
-            EmailTemplateId = EmailTemplateIds.OneLoginCannotFindRecord,
-            EmailReplyToId = customReplyToId
+            SupportTask = supportTask
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -470,9 +480,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
                 KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-            ],
-            EmailTemplateId = null,
-            EmailReplyToId = null
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -519,14 +527,17 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
         var matchedPerson = await TestData.CreatePersonAsync();
 
+        var customTemplateId = "custom-template-id";
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            appContent: new AppContent { OneLoginRecordMatchedEmailTemplateId = customTemplateId });
+
         var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
             oneLoginUser.Subject, t => t
                 .WithStatedFirstName(matchedPerson.FirstName)
                 .WithStatedLastName(matchedPerson.LastName)
                 .WithStatedDateOfBirth(matchedPerson.DateOfBirth)
-                .WithStatedTrn(matchedPerson.Trn!));
-
-        var customTemplateId = "custom-template-id";
+                .WithStatedTrn(matchedPerson.Trn!)
+                .WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new VerifiedAndConnectedOutcomeOptions
         {
@@ -538,9 +549,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
                 KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-            ],
-            EmailTemplateId = customTemplateId,
-            EmailReplyToId = null
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -561,14 +570,17 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
         var matchedPerson = await TestData.CreatePersonAsync();
 
+        var customReplyToId = "custom-reply-to-id";
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            appContent: new AppContent { SupportEmailAddressNotifyId = customReplyToId });
+
         var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
             oneLoginUser.Subject, t => t
                 .WithStatedFirstName(matchedPerson.FirstName)
                 .WithStatedLastName(matchedPerson.LastName)
                 .WithStatedDateOfBirth(matchedPerson.DateOfBirth)
-                .WithStatedTrn(matchedPerson.Trn!));
-
-        var customReplyToId = "custom-reply-to-id";
+                .WithStatedTrn(matchedPerson.Trn!)
+                .WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new VerifiedAndConnectedOutcomeOptions
         {
@@ -580,9 +592,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests(ServiceFixture 
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
                 KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-            ],
-            EmailTemplateId = null,
-            EmailReplyToId = customReplyToId
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskServiceTests_RecordMatching.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskServiceTests_RecordMatching.cs
@@ -71,9 +71,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
         {
             SupportTask = supportTask,
             NotConnectingReason = notConnectingReason,
-            NotConnectingAdditionalDetails = notConnectingAdditionalDetails,
-            RecordMatchingPolicy = RecordMatchingPolicy.Required,
-            EmailTemplateId = null
+            NotConnectingAdditionalDetails = notConnectingAdditionalDetails
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -99,18 +97,22 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject);
 
         var customTemplateId = "custom-template-id";
         var notConnectingReason = OneLoginUserNotConnectingReason.NoMatchingRecord;
+
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Deferred,
+            appContent: new AppContent { OneLoginNotConnectedEmailTemplateId = customTemplateId });
+
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new NotConnectingOutcomeOptions
         {
             SupportTask = supportTask,
             NotConnectingReason = notConnectingReason,
-            NotConnectingAdditionalDetails = null,
-            RecordMatchingPolicy = RecordMatchingPolicy.Deferred,
-            EmailTemplateId = customTemplateId
+            NotConnectingAdditionalDetails = null
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -134,18 +136,22 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject);
 
         var customTemplateId = "custom-template-id";
         var notConnectingAdditionalDetails = Faker.Lorem.Paragraph();
+
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Deferred,
+            appContent: new AppContent { OneLoginNotConnectedEmailTemplateId = customTemplateId });
+
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new NotConnectingOutcomeOptions
         {
             SupportTask = supportTask,
             NotConnectingReason = OneLoginUserNotConnectingReason.AnotherReason,
-            NotConnectingAdditionalDetails = notConnectingAdditionalDetails,
-            RecordMatchingPolicy = RecordMatchingPolicy.Deferred,
-            EmailTemplateId = customTemplateId
+            NotConnectingAdditionalDetails = notConnectingAdditionalDetails
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -169,15 +175,19 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject);
+
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Required,
+            appContent: new AppContent { OneLoginNotConnectedEmailTemplateId = "custom-template-id" });
+
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new NotConnectingOutcomeOptions
         {
             SupportTask = supportTask,
             NotConnectingReason = OneLoginUserNotConnectingReason.AnotherReason,
-            NotConnectingAdditionalDetails = Faker.Lorem.Paragraph(),
-            RecordMatchingPolicy = RecordMatchingPolicy.Required,
-            EmailTemplateId = "custom-template-id"
+            NotConnectingAdditionalDetails = Faker.Lorem.Paragraph()
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -192,29 +202,39 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData(EmailTemplateIds.OneLoginCannotFindRecord)]
-    public async Task ResolveRecordMatchingSupportTaskAsync_WithNoMatchesOutcome_ClosesSupportTaskSetsOutcomeAsExpected(string? emailTemplateId)
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ResolveRecordMatchingSupportTaskAsync_WithNoMatchesOutcome_ClosesSupportTaskSetsOutcomeAsExpected(bool emailExpected)
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject);
+
+        // An email is only sent when the application user has a Required record matching policy and a
+        // "cannot find record" email template configured in its app content.
+        var applicationUser = emailExpected
+            ? await TestData.CreateApplicationUserAsync(
+                recordMatchingPolicy: RecordMatchingPolicy.Required,
+                appContent: new AppContent { OneLoginCannotFindRecordEmailTemplateId = EmailTemplateIds.OneLoginCannotFindRecord })
+            : await TestData.CreateApplicationUserAsync(recordMatchingPolicy: RecordMatchingPolicy.Deferred);
+
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var data = supportTask.GetData<OneLoginUserRecordMatchingData>();
 
         var options = new NoMatchesOutcomeOptions
         {
-            SupportTask = supportTask,
-            EmailTemplateId = emailTemplateId,
-            EmailReplyToId = null
+            SupportTask = supportTask
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
 
         // Act
-        await WithServiceAsync(s => s.ResolveRecordMatchingSupportTaskAsync(options, processContext));
+        var result = await WithServiceAsync(s => s.ResolveRecordMatchingSupportTaskAsync(options, processContext));
 
         // Assert
+        Assert.Equal(emailExpected, result.EmailSent);
+
         var updatedSupportTask =
             await WithDbContextAsync(dbContext => dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
         var updatedData = updatedSupportTask.GetData<OneLoginUserRecordMatchingData>();
@@ -225,9 +245,9 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
         await BackgroundJobScheduler.ExecuteDeferredJobsAsync();
         var emails = await WithDbContextAsync(dbContext => dbContext.Emails.Where(e => e.EmailAddress == oneLoginUser.EmailAddress).ToArrayAsync());
 
-        if (emailTemplateId is not null)
+        if (emailExpected)
         {
-            Assert.Collection(emails, e => Assert.Equal(emailTemplateId, e.TemplateId));
+            Assert.Collection(emails, e => Assert.Equal(EmailTemplateIds.OneLoginCannotFindRecord, e.TemplateId));
             Events.AssertEventsPublished(
                 e => Assert.IsType<EmailSentEvent>(e),
                 e => Assert.IsType<SupportTaskUpdatedEvent>(e));
@@ -245,15 +265,22 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject);
 
         var customReplyToId = "custom-reply-to-id";
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Required,
+            appContent: new AppContent
+            {
+                OneLoginCannotFindRecordEmailTemplateId = EmailTemplateIds.OneLoginCannotFindRecord,
+                SupportEmailAddressNotifyId = customReplyToId
+            });
+
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new NoMatchesOutcomeOptions
         {
-            SupportTask = supportTask,
-            EmailTemplateId = EmailTemplateIds.OneLoginCannotFindRecord,
-            EmailReplyToId = customReplyToId
+            SupportTask = supportTask
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -292,9 +319,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
                 KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-            ],
-            EmailTemplateId = null,
-            EmailReplyToId = null
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -335,13 +360,16 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
 
+        var customTemplateId = "custom-template-id";
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            appContent: new AppContent { OneLoginRecordMatchedEmailTemplateId = customTemplateId });
+
         var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
             oneLoginUser.Subject, t => t
                 .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
                 .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
-                .WithStatedTrn(matchedPerson.Trn!));
-
-        var customTemplateId = "custom-template-id";
+                .WithStatedTrn(matchedPerson.Trn!)
+                .WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new ConnectedOutcomeOptions
         {
@@ -354,9 +382,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
                 KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-            ],
-            EmailTemplateId = customTemplateId,
-            EmailReplyToId = null
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -378,13 +404,16 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
 
+        var customReplyToId = "custom-reply-to-id";
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            appContent: new AppContent { SupportEmailAddressNotifyId = customReplyToId });
+
         var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
             oneLoginUser.Subject, t => t
                 .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
                 .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
-                .WithStatedTrn(matchedPerson.Trn!));
-
-        var customReplyToId = "custom-reply-to-id";
+                .WithStatedTrn(matchedPerson.Trn!)
+                .WithClientApplicationUserId(applicationUser.UserId));
 
         var options = new ConnectedOutcomeOptions
         {
@@ -397,9 +426,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
                 KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-            ],
-            EmailTemplateId = null,
-            EmailReplyToId = customReplyToId
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -440,9 +467,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
                 KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson.FirstName),
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd"))
-            ],
-            EmailTemplateId = null,
-            EmailReplyToId = null
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
@@ -503,9 +528,7 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
             [
                 KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson.FirstName),
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName)
-            ],
-            EmailTemplateId = null,
-            EmailReplyToId = null
+            ]
         };
 
         var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
@@ -113,9 +113,7 @@ public partial class ChangeHistoryTests
                     KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd"))
                 ],
                 SupportTask = supportTask,
-                Trn = matchedPerson.Trn,
-                EmailTemplateId = null,
-                EmailReplyToId = null
+                Trn = matchedPerson.Trn
             },
             process);
 
@@ -164,9 +162,7 @@ public partial class ChangeHistoryTests
                 KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
                 KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
                 KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-            ],
-            EmailTemplateId = null,
-            EmailReplyToId = null
+            ]
         };
 
         var processContext = new ProcessContext(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, Clock.UtcNow, SystemUser.SystemUserId);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnectingTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnectingTests.cs
@@ -492,10 +492,21 @@ public class ConfirmNotConnectingTests(HostFixture hostFixture) : ResolveOneLogi
         // Assert
         var nextPage = await response.FollowRedirectAsync(HttpClient);
         var nextPageDoc = await nextPage.GetDocumentAsync();
-        AssertEx.HtmlDocumentHasFlashNotificationBanner(
-            nextPageDoc,
-            "Email sent",
-            string.Format(customFlashMessage, $"{firstName} {lastName}"));
+        if (isRecordMatchingOnlySupportTask)
+        {
+            AssertEx.HtmlDocumentHasFlashNotificationBanner(
+                nextPageDoc,
+                "Email sent",
+                string.Format(customFlashMessage, $"{firstName} {lastName}"));
+        }
+        else
+        {
+            // Id verification support tasks do not report an email as sent, so the default banner is shown.
+            AssertEx.HtmlDocumentHasFlashNotificationBanner(
+                nextPageDoc,
+                "GOV.UK One Login not connected to a record",
+                $"Request closed for {firstName} {lastName}.");
+        }
     }
 
     [Theory]
@@ -514,7 +525,11 @@ public class ConfirmNotConnectingTests(HostFixture hostFixture) : ResolveOneLogi
                 Name = TestData.GenerateApplicationUserName(),
                 ApiRoles = [],
                 IsOidcClient = false,
-                RecordMatchingPolicy = RecordMatchingPolicy.Deferred
+                RecordMatchingPolicy = RecordMatchingPolicy.Deferred,
+                AppContent = new AppContent
+                {
+                    OneLoginNotConnectedEmailTemplateId = Guid.NewGuid().ToString()
+                }
             };
             dbContext.ApplicationUsers.Add(applicationUser);
             await dbContext.SaveChangesAsync();
@@ -551,10 +566,21 @@ public class ConfirmNotConnectingTests(HostFixture hostFixture) : ResolveOneLogi
         // Assert
         var nextPage = await response.FollowRedirectAsync(HttpClient);
         var nextPageDoc = await nextPage.GetDocumentAsync();
-        AssertEx.HtmlDocumentHasFlashNotificationBanner(
-            nextPageDoc,
-            "Email sent",
-            $"Request closed for {firstName} {lastName}. We’ve sent them an email confirming their GOV.UK One Login is not connected to a teaching record.");
+        if (isRecordMatchingOnlySupportTask)
+        {
+            AssertEx.HtmlDocumentHasFlashNotificationBanner(
+                nextPageDoc,
+                "Email sent",
+                $"Request closed for {firstName} {lastName}. We’ve sent them an email confirming their GOV.UK One Login is not connected to a teaching record.");
+        }
+        else
+        {
+            // Id verification support tasks do not report an email as sent, so the default banner is shown.
+            AssertEx.HtmlDocumentHasFlashNotificationBanner(
+                nextPageDoc,
+                "GOV.UK One Login not connected to a record",
+                $"Request closed for {firstName} {lastName}.");
+        }
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NoMatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NoMatchesTests.cs
@@ -86,14 +86,7 @@ public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchi
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
-            state =>
-            {
-                state.Verified = true;
-                state.AppContent = new Core.Models.AppContent
-                {
-                    OneLoginCannotFindRecordEmailTemplateId = Guid.NewGuid().ToString()
-                };
-            },
+            state => state.Verified = true,
             matchedPersons: []);
 
         var request = new HttpRequestMessage(
@@ -136,21 +129,22 @@ public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchi
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
         var firstName = TestData.GenerateFirstName();
         var lastName = TestData.GenerateLastName();
+
+        // An email is only sent for a record matching task when the application user has a Required
+        // record matching policy and a "cannot find record" email template configured.
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            recordMatchingPolicy: RecordMatchingPolicy.Required,
+            appContent: new AppContent { OneLoginCannotFindRecordEmailTemplateId = Guid.NewGuid().ToString() });
+
         var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
             oneLoginUser.Subject, t => t
-                .WithVerifiedNames([firstName, lastName]));
+                .WithVerifiedNames([firstName, lastName])
+                .WithClientApplicationUserId(applicationUser.UserId));
         var supportTaskData = supportTask.GetData<OneLoginUserRecordMatchingData>();
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
-            state =>
-            {
-                state.Verified = true;
-                state.AppContent = new AppContent
-                {
-                    OneLoginCannotFindRecordEmailTemplateId = Guid.NewGuid().ToString()
-                };
-            },
+            state => state.Verified = true,
             matchedPersons: []);
 
         var request = new HttpRequestMessage(
@@ -314,20 +308,21 @@ public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchi
         // Arrange
         var customFlashMessage = "Request closed for {0}. We’ve sent them an email with a link to continue their national professional qualification (NPQ) registration.";
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
+
+        var applicationUser = await TestData.CreateApplicationUserAsync(
+            appContent: new AppContent
+            {
+                OneLoginCannotFindRecordEmailTemplateId = Guid.NewGuid().ToString(),
+                OneLoginNoMatchesEmailSentFlashMessage = customFlashMessage
+            });
+
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithClientApplicationUserId(applicationUser.UserId));
         var supportTaskData = supportTask.GetData<OneLoginUserIdVerificationData>();
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
-            state =>
-            {
-                state.Verified = true;
-                state.AppContent = new AppContent
-                {
-                    OneLoginCannotFindRecordEmailTemplateId = Guid.NewGuid().ToString(),
-                    OneLoginNoMatchesEmailSentFlashMessage = customFlashMessage
-                };
-            },
+            state => state.Verified = true,
             matchedPersons: []);
 
         var request = new HttpRequestMessage(
@@ -376,9 +371,11 @@ public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchi
     }
 
     [Fact]
-    public async Task Post_RecordMatchingSupportTaskWithoutAppContent_UsesDefaultTemplateAndSendsEmail()
+    public async Task Post_RecordMatchingSupportTaskWithoutAppContent_DoesNotSendEmailAndUsesRequestClosedFlashMessage()
     {
         // Arrange
+        // The default application user has a Deferred record matching policy and no app content, so no
+        // "cannot find record" email is sent for a record matching task.
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
         var firstName = TestData.GenerateFirstName();
         var lastName = TestData.GenerateLastName();
@@ -403,7 +400,7 @@ public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchi
         var nextPageDoc = await nextPage.GetDocumentAsync();
         AssertEx.HtmlDocumentHasFlashNotificationBanner(
             nextPageDoc,
-            "Email sent",
-            $"Request closed for {firstName} {lastName}. We’ve sent them an email confirming we could not find a teaching record matching their GOV.UK One Login.");
+            "Request closed",
+            $"Request closed for {firstName} {lastName}.");
     }
 }


### PR DESCRIPTION
We don't want reference data in journey state, particularly as it ends up getting stored again in the DB when task journey states are saved.

Also moves more logic out of the UI and into the service.