### PR TITLE
2849 - prod pg db maintenance window

### DIFF
--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -15,6 +15,11 @@
   "ui_replicas": 2,
   "worker_replicas": 1,
   "worker_max_memory": "8Gi",
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 3,
+    "start_minute": 0
+  },
   "postgres_flexible_server_sku": "GP_Standard_D2ds_v4",
   "postgres_azure_storage_mb": 262144,
   "postgres_enable_high_availability": true,

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -37,6 +37,7 @@ module "postgres" {
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_storage_mb               = var.postgres_azure_storage_mb
+  azure_maintenance_window       = var.azure_maintenance_window
 
   use_airbyte = var.pg_airbyte_enabled
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -65,6 +65,8 @@ variable "run_dqt_reporting_service" {
   type = bool
 }
 
+variable "azure_maintenance_window" { default = null }
+
 variable "api_replicas" {
   type    = number
   default = 1


### PR DESCRIPTION
### Context

The production Postgres database doesn’t have a maintenance window set, so add one as per our normal standards, that runs Sunday morning. Without it it runs at the same time as the others causing problems. 
https://trello.com/c/TyRmQvgw/2849-trs-airbyte-changes

### Changes proposed in this pull request

Add a database maintenance that runs at 3am Sunday morning by declaring the variable and configuring it in production.tfvars

### Guidance to review

Run the plan locally to ensure only the maintenance window is added to Postgres.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally