### PR TITLE
Don't create support task for TRN request when we already have one

### DIFF
--- a/src/TeachingRecordSystem.Api/V3/Operations/CreateTrnRequest.cs
+++ b/src/TeachingRecordSystem.Api/V3/Operations/CreateTrnRequest.cs
@@ -1,7 +1,5 @@
 using TeachingRecordSystem.Api.Infrastructure.Security;
 using TeachingRecordSystem.Api.V3.Operations.Common;
-using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.Core.Services.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using Gender = TeachingRecordSystem.Core.Models.Gender;
 using TrnRequestInfo = TeachingRecordSystem.Api.V3.Operations.Common.TrnRequestInfo;
@@ -24,7 +22,6 @@ public record CreateTrnRequestCommand : ICommand<TrnRequestInfo>
 
 public class CreateTrnRequestHandler(
     TrnRequestService trnRequestService,
-    SupportTaskService supportTaskService,
     ICurrentUserProvider currentUserProvider,
     TimeProvider timeProvider) :
     ICommandHandler<CreateTrnRequestCommand, TrnRequestInfo>
@@ -60,20 +57,6 @@ public class CreateTrnRequestHandler(
                 Gender = command.Gender
             },
             processContext);
-
-        if (trnRequest.PotentialDuplicate)
-        {
-            await supportTaskService.CreateSupportTaskAsync(
-                new CreateSupportTaskOptions
-                {
-                    SupportTaskType = SupportTaskType.TrnRequest,
-                    Data = new TrnRequestData(),
-                    PersonId = null,
-                    OneLoginUserSubject = null,  // This must be null as we likely won't have an entry in the one_login_users table yet
-                    TrnRequest = (trnRequest.ApplicationUserId, trnRequest.RequestId)
-                },
-                processContext);
-        }
 
         var trnToken = trnRequest.TrnToken;
         var aytqLink = trnToken is not null ? trnRequestService.GetAccessYourTeachingQualificationsLink(trnToken) : null;

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.RecordMatching.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskService.RecordMatching.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
@@ -51,7 +52,29 @@ public partial class OneLoginUserMatchingSupportTaskService
         var appContent = applicationUser.AppContent;
         var recordMatchingPolicy = applicationUser.RecordMatchingPolicy;
 
-        bool emailSent = false;
+        await supportTaskService.UpdateSupportTaskAsync(
+            new UpdateSupportTaskOptions<OneLoginUserRecordMatchingData>
+            {
+                SupportTaskReference = supportTask.SupportTaskReference,
+                UpdateData = data => data with
+                {
+                    Outcome = OneLoginUserRecordMatchingOutcome.NotConnecting,
+                    NotConnectingReason = options.NotConnectingReason,
+                    NotConnectingAdditionalDetails = options.NotConnectingAdditionalDetails
+                },
+                Status = SupportTaskStatus.Closed
+            },
+            processContext);
+
+        if (supportTask.TrnRequestId is not null)
+        {
+            Debug.Assert(supportTask.TrnRequestMetadata is not null);
+
+            if (supportTask.TrnRequestMetadata.Status is TrnRequestStatus.Pending)
+            {
+                await trnRequestService.TryResolveAsync(supportTask.TrnRequestMetadata, processContext);
+            }
+        }
 
         if (recordMatchingPolicy == RecordMatchingPolicy.Deferred && appContent?.OneLoginNotConnectedEmailTemplateId is { } templateId)
         {
@@ -68,24 +91,10 @@ public partial class OneLoginUserMatchingSupportTaskService
                 templateId,
                 processContext);
 
-            emailSent = true;
+            return new() { EmailSent = true };
         }
 
