### PR TITLE
2849 - add fix-airbyte-replication workflow

### DIFF
--- a/.github/workflows/fix-airbyte-replication.yml
+++ b/.github/workflows/fix-airbyte-replication.yml
@@ -1,0 +1,63 @@
+name: Fix Airbyte Replication
+
+on:
+    workflow_dispatch:
+        inputs:
+            environment:
+                description: Environment to fix
+                required: true
+                default: dev
+                type: choice
+                options:
+                    - dev
+                    - pre-production
+                    - production
+            dry-run:
+                description: Check slot status only do not create slot
+                required: false
+                default: "true"
+                type: choice
+                options:
+                    - "true"
+                    - "false"
+    # schedule: # hourly every Sunday midnight until 9am
+    #     - cron: "0 0-9 * * 0"
+
+permissions:
+    id-token: write
+
+env:
+    SERVICE_NAME: teaching-record-system
+    SERVICE_SHORT: trs
+    TF_VARS_PATH: terraform/aks/config
+
+jobs:
+    fix-replication:
+        name: Fix Airbyte replication slot
+        runs-on: ubuntu-latest
+        environment:
+            name: ${{ inputs.environment || 'production' }}
+        env:
+            DEPLOY_ENV: ${{ inputs.environment || 'production' }}
+            DRY_RUN: ${{ inputs.dry-run || 'false' }}
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Set environment variables
+              run: |
+                  tf_vars_file=${TF_VARS_PATH}/${DEPLOY_ENV}.tfvars.json
+                  echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+                  echo "NAMESPACE=$(jq -r '.namespace' ${tf_vars_file})" >> $GITHUB_ENV
+
+            - name: Fix Airbyte replication slot
+              uses: DFE-Digital/github-actions/fix-airbyte-replication-slot@master
+              with:
+                  azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+                  azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+                  azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+                  app-name: ${{ env.SERVICE_NAME }}-${{ env.DEPLOY_ENV }}
+                  namespace: ${{ env.NAMESPACE }}
+                  cluster: ${{ env.CLUSTER }}
+                  dry-run: ${{ env.DRY_RUN }}


### PR DESCRIPTION
### Context

We need to add a workflow that is used to monitor and fix Postgres replication slots.
https://trello.com/c/TyRmQvgw/2849-trs-airbyte-changes

### Changes proposed in this pull request

Add the fix-airbyte-replication.yml

### Guidance to review

We cannot test the workflow without registering it first. So in this commit the workflow can only be run manually with the schedule commented out. Once merged we can test the workflow manually against the lower environments.
Once successfully tested a ne PR will be used to add in the schedule.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally