### PR TITLE
Don't lookup on email address when matching a TRN request to a One Login

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -652,7 +652,8 @@ public class OneLoginService(
 
         var requestAndResolvedPerson = await dbContext.TrnRequestMetadata
             .Join(dbContext.Persons, r => r.ResolvedPersonId, p => p.PersonId, (m, p) => new { TrnRequestMetadata = m, ResolvedPerson = p })
-            .Where(m => m.TrnRequestMetadata.OneLoginUserSubject == oneLoginUser.Subject || m.TrnRequestMetadata.EmailAddress == oneLoginUser.EmailAddress)
+            .Where(m => m.TrnRequestMetadata.OneLoginUserSubject == oneLoginUser.Subject)
+            .Where(m => m.TrnRequestMetadata.IdentityVerified == true && m.TrnRequestMetadata.Status == TrnRequestStatus.Completed)
             .ToArrayAsync();
 
         if (requestAndResolvedPerson is not [{ TrnRequestMetadata: var trnRequestMetadata, ResolvedPerson: var resolvedPerson }])
@@ -660,15 +661,6 @@ public class OneLoginService(
             return null;
         }
 
-        if (trnRequestMetadata.IdentityVerified != true)
-        {
-            return null;
-        }
-
-        if (trnRequestMetadata.Status is not TrnRequestStatus.Completed)
-        {
-            return null;
-        }
         Debug.Assert(trnRequestMetadata.ResolvedPersonId.HasValue);
 
         var verifiedInfo = trnRequestMetadata.GetVerifiedInfo()!.Value;

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
@@ -188,7 +188,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
             });
 
     [Fact]
-    public Task OnOneLoginCallback_AuthenticationOnly_NewUserWithResolvedTrnRequestMatchedOnEmail_SetsUserVerifiedAssignsTrnAndCompletesJourney() =>
+    public Task OnOneLoginCallback_AuthenticationOnly_NewUserWithResolvedTrnRequestMatchedOnEmailOnly_RequestsIdentityVerification() =>
         WithJourneyCoordinatorAsync(
             (instanceId, processId) => new SignInJourneyState(
                 processId,
@@ -211,43 +211,6 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                     .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: true));
 
                 var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: AuthenticationOnly, sub: subject, email: email);
-
-                // Act
-                var result = await coordinator.OnOneLoginCallbackAsync(authenticationTicket);
-
-                // Assert
-                Assert.NotNull(coordinator.State.AuthenticationTicket);
-
-                var user = await WithDbContextAsync(dbContext => dbContext.OneLoginUsers.SingleAsync(u => u.Subject == subject));
-
-                var redirectResult = Assert.IsType<RedirectHttpResult>(result);
-                Assert.Equal(coordinator.GetRedirectUri(), redirectResult.Url);
-            });
-
-    [Fact]
-    public Task OnOneLoginCallback_AuthenticationOnly_NewUserWithPendingTrnRequestMatchedOnEmail_RequestsIdentityVerification() =>
-        WithJourneyCoordinatorAsync(
-            (instanceId, processId) => new SignInJourneyState(
-                processId,
-                redirectUri: instanceId.EnsureUrlHasKey("https://localhost/callback"),
-                serviceName: "Test Service",
-                serviceUrl: "https://service",
-                oneLoginAuthenticationScheme: "dummy",
-                clientApplicationUserId: default,
-                recordMatchingPolicy: RecordMatchingPolicy.Required),
-            async coordinator =>
-            {
-                // Arrange
-                var subject = TestData.CreateOneLoginUserSubject();
-                var email = TestData.GenerateUniqueEmail();
-
-                var trnRequestId = Guid.NewGuid().ToString();
-                var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
-                await TestData.CreatePersonAsync(p => p
-                    .WithEmailAddress(email)
-                    .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: true));
-
-                var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: AuthenticationOnly, sub: subject);
 
                 // Act
                 var result = await coordinator.OnOneLoginCallbackAsync(authenticationTicket);
@@ -282,44 +245,6 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
                 await TestData.CreatePersonAsync(p => p
                     .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: false, oneLoginUserSubject: subject));
-
-                var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: AuthenticationOnly, sub: subject);
-
-                // Act
-                var result = await coordinator.OnOneLoginCallbackAsync(authenticationTicket);
-
-                // Assert
-                Assert.NotNull(coordinator.State.OneLoginAuthenticationTicket);
-                Assert.Null(coordinator.State.AuthenticationTicket);
-
-                var challengeResult = Assert.IsType<ChallengeHttpResult>(result);
-                Assert.Collection(
-                    challengeResult.Properties!.GetVectorsOfTrust(),
-                    vtr => Assert.Equal(AuthenticationAndIdentityVerification, vtr));
-            });
-
-    [Fact]
-    public Task OnOneLoginCallback_AuthenticationOnly_NewUserWithTrnRequestMatchedOnEmailWithoutIdentityVerified_RequestsIdentityVerification() =>
-        WithJourneyCoordinatorAsync(
-            (instanceId, processId) => new SignInJourneyState(
-                processId,
-                redirectUri: instanceId.EnsureUrlHasKey("https://localhost/callback"),
-                serviceName: "Test Service",
-                serviceUrl: "https://service",
-                oneLoginAuthenticationScheme: "dummy",
-                clientApplicationUserId: default,
-                recordMatchingPolicy: RecordMatchingPolicy.Required),
-            async coordinator =>
-            {
-                // Arrange
-                var subject = TestData.CreateOneLoginUserSubject();
-                var email = TestData.GenerateUniqueEmail();
-
-                var trnRequestId = Guid.NewGuid().ToString();
-                var trnRequestFromApplicationUser = await TestData.CreateApplicationUserAsync();
-                await TestData.CreatePersonAsync(p => p
-                    .WithEmailAddress(email)
-                    .WithTrnRequest(trnRequestFromApplicationUser.UserId, trnRequestId, identityVerified: false));
 
                 var authenticationTicket = CreateOneLoginAuthenticationTicket(vtr: AuthenticationOnly, sub: subject);
 

--- a/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.cs
+++ b/tests/TeachingRecordSystem.EndToEndTests/AuthorizeAccessJourneys/SignInTests.cs
@@ -228,30 +228,6 @@ public partial class SignInTests(HostFixture hostFixture) : TestBase(hostFixture
     }
 
     [Fact]
-    public async Task SignIn_UnknownUser_EmailIsAttachedToTrnRequest()
-    {
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-        var trnRequestId = Guid.NewGuid().ToString();
-
-        var email = TestData.GenerateUniqueEmail();
-
-        var person = await TestData.CreatePersonAsync(p => p
-            .WithEmailAddress(email)
-            .WithTrnRequest(applicationUser.UserId, trnRequestId, identityVerified: true));
-
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(email: Option.Some((string?)email));
-
-        SetCurrentOneLoginUser(OneLoginUserInfo.Create(oneLoginUser.Subject, oneLoginUser.EmailAddress!));
-
-        await using var context = await HostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        await page.GoToAuthorizeAccessTestStartPageAsync();
-
-        await page.AssertSignedInAsync(person.Trn);
-    }
-
-    [Fact]
     public async Task SignIn_UnknownUnverifiedUser()
     {
         var subject = TestData.CreateOneLoginUserSubject();


### PR DESCRIPTION
Email address isn't a stable identifier.