-        await supportTaskService.UpdateSupportTaskAsync(
-            new UpdateSupportTaskOptions<OneLoginUserRecordMatchingData>
-            {
-                SupportTaskReference = supportTask.SupportTaskReference,
-                UpdateData = data => data with
-                {
-                    Outcome = OneLoginUserRecordMatchingOutcome.NotConnecting,
-                    NotConnectingReason = options.NotConnectingReason,
-                    NotConnectingAdditionalDetails = options.NotConnectingAdditionalDetails
-                },
-                Status = SupportTaskStatus.Closed
-            },
-            processContext);
-
-        return new() { EmailSent = emailSent };
+        return new() { EmailSent = false };
     }
 
     public async Task<ResolveRecordMatchingSupportTaskResult> ResolveRecordMatchingSupportTaskAsync(NoMatchesOutcomeOptions options, ProcessContext processContext)
@@ -109,6 +118,16 @@ public partial class OneLoginUserMatchingSupportTaskService
                 Status = SupportTaskStatus.Closed
             },
             processContext);
+
+        if (supportTask.TrnRequestId is not null)
+        {
+            Debug.Assert(supportTask.TrnRequestMetadata is not null);
+
+            if (supportTask.TrnRequestMetadata.Status is TrnRequestStatus.Pending)
+            {
+                await trnRequestService.TryResolveAsync(supportTask.TrnRequestMetadata, processContext);
+            }
+        }
 
         var emailTemplateId = applicationUser.RecordMatchingPolicy is RecordMatchingPolicy.Deferred
             ? null

