### PR TITLE
Remove SupportTask.Create calls from TestData methods

### DIFF
--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeDateOfBirthRequestSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeDateOfBirthRequestSupportTask.cs
@@ -103,22 +103,19 @@ public partial class TestData
                 ChangeRequestOutcome = null
             };
 
-            var supportTask = SupportTask.Create(
-                SupportTaskType.ChangeDateOfBirthRequest,
-                data,
-                personId: personId,
-                oneLoginUserSubject: null,
-                trnRequestApplicationUserId: null,
-                trnRequestId: null,
-                createdBy: SystemUser.SystemUserId,
-                createdOn,
-                out var createdEvent);
-            supportTask.Status = status;
+            var supportTask = new SupportTask
+            {
+                CreatedOn = createdOn,
+                UpdatedOn = createdOn,
+                SupportTaskType = SupportTaskType.ChangeDateOfBirthRequest,
+                Status = status,
+                Data = data,
+                PersonId = personId
+            };
 
             return testData.WithDbContextAsync(async dbContext =>
             {
                 dbContext.SupportTasks.Add(supportTask);
-                dbContext.AddEventWithoutBroadcast(createdEvent);
                 await dbContext.SaveChangesAsync();
 
                 return supportTask;

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeNameRequestSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeNameRequestSupportTask.cs
@@ -125,22 +125,19 @@ public partial class TestData
                 ChangeRequestOutcome = null
             };
 
-            var supportTask = SupportTask.Create(
-                SupportTaskType.ChangeNameRequest,
-                data,
-                personId: personId,
-                oneLoginUserSubject: null,
-                trnRequestApplicationUserId: null,
-                trnRequestId: null,
-                createdBy: SystemUser.SystemUserId,
-                createdOn,
-                out var createdEvent);
-            supportTask.Status = status;
+            var supportTask = new SupportTask
+            {
+                CreatedOn = createdOn,
+                UpdatedOn = createdOn,
+                SupportTaskType = SupportTaskType.ChangeNameRequest,
+                Status = status,
+                Data = data,
+                PersonId = personId
+            };
 
             return testData.WithDbContextAsync(async dbContext =>
             {
                 dbContext.SupportTasks.Add(supportTask);
-                dbContext.AddEventWithoutBroadcast(createdEvent);
                 await dbContext.SaveChangesAsync();
 
                 return supportTask;

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUserRecordMatchingSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUserRecordMatchingSupportTask.cs
@@ -177,20 +177,19 @@ public partial class TestData
                     TrnTokenTrn = trnTokenTrn
                 };
 
-                var supportTask = SupportTask.Create(
-                    supportTaskType: SupportTaskType.OneLoginUserRecordMatching,
-                    data: data,
-                    personId: null,
-                    oneLoginUserSubject: oneLoginUserSubject,
-                    trnRequestApplicationUserId: trnRequestId is not null ? clientApplicationUserId : null,
-                    trnRequestId: trnRequestId,
-                    createdBy: SystemUser.SystemUserId,
-                    now: createdOn,
-                    out var createdEvent);
-                supportTask.Status = status;
+                var supportTask = new SupportTask
+                {
+                    CreatedOn = createdOn,
+                    UpdatedOn = createdOn,
+                    SupportTaskType = SupportTaskType.OneLoginUserRecordMatching,
+                    Status = status,
+                    Data = data,
+                    OneLoginUserSubject = oneLoginUserSubject,
+                    TrnRequestApplicationUserId = trnRequestId is not null ? clientApplicationUserId : null,
+                    TrnRequestId = trnRequestId
+                };
 
                 dbContext.SupportTasks.Add(supportTask);
-                dbContext.AddEventWithoutBroadcast(createdEvent);
                 await dbContext.SaveChangesAsync();
 
                 return await dbContext.SupportTasks

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateTeacherPensionsPotentialDuplicateTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateTeacherPensionsPotentialDuplicateTask.cs
@@ -168,28 +168,26 @@ public partial class TestData
                 Gender = gender,
                 PotentialDuplicate = true
             };
-            var supportTask = SupportTask.Create(
-                SupportTaskType.TeacherPensionsPotentialDuplicate,
-                new Core.Models.SupportTasks.TeacherPensionsPotentialDuplicateData()
+            var supportTask = new SupportTask
+            {
+                CreatedOn = createdOn!.Value,
+                UpdatedOn = createdOn!.Value,
+                SupportTaskType = SupportTaskType.TeacherPensionsPotentialDuplicate,
+                Status = _status.ValueOr(SupportTaskStatus.Open),
+                Data = new Core.Models.SupportTasks.TeacherPensionsPotentialDuplicateData()
                 {
                     FileName = fileName,
                     IntegrationTransactionId = integrationTransactionId
                 },
-                personId: personId,
-                null,
-                trnRequestApplicationUserId: userId,
-                trnRequestId: trnRequestMetadata.RequestId,
-                createdBy: userId,
-                now: createdOn!.Value,
-                out var supportTaskCreatedEvent);
-
-            supportTask.Status = _status.ValueOr(SupportTaskStatus.Open);
+                PersonId = personId,
+                TrnRequestApplicationUserId = userId,
+                TrnRequestId = trnRequestMetadata.RequestId
+            };
 
             return await testData.WithDbContextAsync(async dbContext =>
             {
                 dbContext.TrnRequestMetadata.Add(trnRequestMetadata);
                 dbContext.SupportTasks.Add(supportTask);
-                dbContext.AddEventWithoutBroadcast(supportTaskCreatedEvent);
                 await dbContext.SaveChangesAsync();
 
                 return supportTask;

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateTrnRequestManualChecksNeededSupportTaskAsync.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateTrnRequestManualChecksNeededSupportTaskAsync.cs
@@ -43,20 +43,20 @@ public partial class TestData
     {
         return WithDbContextAsync(async dbContext =>
         {
-            var task = SupportTask.Create(
-                SupportTaskType.TrnRequestManualChecksNeeded,
-                new TrnRequestManualChecksNeededData(),
-                personId: null,
-                oneLoginUserSubject: null,
-                trnRequestApplicationUserId,
-                trnRequestId,
-                SystemUser.SystemUserId,
-                (createdOn ?? TimeProvider.UtcNow).ToUniversalTime(),
-                out var createdEvent);
-            task.Status = status;
+            var createdOnUtc = (createdOn ?? TimeProvider.UtcNow).ToUniversalTime();
+
+            var task = new SupportTask
+            {
+                CreatedOn = createdOnUtc,
+                UpdatedOn = createdOnUtc,
+                SupportTaskType = SupportTaskType.TrnRequestManualChecksNeeded,
+                Status = status,
+                Data = new TrnRequestManualChecksNeededData(),
+                TrnRequestApplicationUserId = trnRequestApplicationUserId,
+                TrnRequestId = trnRequestId
+            };
 
             dbContext.SupportTasks.Add(task);
-            dbContext.AddEventWithoutBroadcast(createdEvent);
             await dbContext.SaveChangesAsync();
 
             // Re-query what we've just added so we return a SupportTask with TrnRequestMetadata populated

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateTrnRequestSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateTrnRequestSupportTask.cs
@@ -264,24 +264,21 @@ public partial class TestData
 
             var status = _status.ValueOr(() => SupportTaskStatus.Open);
 
-            var task = SupportTask.Create(
-                SupportTaskType.TrnRequest,
-                new TrnRequestData(),
-                personId: null,
-                oneLoginUserSubject: null,
-                applicationUserId,
-                trnRequestId,
-                SystemUser.SystemUserId,
-                createdOn,
-                out var createdEvent);
-
-            task.Status = status;
+            var task = new SupportTask
+            {
+                CreatedOn = createdOn,
+                UpdatedOn = createdOn,
+                SupportTaskType = SupportTaskType.TrnRequest,
+                Status = status,
+                Data = new TrnRequestData(),
+                TrnRequestApplicationUserId = applicationUserId,
+                TrnRequestId = trnRequestId
+            };
 
             return await testData.WithDbContextAsync(async dbContext =>
             {
                 dbContext.TrnRequestMetadata.Add(metadata);
                 dbContext.SupportTasks.Add(task);
-                dbContext.AddEventWithoutBroadcast(createdEvent);
                 await dbContext.SaveChangesAsync();
 
                 // Re-query what we've just added so we return a SupportTask with TrnRequestMetadata populated

--- a/tests/TeachingRecordSystem.TestCommon/TestData.OneLoginUserIdVerificationSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.OneLoginUserIdVerificationSupportTask.cs
@@ -203,20 +203,17 @@ public partial class TestData
                     ClientApplicationUserId = clientApplicationUserId
                 };
 
-                var supportTask = SupportTask.Create(
-                    supportTaskType: SupportTaskType.OneLoginUserIdVerification,
-                    data: data,
-                    personId: null,
-                    oneLoginUserSubject: oneLoginUserSubject,
-                    trnRequestApplicationUserId: null,
-                    trnRequestId: null,
-                    createdBy: SystemUser.SystemUserId,
-                    now: createdOn,
-                    out var createdEvent);
-                supportTask.Status = status;
+                var supportTask = new SupportTask
+                {
+                    CreatedOn = createdOn,
+                    UpdatedOn = createdOn,
+                    SupportTaskType = SupportTaskType.OneLoginUserIdVerification,
+                    Status = status,
+                    Data = data,
+                    OneLoginUserSubject = oneLoginUserSubject
+                };
 
                 dbContext.SupportTasks.Add(supportTask);
-                dbContext.AddEventWithoutBroadcast(createdEvent);
                 await dbContext.SaveChangesAsync();
 
                 return await dbContext.SupportTasks


### PR DESCRIPTION
We're moving away from factory methods for creating entities and using services instead.