### PR TITLE
Complete Clock rename to TimeProvider

### DIFF
--- a/src/TeachingRecordSystem.Cli/Commands.AppContent.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.AppContent.cs
@@ -132,7 +132,7 @@ public partial class Commands
                     }
 
                     var services = new ServiceCollection()
-                        .AddClock()
+                        .AddTimeProvider()
                         .AddDatabase(connectionString)
                         .AddMemoryCache()
                         .AddWebhookMessageFactory()

--- a/src/TeachingRecordSystem.Cli/Commands.CorrectQualificationStartDate.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.CorrectQualificationStartDate.cs
@@ -45,7 +45,7 @@ public static partial class Commands
             }
 
             var services = new ServiceCollection()
-                .AddClock()
+                .AddTimeProvider()
                 .AddDatabase(connectionString);
 
             var serviceProvider = services.BuildServiceProvider();

--- a/src/TeachingRecordSystem.Cli/Commands.DeleteSupportTask.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.DeleteSupportTask.cs
@@ -35,7 +35,7 @@ public partial class Commands
                 var connectionString = parseResult.GetRequiredValue(connectionStringOption);
 
                 var services = new ServiceCollection()
-                    .AddClock()
+                    .AddTimeProvider()
                     .AddDatabase(connectionString)
                     .AddMemoryCache()
                     .AddWebhookMessageFactory()

--- a/src/TeachingRecordSystem.Cli/Commands.ImportCapitaFile.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.ImportCapitaFile.cs
@@ -47,7 +47,7 @@ public static partial class Commands
             }
 
             var services = new ServiceCollection()
-                .AddClock()
+                .AddTimeProvider()
                 .AddLogging()
                 .AddDatabase(connectionString)
                 .AddMemoryCache()

--- a/src/TeachingRecordSystem.Cli/Commands.ImportClaimTestData.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.ImportClaimTestData.cs
@@ -44,7 +44,7 @@ public static partial class Commands
             var environment = new HostingEnvironment { EnvironmentName = Environments.Production };
 
             var services = new ServiceCollection()
-                .AddClock()
+                .AddTimeProvider()
                 .AddDatabase(connectionString)
                 .AddTrnRequestService(configuration)
                 .AddPersonService()

--- a/src/TeachingRecordSystem.Cli/Commands.ResetTrnRequest.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.ResetTrnRequest.cs
@@ -39,7 +39,7 @@ public partial class Commands
                 var connectionString = parseResult.GetRequiredValue(connectionStringOption);
 
                 var services = new ServiceCollection()
-                    .AddClock()
+                    .AddTimeProvider()
                     .AddDatabase(connectionString)
                     .AddMemoryCache()
                     .AddWebhookMessageFactory()

--- a/src/TeachingRecordSystem.Core/Extensions.cs
+++ b/src/TeachingRecordSystem.Core/Extensions.cs
@@ -97,7 +97,7 @@ public static class Extensions
         }
 
         services
-            .AddClock()
+            .AddTimeProvider()
             .AddSingleton<IFeatureProvider, ConfigurationFeatureProvider>()
             .AddDatabase(configuration)
             .AddHangfire(environment)
@@ -152,7 +152,7 @@ public static class Extensions
         return services;
     }
 
-    public static IServiceCollection AddClock(this IServiceCollection services)
+    public static IServiceCollection AddTimeProvider(this IServiceCollection services)
     {
         services.AddSingleton(TimeProvider.System);
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/ApplicationUsers/EditApplicationUser/Index.cshtml
@@ -1,7 +1,7 @@
 @page "/application-users/{userId}"
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 @model TeachingRecordSystem.SupportUi.Pages.ApplicationUsers.EditApplicationUser.IndexModel
-@inject TimeProvider Clock
+@inject TimeProvider TimeProvider
 @{
     ViewBag.Title = $"Edit {Model.Name}";
 }
@@ -54,7 +54,7 @@
                                     @if (key.Expires is DateTime expires)
                                     {
                                         <time datetime="@expires.ToString("s")">
-                                            <span class="@(expires < Clock.UtcNow ? "govuk-caption-m" : "")">
+                                            <span class="@(expires < TimeProvider.UtcNow ? "govuk-caption-m" : "")">
                                                 @expires.ToString("dd/MM/yyyy HH:mm")
                                             </span>
                                         </time>

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/TestBase.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/TestBase.cs
@@ -49,7 +49,7 @@ public abstract class TestBase
 
     protected Guid ApplicationUserId { get; } = HostFixture.DefaultApplicationUserId;
 
-    protected FakeTimeProvider Clock => _testServices.Clock;
+    protected FakeTimeProvider TimeProvider => _testServices.TimeProvider;
 
     protected ReferenceDataCache ReferenceDataCache => HostFixture.Services.GetRequiredService<ReferenceDataCache>();
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/TestScopedServices.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/TestScopedServices.cs
@@ -15,7 +15,7 @@ public class TestScopedServices
 
     public TestScopedServices(IServiceProvider serviceProvider)
     {
-        Clock = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+        TimeProvider = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
         BlobStorageFileServiceMock = new();
         FeatureProvider = ActivatorUtilities.CreateInstance<TestableFeatureProvider>(serviceProvider);
         BackgroundJobScheduler = new(serviceProvider);
@@ -60,7 +60,7 @@ public class TestScopedServices
         return false;
     }
 
-    public FakeTimeProvider Clock { get; }
+    public FakeTimeProvider TimeProvider { get; }
 
     public IOptions<AccessYourTeachingQualificationsOptions> AccessYourTeachingQualificationsOptions { get; }
 
@@ -74,7 +74,7 @@ public class TestScopedServices
 
     private class ForwardToTestScopedTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => GetCurrent().Clock.GetUtcNow();
+        public override DateTimeOffset GetUtcNow() => GetCurrent().TimeProvider.GetUtcNow();
     }
 }
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240101/FindTeachersTests.cs
@@ -199,8 +199,8 @@ public class FindTeachersTests : TestBase
             {
                 PreviousNameId = Guid.NewGuid(),
                 PersonId = person2.PersonId,
-                CreatedOn = Clock.UtcNow,
-                UpdatedOn = Clock.UtcNow,
+                CreatedOn = TimeProvider.UtcNow,
+                UpdatedOn = TimeProvider.UtcNow,
                 FirstName = person2.FirstName,
                 MiddleName = person2.MiddleName,
                 LastName = lastName

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240307/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240307/CreateTrnRequestTests.cs
@@ -110,7 +110,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240307/FindTeachersTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240307/FindTeachersTests.cs
@@ -199,8 +199,8 @@ public class FindTeachersTests : TestBase
             {
                 PreviousNameId = Guid.NewGuid(),
                 PersonId = person2.PersonId,
-                CreatedOn = Clock.UtcNow,
-                UpdatedOn = Clock.UtcNow,
+                CreatedOn = TimeProvider.UtcNow,
+                UpdatedOn = TimeProvider.UtcNow,
                 FirstName = person2.FirstName,
                 MiddleName = person2.MiddleName,
                 LastName = lastName

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/CreateTrnRequestTests.cs
@@ -110,7 +110,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/FindTeachersTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240412/FindTeachersTests.cs
@@ -199,8 +199,8 @@ public class FindTeachersTests : TestBase
             {
                 PreviousNameId = Guid.NewGuid(),
                 PersonId = person2.PersonId,
-                CreatedOn = Clock.UtcNow,
-                UpdatedOn = Clock.UtcNow,
+                CreatedOn = TimeProvider.UtcNow,
+                UpdatedOn = TimeProvider.UtcNow,
                 FirstName = person2.FirstName,
                 MiddleName = person2.MiddleName,
                 LastName = lastName

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/CreateTrnRequestTests.cs
@@ -110,7 +110,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/FindTeachersTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240416/FindTeachersTests.cs
@@ -199,8 +199,8 @@ public class FindTeachersTests : TestBase
             {
                 PreviousNameId = Guid.NewGuid(),
                 PersonId = person2.PersonId,
-                CreatedOn = Clock.UtcNow,
-                UpdatedOn = Clock.UtcNow,
+                CreatedOn = TimeProvider.UtcNow,
+                UpdatedOn = TimeProvider.UtcNow,
                 FirstName = person2.FirstName,
                 MiddleName = person2.MiddleName,
                 LastName = lastName

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240606/FindPersonByLastNameAndDateOfBirthTests.cs
@@ -199,8 +199,8 @@ public class FindPersonByLastNameAndDateOfBirthTests : TestBase
             {
                 PreviousNameId = Guid.NewGuid(),
                 PersonId = person2.PersonId,
-                CreatedOn = Clock.UtcNow,
-                UpdatedOn = Clock.UtcNow,
+                CreatedOn = TimeProvider.UtcNow,
+                UpdatedOn = TimeProvider.UtcNow,
                 FirstName = person2.FirstName,
                 MiddleName = person2.MiddleName,
                 LastName = lastName

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240814/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240912/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20240920/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250203/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonByTrnTests.cs
@@ -205,7 +205,7 @@ public class GetPersonByTrnTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
             .WithQts()
-            .WithQtls(Clock.Today));
+            .WithQtls(TimeProvider.Today));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/GetPersonTests.cs
@@ -138,7 +138,7 @@ public class GetPersonTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
             .WithQts()
-            .WithQtls(Clock.Today));
+            .WithQtls(TimeProvider.Today));
 
         var httpClient = GetHttpClientWithAuthorizeAccessToken(person.Trn!, Version);
         var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person");

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250327/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/GetPersonByTrnTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/GetPersonByTrnTests.cs
@@ -205,7 +205,7 @@ public class GetPersonByTrnTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
             .WithQts()
-            .WithQtls(Clock.Today));
+            .WithQtls(TimeProvider.Today));
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}");
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/GetPersonTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/GetPersonTests.cs
@@ -138,7 +138,7 @@ public class GetPersonTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync(p => p
             .WithQts()
-            .WithQtls(Clock.Today));
+            .WithQtls(TimeProvider.Today));
 
         var httpClient = GetHttpClientWithAuthorizeAccessToken(person.Trn!, Version);
         var request = new HttpRequestMessage(HttpMethod.Get, "/v3/person");

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetProfessionalStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetProfessionalStatusTests.cs
@@ -180,7 +180,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.HeiProgrammeTypeId,
                 Status = status,
-                AwardedDate = Clock.Today
+                AwardedDate = TimeProvider.Today
             });
 
         // Act
@@ -202,7 +202,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.HeiProgrammeTypeId,
                 Status = ProfessionalStatusStatus.Awarded,
-                AwardedDate = Clock.Today.AddDays(1)
+                AwardedDate = TimeProvider.Today.AddDays(1)
             });
 
         // Act
@@ -268,8 +268,8 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.HeiProgrammeTypeId,
                 Status = ProfessionalStatusStatus.InTraining,
-                TrainingStartDate = Clock.Today.AddMonths(-1),
-                TrainingEndDate = Clock.Today.AddMonths(-2)
+                TrainingStartDate = TimeProvider.Today.AddMonths(-1),
+                TrainingEndDate = TimeProvider.Today.AddMonths(-2)
             });
 
         // Act
@@ -450,7 +450,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = routeTypeId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = null
             });
 
@@ -497,7 +497,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = routeTypeId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = "GB"
             });
 
@@ -520,7 +520,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.ScotlandRId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = "PT"
             });
 
@@ -543,7 +543,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.ApplyForQtsId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = "GB-SCT"
             });
 
@@ -566,7 +566,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.NiRId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = "PT"
             });
 
@@ -589,7 +589,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.ApplyForQtsId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = "GB-NIR"
             });
 
@@ -612,7 +612,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.WelshRId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = "PT"
             });
 
@@ -682,7 +682,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = routeTypeId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = "PT"
             });
 
@@ -706,7 +706,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = routeTypeId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingCountryReference = trainingCountryReference,
                 TrainingProviderUkprn = routeTypeId == RouteToProfessionalStatusType.QtlsAndSetMembershipId ? "11111111" : null
             });
@@ -796,7 +796,7 @@ public class SetProfessionalStatusTests : TestBase
             {
                 RouteTypeId = RouteToProfessionalStatusType.ApplyForQtsId,
                 Status = ProfessionalStatusStatus.Approved,
-                AwardedDate = Clock.Today,
+                AwardedDate = TimeProvider.Today,
                 TrainingProviderUkprn = null,
                 TrainingCountryReference = "9999",
                 IsExemptFromInduction = true
@@ -858,8 +858,8 @@ public class SetProfessionalStatusTests : TestBase
             RouteTypeId = RouteToProfessionalStatusType.HeiProgrammeTypeId,
             Status = ProfessionalStatusStatus.InTraining,
             AwardedDate = null,
-            TrainingStartDate = Clock.Today.AddMonths(-1),
-            TrainingEndDate = Clock.Today.AddMonths(9),
+            TrainingStartDate = TimeProvider.Today.AddMonths(-1),
+            TrainingEndDate = TimeProvider.Today.AddMonths(9),
             TrainingSubjectReferences = Option.Some<string[]>(["100343", "100300", "100079"]),
             TrainingAgeSpecialism = new()
             {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250425/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250804/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250905/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260120/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260224/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260416/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260515/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20260612/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/CreateTrnRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/CreateTrnRequestTests.cs
@@ -109,7 +109,7 @@ public class CreateTrnRequestTests : TestBase
     public async Task Post_RequestWithDateOfBirthEqualOrAfterToday_ReturnsError(int daysAfterToday)
     {
         // Arrange
-        var dateOfBirth = Clock.Today.AddDays(daysAfterToday);
+        var dateOfBirth = TimeProvider.Today.AddDays(daysAfterToday);
 
         var requestBody = CreateJsonContent(CreateDummyRequest() with
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetCpdInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetCpdInductionStatusTests.cs
@@ -32,7 +32,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -54,7 +54,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -76,7 +76,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -101,7 +101,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = status,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -128,9 +128,9 @@ public class SetCpdInductionStatusTests : TestBase
                 InductionStatus.InProgress,
                 startDate,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             await dbContext.SaveChangesAsync();
@@ -145,7 +145,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow.AddDays(-1)
+                modifiedOn = TimeProvider.UtcNow.AddDays(-1)
             })
         };
 
@@ -170,7 +170,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -196,7 +196,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.RequiredToComplete,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -218,7 +218,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.InProgress,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -245,7 +245,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.InProgress,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -271,7 +271,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -297,7 +297,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Failed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -323,7 +323,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -348,7 +348,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.Passed,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -373,7 +373,7 @@ public class SetCpdInductionStatusTests : TestBase
             Content = CreateJsonContent(new
             {
                 status = InductionStatus.RequiredToComplete,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -401,7 +401,7 @@ public class SetCpdInductionStatusTests : TestBase
             {
                 status = InductionStatus.InProgress,
                 startDate = startDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -431,7 +431,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Failed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 
@@ -461,7 +461,7 @@ public class SetCpdInductionStatusTests : TestBase
                 status = InductionStatus.Passed,
                 startDate = startDate,
                 completedDate = completedDate,
-                modifiedOn = Clock.UtcNow
+                modifiedOn = TimeProvider.UtcNow
             })
         };
 

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetDeceasedTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetDeceasedTests.cs
@@ -33,7 +33,7 @@ public class SetDeceasedTests : TestBase
     public async Task Put_DateOfDeathInFuture_ReturnsError()
     {
         // Arrange
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
         var person = await TestData.CreatePersonAsync();
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/deceased/{person.Trn}")
         {

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetQtlsDateRequestTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/VNext/SetQtlsDateRequestTests.cs
@@ -38,7 +38,7 @@ public class SetQtlsDateRequestTests : TestBase
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var futureDate = Clock.Today.AddDays(1);
+        var futureDate = TimeProvider.Today.AddDays(1);
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"v3/persons/{person.Trn}/qtls")
         {

--- a/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
+++ b/tests/TeachingRecordSystem.Api.UnitTests/OperationTestBase.cs
@@ -30,7 +30,7 @@ public abstract class OperationTestBase : IDisposable
 
     public IServiceProvider Services { get; }
 
-    protected FakeTimeProvider Clock => TestScopedServices.GetCurrent().Clock;
+    protected FakeTimeProvider TimeProvider => TestScopedServices.GetCurrent().TimeProvider;
 
     protected ICurrentUserProvider CurrentUserProvider => Services.GetRequiredService<ICurrentUserProvider>();
 

--- a/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
+++ b/tests/TeachingRecordSystem.Api.UnitTests/TestScopedServices.cs
@@ -15,8 +15,8 @@ public class TestScopedServices
 
     public TestScopedServices(IServiceProvider serviceProvider)
     {
-        Clock = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
-        Events = new(Clock);
+        TimeProvider = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+        Events = new(TimeProvider);
         LegacyEventObserver = new();
         FeatureProvider = ActivatorUtilities.CreateInstance<TestableFeatureProvider>(serviceProvider);
         TrnRequestOptions = new();
@@ -60,7 +60,7 @@ public class TestScopedServices
         return false;
     }
 
-    public FakeTimeProvider Clock { get; }
+    public FakeTimeProvider TimeProvider { get; }
 
     public EventCapture Events { get; }
 
@@ -76,7 +76,7 @@ public class TestScopedServices
 
     private class ForwardToTestScopedTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => TestScopedServices.GetCurrent().Clock.GetUtcNow();
+        public override DateTimeOffset GetUtcNow() => TestScopedServices.GetCurrent().TimeProvider.GetUtcNow();
     }
 
     private class ForwardToTestScopedEventObserver : IEventObserver

--- a/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
+++ b/tests/TeachingRecordSystem.Api.UnitTests/V3/SetQtlsTests.cs
@@ -55,7 +55,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         AssertSuccess(result);
 
         var route = await GetQtlsRoute(person.PersonId);
-        Assert.Equal(Clock.UtcNow, route?.DeletedOn);
+        Assert.Equal(TimeProvider.UtcNow, route?.DeletedOn);
 
         var qtlsStatus = await GetQtlsStatus(person.PersonId);
         Assert.Equal(QtlsStatus.Expired, qtlsStatus);
@@ -63,7 +63,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         LegacyEventObserver.AssertEventsSaved(e =>
         {
             var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
-            Assert.Equal(Clock.UtcNow, deletedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, deletedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, deletedEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), deletedEvent.RaisedBy);
         });
@@ -90,7 +90,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(qtlsDate, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.CreatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.CreatedOn);
 
         var qtlsStatus = await GetQtlsStatus(person.PersonId);
         Assert.Equal(QtlsStatus.Active, qtlsStatus);
@@ -98,7 +98,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         LegacyEventObserver.AssertEventsSaved(e =>
         {
             var createdEvent = Assert.IsType<RouteToProfessionalStatusCreatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, createdEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, createdEvent.CreatedUtc);
             Assert.Equal(person.PersonId, createdEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), createdEvent.RaisedBy);
         });
@@ -146,12 +146,12 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(newQtlsDate, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.UpdatedOn);
 
         LegacyEventObserver.AssertEventsSaved(e =>
         {
             var updatedEvent = Assert.IsType<RouteToProfessionalStatusUpdatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, updatedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, updatedEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), updatedEvent.RaisedBy);
             Assert.True(updatedEvent.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.HoldsFrom));
@@ -180,12 +180,12 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(QtsCutoff, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.UpdatedOn);
 
         LegacyEventObserver.AssertEventsSaved(e =>
         {
             var updatedEvent = Assert.IsType<RouteToProfessionalStatusUpdatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, updatedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, updatedEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), updatedEvent.RaisedBy);
             Assert.True(updatedEvent.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.HoldsFrom));
@@ -214,12 +214,12 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(newQtlsDate, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.UpdatedOn);
 
         LegacyEventObserver.AssertEventsSaved(e =>
         {
             var updatedEvent = Assert.IsType<RouteToProfessionalStatusUpdatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, updatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, updatedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, updatedEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), updatedEvent.RaisedBy);
             Assert.True(updatedEvent.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.HoldsFrom));
@@ -251,7 +251,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(QtsCutoff, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.UpdatedOn);
 
         LegacyEventObserver.AssertEventsSaved(
             e1 =>
@@ -262,7 +262,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
                     RouteToProfessionalStatusType.QtlsAndSetMembershipId,
                     createdQtlsEventEvent.RouteToProfessionalStatus.RouteToProfessionalStatusTypeId
                 );
-                Assert.Equal(Clock.UtcNow, createdQtlsEventEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, createdQtlsEventEvent.CreatedUtc);
                 Assert.Equal(person.PersonId, createdQtlsEventEvent.PersonId);
                 Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), createdQtlsEventEvent.RaisedBy);
                 Assert.True(createdQtlsEventEvent.Changes.HasFlag(RouteToProfessionalStatusCreatedEventChanges.PersonQtsDate));
@@ -300,7 +300,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(QtsCutoff, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.UpdatedOn);
 
         LegacyEventObserver.AssertEventsSaved(e1 =>
         {
@@ -310,7 +310,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
                 RouteToProfessionalStatusType.QtlsAndSetMembershipId,
                 updatedQtlsEvent.RouteToProfessionalStatus.RouteToProfessionalStatusTypeId
             );
-            Assert.Equal(Clock.UtcNow, updatedQtlsEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, updatedQtlsEvent.CreatedUtc);
             Assert.Equal(person.PersonId, updatedQtlsEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), updatedQtlsEvent.RaisedBy);
             Assert.True(updatedQtlsEvent.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.PersonQtsDate));
@@ -343,7 +343,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(QtsCutoff, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.UpdatedOn);
 
         LegacyEventObserver.AssertEventsSaved(e1 =>
         {
@@ -353,7 +353,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
                 RouteToProfessionalStatusType.QtlsAndSetMembershipId,
                 updatedQtlsEvent.RouteToProfessionalStatus.RouteToProfessionalStatusTypeId
             );
-            Assert.Equal(Clock.UtcNow, updatedQtlsEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, updatedQtlsEvent.CreatedUtc);
             Assert.Equal(person.PersonId, updatedQtlsEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), updatedQtlsEvent.RaisedBy);
             Assert.True(updatedQtlsEvent.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.PersonQtsDate));
@@ -391,7 +391,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
         Assert.NotNull(route);
         Assert.Equal(QtsCutoff, route.HoldsFrom);
         Assert.Equal(RouteToProfessionalStatusStatus.Holds, route.Status);