--- a/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
+++ b/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
@@ -24,6 +24,14 @@ public class TrnRequestService(
     IOptions<AccessYourTeachingQualificationsOptions> aytqOptionsAccessor,
     IOptions<TrnRequestOptions> trnRequestOptionsAccessor)
 {
+    /// The set of SupportTaskTypes that can resolve the attached TRN request
+    private static readonly HashSet<SupportTaskType> _trnRequestResolvingSupportTaskTypes =
+    [
+        SupportTaskType.TrnRequest,
+        SupportTaskType.OneLoginUserRecordMatching,
+        SupportTaskType.OneLoginUserIdVerification
+    ];
+
     public async Task<TrnRequestInfo> CreateTrnRequestAsync(CreateTrnRequestOptions options, ProcessContext processContext)
     {
         await using var eventScope = eventPublisher.GetOrCreateEventScope(processContext);
@@ -489,36 +497,36 @@ public class TrnRequestService(
         }
 
         var results = (await GetMatchesFromTrnRequestAsync(request)).ToList();
-        results.RemoveAll(r => excludePersonIds.Contains(r.person_id));
+        results.RemoveAll(r => excludePersonIds.Contains(r.PersonId));
 
         if (results.Count == 0)
         {
             return MatchPersonsResult.NoMatches();
         }
 
-        var matchedOnDobAndNino = results.Where(r => r is { date_of_birth_matches: true, national_insurance_number_matches: true }).ToArray();
+        var matchedOnDobAndNino = results.Where(r => r is { DateOfBirthMatches: true, NationalInsuranceNumberMatches: true }).ToArray();
 
         if (matchedOnDobAndNino is [var singleDobAndNinoMatch])
         {
             var matchedAttributes = GetMatchedAttributes(singleDobAndNinoMatch);
-            return MatchPersonsResult.DefiniteMatch(singleDobAndNinoMatch.person_id, singleDobAndNinoMatch.trn, matchedAttributes);
+            return MatchPersonsResult.DefiniteMatch(singleDobAndNinoMatch.PersonId, singleDobAndNinoMatch.Trn, matchedAttributes);
         }
 
         var matchedOnNameDateOfBirthEmailAndGender = results
             .Where(r => r is
             {
-                first_name_matches: true,
-                last_name_matches: true,
-                date_of_birth_matches: true,
-                email_address_matches: true,
-                gender_matches: true
+                FirstNameMatches: true,
+                LastNameMatches: true,
+                DateOfBirthMatches: true,
+                EmailAddressMatches: true,
+                GenderMatches: true
             })
             .ToArray();
 
         if (matchedOnNameDateOfBirthEmailAndGender is [var singleNameDobEmailGenderMatch] && string.IsNullOrEmpty(request.NationalInsuranceNumber))
         {
             var matchedAttributes = GetMatchedAttributes(singleNameDobEmailGenderMatch);
-            return MatchPersonsResult.DefiniteMatch(singleNameDobEmailGenderMatch.person_id, singleNameDobEmailGenderMatch.trn, matchedAttributes);
+            return MatchPersonsResult.DefiniteMatch(singleNameDobEmailGenderMatch.PersonId, singleNameDobEmailGenderMatch.Trn, matchedAttributes);
         }
 
         request.PotentialDuplicate = true;
@@ -527,12 +535,12 @@ public class TrnRequestService(
             results
                 .Select(r =>
                 {
-                    var score = (r.date_of_birth_matches ? 1 : 0) +
-                        (r.first_name_matches ? 1 : 0) +
-                        (r.middle_name_matches ? 1 : 0) +
-                        (r.last_name_matches ? 1 : 0) +
-                        (r.email_address_matches ? 5 : 0) +
-                        (r.national_insurance_number_matches ? 10 : 0);
+                    var score = (r.DateOfBirthMatches ? 1 : 0) +
+                        (r.FirstNameMatches ? 1 : 0) +
+                        (r.MiddleNameMatches ? 1 : 0) +
+                        (r.LastNameMatches ? 1 : 0) +
+                        (r.EmailAddressMatches ? 5 : 0) +
+                        (r.NationalInsuranceNumberMatches ? 10 : 0);
 
                     var potentialMatch = GetMatchedPerson(r);
 
@@ -554,23 +562,30 @@ public class TrnRequestService(
         var oldTrnRequestEventModel = EventModels.TrnRequestMetadata.FromModel(trnRequest);
 
         trnRequest.Status = TrnRequestStatus.Pending;
-        var result = await TryResolveAsync(trnRequest, processContext);
+        await dbContext.SaveChangesAsync();
 
-        if (result.TrnRequest.Status is TrnRequestStatus.Pending)
+        var changes = TrnRequestUpdatedChanges.Status;
+
+        TrnRequestInfo result;
+
+        // If there's an outstanding support task for this request then leave resolution to that task
+        if (await dbContext.SupportTasks.AnyAsync(
+            t => t.TrnRequestApplicationUserId == trnRequest.ApplicationUserId &&
+                t.TrnRequestId == trnRequest.RequestId &&
+                t.Status != SupportTaskStatus.Closed &&
+                _trnRequestResolvingSupportTaskTypes.Contains(t.SupportTaskType)))
         {
-            await supportTaskService.CreateSupportTaskAsync(
-                new CreateSupportTaskOptions
-                {
-                    SupportTaskType = SupportTaskType.TrnRequest,
-                    Data = new TrnRequestData(),
-                    PersonId = null,
-                    OneLoginUserSubject = null,
-                    TrnRequest = (trnRequest.ApplicationUserId, trnRequest.RequestId)
-                },
-                processContext);
+            result = new TrnRequestInfo(trnRequest, ResolvedPersonTrn: null);
         }
+        else
+        {
+            result = await TryResolveAsync(trnRequest, processContext);
 
-        var changes = TrnRequestUpdatedChanges.Status | (trnRequest.ResolvedPersonId is not null ? TrnRequestUpdatedChanges.ResolvedPersonId : 0);
+            if (result.TrnRequest.ResolvedPersonId is not null)
+            {
+                changes |= TrnRequestUpdatedChanges.ResolvedPersonId;
+            }
+        }
 
         await eventScope.PublishEventAsync(
             new TrnRequestUpdatedEvent
@@ -664,26 +679,26 @@ public class TrnRequestService(
 
     private MatchPersonsResultPerson GetMatchedPerson(TrnRequestMatchQueryResult result) =>
         new(
-            PersonId: result.person_id,
+            PersonId: result.PersonId,
             MatchedAttributes: GetMatchedAttributes(result)
         );
 
     private IReadOnlyCollection<PersonMatchedAttribute> GetMatchedAttributes(TrnRequestMatchQueryResult result) =>
         new[]
         {
-            result.first_name_matches ? PersonMatchedAttribute.FirstName : (PersonMatchedAttribute?)null,
-            result.middle_name_matches ? PersonMatchedAttribute.MiddleName : null,
-            result.last_name_matches ? PersonMatchedAttribute.LastName : null,
-            result.date_of_birth_matches ? PersonMatchedAttribute.DateOfBirth : null,
-            result.email_address_matches ? PersonMatchedAttribute.EmailAddress : null,
-            result.national_insurance_number_matches ? PersonMatchedAttribute.NationalInsuranceNumber : null,
-            result.gender_matches ? PersonMatchedAttribute.Gender : null
+            result.FirstNameMatches ? PersonMatchedAttribute.FirstName : (PersonMatchedAttribute?)null,
+            result.MiddleNameMatches ? PersonMatchedAttribute.MiddleName : null,
+            result.LastNameMatches ? PersonMatchedAttribute.LastName : null,
+            result.DateOfBirthMatches ? PersonMatchedAttribute.DateOfBirth : null,
+            result.EmailAddressMatches ? PersonMatchedAttribute.EmailAddress : null,
+            result.NationalInsuranceNumberMatches ? PersonMatchedAttribute.NationalInsuranceNumber : null,
+            result.GenderMatches ? PersonMatchedAttribute.Gender : null
         }
         .Where(a => a is not null)
         .Select(a => a!.Value)
         .ToArray();
 
-    private async Task<TrnRequestInfo> TryResolveAsync(TrnRequestMetadata trnRequest, ProcessContext processContext)
+    public async Task<TrnRequestInfo> TryResolveAsync(TrnRequestMetadata trnRequest, ProcessContext processContext)
     {
         string? trn = null;
         var matchResult = await MatchPersonsAsync(trnRequest);
@@ -700,28 +715,37 @@ public class TrnRequestService(
         else
         {
             Debug.Assert(matchResult.Outcome is MatchPersonsResultOutcome.PotentialMatches);
+
+            await supportTaskService.CreateSupportTaskAsync(
+                new CreateSupportTaskOptions
+                {
+                    SupportTaskType = SupportTaskType.TrnRequest,
+                    Data = new TrnRequestData(),
+                    PersonId = null,
+                    OneLoginUserSubject = null,
+                    TrnRequest = (trnRequest.ApplicationUserId, trnRequest.RequestId)
+                },
+                processContext);
         }
 
         return new TrnRequestInfo(trnRequest, trn);
     }
 
-#pragma warning disable IDE1006 // Naming Styles
     private record TrnRequestMatchQueryResult(
-        Guid person_id,
-        string trn,
-        string first_name,
-        string? middle_name,
-        string last_name,
-        DateOnly? date_of_birth,
-        string? email_address,
-        string? national_insurance_number,
-        Gender? gender,
-        bool first_name_matches,
-        bool middle_name_matches,
-        bool last_name_matches,
-        bool date_of_birth_matches,
-        bool email_address_matches,
-        bool national_insurance_number_matches,
-        bool gender_matches);
-#pragma warning restore IDE1006 // Naming Styles
+        Guid PersonId,
+        string Trn,
+        string FirstName,
+        string? MiddleName,
+        string LastName,
+        DateOnly? DateOfBirth,
+        string? EmailAddress,
+        string? NationalInsuranceNumber,
+        Gender? Gender,
+        bool FirstNameMatches,
+        bool MiddleNameMatches,
+        bool LastNameMatches,
+        bool DateOfBirthMatches,
+        bool EmailAddressMatches,
+        bool NationalInsuranceNumberMatches,
+        bool GenderMatches);
 }

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskServiceTests_RecordMatching.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/OneLoginUserMatching/OneLoginUserMatchingSupportTaskServiceTests_RecordMatching.cs
@@ -557,4 +557,124 @@ public partial class OneLoginUserMatchingSupportTaskServiceTests
             e => Assert.IsType<OneLoginUserUpdatedEvent>(e),
             e => Assert.IsType<SupportTaskUpdatedEvent>(e));
     }
+
+    [Fact]
+    public async Task ResolveRecordMatchingSupportTaskAsync_WithNotConnectingOutcomeAndPendingTrnRequest_ResolvesTrnRequestWithMatchedPerson()
+    {
+        // Arrange
+        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
+
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
+        var trnRequestId = Guid.NewGuid().ToString();
+
+        // The support task's TRN request matches an existing person on date of birth + NINO (a definite match)
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t
+                .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
+                .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
+                .WithStatedNationalInsuranceNumber(matchedPerson.NationalInsuranceNumber)
+                .WithTrnRequestId(trnRequestId));
+
+        // The TRN request has been activated and deferred to this support task, so it's Pending
+        await SetTrnRequestToPendingAsync(supportTask);
+
+        var options = new NotConnectingOutcomeOptions
+        {
+            SupportTask = supportTask,
+            NotConnectingReason = OneLoginUserNotConnectingReason.AnotherReason,
+            NotConnectingAdditionalDetails = Faker.Lorem.Paragraph()
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync(s => s.ResolveRecordMatchingSupportTaskAsync(options, processContext));
+
+        // Assert
+        var updatedSupportTask =
+            await WithDbContextAsync(dbContext => dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
+        Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
+
+        // Because the linked TRN request was Pending, it's resolved to the matched person
+        Assert.Equal(matchedPerson.PersonId, supportTask.TrnRequestMetadata!.ResolvedPersonId);
+        Assert.Equal(TrnRequestStatus.Completed, supportTask.TrnRequestMetadata.Status);
+    }
+
+    [Fact]
+    public async Task ResolveRecordMatchingSupportTaskAsync_WithNoMatchesOutcomeAndPendingTrnRequest_ResolvesTrnRequestWithNewRecord()
+    {
+        // Arrange
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
+        var trnRequestId = Guid.NewGuid().ToString();
+
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithTrnRequestId(trnRequestId));
+
+        // The TRN request has been activated and deferred to this support task, so it's Pending
+        await SetTrnRequestToPendingAsync(supportTask);
+
+        var options = new NoMatchesOutcomeOptions { SupportTask = supportTask };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync(s => s.ResolveRecordMatchingSupportTaskAsync(options, processContext));
+
+        // Assert
+        var updatedSupportTask =
+            await WithDbContextAsync(dbContext => dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
+        Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
+
+        // Because the linked TRN request was Pending and had no match, it's resolved with a newly-created record
+        Assert.NotNull(supportTask.TrnRequestMetadata!.ResolvedPersonId);
+        Assert.Equal(TrnRequestStatus.Completed, supportTask.TrnRequestMetadata.Status);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var person = await dbContext.Persons.SingleOrDefaultAsync(p => p.PersonId == supportTask.TrnRequestMetadata.ResolvedPersonId);
+            Assert.NotNull(person);
+        });
+    }
+
+    [Fact]
+    public async Task ResolveRecordMatchingSupportTaskAsync_WithNoMatchesOutcomeAndNonPendingTrnRequest_DoesNotResolveTrnRequest()
+    {
+        // Arrange
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
+        var trnRequestId = Guid.NewGuid().ToString();
+
+        // The linked TRN request is left Dormant (it has not been activated), so resolution should not be triggered
+        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject, t => t.WithTrnRequestId(trnRequestId));
+
+        var options = new NoMatchesOutcomeOptions { SupportTask = supportTask };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync(s => s.ResolveRecordMatchingSupportTaskAsync(options, processContext));
+
+        // Assert
+        var updatedSupportTask =
+            await WithDbContextAsync(dbContext => dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
+        Assert.Equal(SupportTaskStatus.Closed, updatedSupportTask.Status);
+
+        // The TRN request wasn't Pending, so it's untouched
+        var updatedTrnRequest =
+            await WithDbContextAsync(dbContext => dbContext.TrnRequestMetadata.SingleAsync(r => r.RequestId == trnRequestId));
+        Assert.Null(updatedTrnRequest.ResolvedPersonId);
+        Assert.Equal(TrnRequestStatus.Dormant, updatedTrnRequest.Status);
+    }
+
+    private async Task SetTrnRequestToPendingAsync(SupportTask supportTask)
+    {
+        await WithDbContextAsync(async dbContext =>
+        {
+            var metadata = await dbContext.TrnRequestMetadata.SingleAsync(m => m.RequestId == supportTask.TrnRequestId);
+            metadata.Status = TrnRequestStatus.Pending;
+            await dbContext.SaveChangesAsync();
+        });
+
+        supportTask.TrnRequestMetadata!.Status = TrnRequestStatus.Pending;
+    }
 }

--- a/tests/TeachingRecordSystem.Core.Tests/Services/TrnRequests/TrnRequestServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/TrnRequests/TrnRequestServiceTests.cs
@@ -215,6 +215,59 @@ public partial class TrnRequestServiceTests(ServiceFixture fixture) : ServiceTes
     }
 
     [Fact]
+    public async Task CreateTrnRequestAsync_WithTryResolveAndPotentialMatches_CreatesSupportTaskAndSetsStatusToPending()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var firstName = TestData.GenerateFirstName();
+        var middleName = TestData.GenerateMiddleName();
+        var lastName = TestData.GenerateLastName();
+        var dateOfBirth = TestData.GenerateDateOfBirth();
+
+        var options = GetCreateTrnRequestOptions(applicationUser.UserId, tryResolve: true) with
+        {
+            FirstName = firstName,
+            MiddleName = middleName,
+            LastName = lastName,
+            DateOfBirth = dateOfBirth
+        };
+
+        // A potential (but not definite) match: same name + DOB, but no matching NINO
+        await TestData.CreatePersonAsync(p => p
+            .WithFirstName(firstName)
+            .WithMiddleName(middleName)
+            .WithLastName(lastName)
+            .WithDateOfBirth(dateOfBirth));
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var result = await WithServiceAsync(s => s.CreateTrnRequestAsync(options, processContext));
+
+        // Assert
+        Assert.True(result.TrnRequest.PotentialDuplicate);
+        Assert.Null(result.ResolvedPersonTrn);
+
+        var trnRequest = await WithDbContextAsync(dbContext =>
+            dbContext.TrnRequestMetadata.SingleAsync(m => m.ApplicationUserId == applicationUser.UserId && m.RequestId == options.RequestId));
+        Assert.Null(trnRequest.ResolvedPersonId);
+        Assert.Equal(TrnRequestStatus.Pending, trnRequest.Status);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var supportTask = await dbContext.SupportTasks
+                .SingleOrDefaultAsync(t =>
+                    t.TrnRequestApplicationUserId == applicationUser.UserId &&
+                    t.TrnRequestId == options.RequestId &&
+                    t.SupportTaskType == SupportTaskType.TrnRequest);
+
+            Assert.NotNull(supportTask);
+            Assert.Equal(SupportTaskStatus.Open, supportTask.Status);
+        });
+    }
+
+    [Fact]
     public async Task CreateTrnRequest_WithTryResolveFalse_DoesNotCreateSupportTaskForPotentialMatches()
     {
         // Arrange
@@ -405,6 +458,86 @@ public partial class TrnRequestServiceTests(ServiceFixture fixture) : ServiceTes
                     t.SupportTaskType == SupportTaskType.TrnRequest);
             Assert.NotNull(supportTask);
             Assert.Equal(SupportTaskStatus.Open, supportTask.Status);
