### PR TITLE
Make processes queryable by task or onelogin

### DIFF
--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessEventMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessEventMapping.cs
@@ -22,6 +22,7 @@ public class ProcessEventMapping : IEntityTypeConfiguration<ProcessEvent>
         builder.HasOne<Process>().WithMany(a => a.Events).HasForeignKey(ae => ae.ProcessId).HasConstraintName("fk_process_events_process_process_id");
         builder.HasIndex(e => new { e.PersonIds, e.EventName }).HasMethod("GIN").IsCreatedConcurrently();
         builder.HasIndex(e => new { e.OneLoginUserSubjects, e.EventName }).HasMethod("GIN").IsCreatedConcurrently();
+        builder.HasIndex(e => new { e.SupportTaskReferences, e.EventName }).HasMethod("GIN").IsCreatedConcurrently();
         builder.HasIndex(e => e.ProcessId).IsCreatedConcurrently();
     }
 }

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessMapping.cs
@@ -15,6 +15,8 @@ public class ProcessMapping : IEntityTypeConfiguration<Process>
         builder.HasOne(p => p.User).WithMany().HasForeignKey(p => p.UserId);
         builder.HasIndex(p => p.ProcessType);
         builder.HasIndex(p => p.PersonIds).HasMethod("GIN");
+        builder.HasIndex(p => p.OneLoginUserSubjects).HasMethod("GIN").IsCreatedConcurrently();
+        builder.HasIndex(p => p.SupportTaskReferences).HasMethod("GIN").IsCreatedConcurrently();
         builder.Property(p => p.ChangeReason)
             .HasColumnType("jsonb")
             .HasConversion(

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260624124401_ProcessSupportTasksAndOneLogins.Designer.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260624124401_ProcessSupportTasksAndOneLogins.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624124401_ProcessSupportTasksAndOneLogins")]
+    partial class ProcessSupportTasksAndOneLogins
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260624124401_ProcessSupportTasksAndOneLogins.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260624124401_ProcessSupportTasksAndOneLogins.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProcessSupportTasksAndOneLogins : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<List<string>>(
+                name: "one_login_user_subjects",
+                table: "processes",
+                type: "text[]",
+                nullable: false);
+
+            migrationBuilder.AddColumn<List<string>>(
+                name: "support_task_references",
+                table: "processes",
+                type: "text[]",
+                nullable: false);
+
+            migrationBuilder.AddColumn<string[]>(
+                name: "support_task_references",
+                table: "process_events",
+                type: "text[]",
+                nullable: false,
+                defaultValue: new string[0]);
+
+            migrationBuilder.Sql(
+                """
+                update process_events set one_login_user_subjects = ARRAY[payload->'SupportTask'->>'OneLoginUserSubject']::varchar[]
+                where event_name in ('SupportTaskCreatedEvent', 'SupportTaskDeletedEvent', 'SupportTaskUpdatedEvent')
+                and payload->'SupportTask'->>'OneLoginUserSubject' is not null;
+
+                update process_events set support_task_references = ARRAY[payload->'SupportTask'->>'SupportTaskReference']::varchar[]
+                where event_name in ('SupportTaskCreatedEvent', 'SupportTaskDeletedEvent', 'SupportTaskUpdatedEvent');
+
+                update processes set one_login_user_subjects = pe.one_login_user_subjects
+                from (
+                    select process_id, array_agg(distinct one_login_user_subject) one_login_user_subjects
+                    from process_events, unnest(one_login_user_subjects) as one_login_user_subject
+                	group by process_id
+                ) as pe
+                where processes.process_id = pe.process_id;
+
+                update processes set support_task_references = pe.support_task_references
+                from (
+                    select process_id, array_agg(distinct support_task_reference) support_task_references
+                    from process_events, unnest(support_task_references) as support_task_reference
+                	group by process_id
+                ) as pe
+                where processes.process_id = pe.process_id;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_processes_one_login_user_subjects",
+                table: "processes",
+                column: "one_login_user_subjects")
+                .Annotation("Npgsql:CreatedConcurrently", true)
+                .Annotation("Npgsql:IndexMethod", "GIN");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_processes_support_task_references",
+                table: "processes",
+                column: "support_task_references")
+                .Annotation("Npgsql:CreatedConcurrently", true)
+                .Annotation("Npgsql:IndexMethod", "GIN");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_process_events_support_task_references_event_name",
+                table: "process_events",
+                columns: new[] { "support_task_references", "event_name" })
+                .Annotation("Npgsql:CreatedConcurrently", true)
+                .Annotation("Npgsql:IndexMethod", "GIN");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_processes_one_login_user_subjects",
+                table: "processes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_processes_support_task_references",
+                table: "processes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_process_events_support_task_references_event_name",
+                table: "process_events");
+
+            migrationBuilder.DropColumn(
+                name: "one_login_user_subjects",
+                table: "processes");
+
+            migrationBuilder.DropColumn(
+                name: "support_task_references",
+                table: "processes");
+
+            migrationBuilder.DropColumn(
+                name: "support_task_references",
+                table: "process_events");
+        }
+    }
+}

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Process.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/Process.cs
@@ -14,5 +14,7 @@ public class Process
     public required string? DqtUserName { get; init; }
     public ICollection<ProcessEvent>? Events { get; init; }
     public required List<Guid> PersonIds { get; init; }
+    public required List<string> OneLoginUserSubjects { get; init; }
+    public required List<string> SupportTaskReferences { get; init; }
     public required IChangeReasonInfo? ChangeReason { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ProcessEvent.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/ProcessEvent.cs
@@ -8,5 +8,6 @@ public class ProcessEvent
     public required IEvent Payload { get; init; }
     public required ICollection<Guid> PersonIds { get; init; }
     public required ICollection<string> OneLoginUserSubjects { get; init; }
+    public required ICollection<string> SupportTaskReferences { get; init; }
     public required DateTime CreatedOn { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/EventPublisher.cs
+++ b/src/TeachingRecordSystem.Core/EventPublisher.cs
@@ -71,6 +71,8 @@ public class EventPublisher(TrsDbContext dbContext, IServiceProvider serviceProv
             processContext.Process.UpdatedOn = processContext.Now;
 
             @event.PersonIds.Except(processContext.Process.PersonIds).ForEach(e => processContext.Process.PersonIds.Add(e));
+            @event.OneLoginUserSubjects.Except(processContext.Process.OneLoginUserSubjects).ForEach(e => processContext.Process.OneLoginUserSubjects.Add(e));
+            @event.SupportTaskReferences.Except(processContext.Process.SupportTaskReferences).ForEach(e => processContext.Process.SupportTaskReferences.Add(e));
 
             var processEvent = new ProcessEvent
             {
@@ -80,6 +82,7 @@ public class EventPublisher(TrsDbContext dbContext, IServiceProvider serviceProv
                 Payload = @event,
                 PersonIds = @event.PersonIds,
                 OneLoginUserSubjects = @event.OneLoginUserSubjects,
+                SupportTaskReferences = @event.SupportTaskReferences,
                 CreatedOn = processContext.Now
             };
             dbContext.Set<ProcessEvent>().Add(processEvent);
@@ -165,6 +168,8 @@ public class ProcessContext
             DqtUserId = raisedBy.DqtUserId,
             DqtUserName = raisedBy.DqtUserName,
             PersonIds = [],
+            OneLoginUserSubjects = [],
+            SupportTaskReferences = [],
             Events = [],
             ChangeReason = changeReason
         };

--- a/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/AlertCreatedEvent.cs
@@ -5,6 +5,7 @@ public record AlertCreatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required EventModels.Alert Alert { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/AlertDeletedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/AlertDeletedEvent.cs
@@ -5,6 +5,7 @@ public record AlertDeletedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required EventModels.Alert Alert { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/AlertUpdatedEvent.cs
@@ -5,6 +5,7 @@ public record AlertUpdatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required EventModels.Alert Alert { get; init; }
     public required EventModels.Alert OldAlert { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/AuthorizeAccessRequestCompletedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/AuthorizeAccessRequestCompletedEvent.cs
@@ -5,4 +5,5 @@ public record AuthorizeAccessRequestCompletedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
 }

--- a/src/TeachingRecordSystem.Core/Events/AuthorizeAccessRequestStartedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/AuthorizeAccessRequestStartedEvent.cs
@@ -5,6 +5,7 @@ public record AuthorizeAccessRequestStartedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required string JourneyInstanceId { get; init; }
     public required Guid ApplicationUserId { get; init; }
     public required string ClientId { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/EmailSentEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/EmailSentEvent.cs
@@ -6,5 +6,6 @@ public record EmailSentEvent : IEvent
     Guid[] IEvent.PersonIds => IEvent.CoalescePersonIds(PersonId);
     public required Guid? PersonId { get; set; }
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required EventModels.Email Email { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/IEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/IEvent.cs
@@ -9,6 +9,7 @@ public interface IEvent
     Guid EventId { get; }
     Guid[] PersonIds { get; }
     string[] OneLoginUserSubjects { get; }
+    string[] SupportTaskReferences { get; }
 
     public static JsonSerializerOptions SerializerOptions => new()
     {

--- a/src/TeachingRecordSystem.Core/Events/NoteCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/NoteCreatedEvent.cs
@@ -5,6 +5,7 @@ public class NoteCreatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required EventModels.Note Note { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/NoteUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/NoteUpdatedEvent.cs
@@ -5,6 +5,7 @@ public record NoteUpdatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required NoteUpdatedInDqtEventChanges Changes { get; init; }
     public required EventModels.Note Note { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/OneLoginUserCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/OneLoginUserCreatedEvent.cs
@@ -7,6 +7,7 @@ public record OneLoginUserCreatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => IEvent.CoalescePersonIds(OneLoginUser.PersonId);
     public string[] OneLoginUserSubjects => [OneLoginUser.Subject];
+    string[] IEvent.SupportTaskReferences => [];
     [JsonIgnore]
     public Guid? PersonId => OneLoginUser.PersonId;
     public required EventModels.OneLoginUser OneLoginUser { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/OneLoginUserSignedInEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/OneLoginUserSignedInEvent.cs
@@ -7,6 +7,7 @@ public record OneLoginUserSignedInEvent : IEvent
     public required Guid EventId { get; init; }
     public Guid[] PersonIds => IEvent.CoalescePersonIds(OneLoginUser.PersonId);
     public string[] OneLoginUserSubjects => [OneLoginUser.Subject];
+    string[] IEvent.SupportTaskReferences => [];
     [JsonIgnore]
     public Guid? PersonId => OneLoginUser.PersonId;
     public required EventModels.OneLoginUser OneLoginUser { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/OneLoginUserUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/OneLoginUserUpdatedEvent.cs
@@ -7,6 +7,7 @@ public record OneLoginUserUpdatedEvent : IEvent
     public required Guid EventId { get; init; }
     public Guid[] PersonIds => IEvent.CoalescePersonIds(OneLoginUser.PersonId, OldOneLoginUser.PersonId);
     public string[] OneLoginUserSubjects => [OneLoginUser.Subject];
+    string[] IEvent.SupportTaskReferences => [];
     [JsonIgnore]
     public Guid? PersonId => OneLoginUser.PersonId;
     public required EventModels.OneLoginUser OneLoginUser { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/PersonCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/PersonCreatedEvent.cs
@@ -5,6 +5,7 @@ public record PersonCreatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required EventModels.PersonDetails Details { get; init; }
     public required EventModels.TrnRequestMetadata? TrnRequestMetadata { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/PersonDeactivatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/PersonDeactivatedEvent.cs
@@ -5,6 +5,7 @@ public record PersonDeactivatedEvent : IEvent
     public required Guid EventId { get; init; }
     public Guid[] PersonIds => IEvent.CoalescePersonIds(MergedWithPersonId, PersonId);
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required PersonDeactivatedEventChanges Changes { get; init; }
     public required Guid PersonId { get; init; }
     public required Guid? MergedWithPersonId { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/PersonDetailsUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/PersonDetailsUpdatedEvent.cs
@@ -5,6 +5,7 @@ public record PersonDetailsUpdatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required EventModels.PersonDetails PersonDetails { get; init; }
     public required EventModels.PersonDetails OldPersonDetails { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/PersonImportedIntoDqtEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/PersonImportedIntoDqtEvent.cs
@@ -5,6 +5,7 @@ public record PersonImportedIntoDqtEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required EventModels.DqtPersonDetails Details { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/PersonReactivatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/PersonReactivatedEvent.cs
@@ -5,6 +5,7 @@ public record PersonReactivatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required PersonReactivatedEventChanges Changes { get; init; }
     public required Guid PersonId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/PersonUpdatedInDqtEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/PersonUpdatedInDqtEvent.cs
@@ -5,6 +5,7 @@ public record PersonUpdatedInDqtEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [PersonId];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid PersonId { get; init; }
     public required PersonUpdatedInDqtEventChanges Changes { get; init; }
     public required EventModels.DqtPersonDetails Details { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/SupportTaskCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/SupportTaskCreatedEvent.cs
@@ -6,7 +6,8 @@ public record SupportTaskCreatedEvent : IEvent
 {
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => IEvent.CoalescePersonIds(SupportTask.PersonId);
-    string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.OneLoginUserSubjects => SupportTask.OneLoginUserSubject is { } oneLoginUserSubject ? [oneLoginUserSubject] : [];
+    string[] IEvent.SupportTaskReferences => [SupportTask.SupportTaskReference];
     [JsonIgnore]
     public Guid? PersonId => SupportTask.PersonId;
     public required EventModels.SupportTask SupportTask { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/SupportTaskDeletedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/SupportTaskDeletedEvent.cs
@@ -6,7 +6,8 @@ public record SupportTaskDeletedEvent : IEvent
 {
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => IEvent.CoalescePersonIds(SupportTask.PersonId);
-    string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.OneLoginUserSubjects => SupportTask.OneLoginUserSubject is { } oneLoginUserSubject ? [oneLoginUserSubject] : [];
+    string[] IEvent.SupportTaskReferences => [SupportTask.SupportTaskReference];
     [JsonIgnore]
     public Guid? PersonId => SupportTask.PersonId;
     public required string SupportTaskReference { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/SupportTaskUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/SupportTaskUpdatedEvent.cs
@@ -6,7 +6,8 @@ public record SupportTaskUpdatedEvent : IEvent
 {
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => IEvent.CoalescePersonIds(SupportTask.PersonId);
-    string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.OneLoginUserSubjects => SupportTask.OneLoginUserSubject is { } oneLoginUserSubject ? [oneLoginUserSubject] : [];
+    string[] IEvent.SupportTaskReferences => [SupportTask.SupportTaskReference];
     [JsonIgnore]
     public Guid? PersonId => SupportTask.PersonId;
     public required string SupportTaskReference { get; init; }

--- a/src/TeachingRecordSystem.Core/Events/TrnRequestCreatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/TrnRequestCreatedEvent.cs
@@ -5,5 +5,6 @@ public record TrnRequestCreatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds { get; } = [];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required EventModels.TrnRequestMetadata TrnRequest { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Events/TrnRequestUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/TrnRequestUpdatedEvent.cs
@@ -5,6 +5,7 @@ public record TrnRequestUpdatedEvent : IEvent
     public required Guid EventId { get; init; }
     Guid[] IEvent.PersonIds => [];
     string[] IEvent.OneLoginUserSubjects => [];
+    string[] IEvent.SupportTaskReferences => [];
     public required Guid SourceApplicationUserId { get; init; }
     public required string RequestId { get; init; }
     public required TrnRequestUpdatedChanges Changes { get; init; }

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateProcess.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateProcess.cs
@@ -28,6 +28,8 @@ public partial class TestData
                 DqtUserId = null,
                 DqtUserName = null,
                 PersonIds = events.SelectMany(e => e.PersonIds).Distinct().ToList(),
+                OneLoginUserSubjects = events.SelectMany(e => e.OneLoginUserSubjects).Distinct().ToList(),
+                SupportTaskReferences = events.SelectMany(e => e.SupportTaskReferences).Distinct().ToList(),
                 ChangeReason = changeReason
             };
 
@@ -43,6 +45,7 @@ public partial class TestData
                     Payload = @event,
                     PersonIds = @event.PersonIds,
                     OneLoginUserSubjects = @event.OneLoginUserSubjects,
+                    SupportTaskReferences = @event.SupportTaskReferences,
                     CreatedOn = TimeProvider.UtcNow
                 });
             }


### PR DESCRIPTION
Adds `OneLoginUserSubjects` and `SupportTaskReferences` columns to `Process`, similar to how we have `PersonIds`.

Also fixes up some event data where we should have been populating `OneLoginUserSubjects` on `ProcessEvent` but we were not.

Closes https://github.com/DFE-Digital/teaching-record-team-project-board/issues/320