### PR TITLE
2849 - fix fix-airbyte-replication wf service_name and schedule

### DIFF
--- a/.github/workflows/fix-airbyte-replication.yml
+++ b/.github/workflows/fix-airbyte-replication.yml
@@ -20,15 +20,16 @@ on:
                 options:
                     - "true"
                     - "false"
-    # schedule: # hourly every Sunday midnight until 9am
-    #     - cron: "0 0-9 * * 0"
+    schedule: # hourly every Sunday midnight until 9am
+        - cron: "0 0-9 * * 0"
 
 permissions:
     id-token: write
 
 env:
-    SERVICE_NAME: teaching-record-system
+    SERVICE_NAME: trs
     SERVICE_SHORT: trs
+    APP_NAME_SUFFIX: api
     TF_VARS_PATH: terraform/aks/config
 
 jobs:
@@ -57,7 +58,7 @@ jobs:
                   azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-                  app-name: ${{ env.SERVICE_NAME }}-${{ env.DEPLOY_ENV }}
+                  app-name: ${{ env.SERVICE_NAME }}-${{ env.DEPLOY_ENV }}-${{ env.APP_NAME_SUFFIX }}
                   namespace: ${{ env.NAMESPACE }}
                   cluster: ${{ env.CLUSTER }}
                   dry-run: ${{ env.DRY_RUN }}


### PR DESCRIPTION
### Context

We need to add a workflow that is used to monitor and fix Postgres replication slots.
https://trello.com/c/TyRmQvgw/2849-trs-airbyte-changes

### Changes proposed in this pull request

- New APP_NAME_SUFFIX env variable created as trs use a suffix on the container deployment name.
- The deployment prefix is not the service_name but the service_short.
- The schedule has been uncommented so that the workflow will run every hour between 00:00 and 09:00

### Guidance to review

The workflow has been tested manually against this branch for dev, pre-production and production with the with check slot = true so that no actions are taken.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running workflow against the branch in check mode