+        });
+    }
+
+    [Fact]
+    public async Task ActivateTrnRequestAsync_WithDefiniteMatchAndFurtherChecksRequired_OnlyCreatesFurtherChecksSupportTask()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        TrnRequestOptionsAccessor.Value.FlagFurtherChecksRequiredFromUserIds = [applicationUser.UserId];
+
+        var trnRequest = await TestData.CreateDormantTrnRequestAsync(applicationUser.UserId);
+
+        var definiteMatch = await TestData.CreatePersonAsync(p => p
+            .WithDateOfBirth(trnRequest.DateOfBirth)
+            .WithNationalInsuranceNumber(trnRequest.NationalInsuranceNumber!)
+            .WithAlert());
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync(s => s.ActivateTrnRequestAsync(trnRequest, processContext));
+
+        // Assert
+        Assert.Equal(definiteMatch.PersonId, trnRequest.ResolvedPersonId);
+        Assert.Equal(TrnRequestStatus.Pending, trnRequest.Status);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var supportTasks = await dbContext.SupportTasks
+                .Where(t =>
+                    t.TrnRequestApplicationUserId == applicationUser.UserId &&
+                    t.TrnRequestId == trnRequest.RequestId)
+                .ToArrayAsync();
+
+            var supportTask = Assert.Single(supportTasks);
+            Assert.Equal(SupportTaskType.TrnRequestManualChecksNeeded, supportTask.SupportTaskType);
+        });
+    }
+
+    [Fact]
+    public async Task ActivateTrnRequestAsync_WithOutstandingResolvingSupportTask_DefersResolutionWithoutCreatingNewSupportTask()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync();
+        var trnRequest = await TestData.CreateDormantTrnRequestAsync(applicationUser.UserId, oneLoginUser.Subject);
+
+        // A definite match exists, so the request *would* be resolved if resolution ran
+        await TestData.CreatePersonAsync(p => p
+            .WithDateOfBirth(trnRequest.DateOfBirth)
+            .WithNationalInsuranceNumber(trnRequest.NationalInsuranceNumber!));
+
+        // ...but there's an outstanding support task for the request, so resolution should be left to that task
+        await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
+            oneLoginUser.Subject,
+            t => t
+                .WithClientApplicationUserId(applicationUser.UserId)
+                .WithTrnRequestId(trnRequest.RequestId));
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var result = await WithServiceAsync(s => s.ActivateTrnRequestAsync(trnRequest, processContext));
+
+        // Assert
+        Assert.Equal(TrnRequestStatus.Pending, trnRequest.Status);
+        Assert.Null(trnRequest.ResolvedPersonId);
+        Assert.Null(result.ResolvedPersonTrn);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            // The existing matching task should be the only support task; no new TrnRequest task was created
+            var supportTasks = await dbContext.SupportTasks
+                .Where(t =>
+                    t.TrnRequestApplicationUserId == applicationUser.UserId &&
+                    t.TrnRequestId == trnRequest.RequestId)
+                .ToArrayAsync();
+
+            var supportTask = Assert.Single(supportTasks);
+            Assert.Equal(SupportTaskType.OneLoginUserRecordMatching, supportTask.SupportTaskType);
         });
     }
 

