### PR TITLE
Increase width of TRN and DOB columns in One Login list page

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/Index.cshtml
@@ -9,7 +9,7 @@
 }
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">        
+    <div class="govuk-grid-column-two-thirds">
         <form method="get" asp-antiforgery="false" data-testid="search-form">
             <span class="govuk-caption-l">Search</span>
             <govuk-input for="Search" label-class="govuk-label--l" data-testid="search-input" type="search">
@@ -40,12 +40,12 @@
                         link-template="@(direction => LinkGenerator.OneLogins.Index(Model.Search, OneLoginSearchSortByOption.Name, direction, Model.PageNumber))">
                         Name
                     </th>
-                    <th scope="col" class="govuk-table__header trs-!-width-130"
+                    <th scope="col" class="govuk-table__header trs-!-width-160"
                         sort-direction="@(Model.SortBy == OneLoginSearchSortByOption.DateOfBirth ? Model.SortDirection : null)"
                         link-template="@(direction => LinkGenerator.OneLogins.Index(Model.Search, OneLoginSearchSortByOption.DateOfBirth, direction, Model.PageNumber))">
                         DOB
                     </th>
-                    <th scope="col" class="govuk-table__header trs-!-width-80"
+                    <th scope="col" class="govuk-table__header trs-!-width-130"
                         sort-direction="@(Model.SortBy == OneLoginSearchSortByOption.Trn ? Model.SortDirection : null)"
                         link-template="@(direction => LinkGenerator.OneLogins.Index(Model.Search, OneLoginSearchSortByOption.Trn, direction, Model.PageNumber))">
                         TRN

--- a/src/TeachingRecordSystem.SupportUi/Styles/app.scss
+++ b/src/TeachingRecordSystem.SupportUi/Styles/app.scss
@@ -88,7 +88,7 @@
   display: inline;
 }
 
-@each $size in 70, 80, 90, 100, 110, 120, 130, 150, 200 {
+@each $size in 70, 80, 90, 100, 110, 120, 130, 150, 160, 200 {
   .trs-\!-width-#{$size} {
     width: #{$size}px !important;
   }


### PR DESCRIPTION
Prevents some rows wrapping onto multiple lines.