-        Assert.Equal(Clock.UtcNow, route.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, route.UpdatedOn);
 
         LegacyEventObserver.AssertEventsSaved(e1 =>
         {
@@ -401,7 +401,7 @@ public class SetQtlsTests(OperationTestFixture operationTestFixture) : Operation
                 RouteToProfessionalStatusType.QtlsAndSetMembershipId,
                 createdQtlsEventEvent.RouteToProfessionalStatus.RouteToProfessionalStatusTypeId
             );
-            Assert.Equal(Clock.UtcNow, createdQtlsEventEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, createdQtlsEventEvent.CreatedUtc);
             Assert.Equal(person.PersonId, createdQtlsEventEvent.PersonId);
             Assert.Equal(CurrentUserProvider.GetCurrentApplicationUserId(), createdQtlsEventEvent.RaisedBy);
             Assert.False(

--- a/tests/TeachingRecordSystem.Api.UnitTests/V3/SetRouteToProfessionalStatusTests.cs
+++ b/tests/TeachingRecordSystem.Api.UnitTests/V3/SetRouteToProfessionalStatusTests.cs
@@ -315,7 +315,7 @@ public class SetRouteToProfessionalStatusTests(OperationTestFixture operationTes
                 degreeTypeId: null,
                 isExemptFromInduction: null,
                 createdBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 changeReason: null,
                 changeReasonDetail: null,
                 evidenceFile: null,

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/CheckAnswersTests.cs
@@ -111,8 +111,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
 
                 var supportTask = await WithDbContextAsync(dbContext => dbContext.SupportTasks.SingleAsync(t => t.OneLoginUserSubject == oneLoginUser.Subject));
                 Assert.NotNull(supportTask);
-                Assert.Equal(Clock.UtcNow, supportTask.CreatedOn);
-                Assert.Equal(Clock.UtcNow, supportTask.UpdatedOn);
+                Assert.Equal(TimeProvider.UtcNow, supportTask.CreatedOn);
+                Assert.Equal(TimeProvider.UtcNow, supportTask.UpdatedOn);
                 Assert.Equal(SupportTaskType.OneLoginUserRecordMatching, supportTask.SupportTaskType);
                 Assert.Equal(SupportTaskStatus.Open, supportTask.Status);
                 Assert.Equal(oneLoginUser.Subject, supportTask.OneLoginUserSubject);
@@ -129,7 +129,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 LegacyEventPublisher.AssertEventsSaved(e =>
                 {
                     var supportTaskCreatedEvent = Assert.IsType<LegacyEvents.SupportTaskCreatedEvent>(e);
-                    Assert.Equal(Clock.UtcNow, supportTaskCreatedEvent.CreatedUtc);
+                    Assert.Equal(TimeProvider.UtcNow, supportTaskCreatedEvent.CreatedUtc);
                     Assert.Equal(supportTaskCreatedEvent.RaisedBy.UserId, SystemUser.SystemUserId);
                     Assert.Equal(supportTask.SupportTaskReference, supportTaskCreatedEvent.SupportTask.SupportTaskReference);
                     Assert.Equal(SupportTaskType.OneLoginUserRecordMatching, supportTaskCreatedEvent.SupportTask.SupportTaskType);
@@ -205,8 +205,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
 
                 var supportTask = await WithDbContextAsync(dbContext => dbContext.SupportTasks.SingleAsync(t => t.OneLoginUserSubject == oneLoginUser.Subject));
                 Assert.NotNull(supportTask);
-                Assert.Equal(Clock.UtcNow, supportTask.CreatedOn);
-                Assert.Equal(Clock.UtcNow, supportTask.UpdatedOn);
+                Assert.Equal(TimeProvider.UtcNow, supportTask.CreatedOn);
+                Assert.Equal(TimeProvider.UtcNow, supportTask.UpdatedOn);
                 Assert.Equal(SupportTaskType.OneLoginUserIdVerification, supportTask.SupportTaskType);
                 Assert.Equal(SupportTaskStatus.Open, supportTask.Status);
                 Assert.Equal(oneLoginUser.Subject, supportTask.OneLoginUserSubject);
@@ -226,7 +226,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 LegacyEventPublisher.AssertEventsSaved(e =>
                 {
                     var supportTaskCreatedEvent = Assert.IsType<LegacyEvents.SupportTaskCreatedEvent>(e);
-                    Assert.Equal(Clock.UtcNow, supportTaskCreatedEvent.CreatedUtc);
+                    Assert.Equal(TimeProvider.UtcNow, supportTaskCreatedEvent.CreatedUtc);
                     Assert.Equal(supportTaskCreatedEvent.RaisedBy.UserId, SystemUser.SystemUserId);
                     Assert.Equal(supportTask.SupportTaskReference, supportTaskCreatedEvent.SupportTask.SupportTaskReference);
                     Assert.Equal(SupportTaskType.OneLoginUserIdVerification, supportTaskCreatedEvent.SupportTask.SupportTaskType);

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/PageTests/SupportRequestSubmittedTests.cs
@@ -72,7 +72,7 @@ public class SupportRequestSubmittedTests(HostFixture hostFixture) : TestBase(ho
             {
                 ApplicationUserId = applicationUser.UserId,
                 RequestId = trnRequestId,
-                CreatedOn = Clock.UtcNow,
+                CreatedOn = TimeProvider.UtcNow,
                 OneLoginUserSubject = oneLoginUser.Subject,
                 IdentityVerified = true,
                 EmailAddress = oneLoginUser.EmailAddress,

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
@@ -37,7 +37,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 // Arrange
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(person);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: AuthenticationOnly, sub: user.Subject);
 
@@ -69,7 +69,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 // Arrange
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(person, email: Option.Some((string?)null));
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 var email = Faker.Internet.Email();
                 var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: AuthenticationOnly, sub: user.Subject, email);
@@ -135,7 +135,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             {
                 // Arrange
                 var user = await TestData.CreateOneLoginUserAsync();
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(user.Subject);
 
@@ -353,7 +353,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             {
                 // Arrange
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: AuthenticationOnly, sub: user.Subject);
 
@@ -428,7 +428,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                         RequestId = trnRequestId,
                         ApplicationUserId = trnRequestApplicationUser.UserId,
                         OneLoginUserSubject = oneLoginUser.Subject,
-                        CreatedOn = Clock.UtcNow.AddDays(-1),
+                        CreatedOn = TimeProvider.UtcNow.AddDays(-1),
                         EmailAddress = oneLoginUser.EmailAddress,
                         FirstName = "Test",
                         MiddleName = null,
@@ -486,7 +486,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             await dbContext.SaveChangesAsync();
         });
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         await WithJourneyCoordinatorAsync(
             (instanceId, processId) => new SignInJourneyState(
@@ -550,7 +550,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                         RequestId = trnRequestId,
                         ApplicationUserId = differentAppUser.UserId,
                         OneLoginUserSubject = oneLoginUser.Subject,
-                        CreatedOn = Clock.UtcNow.AddDays(-7),
+                        CreatedOn = TimeProvider.UtcNow.AddDays(-7),
                         EmailAddress = oneLoginUser.EmailAddress,
                         FirstName = "Test",
                         MiddleName = null,
@@ -595,7 +595,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             {
                 // Arrange
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 var authenticationTicket = CreateOneLoginAuthenticationTicket(
                     vtr: AuthenticationOnly,
@@ -631,7 +631,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             {
                 // Arrange
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 var firstName = Faker.Name.First();
                 var lastName = Faker.Name.Last();
@@ -661,7 +661,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 Assert.Null(coordinator.State.AuthenticationTicket);
 
                 user = await WithDbContextAsync(dbContext => dbContext.OneLoginUsers.SingleAsync(u => u.Subject == user.Subject));
-                Assert.Equal(Clock.UtcNow, user.VerifiedOn);
+                Assert.Equal(TimeProvider.UtcNow, user.VerifiedOn);
                 Assert.Equal(OneLoginUserVerificationRoute.OneLogin, user.VerificationRoute);
                 Assert.NotNull(user.VerifiedNames);
                 Assert.Collection(user.VerifiedNames,
@@ -691,7 +691,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 var email = Faker.Internet.Email();
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 await CreateIdentityUser(person.FirstName, person.LastName, person.Trn, user.EmailAddress!, TrnVerificationLevel.Medium);
 
@@ -746,7 +746,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 var email = Faker.Internet.Email();
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 await CreateIdentityUser(person.FirstName, person.LastName, person.Trn, user.EmailAddress!, TrnVerificationLevel.Low,
                     TrnAssociationSource.SupportUi);
@@ -802,7 +802,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 var email = Faker.Internet.Email();
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 await CreateIdentityUser(person.FirstName, person.LastName, person.Trn, user.EmailAddress!, TrnVerificationLevel.Low,
                     TrnAssociationSource.TrnToken);
@@ -856,7 +856,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 // Arrange
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 await CreateIdentityUser(person.FirstName, person.LastName, person.Trn, user.EmailAddress!, TrnVerificationLevel.Low);
 
@@ -905,7 +905,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 // Arrange
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 await CreateIdentityUser(person.FirstName, person.LastName, person.Trn, user.EmailAddress!, TrnVerificationLevel.Medium);
 
@@ -954,7 +954,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 // Arrange
                 var person = await TestData.CreatePersonAsync();
                 var user = await TestData.CreateOneLoginUserAsync(personId: null);
-                Clock.Advance(TimeSpan.FromDays(1));
+                TimeProvider.Advance(TimeSpan.FromDays(1));
 
                 await CreateIdentityUser(person.FirstName, person.LastName, person.Trn, user.EmailAddress!, TrnVerificationLevel.Medium);
 
@@ -992,7 +992,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!, isActive: true);
 
@@ -1048,7 +1048,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var trnToken = Guid.NewGuid().ToString();
 
@@ -1099,7 +1099,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!, expires: TimeSpan.FromSeconds(-1));
 
@@ -1150,7 +1150,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!, userId: Guid.NewGuid(), isActive: false);
 
@@ -1197,7 +1197,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!);
 
@@ -1248,7 +1248,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var user = await TestData.CreateOneLoginUserAsync(personId: null);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var trnToken = await CreateTrnToken(person.Trn, user.EmailAddress!);
 
@@ -1301,7 +1301,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         var verifiedLastName = Faker.Name.Last();
         var verifiedDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var user = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([verifiedFirstName, verifiedLastName], verifiedDateOfBirth));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         await WithJourneyCoordinatorAsync(
             (instanceId, processId) => new SignInJourneyState(
@@ -1348,7 +1348,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
         var person = await TestData.CreatePersonAsync(p => p.WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth).WithNationalInsuranceNumber());
 
         var user = await TestData.CreateOneLoginUserAsync(personId: null, verifiedInfo: ([firstName, lastName], dateOfBirth));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         await WithJourneyCoordinatorAsync(
             (instanceId, processId) => new SignInJourneyState(
@@ -1431,7 +1431,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             idDbContext,
             eventPublisher,
             Mock.Of<IBackgroundJobScheduler>(),
-            Clock)
+            TimeProvider)
         {
             CallBase = true
         };
@@ -1462,7 +1462,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 return state;
             },
             pathUrls,
-            () => ActivatorUtilities.CreateInstance<SignInJourneyCoordinator>(scope.ServiceProvider, dbContext, oneLoginService, linkGenerator, options, Clock));
+            () => ActivatorUtilities.CreateInstance<SignInJourneyCoordinator>(scope.ServiceProvider, dbContext, oneLoginService, linkGenerator, options, TimeProvider));
 
         await action(signInJourneyCoordinator);
     }
@@ -1477,8 +1477,8 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 EmailAddress = email,
                 FirstName = firstName,
                 LastName = lastName,
-                Created = Clock.UtcNow,
-                Updated = Clock.UtcNow,
+                Created = TimeProvider.UtcNow,
+                Updated = TimeProvider.UtcNow,
                 UserType = IdModelTypes.UserType.Teacher,
                 TrnVerificationLevel = trnVerificationLevel,
                 TrnAssociationSource = trnAssociationSource,
@@ -1492,7 +1492,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
     private async Task<string> CreateTrnToken(string trn, string email, TimeSpan? expires = null, Guid? userId = null, bool isActive = true)
     {
         var trnToken = Guid.NewGuid().ToString();
-        var expiresUtc = Clock.UtcNow.Add(expires ?? TimeSpan.FromHours(1));
+        var expiresUtc = TimeProvider.UtcNow.Add(expires ?? TimeSpan.FromHours(1));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -1500,7 +1500,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             {
                 Token = trnToken,
                 Trn = trn,
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 ExpiresUtc = expiresUtc,
                 EmailAddress = email,
                 IsActive = isActive

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestBase.cs
@@ -38,7 +38,7 @@ public abstract class TestBase
 
     protected CaptureEventObserver LegacyEventPublisher => _testServices.LegacyEventObserver;
 
-    protected FakeTimeProvider Clock => _testServices.Clock;
+    protected FakeTimeProvider TimeProvider => _testServices.TimeProvider;
 
     protected HttpClient HttpClient { get; }
 
@@ -202,9 +202,9 @@ public abstract class TestBase
 
         var trnToken = new IdTrnToken()
         {
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             Email = email,
-            ExpiresUtc = Clock.UtcNow.AddDays(30),
+            ExpiresUtc = TimeProvider.UtcNow.AddDays(30),
             Trn = trn,
             TrnToken = trnTokenStr,
             UserId = null

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestScopedServices.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/TestScopedServices.cs
@@ -11,8 +11,8 @@ public class TestScopedServices
 
     public TestScopedServices(IServiceProvider serviceProvider)
     {
-        Clock = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
-        Events = new(Clock);
+        TimeProvider = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+        Events = new(TimeProvider);
         LegacyEventObserver = new();
         BlobStorageFileService = new();
         SafeFileService = new();
@@ -52,7 +52,7 @@ public class TestScopedServices
         return _current.Value = new(serviceProvider);
     }
 
-    public FakeTimeProvider Clock { get; }
+    public FakeTimeProvider TimeProvider { get; }
 
     public EventCapture Events { get; }
 
@@ -66,7 +66,7 @@ public class TestScopedServices
 
     private class ForwardToTestScopedTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => GetCurrent().Clock.GetUtcNow();
+        public override DateTimeOffset GetUtcNow() => GetCurrent().TimeProvider.GetUtcNow();
     }
 
     private class ForwardToTestScopedEventObserver : IEventObserver

--- a/tests/TeachingRecordSystem.Cli.Tests/CommandTests/CommandTestBase.cs
+++ b/tests/TeachingRecordSystem.Cli.Tests/CommandTests/CommandTestBase.cs
@@ -8,7 +8,7 @@ namespace TeachingRecordSystem.Cli.Tests.CommandTests;
 [Collection(nameof(DisableParallelization))]
 public abstract class CommandTestBase(IServiceProvider services)
 {
-    protected FakeTimeProvider Clock => (FakeTimeProvider)services.GetRequiredService<TimeProvider>();
+    protected FakeTimeProvider TimeProvider => (FakeTimeProvider)services.GetRequiredService<TimeProvider>();
 
     protected DbHelper DbHelper => services.GetRequiredService<DbHelper>();
 

--- a/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/DataStore/Postgres/Models/PersonTests.cs
@@ -6,7 +6,7 @@ namespace TeachingRecordSystem.Core.Tests.DataStore.Postgres.Models;
 
 public class PersonTests
 {
-    public FakeTimeProvider Clock { get; } = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+    public FakeTimeProvider TimeProvider { get; } = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
 
     [Fact]
     public void SetInductionStatus_None_UpdatesStatus()
@@ -24,7 +24,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -48,7 +48,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -72,7 +72,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -96,7 +96,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -120,7 +120,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -144,7 +144,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -168,7 +168,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -190,16 +190,16 @@ public class PersonTests
             status,
             startDate: status != InductionStatus.RequiredToComplete ? new DateOnly(2024, 1, 1) : null,
             completedDate: status == InductionStatus.Passed ? new DateOnly(2024, 10, 1) : null,
-            cpdModifiedOn: Clock.UtcNow,
+            cpdModifiedOn: TimeProvider.UtcNow,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Assert
         Assert.Equal(status, person.InductionStatus);
         Assert.Equal(status, person.InductionStatusWithoutExemption);
-        Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
-        Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
+        Assert.Equal(TimeProvider.UtcNow, person.InductionModifiedOn);
+        Assert.Equal(TimeProvider.UtcNow, person.CpdInductionModifiedOn);
     }
 
     [Fact]
@@ -217,28 +217,28 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
         Debug.Assert(person.InductionStatus == InductionStatus.Exempt);
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         // Act
         person.SetCpdInductionStatus(
             InductionStatus.Passed,
             startDate: new DateOnly(2024, 1, 1),
             completedDate: new DateOnly(2024, 10, 1),
-            cpdModifiedOn: Clock.UtcNow,
+            cpdModifiedOn: TimeProvider.UtcNow,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Assert
         Assert.Equal(InductionStatus.Passed, person.InductionStatus);
         Assert.Equal(InductionStatus.Passed, person.InductionStatusWithoutExemption);
-        Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
-        Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
+        Assert.Equal(TimeProvider.UtcNow, person.InductionModifiedOn);
+        Assert.Equal(TimeProvider.UtcNow, person.CpdInductionModifiedOn);
     }
 
     [Theory]
@@ -258,28 +258,28 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
         Debug.Assert(person.InductionStatus == InductionStatus.Exempt);
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         // Act
         person.SetCpdInductionStatus(
             status,
             startDate: status == InductionStatus.InProgress ? new DateOnly(2024, 1, 1) : null,
             completedDate: null,
-            cpdModifiedOn: Clock.UtcNow,
+            cpdModifiedOn: TimeProvider.UtcNow,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Assert
         Assert.Equal(InductionStatus.Exempt, person.InductionStatus);
         Assert.Equal(status, person.InductionStatusWithoutExemption);
-        Assert.Equal(Clock.UtcNow, person.InductionModifiedOn);
-        Assert.Equal(Clock.UtcNow, person.CpdInductionModifiedOn);
+        Assert.Equal(TimeProvider.UtcNow, person.InductionModifiedOn);
+        Assert.Equal(TimeProvider.UtcNow, person.CpdInductionModifiedOn);
     }
 
     [Theory]
@@ -305,11 +305,11 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         // Act
         person.TrySetWelshInductionStatus(
@@ -317,7 +317,7 @@ public class PersonTests
             startDate: !passed ? new DateOnly(2024, 1, 1) : null,
             completedDate: !passed ? new DateOnly(2024, 10, 1) : null,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -341,11 +341,11 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         // Act
         person.TrySetWelshInductionStatus(
@@ -353,7 +353,7 @@ public class PersonTests
             startDate: null,
             completedDate: null,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -377,11 +377,11 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         // Act
         person.TrySetWelshInductionStatus(
@@ -389,7 +389,7 @@ public class PersonTests
             startDate: new DateOnly(2024, 1, 1),
             completedDate: new DateOnly(2024, 10, 1),
             updatedBy: SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -407,13 +407,13 @@ public class PersonTests
             status: InductionStatus.InProgress,
             startDate: new DateOnly(2024, 1, 1),
             completedDate: null,
-            cpdModifiedOn: Clock.UtcNow,
+            cpdModifiedOn: TimeProvider.UtcNow,
             SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Act
-        var result = person.InductionStatusManagedByCpd(Clock.Today);
+        var result = person.InductionStatusManagedByCpd(TimeProvider.Today);
 
         // Assert
         Assert.True(result);
@@ -427,15 +427,15 @@ public class PersonTests
 
         person.SetCpdInductionStatus(
             status: InductionStatus.Passed,
-            startDate: Clock.Today.AddYears(-1),
-            completedDate: Clock.Today,
-            cpdModifiedOn: Clock.UtcNow,
+            startDate: TimeProvider.Today.AddYears(-1),
+            completedDate: TimeProvider.Today,
+            cpdModifiedOn: TimeProvider.UtcNow,
             SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Act
-        var result = person.InductionStatusManagedByCpd(Clock.Today);
+        var result = person.InductionStatusManagedByCpd(TimeProvider.Today);
 
         // Assert
         Assert.True(result);
@@ -449,15 +449,15 @@ public class PersonTests
 
         person.SetCpdInductionStatus(
             status: InductionStatus.Passed,
-            startDate: Clock.Today.AddYears(-9),
-            completedDate: Clock.Today.AddYears(-7),
-            cpdModifiedOn: Clock.UtcNow,
+            startDate: TimeProvider.Today.AddYears(-9),
+            completedDate: TimeProvider.Today.AddYears(-7),
+            cpdModifiedOn: TimeProvider.UtcNow,
             SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             out _);
 
         // Act
-        var result = person.InductionStatusManagedByCpd(Clock.Today);
+        var result = person.InductionStatusManagedByCpd(TimeProvider.Today);
 
         // Assert
         Assert.False(result);
@@ -471,19 +471,19 @@ public class PersonTests
 
         person.SetInductionStatus(
             status: InductionStatus.InProgress,
-            startDate: Clock.Today,
+            startDate: TimeProvider.Today,
             completedDate: null,
             exemptionReasonIds: [],
             changeReason: null,
             changeReasonDetail: null,
             evidenceFile: null,
             SystemUser.SystemUserId,
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
         // Act
-        var result = person.InductionStatusManagedByCpd(Clock.Today);
+        var result = person.InductionStatusManagedByCpd(TimeProvider.Today);
 
         // Assert
         Assert.False(result);
@@ -508,7 +508,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -516,7 +516,7 @@ public class PersonTests
         person.AddInductionExemptionReason(
             InductionExemptionReason.QtlsId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -540,7 +540,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -548,7 +548,7 @@ public class PersonTests
         person.AddInductionExemptionReason(
             InductionExemptionReason.QtlsId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -574,14 +574,14 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
         person.AddInductionExemptionReason(
             InductionExemptionReason.QtlsId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         Debug.Assert(person.InductionStatus == InductionStatus.Exempt);
@@ -590,7 +590,7 @@ public class PersonTests
         person.RemoveInductionExemptionReason(
             InductionExemptionReason.QtlsId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -614,14 +614,14 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
         person.AddInductionExemptionReason(
             InductionExemptionReason.QtlsId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         Debug.Assert(person.InductionStatus == currentStatus);
@@ -630,7 +630,7 @@ public class PersonTests
         person.RemoveInductionExemptionReason(
             InductionExemptionReason.QtlsId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -652,7 +652,7 @@ public class PersonTests
             changeReasonDetail: null,
             evidenceFile: null,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             additionalInformation: null,
             out _);
 
@@ -662,7 +662,7 @@ public class PersonTests
         person.RemoveInductionExemptionReason(
             InductionExemptionReason.QtlsId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -686,7 +686,7 @@ public class PersonTests
         person.RemoveInductionExemptionReason(
             exemptionReasonId,
             updatedBy: SystemUser.SystemUserId,
-            now: Clock.UtcNow,
+            now: TimeProvider.UtcNow,
             out _);
 
         // Assert
@@ -703,10 +703,10 @@ public class PersonTests
         var allRoutes = new List<RouteToProfessionalStatusType>();
         var professionalStatuses = new List<RouteToProfessionalStatus>();
 
-        DateOnly? existingRouteHoldsFrom = Clock.Today.AddDays(-10);
+        DateOnly? existingRouteHoldsFrom = TimeProvider.Today.AddDays(-10);
         RouteToProfessionalStatusStatus existingRouteStatus =
             testCaseData.ExistingRouteIsHoldsStatus ? RouteToProfessionalStatusStatus.Holds : RouteToProfessionalStatusStatus.InTraining;
-        DateOnly? newRouteHoldsFrom = testCaseData.NewHoldsFromIsAfterExistingHoldsFrom ? Clock.Today.AddDays(-1) : Clock.Today.AddDays(-20);
+        DateOnly? newRouteHoldsFrom = testCaseData.NewHoldsFromIsAfterExistingHoldsFrom ? TimeProvider.Today.AddDays(-1) : TimeProvider.Today.AddDays(-20);
         RouteToProfessionalStatusStatus newRouteStatus =
             testCaseData.NewRouteIsHoldsStatus ? RouteToProfessionalStatusStatus.Holds : RouteToProfessionalStatusStatus.InTraining;
 
@@ -829,8 +829,8 @@ public class PersonTests
             new TestableRouteToProfessionalStatus()
             {
                 QualificationId = Guid.NewGuid(),
-                CreatedOn = Clock.UtcNow,
-                UpdatedOn = Clock.UtcNow,
+                CreatedOn = TimeProvider.UtcNow,
+                UpdatedOn = TimeProvider.UtcNow,
                 DeletedOn = null,
                 PersonId = person.PersonId,
                 RouteToProfessionalStatusTypeId = route.RouteToProfessionalStatusTypeId,
@@ -867,7 +867,7 @@ public class PersonTests
 
         // Act
         person.RefreshInductionStatusForQtsProfessionalStatusChanged(
-            Clock.UtcNow,
+            TimeProvider.UtcNow,
             []);
 
         // Assert
@@ -888,7 +888,7 @@ public class PersonTests
             .ToArray();
 
         // Act
-        person.RefreshInductionStatusForQtsProfessionalStatusChanged(Clock.UtcNow, allRouteTypes, newRoutes);
+        person.RefreshInductionStatusForQtsProfessionalStatusChanged(TimeProvider.UtcNow, allRouteTypes, newRoutes);
 
         // Assert
         Assert.Equal(expectedInductionStatus, person.InductionStatus);

--- a/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/EventPipelineTestBase.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/EventPipelineTestBase.cs
@@ -15,7 +15,7 @@ public class EventPipelineTestBase
         TestScopedServices.Reset();
     }
 
-    protected FakeTimeProvider Clock => TestScopedServices.GetCurrent().Clock;
+    protected FakeTimeProvider TimeProvider => TestScopedServices.GetCurrent().TimeProvider;
 
     protected IDbContextFactory<TrsDbContext> DbContextFactory => _fixture.Services.GetRequiredService<IDbContextFactory<TrsDbContext>>();
 

--- a/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/SupportTaskEventPipelineTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/SupportTaskEventPipelineTests.cs
@@ -10,7 +10,7 @@ public class SupportTaskEventPipelineTests(EventPipelineFixture fixture) : Event
     public async Task SupportTaskCreatedEventPublished_EmitsLegacySupportTaskCreatedEvent()
     {
         // Arrange
-        var processContext = new ProcessContext(default, Clock.UtcNow, SystemUser.SystemUserId);
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
 
         var @event = new SupportTaskCreatedEvent
         {

--- a/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/TestScopedServices.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/TestScopedServices.cs
@@ -11,12 +11,12 @@ public class TestScopedServices
 
     public TestScopedServices()
     {
-        Clock = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
-        Events = new(Clock);
+        TimeProvider = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+        Events = new(TimeProvider);
         LegacyEventObserver = new();
     }
 
-    public FakeTimeProvider Clock { get; }
+    public FakeTimeProvider TimeProvider { get; }
 
     public EventCapture Events { get; }
 
@@ -56,7 +56,7 @@ public class TestScopedServices
 
     private class ForwardToTestScopedTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => GetCurrent().Clock.GetUtcNow();
+        public override DateTimeOffset GetUtcNow() => GetCurrent().TimeProvider.GetUtcNow();
     }
 
     private class ForwardToTestScopedEventObserver : IEventObserver

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendInductionCompletedEmailsJobTests.cs
@@ -13,7 +13,7 @@ public class BatchSendInductionCompletedEmailsJobTests(JobFixture fixture) : Job
     public async Task Execute_EnqueuesEmailForInductionCompletees()
     {
         // Arrange
-        var initialLastAwardedToUtc = Clock.Today.AddDays(-5).ToDateTime();
+        var initialLastAwardedToUtc = TimeProvider.Today.AddDays(-5).ToDateTime();
         var backgroundJobScheduler = new Mock<IBackgroundJobScheduler>();
 
         var jobOptions = Options.Create(
@@ -44,7 +44,7 @@ public class BatchSendInductionCompletedEmailsJobTests(JobFixture fixture) : Job
                 changeReasonDetail: null,
                 evidenceFile: null,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
 
@@ -54,7 +54,7 @@ public class BatchSendInductionCompletedEmailsJobTests(JobFixture fixture) : Job
             await dbContext.SaveChangesAsync();
         });
 
-        Clock.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
+        TimeProvider.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
 
         // Act
         await WithServiceAsync<BatchSendInductionCompletedEmailsJob>(

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/BatchSendProfessionalStatusEmailsJobTests.cs
@@ -17,10 +17,10 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.AssessmentOnlyRouteId, holdsFrom: Clock.Today)
+            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.AssessmentOnlyRouteId, holdsFrom: TimeProvider.Today)
             .WithEmailAddress(TestData.GenerateUniqueEmail()));
 
-        Clock.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
+        TimeProvider.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
 
         // Act
         await WithServiceAsync<BatchSendProfessionalStatusEmailsJob>(
@@ -52,10 +52,10 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.InternationalQualifiedTeacherStatusId, holdsFrom: Clock.Today)
+            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.InternationalQualifiedTeacherStatusId, holdsFrom: TimeProvider.Today)
             .WithEmailAddress(TestData.GenerateUniqueEmail()));
 
-        Clock.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
+        TimeProvider.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
 
         // Act
         await WithServiceAsync<BatchSendProfessionalStatusEmailsJob>(
@@ -87,10 +87,10 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.QtlsAndSetMembershipId, holdsFrom: Clock.Today)
+            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.QtlsAndSetMembershipId, holdsFrom: TimeProvider.Today)
             .WithEmailAddress(TestData.GenerateUniqueEmail()));
 
-        Clock.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
+        TimeProvider.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
 
         // Act
         await WithServiceAsync<BatchSendProfessionalStatusEmailsJob>(
@@ -120,10 +120,10 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.EarlyYearsTeacherStatus, holdsFrom: Clock.Today)
+            .WithHoldsRouteToProfessionalStatus(ProfessionalStatusType.EarlyYearsTeacherStatus, holdsFrom: TimeProvider.Today)
             .WithEmailAddress(TestData.GenerateUniqueEmail()));
 
-        Clock.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
+        TimeProvider.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
 
         // Act
         await WithServiceAsync<BatchSendProfessionalStatusEmailsJob>(
@@ -155,7 +155,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
         var jobOptions = CreateJobOptions();
 
         var person = await TestData.CreatePersonAsync(p => p
-            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.QtlsAndSetMembershipId, holdsFrom: Clock.Today)
+            .WithHoldsRouteToProfessionalStatus(RouteToProfessionalStatusType.QtlsAndSetMembershipId, holdsFrom: TimeProvider.Today)
             .WithEmailAddress(TestData.GenerateUniqueEmail()));
 
         await WithDbContextAsync(async dbContext =>
@@ -168,14 +168,14 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
                 deletionReasonDetail: null,
                 evidenceFile: null,
                 deletedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var deletedEvent);
             dbContext.AddEventWithoutBroadcast(deletedEvent);
             await dbContext.SaveChangesAsync();
         });
 
-        Clock.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
+        TimeProvider.Advance(TimeSpan.FromDays(jobOptions.Value.EmailDelayDays + 2));
 
         // Act
         await WithServiceAsync<BatchSendProfessionalStatusEmailsJob>(
@@ -201,7 +201,7 @@ public class BatchSendProfessionalStatusEmailsJobTests(JobFixture fixture) : Job
             new BatchSendProfessionalStatusEmailsOptions
             {
                 EmailDelayDays = 3,
-                InitialLastHoldsFromEndUtc = Clock.Today.AddDays(-5).ToDateTime(),
+                InitialLastHoldsFromEndUtc = TimeProvider.Today.AddDays(-5).ToDateTime(),
                 JobSchedule = Cron.Never(),
                 RaisedByUserIds = [SystemUser.SystemUserId]
             });

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportAmendJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportAmendJobTests.cs
@@ -24,7 +24,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
             var expectedTotalCount = 0;
             var expectedDuplicateCount = 0;
 
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
 
             // Act
             var integrationTransactionJobId = await job.ExecuteAsync(CancellationToken.None);
@@ -50,14 +50,14 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
             var jobMetaData = new JobMetadata()
             {
                 JobName = nameof(CapitaExportAmendJob),
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-3).AddHours(-2).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-3).AddHours(-2).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
@@ -84,7 +84,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
             var personUpdatedEvent = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddHours(-1),
+                CreatedUtc = TimeProvider.UtcNow.AddHours(-1),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person.PersonId,
                 PersonAttributes = newPersonDetails,
@@ -134,14 +134,14 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
             var jobMetaData = new JobMetadata()
             {
                 JobName = nameof(CapitaExportAmendJob),
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-3).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-3).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
@@ -167,7 +167,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
             var personUpdatedEvent = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddHours(-1),
+                CreatedUtc = TimeProvider.UtcNow.AddHours(-1),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person.PersonId,
                 PersonAttributes = newPersonDetails,
@@ -216,14 +216,14 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
             var jobMetaData = new JobMetadata()
             {
                 JobName = nameof(CapitaExportAmendJob),
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-3).AddHours(-5).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-3).AddHours(-5).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
@@ -251,7 +251,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
             var personUpdatedEvent = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person.PersonId,
                 PersonAttributes = newPersonDetails,
@@ -312,7 +312,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
             var lastName = new string('x', 25);
             var person = await TestData.CreatePersonAsync(x =>
             {
@@ -359,7 +359,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
             var lastName = "xx";
             var person = await TestData.CreatePersonAsync(x =>
             {
@@ -408,7 +408,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
             var person = await TestData.CreatePersonAsync(x =>
             {
                 x.WithDateOfBirth(new DateOnly(1983, 01, 07));
@@ -457,7 +457,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
             var person = await TestData.CreatePersonAsync(x =>
             {
                 x.WithDateOfBirth(new DateOnly(1983, 01, 07));
@@ -507,7 +507,7 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
 
             // Act
             var updateCode = job.GetUpdateCode(exportType);
@@ -523,11 +523,11 @@ public class CapitaExportAmendJobTests(JobFixture fixture) : JobTestBase(fixture
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, Clock, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
-            var expectedFileName = $"Reg01_DTR_{Clock.UtcNow.ToString("yyyyMMdd")}_{Clock.UtcNow.ToString("HHmmss")}_Amend.txt"; ;
+            var job = new CapitaExportAmendJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportAmendJob>.Instance, dbContext, TimeProvider, Options.Create(new CapitaTpsUserOption { CapitaTpsUserId = ApplicationUser.CapitaTpsImportUser.UserId }));
+            var expectedFileName = $"Reg01_DTR_{TimeProvider.UtcNow.ToString("yyyyMMdd")}_{TimeProvider.UtcNow.ToString("HHmmss")}_Amend.txt"; ;
 
             // Act
-            var fileName = job.GetFileName(Clock);
+            var fileName = job.GetFileName(TimeProvider);
 
             // Assert
             Assert.Equal(expectedFileName, fileName);

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportNewJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaExportNewJobTests.cs
@@ -17,20 +17,20 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var jobMetaData = new JobMetadata()
             {
                 JobName = nameof(CapitaExportNewJob),
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-3).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-3).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
             dbContext.JobMetadata.Add(jobMetaData);
             await dbContext.SaveChangesAsync();
-            var lastRunDate = Clock.UtcNow.AddDays(-2);
+            var lastRunDate = TimeProvider.UtcNow.AddDays(-2);
             var person1 = await TestData.CreatePersonAsync(x =>
             {
                 x.WithGender(Gender.Male);
@@ -57,14 +57,14 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var jobMetaData = new JobMetadata()
             {
                 JobName = nameof(CapitaExportNewJob),
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-3).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-3).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
@@ -90,8 +90,8 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
-            var lastRunDate = Clock.UtcNow.AddDays(1);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
+            var lastRunDate = TimeProvider.UtcNow.AddDays(1);
 
             // Act
             var newPersons = await job.GetNewPersonsAsync(lastRunDate);
@@ -107,7 +107,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var lastRunDate = DateTime.UtcNow.AddDays(-2);
             var person1 = await TestData.CreatePersonAsync();
             var person2 = await TestData.CreatePersonAsync();
@@ -130,7 +130,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var person1 = await TestData.CreatePersonAsync(x =>
             {
                 x.WithGender(gender);
@@ -166,7 +166,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var newLastName = Faker.Name.Last();
             var person1 = await TestData.CreatePersonAsync(x =>
             {
@@ -177,7 +177,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddYears(-2),
+                CreatedUtc = TimeProvider.UtcNow.AddYears(-2),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = personDetails,
@@ -221,7 +221,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             Gender gender = Gender.Male;
             var person1 = await TestData.CreatePersonAsync(x =>
             {
@@ -257,7 +257,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var person1 = await TestData.CreatePersonAsync(x =>
             {
                 x.WithGender(Gender.Male);
@@ -292,7 +292,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var person1 = await TestData.CreatePersonAsync(x =>
             {
                 x.WithGender(Gender.Male);
@@ -329,7 +329,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var person1 = await TestData.CreatePersonAsync(x =>
             {
                 x.WithGender(Gender.Male);
@@ -368,7 +368,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var newLastName = Faker.Name.Last();
             var originalastName = Faker.Name.Last();
             var person1 = await TestData.CreatePersonAsync(x =>
@@ -383,7 +383,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddYears(-2),
+                CreatedUtc = TimeProvider.UtcNow.AddYears(-2),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = newPersonDetails,
@@ -419,7 +419,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var newLastName = Faker.Name.Last();
             var originalastName = Faker.Name.Last();
             var person1 = await TestData.CreatePersonAsync(x =>
@@ -433,7 +433,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddYears(-2),
+                CreatedUtc = TimeProvider.UtcNow.AddYears(-2),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = newPersonDetails,
@@ -469,7 +469,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var newLastName = new string('x', 60);
             var originalastName = new string('a', 75);
             var person1 = await TestData.CreatePersonAsync(x =>
@@ -483,7 +483,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddYears(-2),
+                CreatedUtc = TimeProvider.UtcNow.AddYears(-2),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = newPersonDetails,
@@ -519,7 +519,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var updateLastName1 = Faker.Name.Last();
             var updateLastName2 = Faker.Name.Last();
             var updateLastName3 = Faker.Name.Last();
@@ -537,7 +537,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent1 = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddYears(-3),
+                CreatedUtc = TimeProvider.UtcNow.AddYears(-3),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = newPersonDetails1,
@@ -558,7 +558,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent2 = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow.AddYears(-2),
+                CreatedUtc = TimeProvider.UtcNow.AddYears(-2),
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = newPersonDetails2,
@@ -579,7 +579,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent3 = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = newPersonDetails3,
@@ -615,7 +615,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             await dbContext.IntegrationTransactionRecords.ExecuteDeleteAsync();
             var expectedTotalRowCount = 1;
             var expectedTotalSuccessCount = 1;
@@ -627,7 +627,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-2).AddHours(-2).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-2).AddHours(-2).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
@@ -695,14 +695,14 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-1).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-1).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
             dbContext.JobMetadata.Add(jobMetaData);
             var originalastName = Faker.Name.Last();
             await dbContext.SaveChangesAsync();
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
 
             // Act
             var integrationTransactionJobId = await job.ExecuteAsync(CancellationToken.None);
@@ -737,13 +737,13 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-2).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-2).ToString("s", System.Globalization.CultureInfo.InvariantCulture)
                         }
                     }
             };
             dbContext.JobMetadata.Add(jobMetaData);
             await dbContext.SaveChangesAsync();
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var originalastName = Faker.Name.Last();
             var person1 = await TestData.CreatePersonAsync(x =>
             {
@@ -757,7 +757,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent1 = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = trsPerson.PersonId,
                 PersonAttributes = newPersonDetails,
@@ -804,7 +804,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
             var expectedTotalRowCount = 4;
             var expectedTotalSuccessCount = 4;
             var expectedFailureCount = 0;
@@ -815,7 +815,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
                 Metadata = new Dictionary<string, string>
                     {
                         {
-                            "LastRunDate", Clock.UtcNow.AddDays(-5).AddHours(-2).ToString("o")
+                            "LastRunDate", TimeProvider.UtcNow.AddDays(-5).AddHours(-2).ToString("o")
                         }
                     }
             };
@@ -843,7 +843,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent1 = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person1.PersonId,
                 PersonAttributes = newPersonDetails1,
@@ -862,7 +862,7 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
             var nameChangeEvent2 = new LegacyEvents.PersonDetailsUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person2.PersonId,
                 PersonAttributes = newPersonDetails2,
@@ -939,11 +939,11 @@ public class CapitaExportNewJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             // Arrange
-            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, Clock);
-            var expectedFileName = $"Reg01_DTR_{Clock.UtcNow.ToString("yyyyMMdd")}_{Clock.UtcNow.ToString("HHmmss")}_New.txt"; ;
+            var job = new CapitaExportNewJob(CreateDataLakeServiceClientMock(), NullLogger<CapitaExportNewJob>.Instance, dbContext, TimeProvider);
+            var expectedFileName = $"Reg01_DTR_{TimeProvider.UtcNow.ToString("yyyyMMdd")}_{TimeProvider.UtcNow.ToString("HHmmss")}_New.txt"; ;
 
             // Act
-            var fileName = job.GetFileName(Clock);
+            var fileName = job.GetFileName(TimeProvider);
 
             // Assert
             Assert.Equal(expectedFileName, fileName);

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaImportJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaImportJobTests.cs
@@ -454,7 +454,7 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
         var gender = Gender.Female;
         var dob = new DateOnly(1981, 08, 20);
         var nino = Faker.Identification.UkNationalInsuranceNumber();
-        var dateOfDeath = DateOnly.FromDateTime(Clock.UtcNow.AddDays(-1));
+        var dateOfDeath = DateOnly.FromDateTime(TimeProvider.UtcNow.AddDays(-1));
 
         (var reader, var rowData) = BuildSingleRowCsv(trn, gender, lastName, firstName, dob, nino, dateOfDeath);
 
@@ -498,7 +498,7 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
         var newFirstName = TestData.GenerateChangedFirstName(existingPerson.FirstName);
         var newGender = Gender.Female;
         var newDob = new DateOnly(1981, 08, 20);
-        var dateOfDeath = DateOnly.FromDateTime(Clock.UtcNow.AddDays(-1));
+        var dateOfDeath = DateOnly.FromDateTime(TimeProvider.UtcNow.AddDays(-1));
 
         (var reader, var rowData) = BuildSingleRowCsv(existingPerson.Trn, newGender, existingPerson.LastName, newFirstName, existingPerson.DateOfBirth, existingPerson.NationalInsuranceNumber, dateOfDeath);
 
@@ -543,7 +543,7 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
     public async Task Import_WhenDateOfDeathInvalid_DoesNothing_ReportsFailureWithValidationMessage(string dateOfDeath)
     {
         // Arrange
-        var dateOfBirth = Clock.UtcNow.AddDays(-25).ToString("yyyyMMdd");
+        var dateOfBirth = TimeProvider.UtcNow.AddDays(-25).ToString("yyyyMMdd");
         (var reader, var rowData) = BuildSingleRowCsv("1234567", "1", "Lastname", "Firstname", dateOfBirth, "AB123456D", dateOfDeath);
 
         // Act
@@ -578,8 +578,8 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
     public async Task Import_WhenDateOfDeathInFuture_DoesNothing_ReportsFailureWithValidationMessage()
     {
         // Arrange
-        var dateOfBirth = Clock.UtcNow.AddDays(-25).ToString("yyyyMMdd");
-        var dateOfDeath = Clock.UtcNow.AddDays(25).ToString("yyyyMMdd");
+        var dateOfBirth = TimeProvider.UtcNow.AddDays(-25).ToString("yyyyMMdd");
+        var dateOfDeath = TimeProvider.UtcNow.AddDays(25).ToString("yyyyMMdd");
 
         (var reader, var rowData) = BuildSingleRowCsv("1234567", "1", "Lastname", "Firstname", dateOfBirth, "AB123456D", dateOfDeath);
 
@@ -649,7 +649,7 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
     public async Task Import_WhenDateOfBirthInFuture_DoesNothing_ReportsFailureWithValidationMessage()
     {
         // Arrange
-        var dateOfBirth = Clock.UtcNow.AddDays(25).ToString("yyyyMMdd");
+        var dateOfBirth = TimeProvider.UtcNow.AddDays(25).ToString("yyyyMMdd");
 
         (var reader, var rowData) = BuildSingleRowCsv("1234567", "1", "Lastname", "Firstname", dateOfBirth, "AB123456D");
 
@@ -1694,7 +1694,7 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
         await WithDbContextAsync(async dbContext =>
         {
             var selectedPerson = dbContext.Persons.Single(x => x.Trn == trn);
-            selectedPerson.SetStatus(PersonStatus.Deactivated, "de-activate", "de-activated", "", null, SystemUser.SystemUserId, Clock.UtcNow, out var _);
+            selectedPerson.SetStatus(PersonStatus.Deactivated, "de-activate", "de-activated", "", null, SystemUser.SystemUserId, TimeProvider.UtcNow, out var _);
             await dbContext.SaveChangesAsync();
         });
     }

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/DeleteStaleJourneyStatesJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/DeleteStaleJourneyStatesJobTests.cs
@@ -12,26 +12,26 @@ public class DeleteStaleJourneyStatesJobTests(JobFixture fixture) : JobTestBase(
         var journeyState1 = new JourneyState
         {
             InstanceId = Guid.NewGuid().ToString(),
-            Created = Clock.UtcNow.AddDays(-2),
+            Created = TimeProvider.UtcNow.AddDays(-2),
             State = "State1",
             UserId = Guid.NewGuid().ToString(),
-            Updated = Clock.UtcNow.AddDays(-2)
+            Updated = TimeProvider.UtcNow.AddDays(-2)
         };
         var journeyState2 = new JourneyState
         {
             InstanceId = Guid.NewGuid().ToString(),
-            Created = Clock.UtcNow.AddDays(-1).AddMinutes(Random.Shared.Next(0, 60)),
+            Created = TimeProvider.UtcNow.AddDays(-1).AddMinutes(Random.Shared.Next(0, 60)),
             State = "State2",
             UserId = Guid.NewGuid().ToString(),
-            Updated = Clock.UtcNow.AddDays(-1).AddMinutes(Random.Shared.Next(0, 60))
+            Updated = TimeProvider.UtcNow.AddDays(-1).AddMinutes(Random.Shared.Next(0, 60))
         };
         var journeyState3 = new JourneyState
         {
             InstanceId = Guid.NewGuid().ToString(),
-            Created = Clock.UtcNow.AddMinutes(Random.Shared.Next(-60, 0)),
+            Created = TimeProvider.UtcNow.AddMinutes(Random.Shared.Next(-60, 0)),
             State = "State3",
             UserId = Guid.NewGuid().ToString(),
-            Updated = Clock.UtcNow.AddMinutes(Random.Shared.Next(-60, 0))
+            Updated = TimeProvider.UtcNow.AddMinutes(Random.Shared.Next(-60, 0))
         };
 
         await WithDbContextAsync(async dbContext =>

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Induction.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Induction.cs
@@ -65,10 +65,10 @@ public partial class EwcWalesImportJobTests
         var expectedSuccessCount = 1;
         var expectedDuplicateRowCount = 0;
         var expectedFailureRowCount = 0;
-        var qtlsDate = Clock.Today.AddYears(-2);
-        var holdsDate = Clock.Today.AddYears(-2).AddDays(1);
-        var startDate = Clock.Today.AddYears(-1).AddDays(1);
-        var passDate = Clock.Today.AddYears(-1).AddDays(2);
+        var qtlsDate = TimeProvider.Today.AddYears(-2);
+        var holdsDate = TimeProvider.Today.AddYears(-2).AddDays(1);
+        var startDate = TimeProvider.Today.AddYears(-1).AddDays(1);
+        var passDate = TimeProvider.Today.AddYears(-1).AddDays(2);
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithRouteToProfessionalStatus(s => s

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Qts.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/EwcWalesImportJobTests.Qts.cs
@@ -54,7 +54,7 @@ public partial class EwcWalesImportJobTests
     public async Task EwcWalesImportJobQts_WelshRAfterECDirectiveChange_Format1ImportsQtsFileSuccessfully(string qtsStatus)
     {
         // Arrange
-        var awardedDate = Clock.Today.AddDays(-10);
+        var awardedDate = TimeProvider.Today.AddDays(-10);
         var expectedTotalRowCount = 1;
         var expectedSuccessCount = 1;
         var expectedDuplicateRowCount = 0;
@@ -531,7 +531,7 @@ public partial class EwcWalesImportJobTests
         var expectedFailureRowCount = 0;
         var person1 = await TestData.CreatePersonAsync();
         var trn1 = person1.Trn;
-        var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn1},firstname,lastname,{person1.DateOfBirth.ToString("dd/MM/yyyy")},{qtsStatus},{Clock.Today.AddDays(-10).ToString(QtsImporter.DateFormat)},,,,,,,,,,,,,,,,,,,,,,,,";
+        var csvContent = $"QTS_REF_NO,FORENAME,SURNAME,DATE_OF_BIRTH,QTS_STATUS,QTS_DATE,ITT StartMONTH,ITT START YY,ITT End Date,ITT Course Length,ITT Estab LEA code,ITT Estab Code,ITT Qual Code,ITT Class Code,ITT Subject Code 1,ITT Subject Code 2,ITT Min Age Range,ITT Max Age Range,ITT Min Sp Age Range,ITT Max Sp Age Range,ITT Course Length,PQ Year of Award,COUNTRY,PQ Estab Code,PQ Qual Code,HONOURS,PQ Class Code,PQ Subject Code 1,PQ Subject Code 2,PQ Subject Code 3\r\n{trn1},firstname,lastname,{person1.DateOfBirth.ToString("dd/MM/yyyy")},{qtsStatus},{TimeProvider.Today.AddDays(-10).ToString(QtsImporter.DateFormat)},,,,,,,,,,,,,,,,,,,,,,,,";
         var csvBytes = Encoding.UTF8.GetBytes(csvContent);
         var stream = new MemoryStream(csvBytes);
         var reader = new StreamReader(stream);

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/InductionImporterTests.cs
@@ -8,7 +8,7 @@ public class InductionImporterTests(JobFixture fixture) : JobTestBase(fixture)
     private Task<InductionImporter.InductionImportLookupData> GetLookupDataAsync(EwcWalesInductionImportData row) =>
         WithServiceAsync<InductionImporter, InductionImporter.InductionImportLookupData>(
             importer => importer.GetLookupDataAsync(row),
-            Clock);
+            TimeProvider);
 
     private Task<(List<string> ValidationFailures, List<string> Errors)> ValidateAsync(EwcWalesInductionImportData row) =>
         WithServiceAsync<InductionImporter, (List<string>, List<string>)>(
@@ -17,7 +17,7 @@ public class InductionImporterTests(JobFixture fixture) : JobTestBase(fixture)
                 var lookups = await importer.GetLookupDataAsync(row);
                 return importer.Validate(row, lookups);
             },
-            Clock);
+            TimeProvider);
 
     [Fact]
     public async Task Validate_MissingReferenceNumber_ReturnsError()
@@ -137,8 +137,8 @@ public class InductionImporterTests(JobFixture fixture) : JobTestBase(fixture)
     {
         // Arrange
         var awardDate = new DateOnly(2011, 01, 1);
-        var person1AwardedDate = Clock.Today.AddDays(-100);
-        var qtsDate = Clock.Today.AddDays(-110);
+        var person1AwardedDate = TimeProvider.Today.AddDays(-100);
+        var qtsDate = TimeProvider.Today.AddDays(-110);
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithQtls(qtsDate);
@@ -269,7 +269,7 @@ public class InductionImporterTests(JobFixture fixture) : JobTestBase(fixture)
         {
             x.WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
-                .WithHoldsFrom(Clock.Today.AddDays(-10))
+                .WithHoldsFrom(TimeProvider.Today.AddDays(-10))
                 .WithStatus(RouteToProfessionalStatusStatus.Holds));
         });
         var row = GetDefaultRow(x =>

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/JobTestBase.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/JobTestBase.cs
@@ -17,7 +17,7 @@ public abstract class JobTestBase
 
     protected EventCapture Events => TestScopedServices.GetCurrent().Events;
 
-    protected FakeTimeProvider Clock => TestScopedServices.GetCurrent().Clock;
+    protected FakeTimeProvider TimeProvider => TestScopedServices.GetCurrent().TimeProvider;
 
     protected IDbContextFactory<TrsDbContext> DbContextFactory => _fixture.Services.GetRequiredService<IDbContextFactory<TrsDbContext>>();
 

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/QtsImporterTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/QtsImporterTests.cs
@@ -9,7 +9,7 @@ public class QtsImporterTests(JobFixture fixture) : JobTestBase(fixture)
     private Task<QtsImporter.QtsImportLookupData> GetLookupDataAsync(EwcWalesQtsFileImportData row) =>
         WithServiceAsync<QtsImporter, QtsImporter.QtsImportLookupData>(
             importer => importer.GetLookupDataAsync(row),
-            Clock);
+            TimeProvider);
 
     private Task<(List<string> ValidationFailures, List<string> Errors)> ValidateAsync(EwcWalesQtsFileImportData row) =>
         WithServiceAsync<QtsImporter, (List<string>, List<string>)>(
@@ -18,7 +18,7 @@ public class QtsImporterTests(JobFixture fixture) : JobTestBase(fixture)
                 var lookups = await importer.GetLookupDataAsync(row);
                 return importer.Validate(row, lookups);
             },
-            Clock);
+            TimeProvider);
 
     public Mock<IFileService> BlobStorageFileService { get; } = new Mock<IFileService>();
 
@@ -141,7 +141,7 @@ public class QtsImporterTests(JobFixture fixture) : JobTestBase(fixture)
     public async Task Validate_MatchesExistingWelshR_ReturnsErrorMessage()
     {
         // Arrange
-        var holdsDate = Clock.Today.AddDays(-10);
+        var holdsDate = TimeProvider.Today.AddDays(-10);
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithRouteToProfessionalStatus(s => s
@@ -168,7 +168,7 @@ public class QtsImporterTests(JobFixture fixture) : JobTestBase(fixture)
     public async Task Validate_ExistingWelshR_ReturnsNoErrors()
     {
         // Arrange
-        var holdsDate = Clock.Today.AddDays(-10);
+        var holdsDate = TimeProvider.Today.AddDays(-10);
         var person = await TestData.CreatePersonAsync(x =>
         {
             x.WithRouteToProfessionalStatus(s => s
@@ -225,7 +225,7 @@ public class QtsImporterTests(JobFixture fixture) : JobTestBase(fixture)
             x.QtsRefNo = person.Trn;
             x.DateOfBirth = person.DateOfBirth.ToString("dd/MM/yyyy")!;
             x.QtsStatus = "67";
-            x.QtsDate = Clock.UtcNow.AddDays(1).ToString("dd/MM/yyyy");
+            x.QtsDate = TimeProvider.UtcNow.AddDays(1).ToString("dd/MM/yyyy");
             return x;
         });
 
@@ -338,7 +338,7 @@ public class QtsImporterTests(JobFixture fixture) : JobTestBase(fixture)
         // Act
         var json = await WithServiceAsync<QtsImporter, string>(
             importer => Task.FromResult(importer.ConvertToCsvString(row)),
-            Clock);
+            TimeProvider);
 
         // Assert
         Assert.Contains(expectedJson, json);
@@ -375,7 +375,7 @@ public class QtsImporterTests(JobFixture fixture) : JobTestBase(fixture)
         var person = await TestData.CreatePersonAsync(p => p
             .WithRouteToProfessionalStatus(s => s
                 .WithRouteType(RouteToProfessionalStatusType.WelshRId)
-                .WithHoldsFrom(Clock.Today.AddDays(-10))
+                .WithHoldsFrom(TimeProvider.Today.AddDays(-10))
                 .WithStatus(RouteToProfessionalStatusStatus.Holds)));
         var row = GetDefaultRow(x =>
         {

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/ScheduleTrnRecipientEmailsJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/ScheduleTrnRecipientEmailsJobTests.cs
@@ -33,7 +33,7 @@ public class ScheduleTrnRecipientEmailsJobTests(JobFixture fixture) : JobTestBas
             EmailDelayDays = 1
         });
 
-        Clock.Advance(TimeSpan.FromDays(options.Value.EmailDelayDays + 1));
+        TimeProvider.Advance(TimeSpan.FromDays(options.Value.EmailDelayDays + 1));
 
         // Act
         await WithServiceAsync<ScheduleTrnRecipientEmailsJob>(job => job.ExecuteAsync(CancellationToken.None), options, backgroundJobScheduler.Object);

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/SendAytqInviteEmailJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/SendAytqInviteEmailJobTests.cs
@@ -47,7 +47,7 @@ public class SendAytqInviteEmailJobTests(JobFixture fixture) : JobTestBase(fixtu
                     It.IsAny<IReadOnlyDictionary<string, string>>()), Times.Once);
 
         var updatedEmail = await WithDbContextAsync(dbContext => dbContext.Emails.SingleAsync(e => e.EmailId == email.EmailId));
-        Assert.Equal(Clock.UtcNow, updatedEmail.SentOn);
+        Assert.Equal(TimeProvider.UtcNow, updatedEmail.SentOn);
 
         var events = await WithDbContextAsync(dbContext => dbContext.Events
             .Where(e => e.EventName == nameof(LegacyEvents.EmailSentEvent))

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/SendInductionCompletedEmailJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/SendInductionCompletedEmailJobTests.cs
@@ -29,8 +29,8 @@ public class SendInductionCompletedEmailJobTests(JobFixture fixture) : JobTestBa
             var batchJob = new InductionCompletedEmailsJob
             {
                 InductionCompletedEmailsJobId = inductionCompletedEmailsJobId,
-                PassedEndUtc = Clock.UtcNow.AddDays(-1),
-                ExecutedUtc = Clock.UtcNow
+                PassedEndUtc = TimeProvider.UtcNow.AddDays(-1),
+                ExecutedUtc = TimeProvider.UtcNow
             };
             dbContext.InductionCompletedEmailsJobs.Add(batchJob);
 

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/SendTrnRecipientEmailJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/SendTrnRecipientEmailJobTests.cs
@@ -49,7 +49,7 @@ public class SendTrnRecipientEmailJobTests(JobFixture fixture) : JobTestBase(fix
             It.IsAny<IReadOnlyDictionary<string, string>>()));
 
         email = await WithDbContextAsync(dbContext => dbContext.Emails.SingleAsync(e => e.EmailId == email.EmailId));
-        Assert.Equal(Clock.UtcNow, email.SentOn);
+        Assert.Equal(TimeProvider.UtcNow, email.SentOn);
 
         Events.AssertProcessesCreated(x =>
         {

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/TestScopedServices.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/TestScopedServices.cs
@@ -10,11 +10,11 @@ public class TestScopedServices
 
     public TestScopedServices()
     {
-        Clock = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
-        Events = new(Clock);
+        TimeProvider = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+        Events = new(TimeProvider);
     }
 
-    public FakeTimeProvider Clock { get; }
+    public FakeTimeProvider TimeProvider { get; }
 
     public EventCapture Events { get; }
 
@@ -51,7 +51,7 @@ public class TestScopedServices
 
     private class ForwardToTestScopedTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => GetCurrent().Clock.GetUtcNow();
+        public override DateTimeOffset GetUtcNow() => GetCurrent().TimeProvider.GetUtcNow();
     }
 }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/AddAlertTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/AddAlertTestBase.cs
@@ -19,7 +19,7 @@ public abstract class AddAlertTestBase(HostFixture hostFixture) : TestBase(hostF
             Details = "Alert Details",
             AddLink = populateOptional,
             Link = populateOptional ? "https://www.example.com" : null,
-            StartDate = Clock.Today.AddDays(-30),
+            StartDate = TimeProvider.Today.AddDays(-30),
             AddReason = addReasonOption,
             ProvideAdditionalInformation = provideAdditionalInformation ? true : false,
             AddReasonDetail = addReasonOption == AddAlertReasonOption.AnotherReason ? "More details" : null,
@@ -88,7 +88,7 @@ public abstract class AddAlertTestBase(HostFixture hostFixture) : TestBase(hostF
                         Details = "Alert Details",
                         AddLink = populateOptional,
                         Link = populateOptional ? "https://www.example.com" : null,
-                        StartDate = Clock.Today.AddDays(-30)
+                        StartDate = TimeProvider.Today.AddDays(-30)
                     }),
                 JourneySteps.Reason or JourneySteps.CheckAnswers =>
                     CreateJourneyInstanceForAllStepsCompletedAsync(personId, populateOptional: true),

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/AddAlert/StartDateTests.cs
@@ -170,7 +170,7 @@ public class StartDateTests(HostFixture hostFixture) : AddAlertTestBase(hostFixt
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, person.PersonId);
-        var startDate = Clock.Today.AddDays(2);
+        var startDate = TimeProvider.Today.AddDays(2);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -190,7 +190,7 @@ public class StartDateTests(HostFixture hostFixture) : AddAlertTestBase(hostFixt
         // Arrange
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, person.PersonId);
-        var startDate = Clock.Today;
+        var startDate = TimeProvider.Today;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
@@ -172,7 +172,7 @@ public class IndexTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtur
         // Arrange
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
-        var futureDate = Clock.Today.AddDays(2);
+        var futureDate = TimeProvider.Today.AddDays(2);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/IndexTests.cs
@@ -170,7 +170,7 @@ public class IndexTests(HostFixture hostFixture) : EndDateTestBase(hostFixture),
         // Arrange
         var (person, alert) = await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
-        var newEndDate = Clock.Today.AddDays(2);
+        var newEndDate = TimeProvider.Today.AddDays(2);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
@@ -187,7 +187,7 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = CreatePostContent(newStartDate: Clock.Today.AddDays(1))
+            Content = CreatePostContent(newStartDate: TimeProvider.Today.AddDays(1))
         };
 
         // Act

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKey/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/AddApiKey/IndexTests.cs
@@ -197,8 +197,8 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         {
             var apiKey = await dbContext.ApiKeys.Where(k => k.ApplicationUserId == applicationUser.UserId).SingleOrDefaultAsync();
             Assert.NotNull(apiKey);
-            Assert.Equal(Clock.UtcNow, apiKey.CreatedOn);
-            Assert.Equal(Clock.UtcNow, apiKey.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, apiKey.CreatedOn);
+            Assert.Equal(TimeProvider.UtcNow, apiKey.UpdatedOn);
             Assert.Equal(key, apiKey.Key);
 
             return apiKey;
@@ -208,7 +208,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             e =>
             {
                 var apiKeyCreatedEvent = Assert.IsType<ApiKeyCreatedEvent>(e);
-                Assert.Equal(Clock.UtcNow, apiKeyCreatedEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, apiKeyCreatedEvent.CreatedUtc);
                 Assert.Equal(GetCurrentUserId(), apiKeyCreatedEvent.RaisedBy.UserId);
                 Assert.Equal(apiKey.ApiKeyId, apiKeyCreatedEvent.ApiKey.ApiKeyId);
                 Assert.Equal(apiKey.ApplicationUserId, applicationUser.UserId);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKey/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApiKeys/EditApiKey/IndexTests.cs
@@ -159,18 +159,18 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         await WithDbContextAsync(async dbContext =>
         {
             apiKey = await dbContext.ApiKeys.SingleAsync(k => k.ApiKeyId == apiKey.ApiKeyId);
-            Assert.Equal(Clock.UtcNow, apiKey.Expires);
+            Assert.Equal(TimeProvider.UtcNow, apiKey.Expires);
         });
 
         EventObserver.AssertEventsSaved(
             e =>
             {
                 var apiKeyUpdatedEvent = Assert.IsType<ApiKeyUpdatedEvent>(e);
-                Assert.Equal(Clock.UtcNow, apiKeyUpdatedEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, apiKeyUpdatedEvent.CreatedUtc);
                 Assert.Equal(GetCurrentUserId(), apiKeyUpdatedEvent.RaisedBy.UserId);
                 Assert.Equal(ApiKeyUpdatedEventChanges.Expires, apiKeyUpdatedEvent.Changes);
                 Assert.Null(apiKeyUpdatedEvent.OldApiKey.Expires);
-                Assert.Equal(Clock.UtcNow, apiKeyUpdatedEvent.ApiKey.Expires);
+                Assert.Equal(TimeProvider.UtcNow, apiKeyUpdatedEvent.ApiKey.Expires);
             });
 
         var redirectResponse = await response.FollowRedirectAsync(HttpClient);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUser/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/AddApplicationUser/IndexTests.cs
@@ -158,7 +158,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             e =>
             {
                 var applicationUserCreatedEvent = Assert.IsType<ApplicationUserCreatedEvent>(e);
-                Assert.Equal(Clock.UtcNow, applicationUserCreatedEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, applicationUserCreatedEvent.CreatedUtc);
                 Assert.Equal(GetCurrentUserId(), applicationUserCreatedEvent.RaisedBy.UserId);
                 Assert.Equal(name, applicationUserCreatedEvent.ApplicationUser.Name);
                 Assert.Equal(shortName, applicationUserCreatedEvent.ApplicationUser.ShortName);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUser/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/ApplicationUsers/EditApplicationUser/IndexTests.cs
@@ -303,7 +303,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             e =>
             {
                 var applicationUserUpdatedEvent = Assert.IsType<ApplicationUserUpdatedEvent>(e);
-                Assert.Equal(Clock.UtcNow, applicationUserUpdatedEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, applicationUserUpdatedEvent.CreatedUtc);
                 Assert.Equal(GetCurrentUserId(), applicationUserUpdatedEvent.RaisedBy.UserId);
                 Assert.Equal(originalName, applicationUserUpdatedEvent.OldApplicationUser.Name);
                 Assert.Equal(newName, applicationUserUpdatedEvent.ApplicationUser.Name);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Extracts/SanctionsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Extracts/SanctionsTests.cs
@@ -52,8 +52,8 @@ public class SanctionsTests(HostFixture hostFixture) : TestBase(hostFixture)
         await TestData.CreatePersonAsync(p => p
             .WithAlert(a => a
                 .WithAlertTypeId(AlertType.ProhibitionBySoSMisconduct)
-                .WithStartDate(Clock.Today.AddDays(-10))
-                .WithEndDate(Clock.Today.AddDays(-3))));
+                .WithStartDate(TimeProvider.Today.AddDays(-10))
+                .WithEndDate(TimeProvider.Today.AddDays(-3))));
 
         var user = await TestData.CreateUserAsync(role: UserRoles.Administrator);
         SetCurrentUser(user);
@@ -89,12 +89,12 @@ public class SanctionsTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var path = $"{RequestPath}?handler=NewSanctions";
-        var startDate = Clock.Today.AddDays(-10);
+        var startDate = TimeProvider.Today.AddDays(-10);
         var person = await TestData.CreatePersonAsync(p => p
             .WithAlert(a => a
                 .WithAlertTypeId(AlertType.ProhibitionBySoSMisconduct)
                 .WithStartDate(startDate)
-                .WithCreatedUtc(Clock.UtcNow.AddDays(-10))));
+                .WithCreatedUtc(TimeProvider.UtcNow.AddDays(-10))));
         var user = await TestData.CreateUserAsync(role: UserRoles.Administrator);
         SetCurrentUser(user);
 
@@ -111,7 +111,7 @@ public class SanctionsTests(HostFixture hostFixture) : TestBase(hostFixture)
             response.Content.Headers.ContentDisposition?.FileName?.Trim('"');
 
         Assert.Equal(
-            $"new-sanctions-{Clock.Today:yyyyMMdd}.csv",
+            $"new-sanctions-{TimeProvider.Today:yyyyMMdd}.csv",
             fileName);
 
         var csvContent = await response.Content.ReadAsStringAsync();
@@ -135,14 +135,14 @@ public class SanctionsTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var path = $"{RequestPath}?handler=SpentSanctions";
-        var startDate = Clock.Today.AddDays(-10);
-        var endDate = Clock.Today.AddDays(-3);
+        var startDate = TimeProvider.Today.AddDays(-10);
+        var endDate = TimeProvider.Today.AddDays(-3);
         var person = await TestData.CreatePersonAsync(p => p
             .WithAlert(a => a
                 .WithAlertTypeId(AlertType.ProhibitionBySoSMisconduct)
                 .WithStartDate(startDate)
                 .WithEndDate(endDate)
-                .WithCreatedUtc(Clock.UtcNow.AddDays(-10))));
+                .WithCreatedUtc(TimeProvider.UtcNow.AddDays(-10))));
         var user = await TestData.CreateUserAsync(role: UserRoles.Administrator);
         SetCurrentUser(user);
 
@@ -159,7 +159,7 @@ public class SanctionsTests(HostFixture hostFixture) : TestBase(hostFixture)
             response.Content.Headers.ContentDisposition?.FileName?.Trim('"');
 
         Assert.Equal(
-            $"spent-sanctions-{Clock.Today:yyyyMMdd}.csv",
+            $"spent-sanctions-{TimeProvider.Today:yyyyMMdd}.csv",
             fileName);
 
         var csvContent = await response.Content.ReadAsStringAsync();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -233,7 +233,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             var expectedMqCreatedEvent = new MandatoryQualificationCreatedEvent
             {
                 EventId = Guid.Empty,
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
                 MandatoryQualification = new()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
@@ -201,7 +201,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             var expectedMqDeletedEvent = new MandatoryQualificationDeletedEvent
             {
                 EventId = Guid.Empty,
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
                 MandatoryQualification = new()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
@@ -179,7 +179,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent
             {
                 EventId = Guid.Empty,
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
                 MandatoryQualification = new()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
@@ -177,7 +177,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent
             {
                 EventId = Guid.Empty,
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
                 MandatoryQualification = new()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
@@ -181,7 +181,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent
             {
                 EventId = Guid.Empty,
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
                 MandatoryQualification = new()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Status/CheckAnswersTests.cs
@@ -296,7 +296,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             var expectedMqUpdatedEvent = new MandatoryQualificationUpdatedEvent
             {
                 EventId = Guid.Empty,
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 RaisedBy = GetCurrentUserId(),
                 PersonId = person.PersonId,
                 MandatoryQualification = new()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswersTests.cs
@@ -213,10 +213,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         await WithDbContextAsync(async dbContext =>
         {
             var updatedOneLoginUser = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginUser.Subject);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.VerifiedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.VerifiedOn);
             Assert.Equal(OneLoginUserVerificationRoute.Support, updatedOneLoginUser.VerificationRoute);
             Assert.Equal(person.PersonId, updatedOneLoginUser.PersonId);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.MatchedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.MatchedOn);
             Assert.Equal(OneLoginUserMatchRoute.SupportUi, updatedOneLoginUser.MatchRoute);
             Assert.NotNull(updatedOneLoginUser.VerifiedNames);
             Assert.Single(updatedOneLoginUser.VerifiedNames);
@@ -286,7 +286,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.NotNull(updatedOneLoginUser.VerifiedOn);
             Assert.Equal(OneLoginUserVerificationRoute.OneLogin, updatedOneLoginUser.VerificationRoute);
             Assert.Equal(person.PersonId, updatedOneLoginUser.PersonId);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.MatchedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.MatchedOn);
             Assert.Equal(OneLoginUserMatchRoute.SupportUi, updatedOneLoginUser.MatchRoute);
         });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/IndexTests.cs
@@ -85,7 +85,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         {
             var oneLoginUser = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == user.Subject);
             oneLoginUser.SetVerified(
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 verificationRoute,
                 verifiedByApplicationUserId: verifiedByApplicationUserId,
                 [verifiedName],

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/AddPerson/CheckAnswersTests.cs
@@ -207,8 +207,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         await WithDbContextAsync(async dbContext =>
         {
             var createdPersonRecord = await dbContext.Persons.SingleAsync(p => p.PersonId == personId);
-            Assert.Equal(Clock.UtcNow, createdPersonRecord.CreatedOn);
-            Assert.Equal(Clock.UtcNow, createdPersonRecord.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, createdPersonRecord.CreatedOn);
+            Assert.Equal(TimeProvider.UtcNow, createdPersonRecord.UpdatedOn);
             Assert.Equal(firstName, createdPersonRecord.FirstName);
             Assert.Equal(middleName, createdPersonRecord.MiddleName);
             Assert.Equal(lastName, createdPersonRecord.LastName);
@@ -222,7 +222,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         {
             var actualEvent = Assert.IsType<LegacyEvents.PersonCreatedEvent>(e);
 
-            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
             Assert.Equal(personId, actualEvent.PersonId);
             Assert.Equal(firstName, actualEvent.PersonAttributes.FirstName);
             Assert.Equal(middleName, actualEvent.PersonAttributes.MiddleName);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/MergePerson/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/MergePerson/CheckAnswersTests.cs
@@ -126,7 +126,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : MergePersonTestBase(ho
             sourcedFromSecondaryPersonAttribute.Attribute,
             useNullValues: useNullValues);
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var evidenceFileId = Guid.NewGuid();
         var evidenceFileName = "evidence.jpg";
@@ -217,7 +217,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : MergePersonTestBase(ho
             Assert.Equal(evidenceFileId, actualEvent.EvidenceFile?.FileId);
             Assert.Equal(evidenceFileName, actualEvent.EvidenceFile?.Name);
             Assert.Equal(comments, actualEvent.Comments);
-            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
 
             var expectedChange = sourcedFromSecondaryPersonAttribute.Attribute switch
             {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeHistoryOneLoginTests.cs
@@ -15,7 +15,7 @@ public partial class ChangeHistoryTests
         var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(matchedPerson);
         var user = await TestData.CreateUserAsync();
-        var process = new ProcessContext(ProcessType.PersonOneLoginUserConnecting, Clock.UtcNow, user.UserId);
+        var process = new ProcessContext(ProcessType.PersonOneLoginUserConnecting, TimeProvider.UtcNow, user.UserId);
 
         await OneLoginService.SetUserMatchedAsync(
             new SetUserMatchedOptions
@@ -64,7 +64,7 @@ public partial class ChangeHistoryTests
             Reason = "this is the reason",
             AdditionalInformation = null
         };
-        var process = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, Clock.UtcNow, user.UserId, reason);
+        var process = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, TimeProvider.UtcNow, user.UserId, reason);
 
         await OneLoginService.SetUserUnmatchedAsync(oneLoginUser.Subject!, process);
 
@@ -101,7 +101,7 @@ public partial class ChangeHistoryTests
                 .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
                 .WithStatedTrn(matchedPerson.Trn!));
 
-        var process = new ProcessContext(ProcessType.OneLoginUserRecordMatchingSupportTaskCompleting, Clock.UtcNow, user.UserId);
+        var process = new ProcessContext(ProcessType.OneLoginUserRecordMatchingSupportTaskCompleting, TimeProvider.UtcNow, user.UserId);
         await OneLoginSupportTaskService.ResolveRecordMatchingSupportTaskAsync(
             new ConnectedOutcomeOptions
             {
@@ -165,7 +165,7 @@ public partial class ChangeHistoryTests
             ]
         };
 
-        var processContext = new ProcessContext(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, Clock.UtcNow, SystemUser.SystemUserId);
+        var processContext = new ProcessContext(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, TimeProvider.UtcNow, SystemUser.SystemUserId);
 
         await OneLoginSupportTaskService.ResolveVerificationSupportTaskAsync(options, processContext);
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogApiTrnRequestSupportTaskUpdatedEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogApiTrnRequestSupportTaskUpdatedEventTests.cs
@@ -30,10 +30,10 @@ public class ChangeLogApiTrnRequestSupportTaskUpdatedEventTests : TestBase
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
 
-        _oldDob = Clock.Today.AddYears(-30);
-        _dob = Clock.Today.AddYears(-20);
+        _oldDob = TimeProvider.Today.AddYears(-30);
+        _dob = TimeProvider.Today.AddYears(-20);
     }
 
     [Theory]
@@ -102,7 +102,7 @@ public class ChangeLogApiTrnRequestSupportTaskUpdatedEventTests : TestBase
         Assert.Equal("Record updated from Apply for QTS TRN request", title.TrimmedText());
 
         Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         if (changes.HasAnyFlag(ApiTrnRequestSupportTaskUpdatedEventChanges.PersonNameChange))
         {
@@ -164,7 +164,7 @@ public class ChangeLogApiTrnRequestSupportTaskUpdatedEventTests : TestBase
 
         item.AssertSummaryListRowValue("request-data", "Source", v => Assert.Equal("Apply for QTS", v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Request ID", v => Assert.Equal("TEST-TRN-1", v.TrimmedText()));
-        item.AssertSummaryListRowValue("request-data", "Created on", v => Assert.Equal(Clock.UtcNow.ToString(WebConstants.DateAndTimeDisplayFormat), v.TrimmedText()));
+        item.AssertSummaryListRowValue("request-data", "Created on", v => Assert.Equal(TimeProvider.UtcNow.ToString(WebConstants.DateAndTimeDisplayFormat), v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Name", v => Assert.Equal($"{newFirstName} {newMiddleName} {newLastName}", v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Previous name", v => Assert.Equal("Jim Smith", v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Date of birth", v => Assert.Equal(newDob.ToString(WebConstants.DateDisplayFormat) ?? WebConstants.EmptyFallbackContent, v.TrimmedText()));
@@ -273,7 +273,7 @@ public class ChangeLogApiTrnRequestSupportTaskUpdatedEventTests : TestBase
         {
             ApplicationUserId = applicationUserId,
             RequestId = "TEST-TRN-1",
-            CreatedOn = Clock.UtcNow,
+            CreatedOn = TimeProvider.UtcNow,
             IdentityVerified = null,
             EmailAddress = email,
             OneLoginUserSubject = null,
@@ -308,7 +308,7 @@ public class ChangeLogApiTrnRequestSupportTaskUpdatedEventTests : TestBase
         var updatedEvent = new ApiTrnRequestSupportTaskUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUserId,
             PersonId = personId,
             PersonAttributes = attributes,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogChangeNameOrDobRequestEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogChangeNameOrDobRequestEventTests.cs
@@ -78,7 +78,7 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTask = supportTask,
             OldSupportTask = oldSupportTask,
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = raisedByUser.UserId
         };
 
@@ -159,7 +159,7 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             OldSupportTask = oldSupportTask,
             RejectionReason = "No evidence supplied",
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = raisedByUser.UserId
         };
 
@@ -235,7 +235,7 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTask = supportTask,
             OldSupportTask = oldSupportTask,
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = raisedByUser.UserId,
             Changes = ChangeDateOfBirthRequestSupportTaskApprovedEventChanges.DateOfBirth,
             OldPersonAttributes = new PersonDetails
@@ -330,7 +330,7 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             OldSupportTask = oldSupportTask,
             RejectionReason = "No evidence supplied",
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = raisedByUser.UserId
         };
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogCreateEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogCreateEventTests.cs
@@ -13,7 +13,7 @@ public class ChangeLogCreateEventTests : TestBase
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class ChangeLogCreateEventTests : TestBase
         string firstName = "Alfred";
         string middleName = "The";
         string lastName = "Great";
-        DateOnly? dateOfBirth = Clock.Today.AddYears(-30);
+        DateOnly? dateOfBirth = TimeProvider.Today.AddYears(-30);
         string? emailAddress = "old@email-address.com";
         string? nationalInsuranceNumber = "AB 12 34 56 D";
         Gender? gender = Gender.Female;
@@ -54,7 +54,7 @@ public class ChangeLogCreateEventTests : TestBase
         var createdEvent = new LegacyEvents.PersonCreatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             PersonAttributes = details,
@@ -82,7 +82,7 @@ public class ChangeLogCreateEventTests : TestBase
         var item = doc.GetElementByTestId("timeline-item-created-event");
         Assert.NotNull(item);
         Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         doc.AssertSummaryListRowValue("details", "Name", v => Assert.Equal($"{firstName} {middleName} {lastName}", v.TrimmedText()));
         doc.AssertSummaryListRowValue("details", "Date of birth", v => Assert.Equal(dateOfBirth?.ToString(WebConstants.DateDisplayFormat), v.TrimmedText()));
@@ -106,7 +106,7 @@ public class ChangeLogCreateEventTests : TestBase
         string firstName = "Alfred";
         string middleName = "The";
         string lastName = "Great";
-        DateOnly? dateOfBirth = Clock.Today.AddYears(-30);
+        DateOnly? dateOfBirth = TimeProvider.Today.AddYears(-30);
 
         var createReason = PersonCreateReason.AnotherReason.GetDisplayName();
 
@@ -124,7 +124,7 @@ public class ChangeLogCreateEventTests : TestBase
         var createdEvent = new LegacyEvents.PersonCreatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             PersonAttributes = details,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogEditDetailsEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogEditDetailsEventTests.cs
@@ -16,7 +16,7 @@ public class ChangeLogEditDetailsEventTests : TestBase
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
     }
 
     [Theory]
@@ -45,7 +45,7 @@ public class ChangeLogEditDetailsEventTests : TestBase
         string oldFirstName = "Alfred";
         string oldMiddleName = "The";
         string oldLastName = "Great";
-        DateOnly? oldDateOfBirth = Clock.Today.AddYears(-30);
+        DateOnly? oldDateOfBirth = TimeProvider.Today.AddYears(-30);
         string? oldEmailAddress = "old@email-address.com";
         string? oldNationalInsuranceNumber = "AB 12 34 56 D";
         Gender? oldGender = Gender.Male;
@@ -53,7 +53,7 @@ public class ChangeLogEditDetailsEventTests : TestBase
         string firstName = "Megan";
         string middleName = "Thee";
         string lastName = "Stallion";
-        DateOnly? dateOfBirth = Clock.Today.AddYears(-20);
+        DateOnly? dateOfBirth = TimeProvider.Today.AddYears(-20);
         string emailAddress = "new@email-address.com";
         string? nationalInsuranceNumber = "XY 98 76 54 A";
         Gender? gender = Gender.Female;
@@ -112,7 +112,7 @@ public class ChangeLogEditDetailsEventTests : TestBase
         var updatedEvent = new PersonDetailsUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             PersonAttributes = details,
@@ -142,7 +142,7 @@ public class ChangeLogEditDetailsEventTests : TestBase
         var item = doc.GetElementByTestId("timeline-item-details-updated-event");
         Assert.NotNull(item);
         Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         if (changes.HasAnyFlag(PersonDetailsUpdatedEventChanges.NameChange))
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogInductionEventTests.cs
@@ -16,7 +16,7 @@ public class ChangeLogInductionEventTests : TestBase
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
     }
 
     [Theory]
@@ -34,8 +34,8 @@ public class ChangeLogInductionEventTests : TestBase
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePersonAsync();
 
-        DateOnly? startDate = Clock.Today.AddYears(-1);
-        DateOnly? completionDate = Clock.Today.AddDays(-10);
+        DateOnly? startDate = TimeProvider.Today.AddYears(-1);
+        DateOnly? completionDate = TimeProvider.Today.AddDays(-10);
         var inductionStatus = populatedFields.HasFlag(DqtInductionFields.ExemptionReason) ? InductionStatus.Exempt : InductionStatus.InProgress;
         var inductionExemptionReasonId = InductionExemptionReason.QualifiedThroughEeaMutualRecognitionRouteId;
         var inductionExemptionReason = await ReferenceDataCache.GetInductionExemptionReasonByIdAsync(inductionExemptionReasonId);
@@ -53,7 +53,7 @@ public class ChangeLogInductionEventTests : TestBase
         {
             EventId = Guid.NewGuid(),
             Key = $"{induction.InductionId}-Created",
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByDqtUser,
             PersonId = person.PersonId,
             Induction = induction
@@ -78,7 +78,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 if (populatedFields.HasFlag(DqtInductionFields.StartDate))
                 {
                     Assert.Equal(startDate?.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("start-date")?.TrimmedText());
@@ -134,7 +134,7 @@ public class ChangeLogInductionEventTests : TestBase
         {
             EventId = Guid.NewGuid(),
             Key = $"{induction.InductionId}-Imported",
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByDqtUser,
             PersonId = person.PersonId,
             Induction = induction,
@@ -160,7 +160,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
             });
     }
 
@@ -184,7 +184,7 @@ public class ChangeLogInductionEventTests : TestBase
         {
             EventId = Guid.NewGuid(),
             Key = $"{induction.InductionId}-Deactivated",
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByDqtUser,
             PersonId = person.PersonId,
             Induction = induction
@@ -209,7 +209,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
             });
     }
 
@@ -233,7 +233,7 @@ public class ChangeLogInductionEventTests : TestBase
         {
             EventId = Guid.NewGuid(),
             Key = $"{induction.InductionId}-Reactivated",
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByDqtUser,
             PersonId = person.PersonId,
             Induction = induction
@@ -258,7 +258,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
             });
     }
 
@@ -291,13 +291,13 @@ public class ChangeLogInductionEventTests : TestBase
         var person = await TestData.CreatePersonAsync();
 
         var inductionId = Guid.NewGuid();
-        DateOnly? oldStartDate = Clock.Today.AddYears(-1);
-        DateOnly? oldCompletionDate = Clock.Today.AddDays(-10);
+        DateOnly? oldStartDate = TimeProvider.Today.AddYears(-1);
+        DateOnly? oldCompletionDate = TimeProvider.Today.AddDays(-10);
         var oldInductionStatus = changes.HasFlag(DqtInductionUpdatedEventChanges.ExemptionReason) ? InductionStatus.Exempt : InductionStatus.InProgress;
         var oldInductionExemptionReason = InductionExemptionReason.QualifiedThroughEeaMutualRecognitionRouteId;
 
-        DateOnly? startDate = Clock.Today.AddYears(-1).AddDays(1);
-        DateOnly? completionDate = Clock.Today.AddDays(-9);
+        DateOnly? startDate = TimeProvider.Today.AddYears(-1).AddDays(1);
+        DateOnly? completionDate = TimeProvider.Today.AddDays(-9);
         var inductionStatus = changes.HasFlag(DqtInductionUpdatedEventChanges.ExemptionReason) ? InductionStatus.Exempt : InductionStatus.Passed;
         var inductionExemptionReasonId = InductionExemptionReason.OverseasTrainedTeacherId;
         var inductionExemptionReason = await ReferenceDataCache.GetInductionExemptionReasonByIdAsync(inductionExemptionReasonId);
@@ -324,7 +324,7 @@ public class ChangeLogInductionEventTests : TestBase
         {
             EventId = Guid.NewGuid(),
             Key = $"{induction.InductionId}-Updated",
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByDqtUser,
             PersonId = person.PersonId,
             Induction = induction,
@@ -351,7 +351,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 if (changes.HasFlag(DqtInductionUpdatedEventChanges.StartDate))
                 {
                     Assert.Equal(newValueIsNull ? WebConstants.EmptyFallbackContent : startDate?.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("start-date")?.TrimmedText());
@@ -409,8 +409,8 @@ public class ChangeLogInductionEventTests : TestBase
         var createdByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         var person = await TestData.CreatePersonAsync();
 
-        DateOnly? startDate = Clock.Today.AddYears(-1);
-        DateOnly? completionDate = Clock.Today.AddDays(-10);
+        DateOnly? startDate = TimeProvider.Today.AddYears(-1);
+        DateOnly? completionDate = TimeProvider.Today.AddDays(-10);
         var inductionStatus = populatedFields.HasFlag(DqtInductionFields.ExemptionReason) ? InductionStatus.Exempt : InductionStatus.InProgress;
         string dqtInductionStatus = populatedFields.HasFlag(DqtInductionFields.ExemptionReason) ? "Exempt" : "In progress";
         var inductionExemptionReasonId = InductionExemptionReason.QualifiedThroughEeaMutualRecognitionRouteId;
@@ -432,7 +432,7 @@ public class ChangeLogInductionEventTests : TestBase
         {
             EventId = Guid.NewGuid(),
             Key = $"{induction.InductionId}-Migrated",
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByDqtUser,
             PersonId = person.PersonId,
             InductionStatus = migratedInductionStatus,
@@ -462,7 +462,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 if (populatedFields.HasFlag(DqtInductionFields.StartDate))
                 {
                     Assert.Equal(startDate?.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("start-date")?.TrimmedText());
@@ -506,7 +506,7 @@ public class ChangeLogInductionEventTests : TestBase
         {
             EventId = Guid.NewGuid(),
             Key = $"{person.PersonId}-StatusChanged",
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByDqtUser,
             PersonId = person.PersonId,
             InductionStatus = inductionStatus.ToString(),
@@ -532,7 +532,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 Assert.Equal(inductionStatus.ToString(), item.GetElementByTestId("induction-status")?.TrimmedText());
                 Assert.Equal(oldInductionStatus.ToString(), item.GetElementByTestId("old-induction-status")?.TrimmedText());
             });
@@ -566,19 +566,19 @@ public class ChangeLogInductionEventTests : TestBase
         var createdByUser = await TestData.CreateUserAsync();
         var person = await TestData.CreatePersonAsync();
 
-        DateOnly? oldStartDate = Clock.Today.AddYears(-1);
-        DateOnly? oldCompletedDate = Clock.Today.AddDays(-10);
+        DateOnly? oldStartDate = TimeProvider.Today.AddYears(-1);
+        DateOnly? oldCompletedDate = TimeProvider.Today.AddDays(-10);
         InductionStatus oldInductionStatus = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionExemptionReasons) ? InductionStatus.Exempt : InductionStatus.InProgress;
         Guid[] oldExemptionReasons = [Guid.Parse("5a80cee8-98a8-426b-8422-b0e81cb49b36"), Guid.Parse("15014084-2d8d-4f51-9198-b0e1881f8896")];
         string[] oldExemptionReasonNames = ["They qualified before 07 May 2000", "They qualified between 7 May 1999 and 1 April 2003 and first taught in Wales for at least 2 terms"];
-        var oldCpdModifiedOn = Clock.UtcNow.AddDays(-2);
+        var oldCpdModifiedOn = TimeProvider.UtcNow.AddDays(-2);
 
-        DateOnly? startDate = Clock.Today.AddYears(-1).AddDays(1);
-        DateOnly? completedDate = Clock.Today.AddDays(-9);
+        DateOnly? startDate = TimeProvider.Today.AddYears(-1).AddDays(1);
+        DateOnly? completedDate = TimeProvider.Today.AddDays(-9);
         InductionStatus inductionStatus = changes.HasFlag(PersonInductionUpdatedEventChanges.InductionExemptionReasons) ? InductionStatus.Exempt : InductionStatus.RequiredToComplete;
         Guid[] exemptionReasons = [Guid.Parse("0997ab13-7412-4560-8191-e51ed4d58d2a")];
         string[] exemptionReasonNames = ["They qualified through a further education route between 1 September 2001 and 1 September 2004"];
-        var cpdModifiedOn = Clock.UtcNow;
+        var cpdModifiedOn = TimeProvider.UtcNow;
 
         var changeReason = PersonInductionChangeReason.AnotherReason.GetDisplayName();
         var changeReasonDetail = "Reason detail";
@@ -614,7 +614,7 @@ public class ChangeLogInductionEventTests : TestBase
         var updatedEvent = new PersonInductionUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             Induction = induction,
@@ -645,7 +645,7 @@ public class ChangeLogInductionEventTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 if (changes.HasFlag(PersonInductionUpdatedEventChanges.InductionStartDate))
                 {
                     Assert.Equal(newValueIsDefault ? WebConstants.EmptyFallbackContent : startDate?.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("start-date")?.TrimmedText());
@@ -738,19 +738,19 @@ public class ChangeLogInductionEventTests : TestBase
         var createdByUser = await TestData.CreateUserAsync();
         var person = await TestData.CreatePersonAsync();
 
-        DateOnly? oldStartDate = Clock.Today.AddYears(-1);
-        DateOnly? oldCompletedDate = Clock.Today.AddDays(-10);
+        DateOnly? oldStartDate = TimeProvider.Today.AddYears(-1);
+        DateOnly? oldCompletedDate = TimeProvider.Today.AddDays(-10);
         InductionStatus oldInductionStatus = InductionStatus.Exempt;
         Guid[] oldExemptionReasons = [Guid.Parse("5a80cee8-98a8-426b-8422-b0e81cb49b36")];
         string[] oldExemptionReasonNames = ["Qualified before 07 May 2000"];
-        var oldCpdModifiedOn = Clock.UtcNow.AddDays(-2);
+        var oldCpdModifiedOn = TimeProvider.UtcNow.AddDays(-2);
 
         DateOnly? startDate = oldStartDate;
         DateOnly? completedDate = oldCompletedDate;
         InductionStatus inductionStatus = oldInductionStatus;
         Guid[] exemptionReasons = oldExemptionReasons;
         string[] exemptionReasonNames = oldExemptionReasonNames;
-        var cpdModifiedOn = Clock.UtcNow;
+        var cpdModifiedOn = TimeProvider.UtcNow;
 
         var changeReason = PersonInductionChangeReason.AnotherReason.GetDisplayName();
         var changeReasonDetail = "Reason detail";
@@ -781,7 +781,7 @@ public class ChangeLogInductionEventTests : TestBase
         var updatedEvent = new PersonInductionUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             Induction = induction,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMandatoryQualificationEventsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMandatoryQualificationEventsTests.cs
@@ -17,7 +17,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
     }
 
     [Theory]
@@ -47,7 +47,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 Assert.Equal(mq.Provider!.Name, item.GetElementByTestId("provider")?.TrimmedText());
                 Assert.Equal(mq.Specialism!.Value.GetTitle(), item.GetElementByTestId("specialism")?.TrimmedText());
                 Assert.Equal(mq.StartDate!.Value.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("start-date")?.TrimmedText());
@@ -122,7 +122,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {deletedByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 Assert.Equal(deletionReason, item.GetElementByTestId("deletion-reason")?.TrimmedText());
                 Assert.Equal(deletionReasonDetail, item.GetElementByTestId("deletion-reason-detail")?.TrimmedText());
                 Assert.Equal($"{evidenceFile.Name} (opens in new tab)", item.GetElementByTestId("evidence")?.TrimmedText());
@@ -156,7 +156,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {deletedByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 Assert.Equal(deletionReason, item.GetElementByTestId("deletion-reason")?.TrimmedText());
                 Assert.Equal("None", item.GetElementByTestId("deletion-reason-detail")?.TrimmedText());
                 Assert.Equal("None", item.GetElementByTestId("provider")?.TrimmedText());
@@ -236,7 +236,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var deactivatedByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         await DeactivateMq(mq.QualificationId, deactivatedByDqtUser);
 
@@ -253,7 +253,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {deactivatedByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 Assert.Equal(mq.Provider!.Name, item.GetElementByTestId("provider")?.TrimmedText());
                 Assert.Equal(mq.Specialism!.Value.GetTitle(), item.GetElementByTestId("specialism")?.TrimmedText());
                 Assert.Equal(mq.StartDate!.Value.ToString(WebConstants.DateDisplayFormat), item.GetElementByTestId("start-date")?.TrimmedText());
@@ -267,7 +267,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq, legacyProvider) = await CreateMqWithLegacyProvider();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var deactivatedByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         await DeactivateMq(mq.QualificationId, deactivatedByDqtUser);
 
@@ -289,7 +289,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateMqWithoutProvider();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var deactivatedByDqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         await DeactivateMq(mq.QualificationId, deactivatedByDqtUser);
 
@@ -327,7 +327,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {importedByDqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
             });
     }
 
@@ -336,14 +336,14 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq, legacyProvider) = await CreateMqWithLegacyProvider();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var dqtUser = EventModels.RaisedByUserInfo.FromDqtUser(dqtUserId: Guid.NewGuid(), dqtUserName: "DQT User");
         await DeactivateMq(mq.QualificationId, dqtUser);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         await WithDbContextAsync(async dbContext =>
         {
-            var now = Clock.UtcNow;
+            var now = TimeProvider.UtcNow;
 
             var qualification = await dbContext.MandatoryQualifications.IgnoreQueryFilters().SingleAsync(q => q.QualificationId == mq.QualificationId);
             qualification.DeletedOn = null;
@@ -396,7 +396,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {dqtUser.DqtUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
             });
     }
 
@@ -405,7 +405,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -416,7 +416,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             var migratedEvent = new MandatoryQualificationMigratedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 Key = $"{mq.QualificationId}-migrated",
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person.PersonId,
@@ -441,7 +441,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {SystemUser.SystemUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
             });
     }
 
@@ -450,7 +450,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -461,7 +461,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             var migratedEvent = new MandatoryQualificationMigratedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 Key = $"{mq.QualificationId}-migrated",
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person.PersonId,
@@ -493,7 +493,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
         var person = await TestData.CreatePersonAsync(b => b
             .WithMandatoryQualification(q => q
                 .WithDqtMqEstablishment(establishmentWithProviderMapping.Value)));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var migratedProvider = await WithDbContextAsync(async dbContext =>
         {
@@ -509,7 +509,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             var migratedEvent = new MandatoryQualificationMigratedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 Key = $"{mq.QualificationId}-migrated",
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person.PersonId,
@@ -546,7 +546,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             .WithMandatoryQualification(q => q
                 .WithSpecialism(specialism)
                 .WithDqtMqEstablishment(establishmentWithSpecialismMapping.Value)));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var migratedSpecialism = await WithDbContextAsync(async dbContext =>
         {
@@ -564,7 +564,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             var migratedEvent = new MandatoryQualificationMigratedEvent
             {
                 EventId = Guid.NewGuid(),
-                CreatedUtc = Clock.UtcNow,
+                CreatedUtc = TimeProvider.UtcNow,
                 Key = $"{mq.QualificationId}-migrated",
                 RaisedBy = SystemUser.SystemUserId,
                 PersonId = person.PersonId,
@@ -596,7 +596,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
         var changeReason = "Update from provider";
         var changeReasonDetail = "More information";
@@ -624,7 +624,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             item =>
             {
                 Assert.Equal($"By {updatedByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-                Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+                Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
                 Assert.Equal(changeReason, item.GetElementByTestId("change-reason")?.TrimmedText());
                 Assert.Equal(changeReasonDetail, item.GetElementByTestId("change-reason-detail")?.TrimmedText());
                 Assert.Equal($"{evidenceFile.Name} (opens in new tab)", item.GetElementByTestId("evidence")?.TrimmedText());
@@ -637,7 +637,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
 
         await UpdateMq(
@@ -669,7 +669,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
         var oldProviderId = mq.ProviderId!.Value;
         var oldProvider = MandatoryQualificationProvider.GetById(oldProviderId);
@@ -698,7 +698,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
 
         await UpdateMq(
@@ -725,7 +725,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
         var oldSpecialism = mq.Specialism!.Value;
 
@@ -753,7 +753,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
 
         await UpdateMq(
@@ -780,7 +780,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
         var oldStartDate = mq.StartDate!.Value;
 
@@ -808,7 +808,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
 
         await UpdateMq(
@@ -835,7 +835,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
         var oldStatus = mq.Status!.Value;
 
@@ -867,7 +867,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
 
         await UpdateMq(
@@ -894,7 +894,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         // Arrange
         var (personId, mq) = await CreateFullyPopulatedMq();
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var updatedByUser = await TestData.CreateUserAsync();
         var oldEndDate = mq.EndDate!.Value;
 
@@ -1020,7 +1020,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
             throw new ArgumentException($"{nameof(deactivatedBy)} should be a DQT user.", nameof(deactivatedBy));
         }
 
-        var now = Clock.UtcNow;
+        var now = TimeProvider.UtcNow;
 
         var qualification = await dbContext.MandatoryQualifications
             .SingleAsync(q => q.QualificationId == qualificationId);
@@ -1073,7 +1073,7 @@ public class ChangeLogMandatoryQualificationEventsTests : TestBase
     {
         return WithDbContextAsync(async dbContext =>
         {
-            var now = Clock.UtcNow;
+            var now = TimeProvider.UtcNow;
 
             var qualification = await dbContext.MandatoryQualifications
                 .SingleAsync(q => q.QualificationId == qualificationId);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMergeEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogMergeEventTests.cs
@@ -32,10 +32,10 @@ public class ChangeLogMergeEventTests(HostFixture hostFixture) : TestBase(hostFi
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
 
-        _oldDob = Clock.Today.AddYears(-30);
-        _dob = Clock.Today.AddYears(-20);
+        _oldDob = TimeProvider.Today.AddYears(-30);
+        _dob = TimeProvider.Today.AddYears(-20);
 
         _createdByUser = await TestData.CreateUserAsync();
         _person = await TestData.CreatePersonAsync();
@@ -115,7 +115,7 @@ public class ChangeLogMergeEventTests(HostFixture hostFixture) : TestBase(hostFi
         var item = doc.GetElementByTestId("timeline-item-persons-merged-event");
         Assert.NotNull(item);
         Assert.Equal($"By {_createdByUser!.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         var title = item.QuerySelector(".moj-timeline__title");
         Assert.NotNull(title);
@@ -213,7 +213,7 @@ public class ChangeLogMergeEventTests(HostFixture hostFixture) : TestBase(hostFi
         Assert.Equal($"Record merged into TRN {_person!.Trn} and deactivated", title.TrimmedText());
 
         Assert.Equal($"By {_createdByUser!.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         doc.AssertSummaryListRowValue("change-reason", "Comments", v => Assert.Equal(comments, v.TrimmedText()));
         doc.AssertSummaryListRowValue("change-reason", "Evidence", v => Assert.Equal($"{evidenceFile!.Name} (opens in new tab)", v.TrimmedText()));
@@ -316,7 +316,7 @@ public class ChangeLogMergeEventTests(HostFixture hostFixture) : TestBase(hostFi
         var mergedEvent = new LegacyEvents.PersonsMergedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = _createdByUser!.UserId,
             PersonId = _person!.PersonId,
             PersonTrn = _person!.Trn,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogNpqTrnRequestSupportTaskUpdatedEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogNpqTrnRequestSupportTaskUpdatedEventTests.cs
@@ -30,10 +30,10 @@ public class ChangeLogNpqTrnRequestSupportTaskResolvedEventTests : TestBase
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
 
-        _oldDob = Clock.Today.AddYears(-30);
-        _dob = Clock.Today.AddYears(-20);
+        _oldDob = TimeProvider.Today.AddYears(-30);
+        _dob = TimeProvider.Today.AddYears(-20);
     }
 
     public static TheoryData<NpqTrnRequestSupportTaskResolvedEventChanges, bool, bool, NpqTrnRequestResolvedReason>
@@ -121,7 +121,7 @@ public class ChangeLogNpqTrnRequestSupportTaskResolvedEventTests : TestBase
         }
 
         Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         if (changes.HasAnyFlag(NpqTrnRequestSupportTaskResolvedEventChanges.PersonNameChange))
         {
@@ -189,7 +189,7 @@ public class ChangeLogNpqTrnRequestSupportTaskResolvedEventTests : TestBase
 
         item.AssertSummaryListRowValue("request-data", "Source", v => Assert.Equal("Apply for QTS", v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Request ID", v => Assert.Equal("TEST-TRN-1", v.TrimmedText()));
-        item.AssertSummaryListRowValue("request-data", "Created on", v => Assert.Equal(Clock.UtcNow.ToString(WebConstants.DateAndTimeDisplayFormat), v.TrimmedText()));
+        item.AssertSummaryListRowValue("request-data", "Created on", v => Assert.Equal(TimeProvider.UtcNow.ToString(WebConstants.DateAndTimeDisplayFormat), v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Name", v => Assert.Equal($"{newFirstName} {newMiddleName} {newLastName}", v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Date of birth", v => Assert.Equal(newDob.ToString(WebConstants.DateDisplayFormat) ?? WebConstants.EmptyFallbackContent, v.TrimmedText()));
         item.AssertSummaryListRowValue("request-data", "Email address", v => Assert.Equal(newEmail ?? WebConstants.EmptyFallbackContent, v.TrimmedText()));
@@ -337,7 +337,7 @@ public class ChangeLogNpqTrnRequestSupportTaskResolvedEventTests : TestBase
         {
             ApplicationUserId = applicationUserId,
             RequestId = "TEST-TRN-1",
-            CreatedOn = Clock.UtcNow,
+            CreatedOn = TimeProvider.UtcNow,
             IdentityVerified = null,
             EmailAddress = email,
             OneLoginUserSubject = null,
@@ -372,7 +372,7 @@ public class ChangeLogNpqTrnRequestSupportTaskResolvedEventTests : TestBase
         var updatedEvent = new NpqTrnRequestSupportTaskResolvedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUserId,
             PersonId = personId,
             PersonAttributes = attributes,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogProfessionalStatusEventsTests.cs
@@ -13,8 +13,8 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     public async Task ProfessionalStatusCreatedEvent_RendersExpectedContent()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
         var status = RouteToProfessionalStatusStatus.InTraining;
         var subjects = (await ReferenceDataCache.GetTrainingSubjectsAsync()).Where(s => !s.Name.Contains('\'')).Take(1);
@@ -72,7 +72,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     public async Task ProfessionalStatusCreatedEvent_AffectsPersonProfessionalStatus_RendersExpectedContent()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
 
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.EarlyYearsTeacherStatus)
@@ -83,7 +83,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
             {
                 q.WithRouteType(route.RouteToProfessionalStatusTypeId);
                 q.WithStatus(RouteToProfessionalStatusStatus.Holds);
-                q.WithHoldsFrom(Clock.Today);
+                q.WithHoldsFrom(TimeProvider.Today);
                 q.WithInductionExemption(true);
             }));
 
@@ -108,7 +108,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     public async Task ProfessionalStatusCreatedEvent_RendersExpectedChangeReasonContent()
     {
         // Arrange
-        var awardDate = Clock.Today.AddYears(-2).AddDays(1);
+        var awardDate = TimeProvider.Today.AddYears(-2).AddDays(1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
         var status = RouteToProfessionalStatusStatus.Holds;
         var changeReason = "Text from change reason selection";
@@ -149,7 +149,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     public async Task ProfessionalStatusUpdatedEvent_RendersExpectedContent()
     {
         // Arrange
-        var oldStartDate = Clock.Today.AddYears(-2);
+        var oldStartDate = TimeProvider.Today.AddYears(-2);
         var oldEndDate = oldStartDate.AddYears(1);
         var oldAwardDate = oldEndDate.AddDays(-1);
         var oldRoute = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
@@ -214,7 +214,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 changeReasonDetail: null,
                 evidenceFile: null,
                 updatedBy: updatedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
 
@@ -236,7 +236,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var timelineItem = doc.GetElementByTestId("timeline-item-route-updated-event");
         Assert.NotNull(timelineItem);
         Assert.Equal($"By {updatedByUser.Name} on", timelineItem.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), timelineItem.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), timelineItem.GetElementByTestId("timeline-item-time")?.TrimmedText());
         Assert.Null(timelineItem.GetElementByTestId("status"));
         Assert.Equal(holdsFrom.ToString(WebConstants.DateDisplayFormat), timelineItem.GetElementByTestId("award-date")?.TrimmedText());
         Assert.Equal(startDate.ToString(WebConstants.DateDisplayFormat), timelineItem.GetElementByTestId("start-date")!.TrimmedText());
@@ -267,7 +267,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     {
         // Arrange
         var oldStatus = RouteToProfessionalStatusStatus.InTraining;
-        var startDate = Clock.Today.AddYears(-2);
+        var startDate = TimeProvider.Today.AddYears(-2);
         var endDate = startDate.AddYears(1);
         var awardDate = endDate.AddDays(1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
@@ -310,7 +310,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 changeReasonDetail: null,
                 evidenceFile: null,
                 updatedBy: updatedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
             Debug.Assert(@event is not null && @event.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.Status));
@@ -331,7 +331,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var timelineItem = doc.GetElementByTestId("timeline-item-route-updated-event");
         Assert.NotNull(timelineItem);
         Assert.Equal($"By {updatedByUser.Name} on", timelineItem.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), timelineItem.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), timelineItem.GetElementByTestId("timeline-item-time")?.TrimmedText());
         Assert.Equal(status.GetDisplayName(), timelineItem.GetElementByTestId("status")?.TrimmedText());
         Assert.Equal(awardDate.ToString(WebConstants.DateDisplayFormat), timelineItem.GetElementByTestId("qts-date")?.TrimmedText());
         Assert.Null(timelineItem.GetElementByTestId("pqts-date"));
@@ -364,7 +364,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     {
         // Arrange
         var oldStatus = RouteToProfessionalStatusStatus.InTraining;
-        var startDate = Clock.Today.AddYears(-2);
+        var startDate = TimeProvider.Today.AddYears(-2);
         var endDate = startDate.AddYears(1);
         var awardDate = endDate.AddDays(1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
@@ -394,7 +394,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 changeReasonDetail: changeReasonDetail,
                 evidenceFile: null,
                 updatedBy: updatedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
             Debug.Assert(@event is not null && @event.Changes.HasFlag(RouteToProfessionalStatusUpdatedEventChanges.Status));
@@ -422,8 +422,8 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     public async Task ProfessionalStatusDeletedEvent_RendersExpectedContent()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync(ProfessionalStatusType.QualifiedTeacherStatus);
         var status = RouteToProfessionalStatusStatus.Holds;
@@ -439,7 +439,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
             {
                 q.WithRouteType(route.RouteToProfessionalStatusTypeId);
                 q.WithStatus(status);
-                q.WithHoldsFrom(Clock.Today);
+                q.WithHoldsFrom(TimeProvider.Today);
                 q.WithInductionExemption(true);
                 q.WithTrainingStartDate(startDate);
                 q.WithTrainingEndDate(endDate);
@@ -464,7 +464,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 deletionReasonDetail: null,
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
 
@@ -484,7 +484,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var timelineItem = doc.GetElementByTestId("timeline-item-route-deleted-event");
         Assert.NotNull(timelineItem);
         Assert.Equal($"By {deletedByUser.Name} on", timelineItem.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), timelineItem.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), timelineItem.GetElementByTestId("timeline-item-time")?.TrimmedText());
         Assert.Null(timelineItem.GetElementByTestId("eyts-date"));
         Assert.Null(timelineItem.GetElementByTestId("pqts-date"));
         Assert.Equal(WebConstants.EmptyFallbackContent, timelineItem.GetElementByTestId("qts-date")?.TrimmedText());
@@ -520,7 +520,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 deletionReasonDetail: null,
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
 
@@ -560,7 +560,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 deletionReasonDetail: null,
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
 
@@ -600,7 +600,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 deletionReasonDetail: null,
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
 
@@ -640,7 +640,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
                 deletionReasonDetail: null,
                 evidenceFile: null,
                 deletedBy: deletedByUser.UserId,
-                Clock.UtcNow,
+                TimeProvider.UtcNow,
                 additionalInformation: null,
                 out var @event);
 
@@ -670,8 +670,8 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
     {
         // Arrange
         var person = await TestData.CreatePersonAsync();
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var awardDate = endDate.AddDays(1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
         var status = populateOptional ? RouteToProfessionalStatusStatus.Holds : RouteToProfessionalStatusStatus.InTraining;
@@ -795,7 +795,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var migratedEvent = new RouteToProfessionalStatusMigratedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             RouteToProfessionalStatus = routeToProfessionalStatus,
@@ -874,7 +874,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var createdEvent = new DqtInitialTeacherTrainingCreatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             InitialTeacherTraining = new EventModels.DqtInitialTeacherTraining
@@ -915,7 +915,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var updatedEvent = new DqtInitialTeacherTrainingUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             InitialTeacherTraining = new EventModels.DqtInitialTeacherTraining
@@ -961,14 +961,14 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var person = await TestData.CreatePersonAsync();
         var teacherStatusName = "Trainee teacher";
         var earlyYearsStatusName = "Early Years Trainee";
-        var qtsDate = Clock.Today.AddDays(-100);
-        var eytsDate = Clock.Today.AddDays(-50);
+        var qtsDate = TimeProvider.Today.AddDays(-100);
+        var eytsDate = TimeProvider.Today.AddDays(-50);
         var createdByUser = await TestData.CreateUserAsync();
 
         var createdEvent = new DqtQtsRegistrationCreatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             QtsRegistration = new EventModels.DqtQtsRegistration
@@ -1045,8 +1045,8 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var person = await TestData.CreatePersonAsync();
         var oldTeacherStatusName = "Trainee teacher";
         var oldEarlyYearsStatusName = "Early Years Trainee";
-        var oldQtsDate = Clock.Today.AddDays(-100);
-        var oldEytsDate = Clock.Today.AddDays(-50);
+        var oldQtsDate = TimeProvider.Today.AddDays(-100);
+        var oldEytsDate = TimeProvider.Today.AddDays(-50);
         var teacherStatusName = "Qualified Teacher (trained)";
         var earlyYearsStatusName = "Early Years Teacher Status";
         var qtsDate = oldQtsDate.AddDays(1);
@@ -1056,7 +1056,7 @@ public class ChangeLogProfessionalStatusEventsTests(HostFixture hostFixture) : T
         var updatedEvent = new DqtQtsRegistrationUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             QtsRegistration = new EventModels.DqtQtsRegistration

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogSetStatusEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogSetStatusEventTests.cs
@@ -14,7 +14,7 @@ public class ChangeLogSetStatusEventTests : TestBase
             new DateTime(2024, 1, 1, 12, 13, 14, DateTimeKind.Utc),  // GMT
             new DateTime(2024, 7, 5, 19, 20, 21, DateTimeKind.Utc)   // BST
         };
-        Clock.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
+        TimeProvider.SetUtcNow(new DateTimeOffset(nows.SingleRandom(), TimeSpan.Zero));
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class ChangeLogSetStatusEventTests : TestBase
         var statusUpdatedEvent = new PersonStatusUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             Status = PersonStatus.Deactivated,
@@ -77,7 +77,7 @@ public class ChangeLogSetStatusEventTests : TestBase
         Assert.Equal($"Record deactivated", title.TrimmedText());
 
         Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         doc.AssertSummaryListRowValue("change-reason", "Reason", v => Assert.Equal(reason, v.TrimmedText()));
         doc.AssertSummaryListRowValue("change-reason", "Additional information", v => Assert.Equal(additionalInformation, v.TrimmedText()));
@@ -104,7 +104,7 @@ public class ChangeLogSetStatusEventTests : TestBase
         var statusUpdatedEvent = new PersonStatusUpdatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = createdByUser.UserId,
             PersonId = person.PersonId,
             Status = PersonStatus.Active,
@@ -138,7 +138,7 @@ public class ChangeLogSetStatusEventTests : TestBase
         Assert.Equal($"Record reactivated", title.TrimmedText());
 
         Assert.Equal($"By {createdByUser.Name} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         doc.AssertSummaryListRowValue("change-reason", "Reason", v => Assert.Equal(reason, v.TrimmedText()));
         doc.AssertSummaryListRowValue("change-reason", "Additional information", v => Assert.Equal(additionalInformation, v.TrimmedText()));

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTests.cs
@@ -141,7 +141,7 @@ public class ChangeLogTests(HostFixture hostFixture) : TestBase(hostFixture)
                 var @event = new LegacyEvents.PersonDetailsUpdatedEvent
                 {
                     EventId = Guid.NewGuid(),
-                    CreatedUtc = Clock.UtcNow.AddMinutes(-i),
+                    CreatedUtc = TimeProvider.UtcNow.AddMinutes(-i),
                     RaisedBy = Core.DataStore.Postgres.Models.SystemUser.SystemUserId,
                     PersonId = person.PersonId,
                     PersonAttributes = new EventModels.PersonDetails

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTrnAllocatedEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogTrnAllocatedEventTests.cs
@@ -15,7 +15,7 @@ public class ChangeLogTrnAllocatedEventTests(HostFixture hostFixture) : TestBase
         var trnAllocatedEvent = new TrnAllocatedEvent
         {
             EventId = Guid.NewGuid(),
-            CreatedUtc = Clock.UtcNow,
+            CreatedUtc = TimeProvider.UtcNow,
             RaisedBy = SystemUser.SystemUserId,
             PersonId = person.PersonId,
             Trn = trn
@@ -41,7 +41,7 @@ public class ChangeLogTrnAllocatedEventTests(HostFixture hostFixture) : TestBase
         Assert.NotNull(title);
         Assert.Equal("TRN allocated", title.TrimmedText());
         Assert.Equal($"By {SystemUser.SystemUserName} on", item.GetElementByTestId("raised-by")?.TrimmedText());
-        Assert.Equal(Clock.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
+        Assert.Equal(TimeProvider.NowGmt.ToString(TimelineItem.TimestampFormat), item.GetElementByTestId("timeline-item-time")?.TrimmedText());
 
         doc.AssertSummaryListRowValue("Trn", v => Assert.Equal(trn, v.TrimmedText()));
     }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
@@ -214,10 +214,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         await WithDbContextAsync(async dbContext =>
         {
             var updatedOneLoginUser = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginUser.Subject);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.VerifiedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.VerifiedOn);
             Assert.Equal(OneLoginUserVerificationRoute.Support, updatedOneLoginUser.VerificationRoute);
             Assert.Equal(person.PersonId, updatedOneLoginUser.PersonId);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.MatchedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.MatchedOn);
             Assert.Equal(OneLoginUserMatchRoute.SupportUi, updatedOneLoginUser.MatchRoute);
             Assert.NotNull(updatedOneLoginUser.VerifiedNames);
             Assert.Single(updatedOneLoginUser.VerifiedNames);
@@ -288,7 +288,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.NotNull(updatedOneLoginUser.VerifiedOn);
             Assert.Equal(OneLoginUserVerificationRoute.OneLogin, updatedOneLoginUser.VerificationRoute);
             Assert.Equal(person.PersonId, updatedOneLoginUser.PersonId);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.MatchedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.MatchedOn);
             Assert.Equal(OneLoginUserMatchRoute.SupportUi, updatedOneLoginUser.MatchRoute);
         });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditDetails/CheckAnswersTests.cs
@@ -405,7 +405,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         await WithDbContextAsync(async dbContext =>
         {
             var updatedPersonRecord = await dbContext.Persons.SingleAsync(p => p.PersonId == person.PersonId);
-            Assert.Equal(Clock.UtcNow, updatedPersonRecord.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedPersonRecord.UpdatedOn);
             Assert.Equal(firstName, updatedPersonRecord.FirstName);
             Assert.Equal(middleName, updatedPersonRecord.MiddleName);
             Assert.Equal(lastName, updatedPersonRecord.LastName);
@@ -419,7 +419,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         {
             var actualEvent = Assert.IsType<LegacyEvents.PersonDetailsUpdatedEvent>(e);
 
-            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
             Assert.Equal(person.PersonId, actualEvent.PersonId);
             Assert.Equal(firstName, actualEvent.PersonAttributes.FirstName);
             Assert.Equal(middleName, actualEvent.PersonAttributes.MiddleName);
@@ -498,7 +498,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .Include(p => p.PreviousNames)
                 .SingleAsync(p => p.PersonId == person.PersonId);
 
-            Assert.Equal(Clock.UtcNow, updatedPersonRecord.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedPersonRecord.UpdatedOn);
             Assert.Equal("Alfrede", updatedPersonRecord.FirstName);
             Assert.Equal("Thee", updatedPersonRecord.MiddleName);
             Assert.Equal("Greate", updatedPersonRecord.LastName);
@@ -552,13 +552,13 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .Include(p => p.PreviousNames)
                 .SingleAsync(p => p.PersonId == person.PersonId);
 
-            Assert.Equal(Clock.UtcNow, updatedPersonRecord.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedPersonRecord.UpdatedOn);
             Assert.Equal("Megan", updatedPersonRecord.FirstName);
             Assert.Equal("Thee", updatedPersonRecord.MiddleName);
             Assert.Equal("Stallion", updatedPersonRecord.LastName);
 
             Assert.Collection(updatedPersonRecord.PreviousNames!.OrderByDescending(pn => pn.CreatedOn),
-                pn => Assert.Equal(("Alfred", "The", "Great", Clock.UtcNow, Clock.UtcNow), (pn.FirstName, pn.MiddleName, pn.LastName, pn.CreatedOn, pn.UpdatedOn)),
+                pn => Assert.Equal(("Alfred", "The", "Great", TimeProvider.UtcNow, TimeProvider.UtcNow), (pn.FirstName, pn.MiddleName, pn.LastName, pn.CreatedOn, pn.UpdatedOn)),
                 pn => Assert.Equal(("Conan", "The", "Barbarian", conanDate, conanDate), (pn.FirstName, pn.MiddleName, pn.LastName, pn.CreatedOn, pn.UpdatedOn)),
                 pn => Assert.Equal(("Ethelred", "The", "Unready", ethelredDate, ethelredDate), (pn.FirstName, pn.MiddleName, pn.LastName, pn.CreatedOn, pn.UpdatedOn)));
         });

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CheckYourAnswersTests.cs
@@ -72,8 +72,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         // Arrange
         var labelContent = "Status";
 
-        DateOnly? startDate = inductionStatus.RequiresStartDate() ? Clock.Today.AddYears(-2) : null;
-        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? Clock.Today : null;
+        DateOnly? startDate = inductionStatus.RequiresStartDate() ? TimeProvider.Today.AddYears(-2) : null;
+        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? TimeProvider.Today : null;
 
         var exemptionReasonIds = inductionStatus is InductionStatus.Exempt
             ? (await TestData.ReferenceDataCache.GetInductionExemptionReasonsAsync(activeOnly: true))
@@ -141,8 +141,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         // Arrange
         var labelContent = "Start date";
 
-        DateOnly? startDate = inductionStatus.RequiresStartDate() ? Clock.Today.AddYears(-2) : null;
-        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? Clock.Today : null;
+        DateOnly? startDate = inductionStatus.RequiresStartDate() ? TimeProvider.Today.AddYears(-2) : null;
+        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? TimeProvider.Today : null;
 
         var exemptionReasonIds = inductionStatus is InductionStatus.Exempt
             ? (await TestData.ReferenceDataCache.GetInductionExemptionReasonsAsync(activeOnly: true))
@@ -216,8 +216,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         // Arrange
         var labelContent = "Completion date";
 
-        DateOnly? startDate = inductionStatus.RequiresStartDate() ? Clock.Today.AddYears(-2) : null;
-        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? Clock.Today : null;
+        DateOnly? startDate = inductionStatus.RequiresStartDate() ? TimeProvider.Today.AddYears(-2) : null;
+        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? TimeProvider.Today : null;
 
         var exemptionReasonIds = inductionStatus is InductionStatus.Exempt
             ? (await TestData.ReferenceDataCache.GetInductionExemptionReasonsAsync(activeOnly: true))
@@ -282,8 +282,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         // Arrange
         var labelContent = "Exemption reason";
 
-        DateOnly? startDate = inductionStatus.RequiresStartDate() ? Clock.Today.AddYears(-2) : null;
-        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? Clock.Today : null;
+        DateOnly? startDate = inductionStatus.RequiresStartDate() ? TimeProvider.Today.AddYears(-2) : null;
+        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? TimeProvider.Today : null;
 
         //var exemptionReasonIds = inductionStatus is InductionStatus.Exempt
         //    ? (await TestData.ReferenceDataCache.GetInductionExemptionReasonsAsync(activeOnly: true))
@@ -381,8 +381,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     {
         // Arrange
         var inductionStatus = InductionStatus.InProgress;
-        var startDate = Clock.Today.AddYears(-2);
-        var completedDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-2);
+        var completedDate = TimeProvider.Today;
         var exemptionReasonIds = Array.Empty<Guid>();
 
         var editInductionState = new EditInductionStateBuilder()
@@ -436,7 +436,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     {
         // Arrange
         var inductionStatus = InductionStatus.RequiredToComplete;
-        var startDate = Clock.Today;
+        var startDate = TimeProvider.Today;
         var completedDate = startDate.AddYears(-2);
         var exemptionReasonIds = Array.Empty<Guid>();
 
@@ -475,8 +475,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     {
         // Arrange
         var inductionStatus = InductionStatus.RequiredToComplete;
-        var startDate = Clock.Today.AddYears(-2);
-        var completedDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-2);
+        var completedDate = TimeProvider.Today;
         var exemptionReasonIds = (await TestData.ReferenceDataCache
             .GetInductionExemptionReasonsAsync(activeOnly: true))
             .TakeRandom(1)
@@ -518,8 +518,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         // Arrange
         var inductionStatus = InductionStatus.InProgress;
 
-        DateOnly? startDate = inductionStatus.RequiresStartDate() ? Clock.Today.AddYears(-2) : null;
-        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? Clock.Today : null;
+        DateOnly? startDate = inductionStatus.RequiresStartDate() ? TimeProvider.Today.AddYears(-2) : null;
+        DateOnly? completedDate = inductionStatus.RequiresCompletedDate() ? TimeProvider.Today : null;
 
         var exemptionReasonIds = Array.Empty<Guid>();
 
@@ -570,7 +570,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         {
             var actualInductionUpdatedEvent = Assert.IsType<PersonInductionUpdatedEvent>(e);
 
-            Assert.Equal(actualInductionUpdatedEvent.CreatedUtc, Clock.UtcNow);
+            Assert.Equal(actualInductionUpdatedEvent.CreatedUtc, TimeProvider.UtcNow);
             Assert.Equal(actualInductionUpdatedEvent.PersonId, person.PersonId);
             Assert.Equal(actualInductionUpdatedEvent.Induction.Status, journeyInstance.State.InductionStatus);
             Assert.Equal(actualInductionUpdatedEvent.Induction.StartDate, journeyInstance.State.StartDate);
@@ -594,8 +594,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     {
         // Arrange
         var inductionStatus = InductionStatus.InProgress;
-        var startDate = Clock.Today.AddYears(-2);
-        var completedDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-2);
+        var completedDate = TimeProvider.Today;
         var exemptionReasonIds = Array.Empty<Guid>();
 
         var editInductionState = new EditInductionStateBuilder()
@@ -637,8 +637,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     {
         // Arrange
         var inductionStatus = InductionStatus.InProgress;
-        var startDate = Clock.Today.AddYears(-2);
-        var completedDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-2);
+        var completedDate = TimeProvider.Today;
         var exemptionReasonIds = Array.Empty<Guid>();
 
         var editInductionState = new EditInductionStateBuilder()
@@ -681,8 +681,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         // Arrange
         var evidenceFileId = uploadFile == true ? Guid.NewGuid() : default(Guid?);
         var inductionStatus = InductionStatus.InProgress;
-        var startDate = Clock.Today.AddYears(-2);
-        var completedDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-2);
+        var completedDate = TimeProvider.Today;
         var exemptionReasonIds = Array.Empty<Guid>();
 
         var editInductionState = new EditInductionStateBuilder()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CommonPageTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/CommonPageTests.cs
@@ -42,7 +42,7 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddYears(-2))
+                .WithStartDate(TimeProvider.Today.AddYears(-2))
                 .Build());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/{fromPage}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -50,8 +50,8 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
             Content = new EditInductionPostRequestContentBuilder()
                 .WithInductionStatus(inductionStatus)
                 .WithExemptionReasonIds(exemptionReasonIds)
-                .WithStartDate(Clock.Today.AddDays(-1))
-                .WithCompletedDate(Clock.Today)
+                .WithStartDate(TimeProvider.Today.AddDays(-1))
+                .WithCompletedDate(TimeProvider.Today)
                 .WithChangeReason(PersonInductionChangeReason.IncompleteDetails)
                 .WithProvideAdditionalInformation(false)
                 .WithUploadEvidence(false)
@@ -88,8 +88,8 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddYears(-2))
-                .WithCompletedDate(Clock.Today)
+                .WithStartDate(TimeProvider.Today.AddYears(-2))
+                .WithCompletedDate(TimeProvider.Today)
                 .WithReasonChoice(PersonInductionChangeReason.AnotherReason)
                 .WithAdditionalInformationChoice(true, "Details")
                 .WithFileUploadChoice(false)
@@ -137,8 +137,8 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddYears(-2))
-                .WithCompletedDate(Clock.Today)
+                .WithStartDate(TimeProvider.Today.AddYears(-2))
+                .WithCompletedDate(TimeProvider.Today)
                 .WithReasonChoice(PersonInductionChangeReason.AnotherReason)
                 .WithAdditionalInformationChoice(true, "Details")
                 .WithFileUploadChoice(true, evidenceFileId)
@@ -178,21 +178,21 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
         var exemptionReasonIds = new Guid[] { InductionExemptionReason.ExemptId };
         var person = await TestData.CreatePersonAsync(
             p => p.WithQts()
-                .WithInductionStatus(i => i.WithStatus(inductionStatus).WithStartDate(Clock.Today.AddYears(-2)).WithCompletedDate(Clock.Today)));
+                .WithInductionStatus(i => i.WithStatus(inductionStatus).WithStartDate(TimeProvider.Today.AddYears(-2)).WithCompletedDate(TimeProvider.Today)));
 
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, pageName)
-                .WithStartDate(Clock.Today.AddYears(-2))
-                .WithCompletedDate(Clock.Today)
+                .WithStartDate(TimeProvider.Today.AddYears(-2))
+                .WithCompletedDate(TimeProvider.Today)
                 .Build());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/{page}?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new EditInductionPostRequestContentBuilder()
                 .WithInductionStatus(inductionStatus)
-                .WithStartDate(Clock.Today.AddDays(-1))
-                .WithCompletedDate(Clock.Today)
+                .WithStartDate(TimeProvider.Today.AddDays(-1))
+                .WithCompletedDate(TimeProvider.Today)
                 .WithExemptionReasonIds(exemptionReasonIds)
                 .BuildFormUrlEncoded()
         };
@@ -229,8 +229,8 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, startPage)
-                .WithStartDate(Clock.Today.AddYears(-2))
-                .WithCompletedDate(Clock.Today)
+                .WithStartDate(TimeProvider.Today.AddYears(-2))
+                .WithCompletedDate(TimeProvider.Today)
                 .Build());
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/{fromPage}?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -419,7 +419,7 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddYears(-2))
+                .WithStartDate(TimeProvider.Today.AddYears(-2))
                 .Build());
 
         var request = new HttpRequestMessage(httpMethod,
@@ -450,7 +450,7 @@ public class CommonPageTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddYears(-2))
+                .WithStartDate(TimeProvider.Today.AddYears(-2))
                 .Build());
 
         var request = new HttpRequestMessage(httpMethod,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditCompletedDateTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditCompletedDateTests.cs
@@ -56,7 +56,7 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
     public async Task Get_WithCompletedDate_ShowsDate()
     {
         // Arrange
-        var dateValid = Clock.Today;
+        var dateValid = TimeProvider.Today;
         var inductionStatus = InductionStatus.Passed;
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -84,7 +84,7 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
     public async Task Post_SetValidCompletedDate_PersistsCompletedDate()
     {
         // Arrange
-        var dateValid = Clock.Today;
+        var dateValid = TimeProvider.Today;
         var inductionStatus = InductionStatus.Passed;
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
@@ -92,7 +92,7 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddDays(-1))
+                .WithStartDate(TimeProvider.Today.AddDays(-1))
                 .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -118,7 +118,7 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddDays(-1))
+                .WithStartDate(TimeProvider.Today.AddDays(-1))
                 .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -134,14 +134,14 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
     public async Task Post_CompletedDateIsInTheFuture_ReturnsError()
     {
         // Arrange
-        var dateTomorrow = Clock.Today.AddDays(1);
+        var dateTomorrow = TimeProvider.Today.AddDays(1);
         var inductionStatus = InductionStatus.Passed;
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
             new EditInductionStateBuilder()
                 .WithInitializedState(inductionStatus, InductionJourneyPage.Status)
-                .WithStartDate(Clock.Today.AddDays(-1))
+                .WithStartDate(TimeProvider.Today.AddDays(-1))
                 .Build());
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/edit-induction/date-completed?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -160,7 +160,7 @@ public class EditCompletedDateTests(HostFixture hostFixture) : TestBase(hostFixt
     public async Task Post_CompletedDateIsBeforeStartDate_ReturnsError()
     {
         // Arrange
-        var completedDate = Clock.Today.AddDays(-1);
+        var completedDate = TimeProvider.Today.AddDays(-1);
         var startDate = completedDate.AddDays(1);
         var inductionStatus = InductionStatus.Passed;
         var person = await TestData.CreatePersonAsync(p => p.WithQts());

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditExemptionReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditExemptionReasonTests.cs
@@ -122,7 +122,7 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         // Arrange
         var allGuidsToDisplay = InductionExemptionService.RouteFeatureExemptionReasonIds;
         var route = await ReferenceDataCache.GetRouteToProfessionalStatusTypeByIdAsync(RouteToProfessionalStatusType.ApplyForQtsId);
-        var holdsFromDate = Clock.Today;
+        var holdsFromDate = TimeProvider.Today;
         var exemptionReasons = (await TestData.ReferenceDataCache.GetPersonLevelInductionExemptionReasonsAsync(activeOnly: true))
             .ToArray();
         var exemptionReasonsForDisplay = allGuidsToDisplay
@@ -172,7 +172,7 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         // Arrange
         var allGuidsToDisplay = InductionExemptionService.ExemptionReasonIds;
         var route = await ReferenceDataCache.GetRouteToProfessionalStatusTypeByIdAsync(routeId);
-        var holdsFromDate = Clock.Today;
+        var holdsFromDate = TimeProvider.Today;
         var exemptionReasons = (await TestData.ReferenceDataCache.GetPersonLevelInductionExemptionReasonsAsync(activeOnly: true))
             .ToArray();
         var exemptionReasonsForDisplay = allGuidsToDisplay
@@ -234,7 +234,7 @@ public class EditExemptionReasonTests(HostFixture hostFixture) : TestBase(hostFi
         // Arrange
         var allGuidsToDisplay = InductionExemptionService.ExemptionReasonIds;
         var route = await ReferenceDataCache.GetRouteToProfessionalStatusTypeByIdAsync(routeId);
-        var holdsFromDate = Clock.Today;
+        var holdsFromDate = TimeProvider.Today;
 
         var person = await TestData.CreatePersonAsync(p => p
             .WithQts()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditInductionStatusTests.cs
@@ -103,7 +103,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
         // Arrange
         InductionStatus[] expectedStatuses = new List<InductionStatus> { InductionStatus.Exempt, InductionStatus.FailedInWales, currentInductionStatus }.OrderBy(i => i).ToArray();
         var expectedChoices = expectedStatuses.Select(s => s.ToString());
-        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
+        var lessThanSevenYearsAgo = TimeProvider.Today.AddYears(-1);
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
         await WithDbContextAsync(async dbContext =>
         {
@@ -112,9 +112,9 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 InductionStatus.Passed,
                 startDate: lessThanSevenYearsAgo.AddYears(-1),
                 completedDate: lessThanSevenYearsAgo,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
             await dbContext.SaveChangesAsync();
         });
@@ -159,9 +159,9 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 InductionStatus.RequiredToComplete, // CPD induction status can't be Exempt or FailedInWales
                 startDate: null,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
             person.Person.SetInductionStatus(
                 status,
@@ -172,7 +172,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 changeReasonDetail: null,
                 evidenceFile: null,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 additionalInformation: null,
                 out _);
             await dbContext.SaveChangesAsync();
@@ -274,7 +274,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
     [Fact]
     public async Task Post_PersonManagedByCpd_NoSelectedStatus_ShowsPageError()
     {
-        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
+        var lessThanSevenYearsAgo = TimeProvider.Today.AddYears(-1);
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
         await WithDbContextAsync(async dbContext =>
         {
@@ -283,9 +283,9 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 InductionStatus.Passed,
                 startDate: lessThanSevenYearsAgo.AddYears(-1),
                 completedDate: lessThanSevenYearsAgo,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
             await dbContext.SaveChangesAsync();
         });
@@ -318,7 +318,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
     public async Task Get_ForPersonWithInductionStatusManagedByCPD_ShowsWarning(InductionStatus status, string statusSpecificText)
     {
         //Arrange
-        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
+        var lessThanSevenYearsAgo = TimeProvider.Today.AddYears(-1);
 
         // test setup here is convoluted because I need to set up a person,
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
@@ -342,9 +342,9 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 InductionStatus.RequiredToComplete, // CPD induction status can't be Exempt or FailedInWales
                 startDate: null,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
 
             person.Person.SetInductionStatus(
@@ -356,7 +356,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 changeReasonDetail: null,
                 evidenceFile: null,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 additionalInformation: null,
                 out _);
 
@@ -385,7 +385,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
     public async Task Get_ForPersonWithInductionStatusManagedByCPD_StatusExemptOrFailedInWales_NoWarning(InductionStatus status)
     {
         //Arrange
-        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
+        var lessThanSevenYearsAgo = TimeProvider.Today.AddYears(-1);
 
         // test setup here is convoluted because I need to set up a person,
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
@@ -399,9 +399,9 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 InductionStatus.RequiredToComplete, // CPD induction status can't be Exempt or FailedInWales
                 startDate: null,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
             person.Person.SetInductionStatus(
                 status,
@@ -412,7 +412,7 @@ public class EditInductionStatusTests(HostFixture hostFixture) : TestBase(hostFi
                 changeReasonDetail: null,
                 evidenceFile: null,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 additionalInformation: null,
                 out _);
             await dbContext.SaveChangesAsync();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditStartDateTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/EditInduction/EditStartDateTests.cs
@@ -34,7 +34,7 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithStartDate_ShowsDate()
     {
         // Arrange
-        var dateValid = Clock.Today;
+        var dateValid = TimeProvider.Today;
         var inductionStatus = InductionStatus.InProgress;
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
         var journeyInstance = await CreateJourneyInstanceAsync(
@@ -61,7 +61,7 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_SetValidStartDate_PersistsStartDate()
     {
         // Arrange
-        var dateValid = Clock.Today;
+        var dateValid = TimeProvider.Today;
         var inductionStatus = InductionStatus.InProgress;
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
@@ -109,7 +109,7 @@ public class EditStartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_StartDateIsInTheFuture_ReturnsError()
     {
         // Arrange
-        var dateTomorrow = Clock.Today.AddDays(1);
+        var dateTomorrow = TimeProvider.Today.AddDays(1);
         var inductionStatus = InductionStatus.InProgress;
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
         var journeyInstance = await CreateJourneyInstanceAsync(

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
@@ -51,8 +51,8 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 PreviousNameId = Guid.NewGuid(),
                 PersonId = person.PersonId,
-                CreatedOn = Clock.UtcNow.AddDays(-1),
-                UpdatedOn = Clock.UtcNow.AddDays(-1),
+                CreatedOn = TimeProvider.UtcNow.AddDays(-1),
+                UpdatedOn = TimeProvider.UtcNow.AddDays(-1),
                 FirstName = previousFirstName1,
                 MiddleName = previousMiddleName1,
                 LastName = previousLastName1
@@ -62,8 +62,8 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             {
                 PreviousNameId = Guid.NewGuid(),
                 PersonId = person.PersonId,
-                CreatedOn = Clock.UtcNow.AddDays(-2),
-                UpdatedOn = Clock.UtcNow.AddDays(-2),
+                CreatedOn = TimeProvider.UtcNow.AddDays(-2),
+                UpdatedOn = TimeProvider.UtcNow.AddDays(-2),
                 FirstName = previousFirstName2,
                 MiddleName = previousMiddleName2,
                 LastName = previousLastName2
@@ -204,7 +204,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasQts_ShowsDetails()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
 
         var person = await TestData.CreatePersonAsync(p => p
 
@@ -233,7 +233,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasQtls_ShowsDetails()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
 
         var person = await TestData.CreatePersonAsync(p => p
 
@@ -262,7 +262,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasEyts_ShowsDetails()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
 
         var person = await TestData.CreatePersonAsync(p => p
 
@@ -291,7 +291,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasEyps_ShowsDetails()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
 
         var person = await TestData.CreatePersonAsync(p => p
 
@@ -320,7 +320,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_PersonHasPqts_ShowsDetails()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
 
         var person = await TestData.CreatePersonAsync(p => p
 
@@ -781,7 +781,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync(b => b.WithDateOfBirth(dateOfBirth).WithEmailAddress());
         var email2 = TestData.GenerateUniqueEmail();
         await TestData.CreateOneLoginUserAsync(personId: person.PersonId, email: Option.Some(person.EmailAddress), verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         await TestData.CreateOneLoginUserAsync(personId: person.PersonId, email: Option.Some<string?>(email2), verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}");
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/InductionTests.cs
@@ -36,7 +36,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ForPersonWithRouteInductionExemption_RoutesFeatureFlagOn_DisplaysExpectedRowContent(Guid routeId, bool hasExemption)
     {
         // Arrange
-        var holdsFromDate = Clock.Today;
+        var holdsFromDate = TimeProvider.Today;
         var routeWithExemption = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.RouteToProfessionalStatusTypeId == routeId)
             .Single();
@@ -134,7 +134,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
     [InlineData(InductionStatus.FailedInWales)]
     public async Task Get_WithPersonIdForPersonWithInductionStatusRequiringStartDate_DisplaysExpectedContent(InductionStatus setInductionStatus)
     {
-        var setStartDate = Clock.Today.AddMonths(-1);
+        var setStartDate = TimeProvider.Today.AddMonths(-1);
         var person = await TestData.CreatePersonAsync(
                 personBuilder => personBuilder
                 .WithQts()
@@ -185,8 +185,8 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithPersonIdForPersonWithInductionStatusRequiringCompletedDate_DisplaysExpectedCompletedDate(InductionStatus setInductionStatus)
     {
         // Arrange
-        var setStartDate = Clock.Today.AddMonths(-1);
-        var setCompletedDate = Clock.Today;
+        var setStartDate = TimeProvider.Today.AddMonths(-1);
+        var setCompletedDate = TimeProvider.Today;
         var person = await TestData.CreatePersonAsync(
                 personBuilder => personBuilder
                 .WithQts()
@@ -224,7 +224,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
             ? await TestData.CreateUserAsync(role: UserRoles.RecordManager)
             : await TestData.CreateUserAsync(role: UserRoles.Viewer));
 
-        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
+        var lessThanSevenYearsAgo = TimeProvider.Today.AddYears(-1);
 
         var person = await TestData.CreatePersonAsync(p => p.WithQts());
 
@@ -244,9 +244,9 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
                 status,
                 startDate: status.RequiresStartDate() ? lessThanSevenYearsAgo.AddYears(-1) : null,
                 completedDate: status.RequiresCompletedDate() ? lessThanSevenYearsAgo : null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
             await dbContext.SaveChangesAsync();
         });
@@ -278,7 +278,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         SetCurrentUser(await TestData.CreateUserAsync(role: UserRoles.RecordManager));
 
-        var lessThanSevenYearsAgo = Clock.Today.AddYears(-1);
+        var lessThanSevenYearsAgo = TimeProvider.Today.AddYears(-1);
 
         // test setup here is convoluted because I need to set up a person,
         // then call SetCpdInductionstatus to set the CpdInductionModifiedOn date,
@@ -292,9 +292,9 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
                 InductionStatus.RequiredToComplete, // CPD induction status can't be Exempt or FailedInWales
                 startDate: null,
                 completedDate: null,
-                cpdModifiedOn: Clock.UtcNow,
+                cpdModifiedOn: TimeProvider.UtcNow,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 out _);
             person.Person.SetInductionStatus(
                 trsInductionStatus,
@@ -305,7 +305,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
                 changeReasonDetail: null,
                 evidenceFile: null,
                 updatedBy: SystemUser.SystemUserId,
-                now: Clock.UtcNow,
+                now: TimeProvider.UtcNow,
                 additionalInformation: null,
                 out _);
             await dbContext.SaveChangesAsync();
@@ -326,7 +326,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_WithPersonIdForPersonWithInductionStatusNotManagedByCpd_DoesNotShowWarning()
     {
         //Arrange
-        var underSevenYearsAgo = Clock.Today.AddYears(-6);
+        var underSevenYearsAgo = TimeProvider.Today.AddYears(-6);
 
         var person = await TestData.CreatePersonAsync(
             builder => builder
@@ -374,7 +374,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         SetCurrentUser(await TestData.CreateUserAsync(role: userRole));
 
-        var holdsFromDate = Clock.Today;
+        var holdsFromDate = TimeProvider.Today;
         var routeWithExemption = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.RouteToProfessionalStatusTypeId == RouteToProfessionalStatusType.ScotlandRId)
             .Single();
@@ -453,7 +453,7 @@ public class InductionTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_InductionExemption_PersonStatus_ShowsActionsAsExpected(PersonStatus personStatus, bool canSeeActions)
     {
         // Arrange
-        var holdsFromDate = Clock.Today;
+        var holdsFromDate = TimeProvider.Today;
         var routeWithExemption = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.RouteToProfessionalStatusTypeId == RouteToProfessionalStatusType.ScotlandRId)
             .Single();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/NotesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/NotesTests.cs
@@ -44,14 +44,14 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync(p => p
             .WithAlert(a => a
                 .WithAlertTypeId(AlertType.DbsAlertTypeId)
-                .WithStartDate(Clock.Today.AddDays(-30))
-                .WithEndDate(Clock.Today.AddDays(-1))));
+                .WithStartDate(TimeProvider.Today.AddDays(-30))
+                .WithEndDate(TimeProvider.Today.AddDays(-1))));
 
         var expectedNoteText = "Note without attachment";
         var expectedCreatedBy = TestData.GenerateName();
         var createdByUserId = Guid.NewGuid();
         var note1 = await TestData.CreateNoteFromDqtAsync(person.PersonId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var note2 = await TestData.CreateNoteFromDqtAsync(person.PersonId, expectedNoteText, createdByUserId, expectedCreatedBy, null, null);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/notes");
@@ -76,8 +76,8 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync(p => p
             .WithAlert(a => a
                 .WithAlertTypeId(AlertType.DbsAlertTypeId)
-                .WithStartDate(Clock.Today.AddDays(-30))
-                .WithEndDate(Clock.Today.AddDays(-1))));
+                .WithStartDate(TimeProvider.Today.AddDays(-30))
+                .WithEndDate(TimeProvider.Today.AddDays(-1))));
 
         var expectedNoteText = "Note without attachment";
         var expectedCreatedBy = TestData.GenerateName();
@@ -197,12 +197,12 @@ public class NotesTests(HostFixture hostFixture) : TestBase(hostFixture)
         var expectedCreatedBy1 = TestData.GenerateName();
         var createdByUserId1 = Guid.NewGuid();
         var expectedOriginalFileName1 = "file.png";
-        var expectedCreatedDate1 = Clock.UtcNow.AddMonths(-1);
+        var expectedCreatedDate1 = TimeProvider.UtcNow.AddMonths(-1);
         var expectedNoteText2 = "A second note that means something";
         var expectedCreatedBy2 = TestData.GenerateName();
         var createdByUserId2 = Guid.NewGuid();
         var expectedOriginalFileName2 = "file2.png";
-        var expectedCreatedDate2 = Clock.UtcNow;
+        var expectedCreatedDate2 = TimeProvider.UtcNow;
         var note1 = await TestData.CreateNoteFromDqtAsync(createPersonResult.PersonId, expectedNoteText1, createdByUserId1, expectedCreatedBy1, expectedOriginalFileName1, Guid.NewGuid(), expectedCreatedDate1);
         var note2 = await TestData.CreateNoteFromDqtAsync(createPersonResult.PersonId, expectedNoteText2, createdByUserId2, expectedCreatedBy2, expectedOriginalFileName2, Guid.NewGuid(), expectedCreatedDate2);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{createPersonResult.PersonId}/notes");

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/QualificationsTests.cs
@@ -271,7 +271,7 @@ public class QualificationsTests(HostFixture hostFixture) : TestBase(hostFixture
     {
         // Arrange
         var country = (await ReferenceDataCache.GetTrainingCountriesAsync()).Take(1).First();
-        var holdsFromDate = Clock.Today.AddDays(-1);
+        var holdsFromDate = TimeProvider.Today.AddDays(-1);
         var status = RouteToProfessionalStatusStatus.Holds;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Single(r => r.RouteToProfessionalStatusTypeId == RouteToProfessionalStatusType.NiRId);
         var person = await TestData.CreatePersonAsync(p => p

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/SetStatus/CheckAnswersTests.cs
@@ -211,7 +211,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : SetStatusTestBase(host
             var updatedPersonRecord = await dbContext.Persons
                 .IgnoreQueryFilters()
                 .SingleAsync(p => p.PersonId == person.PersonId);
-            Assert.Equal(Clock.UtcNow, updatedPersonRecord.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedPersonRecord.UpdatedOn);
             Assert.Equal(targetStatus, updatedPersonRecord.Status);
         });
 
@@ -221,7 +221,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : SetStatusTestBase(host
         {
             var actualEvent = Assert.IsType<PersonStatusUpdatedEvent>(e);
 
-            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
             Assert.Equal(person.PersonId, actualEvent.PersonId);
             Assert.Equal(targetStatus, actualEvent.Status);
             Assert.Equal(targetStatus == PersonStatus.Deactivated

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/CheckYourAnswersTests.cs
@@ -86,8 +86,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == routeName).Single();
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var subjects = (await ReferenceDataCache.GetTrainingSubjectsAsync()).Where(s => !s.Name.Contains('\'')).Take(1);
         var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).Where(s => !s.Name.Contains('\'')).SingleRandom();
@@ -210,8 +210,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Get_ShowsAnswers_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
         var status = TestDataHelper.GetRouteStatusWhereAllFieldsApply();
@@ -265,8 +265,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Get_ShowsExemptionAnswer_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
         var country = (await ReferenceDataCache.GetTrainingCountriesAsync())
             .SingleRandom();
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
@@ -311,8 +311,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Get_ShowsOptionalAnswersNotPopulated_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Postgraduate Teaching Apprenticeship").Single();
         var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).Where(s => !s.Name.Contains('\''))
             .SingleRandom();
@@ -369,7 +369,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var addRouteState = new AddRouteStateBuilder()
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusTypeId)
             .WithStatus(status)
-            .WithHoldsStatusFields(Clock)
+            .WithHoldsStatusFields(TimeProvider)
             .WithTrainingProviderId(trainingProvider.TrainingProviderId)
             .WithTrainingSubjectIds(subjects.Select(s => s.TrainingSubjectId).ToArray())
             .WithTrainingCountryId(country.CountryId)
@@ -420,7 +420,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         {
             var actualCreatedEvent = Assert.IsType<RouteToProfessionalStatusCreatedEvent>(e);
 
-            Assert.Equal(Clock.UtcNow, actualCreatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualCreatedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, actualCreatedEvent.PersonId);
             Assert.Equal(journeyInstance.State.Status, actualCreatedEvent.RouteToProfessionalStatus.Status);
             Assert.Equal(journeyInstance.State.RouteToProfessionalStatusId, actualCreatedEvent.RouteToProfessionalStatus.RouteToProfessionalStatusTypeId);
@@ -483,7 +483,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var addRouteState = new AddRouteStateBuilder()
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusTypeId)
             .WithStatus(RouteToProfessionalStatusStatus.Holds)
-            .WithHoldsStatusFields(Clock)
+            .WithHoldsStatusFields(TimeProvider)
             .WithTrainingCountryId(country.CountryId)
             .WithInductionExemption(true)
             .WithTrainingProviderId(trainingProvider.TrainingProviderId)
@@ -530,7 +530,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var addRouteState = new AddRouteStateBuilder()
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusTypeId)
             .WithStatus(RouteToProfessionalStatusStatus.Holds)
-            .WithHoldsStatusFields(Clock)
+            .WithHoldsStatusFields(TimeProvider)
             .WithTrainingCountryId(country.CountryId)
             .WithInductionExemption(true)
             .WithDegreeTypeId(degreeType.DegreeTypeId)
@@ -575,7 +575,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var addRouteState = new AddRouteStateBuilder()
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusTypeId)
             .WithStatus(RouteToProfessionalStatusStatus.Holds)
-            .WithHoldsStatusFields(Clock)
+            .WithHoldsStatusFields(TimeProvider)
             .WithTrainingCountryId(country.CountryId)
             .WithValidChangeReasonOption()
             .WithChangeReasonDetail("test", false)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/HoldsFromTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/HoldsFromTests.cs
@@ -122,7 +122,7 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenAwardDateIsEntered_SavesDateAndRedirectsToInductionExemptionPage()
     {
         // Arrange
-        var holdsFrom = Clock.Today.AddYears(-1);
+        var holdsFrom = TimeProvider.Today.AddYears(-1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory
                 && r.InductionExemptionRequired == FieldRequirement.Mandatory
@@ -168,7 +168,7 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_ImplicitExemptionRoute_WhenAwardDateIsEntered_SavesDateAndRedirectsToNextPage()
     {
         // Arrange
-        var holdsFrom = Clock.Today.AddYears(-1);
+        var holdsFrom = TimeProvider.Today.AddYears(-1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.InductionExemptionReason is not null && r.InductionExemptionReason.RouteImplicitExemption)
             .SingleRandom();
@@ -211,7 +211,7 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_FromCya_WhenAwardDateIsEntered_RedirectsToCya()
     {
         // Arrange
-        var holdsFrom = Clock.Today.AddYears(-1);
+        var holdsFrom = TimeProvider.Today.AddYears(-1);
         var newAwardDate = holdsFrom.AddMonths(1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory)
@@ -288,7 +288,7 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenFutureDateIsEntered_ReturnsError()
     {
         // Arrange
-        var holdsDate = Clock.UtcNow.AddDays(1);
+        var holdsDate = TimeProvider.UtcNow.AddDays(1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory)
             .SingleRandom();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/InductionExemptionTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/AddRoute/InductionExemptionTests.cs
@@ -81,7 +81,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task Post_WhenExemptionEntered_SavesDataAndRedirectsToNextPage(string routeName, string page)
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var endDate = awardDate.AddDays(-1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == routeName)
@@ -200,7 +200,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task PersonIsDeactivated_ReturnsBadRequest(HttpMethod httpMethod)
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var endDate = awardDate.AddDays(-1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == "Graduate Teacher Programme")

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
@@ -87,8 +87,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Get_ShowsAnswers_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
         var status = TestDataHelper.GetRouteStatusWhereAllFieldsApply();
@@ -226,7 +226,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         {
             var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
 
-            Assert.Equal(Clock.UtcNow, deletedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, deletedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, deletedEvent.PersonId);
             Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), deletedEvent.DeletionReason);
             Assert.Equal(journeyInstance.State.ChangeReasonDetail.ChangeReasonDetail, deletedEvent.DeletionReasonDetail);
@@ -245,7 +245,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
             .SingleRandom();
         var status = RouteToProfessionalStatusStatus.Holds;
-        var qtsDate = Clock.Today.AddYears(-1);
+        var qtsDate = TimeProvider.Today.AddYears(-1);
         var person = await TestData.CreatePersonAsync(p => p
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
@@ -282,7 +282,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         {
             var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
             Assert.Equal(RaisedByUserId, deletedEvent.RaisedBy.UserId);
-            Assert.Equal(Clock.UtcNow, deletedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, deletedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, deletedEvent.PersonId);
             Assert.Equal(qtsDate, deletedEvent.OldPersonAttributes.QtsDate);
             Assert.Null(deletedEvent.PersonAttributes.QtsDate);
@@ -299,7 +299,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
             .SingleRandom();
-        var holdsFromEarliest = Clock.Today.AddYears(-1);
+        var holdsFromEarliest = TimeProvider.Today.AddYears(-1);
         var holdsFromLatest = holdsFromEarliest.AddMonths(1);
         var person = await TestData.CreatePersonAsync(p => p
             .WithRouteToProfessionalStatus(r => r
@@ -339,7 +339,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         EventObserver.AssertEventsSaved(e =>
         {
             var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
-            Assert.Equal(Clock.UtcNow, deletedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, deletedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, deletedEvent.PersonId);
             Assert.Equal(holdsFromEarliest, deletedEvent.OldPersonAttributes.QtsDate);
             Assert.Equal(holdsFromLatest, deletedEvent.PersonAttributes.QtsDate);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialismTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/AgeRangeSpecialismTests.cs
@@ -20,8 +20,8 @@ public class AgeRangeSpecialismTests(HostFixture hostFixture) : TestBase(hostFix
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == routeName).Single();
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var subjects = (await ReferenceDataCache.GetTrainingSubjectsAsync()).Where(s => !s.Name.Contains('\'')).Take(1).Select(s => s.TrainingSubjectId).ToArray();
         var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).Where(s => !s.Name.Contains('\'')).SingleRandom();
@@ -97,8 +97,8 @@ public class AgeRangeSpecialismTests(HostFixture hostFixture) : TestBase(hostFix
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == routeName).Single();
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var subjects = (await ReferenceDataCache.GetTrainingSubjectsAsync()).Where(s => !s.Name.Contains('\'')).Take(1).Select(s => s.TrainingSubjectId).ToArray();
         var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).Where(s => !s.Name.Contains('\'')).SingleRandom();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/CheckYourAnswersTests.cs
@@ -91,8 +91,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == routeName).Single();
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var subjects = (await ReferenceDataCache.GetTrainingSubjectsAsync()).Where(s => !s.Name.Contains('\'')).Take(1);
         var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).Where(s => !s.Name.Contains('\'')).SingleRandom();
@@ -224,8 +224,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Get_ShowsAnswers_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today.AddDays(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today.AddDays(-1);
         var holdsFrom = endDate.AddDays(1);
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
         var status = TestDataHelper.GetRouteStatusWhereAllFieldsApply();
@@ -284,8 +284,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Get_ShowsExemptionAnswer_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
         var country = (await ReferenceDataCache.GetTrainingCountriesAsync())
             .SingleRandom();
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
@@ -336,8 +336,8 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     public async Task Get_ShowsOptionalAnswersNotPopulated_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Postgraduate Teaching Apprenticeship").Single();
         var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).Where(s => !s.Name.Contains('\''))
             .SingleRandom();
@@ -446,7 +446,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var editRouteState = new EditRouteStateBuilder()
             .WithRouteToProfessionalStatusId(route.RouteToProfessionalStatusTypeId)
             .WithStatus(status)
-            .WithHoldsStatusFields(Clock)
+            .WithHoldsStatusFields(TimeProvider)
             .WithTrainingProviderId(trainingProvider.TrainingProviderId)
             .WithTrainingSubjectIds(subjects.Select(s => s.TrainingSubjectId).ToArray())
             .WithTrainingCountryId(country.CountryId)
@@ -500,7 +500,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         {
             var actualUpdatedEvent = Assert.IsType<RouteToProfessionalStatusUpdatedEvent>(e);
 
-            Assert.Equal(Clock.UtcNow, actualUpdatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualUpdatedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, actualUpdatedEvent.PersonId);
             Assert.Equal(journeyInstance.State.Status, actualUpdatedEvent.RouteToProfessionalStatus.Status);
             Assert.Equal(journeyInstance.State.RouteToProfessionalStatusId, actualUpdatedEvent.RouteToProfessionalStatus.RouteToProfessionalStatusTypeId);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/DetailTests.cs
@@ -85,9 +85,9 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_RouteAndStatusWithAllFieldsApplicable_AllFieldsShown()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
-        var awardDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
+        var awardDate = TimeProvider.Today;
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsApplyAsync();
         var status = TestDataHelper.GetRouteStatusWhereAllFieldsApply();
         var trainingProvider = (await ReferenceDataCache.GetTrainingProvidersAsync()).Where(s => !s.Name.Contains('\'')).First();
@@ -152,8 +152,8 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_ShowsOptionalAnswers_AsExpected()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
         var route = await ReferenceDataCache.GetRouteWhereAllFieldsHaveFieldRequirementAsync(FieldRequirement.Optional);
         var status = ProfessionalStatusStatusRegistry.All.Where(s => s.Value == RouteToProfessionalStatusStatus.InTraining).SingleRandom();
         var person = await TestData.CreatePersonAsync(p => p
@@ -236,9 +236,9 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_RouteAndStatusWithExemptionInduction_ShowsFieldAndChangeLink(RouteToProfessionalStatusStatus status, bool? hasExemption, string expectedContent)
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
-        var awardDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == "Northern Irish Recognition")
             .SingleRandom();
@@ -280,9 +280,9 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Get_RouteAndStatusWithImplictExemptionInduction_ShowsFieldButNoChangeLink()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
-        var endDate = Clock.Today;
-        var awardDate = Clock.Today;
+        var startDate = TimeProvider.Today.AddYears(-1);
+        var endDate = TimeProvider.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.InductionExemptionReason is not null && r.InductionExemptionReason.RouteImplicitExemption)
             .SingleRandom();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/HoldsFromTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/HoldsFromTests.cs
@@ -238,7 +238,7 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_StatusIsAlreadyHoldsJourney_HoldsFromIsEntered_SavesDateAndRedirectsToDetail()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
         var endDate = startDate.AddMonths(1);
         var holdsFrom = endDate;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
@@ -291,7 +291,7 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var status = RouteToProfessionalStatusStatus.Holds;
-        var startDate = Clock.Today.AddYears(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
         var endDate = startDate.AddMonths(1);
         var holdsFrom = endDate;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
@@ -343,7 +343,7 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var status = RouteToProfessionalStatusStatus.Holds;
-        var startDate = Clock.Today.AddYears(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
         var endDate = startDate.AddMonths(1);
         var holdsFrom = endDate;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()) // an induction exemption route who's exemption is implicit and therefore doesn't require the exemption question
@@ -441,9 +441,9 @@ public class HoldsFromTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_WhenFutureHoldsFromDateIsEntered_ReturnsError()
     {
         // Arrange
-        var startDate = Clock.Today.AddYears(-1);
+        var startDate = TimeProvider.Today.AddYears(-1);
         var endDate = startDate.AddMonths(1);
-        var holdsFrom = Clock.Today.AddDays(1);
+        var holdsFrom = TimeProvider.Today.AddDays(1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.HoldsFromRequired == FieldRequirement.Mandatory)
             .SingleRandom();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/InductionExemptionTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/InductionExemptionTests.cs
@@ -10,7 +10,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task Get_WithInvalidRoute_ThrowsException()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.InductionExemptionRequired == FieldRequirement.NotApplicable)
             .SingleRandom();
@@ -49,7 +49,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task Get_WithPreviouslyStoredChoice_ShowsChoice()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == "Northern Irish Recognition") // a route with mandatory induction exemption that isn't implicit (requires a yes/no answer)
             .SingleRandom();
@@ -92,7 +92,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task Post_WhenExemptionEntered_SavesDataAndRedirectsToDetail()
     {
         // Arrange
-        var holdsFrom = Clock.Today;
+        var holdsFrom = TimeProvider.Today;
         var endDate = holdsFrom.AddDays(-1);
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == "Northern Irish Recognition")
@@ -146,7 +146,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task Post_WhenNoChoiceSelected_ReturnsError()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == "Northern Irish Recognition")
             .SingleRandom();
@@ -187,7 +187,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task Cancel_DeletesJourneyAndRedirectsToExpectedPage()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.Name == "Northern Irish Recognition") // a route that requires the induction exemption question
             .SingleRandom();
@@ -237,7 +237,7 @@ public partial class InductionExemptionTests(HostFixture hostFixture) : TestBase
     public async Task PersonIsDeactivated_ReturnsBadRequest(HttpMethod httpMethod)
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.InductionExemptionRequired == FieldRequirement.NotApplicable)
             .SingleRandom();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/StatusTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/StatusTests.cs
@@ -126,7 +126,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_StatusMovesFromHoldsToAnotherStatus_RemovesHoldsFromAndExemptionFlag()
     {
         // Arrange
-        var holdsFrom = Clock.Today;
+        var holdsFrom = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .SingleRandom();
         var newStatus = RouteToProfessionalStatusStatus.UnderAssessment;
@@ -222,7 +222,7 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task Post_StatusStaysHolds_PersistsDataAndRedirectsToDetail()
     {
         // Arrange
-        var awardDate = Clock.Today;
+        var awardDate = TimeProvider.Today;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .SingleRandom();
         var status = RouteToProfessionalStatusStatus.Holds;

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ChangeRequests/EditChangeRequest/AcceptTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ChangeRequests/EditChangeRequest/AcceptTests.cs
@@ -161,7 +161,7 @@ public class AcceptTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyn
                 Assert.Equal(requestData.FirstName, updatedPerson.FirstName);
                 Assert.Equal(requestData.MiddleName, updatedPerson.MiddleName);
                 Assert.Equal(requestData.LastName, updatedPerson.LastName);
-                Assert.Equal(Clock.UtcNow, updatedPerson.UpdatedOn);
+                Assert.Equal(TimeProvider.UtcNow, updatedPerson.UpdatedOn);
 
                 var previousName = await dbContext.PreviousNames
                     .SingleOrDefaultAsync(pn => pn.PersonId == createPersonResult.PersonId);
@@ -188,7 +188,7 @@ public class AcceptTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyn
             if (isNameChange)
             {
                 var actualEvent = Assert.IsType<ChangeNameRequestSupportTaskApprovedEvent>(e);
-                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
                 Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
                 Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
                 Assert.Equal(createPersonResult.PersonId, actualEvent.PersonId);
@@ -197,7 +197,7 @@ public class AcceptTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyn
             else
             {
                 var actualEvent = Assert.IsType<ChangeDateOfBirthRequestSupportTaskApprovedEvent>(e);
-                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
                 Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
                 Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
                 Assert.Equal(ChangeDateOfBirthRequestSupportTaskApprovedEventChanges.DateOfBirth, actualEvent.Changes);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ChangeRequests/EditChangeRequest/RejectTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ChangeRequests/EditChangeRequest/RejectTests.cs
@@ -199,7 +199,7 @@ public class RejectTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyn
             {
                 var actualEvent = Assert.IsType<ChangeNameRequestSupportTaskRejectedEvent>(e);
                 Assert.Equal("Request and proof don’t match", actualEvent.RejectionReason);
-                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
                 Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
                 Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
             }
@@ -207,7 +207,7 @@ public class RejectTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyn
             {
                 var actualEvent = Assert.IsType<ChangeDateOfBirthRequestSupportTaskRejectedEvent>(e);
                 Assert.Equal("Request and proof don’t match", actualEvent.RejectionReason);
-                Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
                 Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
                 Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
             }
@@ -287,7 +287,7 @@ public class RejectTests(HostFixture hostFixture) : TestBase(hostFixture), IAsyn
                 actualEvent = Assert.IsType<ChangeDateOfBirthRequestSupportTaskCancelledEvent>(e);
             }
 
-            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
             Assert.Equal(SupportTaskStatus.Open, actualEvent.OldSupportTask.Status);
             Assert.Equal(SupportTaskStatus.Closed, actualEvent.SupportTask.Status);
         });

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IntegrationTransactions/DetailTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IntegrationTransactions/DetailTests.cs
@@ -30,7 +30,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -73,7 +73,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -121,7 +121,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = importStatus;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -177,7 +177,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -229,7 +229,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -276,7 +276,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -325,7 +325,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Failed;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -369,7 +369,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Failed;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -413,7 +413,7 @@ public class DetailTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Failed;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IntegrationTransactions/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IntegrationTransactions/IndexTests.cs
@@ -47,7 +47,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
 
 
         var totalCount2 = 10;
@@ -58,7 +58,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName2 = "MoreThanOneRow.csv";
         var importStatus2 = IntegrationTransactionImportStatus.Success;
         var interfaceType2 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn2 = Clock.UtcNow;
+        var createdOn2 = TimeProvider.UtcNow;
 
 
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
@@ -110,7 +110,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName = "FileName.csv";
         var importStatus = IntegrationTransactionImportStatus.Success;
         var interfaceType = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn = Clock.UtcNow;
+        var createdOn = TimeProvider.UtcNow;
         var integrationTransaction = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount);
@@ -178,7 +178,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName = "FileName.csv";
         var importStatus = status;
         var interfaceType = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn = Clock.UtcNow;
+        var createdOn = TimeProvider.UtcNow;
         var integrationTransaction = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IntegrationTransactions/RowTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/IntegrationTransactions/RowTests.cs
@@ -20,7 +20,7 @@ public class RowTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);
@@ -69,7 +69,7 @@ public class RowTests(HostFixture hostFixture) : TestBase(hostFixture)
         var fileName1 = "FileName.csv";
         var importStatus1 = IntegrationTransactionImportStatus.Success;
         var interfaceType1 = IntegrationTransactionInterfaceType.EwcWales;
-        var createdOn1 = Clock.UtcNow;
+        var createdOn1 = TimeProvider.UtcNow;
         var integrationTransaction1 = await TestData.CreateIntegrationTransactionAsync(p =>
         {
             p.WithTotalCount(totalCount1);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/IdVerificationTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/IdVerificationTests.cs
@@ -78,7 +78,7 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var supportTask1 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser1.Subject);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser2.Subject);
         var supportTasks = new[] { supportTask1, supportTask2 };
         var expectedResultsOrderedByReference = supportTasks.OrderBy(s => s.SupportTaskReference).ToArray();
@@ -115,7 +115,7 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
             .WithStatedFirstName("Aaron")
             .WithStatedLastName("Aerosmith")
             .WithClientApplicationUserId(applicationUser1.UserId));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser2.Subject, options => options
             .WithStatedFirstName("Sam")
             .WithStatedLastName("Smith")
@@ -180,7 +180,7 @@ public class IdVerificationTests(HostFixture hostFixture) : TestBase(hostFixture
             .WithStatedFirstName("Aaron")
             .WithStatedLastName("Aerosmith")
             .WithClientApplicationUserId(applicationUser1.UserId));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser2.Subject, options => options
             .WithStatedFirstName("Sam")
             .WithStatedLastName("Smith")

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/RecordMatchingTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/RecordMatchingTests.cs
@@ -85,7 +85,7 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var oneLoginUser2 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
         var supportTask1 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject);
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject);
         var supportTasks = new[] { supportTask1, supportTask2 };
         var expectedResultsOrderedByReference = supportTasks.OrderBy(s => s.SupportTaskReference).ToArray();
@@ -121,7 +121,7 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         var supportTask1 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, options => options
             .WithVerifiedNames(["Aaron", "Aerosmith"])
             .WithClientApplicationUserId(applicationUser1.UserId));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, options => options
             .WithVerifiedNames(["Sam", "Smith"])
             .WithClientApplicationUserId(applicationUser2.UserId));
@@ -184,7 +184,7 @@ public class RecordMatchingTests(HostFixture hostFixture) : TestBase(hostFixture
         var supportTask1 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser1.Subject, options => options
             .WithVerifiedNames(["Aaron", "Aerosmith"])
             .WithClientApplicationUserId(applicationUser1.UserId));
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
         var supportTask2 = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser2.Subject, options => options
             .WithVerifiedNames(["Sam", "Smith"])
             .WithClientApplicationUserId(applicationUser2.UserId));

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnectTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnectTests.cs
@@ -130,7 +130,7 @@ public class ConfirmConnectTests(HostFixture hostFixture) : ResolveOneLoginUserM
             Assert.Equal(OneLoginUserIdVerificationOutcome.VerifiedAndConnected, updatedSupportTaskData.Outcome);
 
             var updatedOneLoginUser = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginUser.Subject);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.VerifiedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.VerifiedOn);
             Assert.Equal(matchedPerson.PersonId, updatedOneLoginUser.PersonId);
         });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnectingTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnectingTests.cs
@@ -294,7 +294,7 @@ public class ConfirmNotConnectingTests(HostFixture hostFixture) : ResolveOneLogi
             Assert.Equal(additionalDetails, updatedSupportTaskData.NotConnectingAdditionalDetails);
 
             var updatedOneLoginUser = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginUser.Subject);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.VerifiedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.VerifiedOn);
         });
 
         Events.AssertProcessesCreated(p => Assert.Equal(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, p.ProcessContext.ProcessType));

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/MatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/MatchesTests.cs
@@ -207,7 +207,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatching
         var matchedPerson3 = await TestData.CreatePersonAsync(p => p
             .WithFirstName(firstVerifiedOrStatedName.First())
             .WithLastName(TestData.GenerateChangedLastName(firstVerifiedOrStatedName.Last()))
-            .WithPreviousNames((TestData.GenerateChangedFirstName(firstVerifiedOrStatedName.First()), TestData.GenerateMiddleName(), firstVerifiedOrStatedName.Last(), Clock.UtcNow))
+            .WithPreviousNames((TestData.GenerateChangedFirstName(firstVerifiedOrStatedName.First()), TestData.GenerateMiddleName(), firstVerifiedOrStatedName.Last(), TimeProvider.UtcNow))
             .WithDateOfBirth(firstVerifiedOrStatedDateOfBirth));
 
         var journeyInstance = await CreateJourneyInstanceAsync(

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NoMatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NoMatchesTests.cs
@@ -106,7 +106,7 @@ public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchi
             Assert.Equal(OneLoginUserIdVerificationOutcome.VerifiedOnlyWithoutMatches, updatedSupportTaskData.Outcome);
 
             var updatedOneLoginUser = await dbContext.OneLoginUsers.SingleAsync(o => o.Subject == oneLoginUser.Subject);
-            Assert.Equal(Clock.UtcNow, updatedOneLoginUser.VerifiedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedOneLoginUser.VerifiedOn);
         });
 
         Events.AssertProcessesCreated(p => Assert.Equal(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, p.ProcessContext.ProcessType));

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/IndexTests.cs
@@ -32,7 +32,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(
             fileName: "SomeFileName.txt",
             integrationTransactionId: 1,
-            createdOn: Clock.UtcNow,
+            createdOn: TimeProvider.UtcNow,
             configurePerson: p => p.WithFirstName("John").WithMiddleName("Maynard").WithLastName("Smith").WithNationalInsuranceNumber());
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/teacher-pensions?_f=1");
@@ -52,7 +52,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         AssertRowHasContent("name", "John Maynard Smith");
         AssertRowHasContent("filename", "SomeFileName.txt");
         AssertRowHasContent("integration-transaction-id", "1");
-        AssertRowHasContent("created-on", Clock.UtcNow.ToString("dd MMM yyyy"));
+        AssertRowHasContent("created-on", TimeProvider.UtcNow.ToString("dd MMM yyyy"));
 
         void AssertRowHasContent(string testId, string expectedText)
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
@@ -53,7 +53,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -135,7 +135,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -194,7 +194,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -252,7 +252,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 .Include(st => st.TrnRequestMetadata)
                 .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
             Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-            Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         });
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -289,7 +289,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -350,7 +350,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 .Include(st => st.TrnRequestMetadata)
                 .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
             Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-            Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         });
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
@@ -380,7 +380,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -431,7 +431,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
                 .Include(st => st.TrnRequestMetadata)
                 .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
             Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-            Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         });
 
         EventObserver.AssertEventsSaved(e =>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReasonTests.cs
@@ -48,7 +48,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -92,7 +92,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -136,7 +136,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -163,7 +163,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
                 .Include(st => st.TrnRequestMetadata)
                 .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
             Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-            Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
             var supportTaskData = updatedSupportTask.GetData<TeacherPensionsPotentialDuplicateData>();
             Assert.Null(supportTaskData.ResolvedAttributes);
             Assert.Null(supportTaskData.SelectedPersonAttributes);
@@ -173,7 +173,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
         {
             var actualEvent = Assert.IsType<TeacherPensionsPotentialDuplicateSupportTaskResolvedEvent>(e);
             Assert.Equal(state.KeepSeparateReason.Value.GetDisplayName(), actualEvent.Comments);
-            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
             Assert.Equal(person.PersonId, actualEvent.PersonId);
         });
 
@@ -221,7 +221,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -249,7 +249,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
                 .Include(st => st.TrnRequestMetadata)
                 .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
             Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-            Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+            Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
             var supportTaskData = updatedSupportTask.GetData<TeacherPensionsPotentialDuplicateData>();
             Assert.Null(supportTaskData.ResolvedAttributes);
             Assert.Null(supportTaskData.SelectedPersonAttributes);
@@ -259,7 +259,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
         {
             var actualEvent = Assert.IsType<TeacherPensionsPotentialDuplicateSupportTaskResolvedEvent>(e);
             Assert.Equal(keepReason, actualEvent.Comments);
-            Assert.Equal(Clock.UtcNow, actualEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, actualEvent.CreatedUtc);
             Assert.Equal(person.PersonId, actualEvent.PersonId);
         });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparateTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparateTests.cs
@@ -47,7 +47,7 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -101,7 +101,7 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -155,7 +155,7 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MatchesTests.cs
@@ -45,7 +45,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Closed);
             });
         var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/matches");
@@ -82,7 +82,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
         var journeyInstance = await CreateJourneyInstance(
@@ -151,7 +151,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
         var journeyInstance = await CreateJourneyInstance(
@@ -201,7 +201,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData("", 0);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -409,7 +409,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData("", 0);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Closed);
             });
 
@@ -458,7 +458,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData("", 0);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -509,7 +509,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData("", 0);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
         var journeyInstance = await CreateJourneyInstance(
@@ -563,7 +563,7 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData("", 0);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
         var journeyInstance = await CreateJourneyInstance(

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MergeTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MergeTests.cs
@@ -30,7 +30,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData("fileName.csv", 1);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
         var journeyInstance = await CreateJourneyInstance(supportTask, null);
@@ -65,7 +65,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -160,7 +160,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -205,7 +205,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -253,7 +253,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -300,7 +300,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 
@@ -365,7 +365,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithGender(person.Gender);
                 s.WithDateOfBirth(person.DateOfBirth);
                 s.WithSupportTaskData(fileName, integrationTransactionId);
-                s.WithCreatedOn(Clock.UtcNow);
+                s.WithCreatedOn(TimeProvider.UtcNow);
                 s.WithStatus(SupportTaskStatus.Open);
             });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/ConfirmTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequestManualChecksNeeded/Resolve/ConfirmTests.cs
@@ -77,7 +77,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         var updatedSupportTask = await WithDbContextAsync(dbContext => dbContext
             .SupportTasks.Include(st => st.TrnRequestMetadata).SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
         Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-        Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         Assert.Equal(TrnRequestStatus.Completed, updatedSupportTask.TrnRequestMetadata!.Status);
 
         Events.AssertProcessesCreated(p =>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
@@ -569,7 +569,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             PersonMatchedAttribute.MiddleName);
         var requestData = supportTask.TrnRequestMetadata!;
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
         var journeyInstance = await CreateJourneyInstance(
@@ -616,7 +616,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         var updatedSupportTask = await WithDbContextAsync(dbContext => dbContext
             .SupportTasks.Include(st => st.TrnRequestMetadata).SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
         Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-        Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         Assert.Equal(person.PersonId, updatedSupportTask.TrnRequestMetadata!.ResolvedPersonId);
         Assert.NotNull(updatedSupportTask.TrnRequestMetadata.TrnToken);
         var supportTaskData = updatedSupportTask.GetData<TrnRequestData>();
@@ -653,7 +653,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             PersonMatchedAttribute.MiddleName);
         var requestData = supportTask.TrnRequestMetadata!;
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
         var journeyInstance = await CreateJourneyInstance(
@@ -695,7 +695,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         var updatedSupportTask = await WithDbContextAsync(dbContext => dbContext
             .SupportTasks.Include(st => st.TrnRequestMetadata).SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
         Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
-        Assert.Equal(Clock.UtcNow, updatedSupportTask.UpdatedOn);
+        Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         Assert.Equal(person.PersonId, updatedSupportTask.TrnRequestMetadata!.ResolvedPersonId);
         Assert.NotNull(updatedSupportTask.TrnRequestMetadata.TrnToken);
         var supportTaskData = updatedSupportTask.GetData<TrnRequestData>();
@@ -734,7 +734,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             matchedPersonHasFlags: false);
         var requestData = supportTask.TrnRequestMetadata!;
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
         var journeyInstance = await CreateJourneyInstance(
@@ -788,7 +788,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             matchedPersonHasFlags: true);
         var requestData = supportTask.TrnRequestMetadata!;
 
-        Clock.Advance(TimeSpan.FromDays(1));
+        TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
         var journeyInstance = await CreateJourneyInstance(
@@ -869,7 +869,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         string? comments)
     {
         Assert.Equal(expectedPersonId, @event.PersonId);
-        Assert.Equal(Clock.UtcNow, @event.CreatedUtc);
+        Assert.Equal(TimeProvider.UtcNow, @event.CreatedUtc);
         Assert.True(@event.Changes.HasFlag(ApiTrnRequestSupportTaskUpdatedEventChanges.Status));
 
         Assert.Equal(SupportTaskStatus.Open, @event.OldSupportTask.Status);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MatchesTests.cs
@@ -273,7 +273,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
     {
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithEyts(Clock.Today.AddDays(-1)));
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithEyts(TimeProvider.Today.AddDays(-1)));
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId, matchedPerson.Person);
 
         var journeyInstance = await CreateJourneyInstance(

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/AddUser/ConfirmTests.cs
@@ -397,7 +397,7 @@ public class ConfirmTests(HostFixture hostFixture) : TestBase(hostFixture)
         EventObserver.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserAddedEvent>(e);
-            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, userCreatedEvent.CreatedUtc);
             Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
             Assert.Equal(newName, userCreatedEvent.User.Name);
             Assert.Equal(email, userCreatedEvent.User.Email);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/DeactivateTests.cs
@@ -587,7 +587,7 @@ public class DeactivateTests(HostFixture hostFixture) : TestBase(hostFixture)
         EventObserver.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, userCreatedEvent.CreatedUtc);
             Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
             Assert.Null(userCreatedEvent.DeactivatedReason);
             Assert.Null(userCreatedEvent.DeactivatedReasonDetail);
@@ -636,7 +636,7 @@ public class DeactivateTests(HostFixture hostFixture) : TestBase(hostFixture)
         EventObserver.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, userCreatedEvent.CreatedUtc);
             Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
             Assert.Equal("Some additional reason", userCreatedEvent.DeactivatedReason);
             Assert.Equal("Some more information", userCreatedEvent.DeactivatedReasonDetail);
@@ -686,7 +686,7 @@ public class DeactivateTests(HostFixture hostFixture) : TestBase(hostFixture)
         EventObserver.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, userCreatedEvent.CreatedUtc);
             Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
             Assert.Null(userCreatedEvent.DeactivatedReason);
             Assert.Null(userCreatedEvent.DeactivatedReasonDetail);
@@ -736,7 +736,7 @@ public class DeactivateTests(HostFixture hostFixture) : TestBase(hostFixture)
         EventObserver.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserDeactivatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, userCreatedEvent.CreatedUtc);
             Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
             Assert.Null(userCreatedEvent.DeactivatedReason);
             Assert.Null(userCreatedEvent.DeactivatedReasonDetail);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Users/EditUser/IndexTests.cs
@@ -309,7 +309,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             EventObserver.AssertEventsSaved(e =>
             {
                 var userCreatedEvent = Assert.IsType<UserUpdatedEvent>(e);
-                Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+                Assert.Equal(TimeProvider.UtcNow, userCreatedEvent.CreatedUtc);
                 Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
                 Assert.Equal(newName, userCreatedEvent.User.Name);
                 Assert.Equal(updatedUser.Email, userCreatedEvent.User.Email);
@@ -442,7 +442,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         EventObserver.AssertEventsSaved(e =>
         {
             var userCreatedEvent = Assert.IsType<UserActivatedEvent>(e);
-            Assert.Equal(Clock.UtcNow, userCreatedEvent.CreatedUtc);
+            Assert.Equal(TimeProvider.UtcNow, userCreatedEvent.CreatedUtc);
             Assert.Equal(userCreatedEvent.RaisedBy.UserId, GetCurrentUserId());
         });
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/Services/ServiceTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/Services/ServiceTestBase.cs
@@ -14,7 +14,7 @@ public abstract class ServiceTestBase
         TestScopedServices.Reset();
     }
 
-    protected FakeTimeProvider Clock => TestScopedServices.GetCurrent().Clock;
+    protected FakeTimeProvider TimeProvider => TestScopedServices.GetCurrent().TimeProvider;
 
     protected IDbContextFactory<TrsDbContext> DbContextFactory => _fixture.Services.GetRequiredService<IDbContextFactory<TrsDbContext>>();
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/Services/TestScopedServices.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/Services/TestScopedServices.cs
@@ -9,11 +9,11 @@ public class TestScopedServices
 
     public TestScopedServices()
     {
-        Clock = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
-        Events = new(Clock);
+        TimeProvider = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+        Events = new(TimeProvider);
     }
 
-    public FakeTimeProvider Clock { get; }
+    public FakeTimeProvider TimeProvider { get; }
 
     public EventCapture Events { get; }
 
@@ -50,7 +50,7 @@ public class TestScopedServices
 
     private class ForwardToTestScopedTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => GetCurrent().Clock.GetUtcNow();
+        public override DateTimeOffset GetUtcNow() => GetCurrent().TimeProvider.GetUtcNow();
     }
 }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -36,7 +36,7 @@ public abstract class TestBase
 
     protected CaptureEventObserver EventObserver => TestScopedServices.GetCurrent().EventObserver;
 
-    protected FakeTimeProvider Clock => TestScopedServices.GetCurrent().Clock;
+    protected FakeTimeProvider TimeProvider => TestScopedServices.GetCurrent().TimeProvider;
 
     protected OneLoginUserMatchingSupportTaskService OneLoginSupportTaskService => HostFixture.Services.GetRequiredService<OneLoginUserMatchingSupportTaskService>();
 
@@ -138,8 +138,8 @@ public abstract class TestBase
         var person = await TestData.CreatePersonAsync(p => p
             .WithAlert(a =>
             {
-                a.WithStartDate(Clock.Today.AddDays(-30));
-                a.WithEndDate(isOpenAlert ? null : Clock.Today.AddDays(-1));
+                a.WithStartDate(TimeProvider.Today.AddDays(-30));
+                a.WithEndDate(isOpenAlert ? null : TimeProvider.Today.AddDays(-1));
                 a.WithExternalLink(populateOptional ? TestData.GenerateUrl() : null);
             }));
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/TestScopedServices.cs
@@ -17,10 +17,10 @@ public class TestScopedServices
 
     public TestScopedServices(IServiceProvider serviceProvider)
     {
-        Clock = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
+        TimeProvider = new FakeTimeProvider(new DateTimeOffset(2021, 1, 4, 0, 0, 0, TimeSpan.Zero));
         AzureActiveDirectoryUserServiceMock = new();
         EventObserver = new();
-        Events = new(Clock);
+        Events = new(TimeProvider);
         FeatureProvider = ActivatorUtilities.CreateInstance<TestableFeatureProvider>(serviceProvider);
         BlobStorageFileServiceMock = new();
         BlobStorageFileServiceMock
@@ -65,7 +65,7 @@ public class TestScopedServices
         return _current.Value = new(serviceProvider);
     }
 
-    public FakeTimeProvider Clock { get; }
+    public FakeTimeProvider TimeProvider { get; }
 
     public Mock<IAadUserService> AzureActiveDirectoryUserServiceMock { get; }
 
@@ -87,7 +87,7 @@ public class TestScopedServices
 
     private class ForwardToTestScopedTimeProvider : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => GetCurrent().Clock.GetUtcNow();
+        public override DateTimeOffset GetUtcNow() => GetCurrent().TimeProvider.GetUtcNow();
     }
 
     private class ForwardToTestScopedEventObserver : IEventObserver


### PR DESCRIPTION
We missed a bunch of places when we swapped out our `IClock` for `TimeProvider`.