--- a/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.Deferred.cs
+++ b/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.Deferred.cs
@@ -1,7 +1,3 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using Microsoft.Playwright;
-using TeachingRecordSystem.Core.ApiSchema;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 
 namespace TeachingRecordSystem.EndToEndTests.AuthorizeAccessJourneys;
@@ -45,8 +41,6 @@ public partial class SignInTests
         await page.AssertSignedInWithDormantTrnRequestAsync(trnRequestId);
 
         await page.CloseAsync();
-
-        await ActivateAndResolveDormantTrnRequestAndSignInAsync(context, trnRequestId);
     }
 
     [Fact]
@@ -81,8 +75,6 @@ public partial class SignInTests
         await page.AssertSignedInWithDormantTrnRequestAsync(trnRequestId);
 
         await page.CloseAsync();
-
-        await ActivateAndResolveDormantTrnRequestAndSignInAsync(context, trnRequestId);
     }
 
     [Fact]
@@ -125,14 +117,13 @@ public partial class SignInTests
                 .SingleOrDefaultAsync();
 
             Assert.NotNull(trnRequest);
+
             return trnRequest.RequestId;
         });
 
         await page.AssertSignedInWithDormantTrnRequestAsync(trnRequestId);
 
         await page.CloseAsync();
-
-        await ActivateAndResolveDormantTrnRequestAndSignInAsync(context, trnRequestId);
     }
 
     [Fact]
@@ -172,7 +163,7 @@ public partial class SignInTests
 
         await page.WaitForUrlPathAsync("/request-submitted");
 
-        var trnRequestId = await WithDbContextAsync(async dbContext =>
+        var (trnRequestId, supportTaskReference) = await WithDbContextAsync(async dbContext =>
         {
             var trnRequest = await dbContext.TrnRequestMetadata
                 .Where(r => r.OneLoginUserSubject == subject)
@@ -193,7 +184,7 @@ public partial class SignInTests
             Assert.Equal(trnRequest.RequestId, supportTask.TrnRequestId);
             Assert.Equal(trnRequest.ApplicationUserId, supportTask.TrnRequestApplicationUserId);
 
-            return trnRequest.RequestId;
+            return (trnRequest.RequestId, supportTask.SupportTaskReference);
         });
 
         await page.ClickGovUkButtonAsync("Continue");
@@ -201,42 +192,5 @@ public partial class SignInTests
         await page.AssertSignedInWithDormantTrnRequestAsync(trnRequestId);
 
         await page.CloseAsync();
-
-        await ActivateAndResolveDormantTrnRequestAndSignInAsync(context, trnRequestId);
-    }
-
-    private async Task ActivateAndResolveDormantTrnRequestAndSignInAsync(IBrowserContext context, string trnRequestId)
-    {
-        var resolvedTrn = await ResolveDormantTrnRequestAsync();
-
-        var page = await context.NewPageAsync();
-
-        await page.GoToAuthorizeAccessTestStartPageAsync(deferred: true);
-
-        await page.AssertSignedInAsync(resolvedTrn);
-
-        async Task<string> ResolveDormantTrnRequestAsync()
-        {
-            var applicationUserId = HostFixture.DeferredRecordMatchingPolicyApplicationUserId;
-
-            using var httpClient = HostFixture.GetHttpClientWithAuthorizeAccessTokenForTrnRequest(
-                applicationUserId,
-                trnRequestId,
-                version: VersionRegistry.V3MinorVersions.V20260416);
-
-            var activateResponse = await httpClient.PutAsync("/v3/trn-request/activate", content: null);
-            activateResponse.EnsureSuccessStatusCode();
-
-            var activateResponseBodyJson = (await activateResponse.Content.ReadFromJsonAsync<JsonDocument>())!;
-
-            var status = activateResponseBodyJson.RootElement.GetProperty("status").GetString();
-            if (status is not "Completed")
-            {
-                throw new InvalidOperationException($"Unexpected status '{status}' when activating dormant TRN request.");
-            }
-
-            var trn = activateResponseBodyJson.RootElement.GetProperty("trn").GetString()!;
-            return trn;
-        }
     }
 }


### PR DESCRIPTION
We have a race currently whereby if we have an `Open` One Login matching task with a dormant TRN request attached and that request is activated *before* the One Login task is completed, we end up creating a TRN request support task for the TRN request as well. That task can never be completed, since the attached TRN request is already Completed.

This change modifies the activate API endpoint to not resolve the TRN request if there's already an open support task for the request. Similarly, when the OL matching/verification task is completed without a match AND the TRN request is activated we will now create a TRN request support task to resolve it.

I've thinned out a few of the e2e tests that were calling the activate endpoint; wiring those up with all the support-related parts is too complicated currently.

Fixes https://github.com/DFE-Digital/teaching-record-team-project-board/issues/346