### PR TITLE
Return age range from and to in routes to professional statuses

### DIFF
--- a/src/TeachingRecordSystem.Api/V3/Operations/GetPerson.cs
+++ b/src/TeachingRecordSystem.Api/V3/Operations/GetPerson.cs
@@ -155,6 +155,8 @@ public record GetPersonResultRouteToProfessionalStatus
     public required DateOnly? TrainingEndDate { get; init; }
     public required IReadOnlyCollection<PostgresModels.TrainingSubject> TrainingSubjects { get; init; }
     public required TrainingAgeSpecialism? TrainingAgeSpecialism { get; init; }
+    public required int? TrainingAgeSpecialismRangeFrom { get; init; }
+    public required int? TrainingAgeSpecialismRangeTo { get; init; }
     public required TrainingCountry? TrainingCountry { get; init; }
     public required PostgresModels.TrainingProvider? TrainingProvider { get; init; }
     public required PostgresModels.DegreeType? DegreeType { get; init; }
@@ -437,6 +439,8 @@ public class GetPersonHandler(GetPersonHelper getPersonHelper, TrsDbContext dbCo
                     .Select(async (Guid id, CancellationToken _) => await referenceDataCache.GetTrainingSubjectByIdAsync(id))
                     .ToArrayAsync(cancellationToken: ct),
                 TrainingAgeSpecialism = r.TrainingAgeSpecialismType,
+                TrainingAgeSpecialismRangeFrom = r.TrainingAgeSpecialismRangeFrom,
+                TrainingAgeSpecialismRangeTo = r.TrainingAgeSpecialismRangeTo,
                 TrainingCountry = r.TrainingCountry,
                 TrainingProvider = r.TrainingProvider,
                 DegreeType = r.DegreeType,

--- a/src/TeachingRecordSystem.Api/V3/V20250627/Responses/GetPersonResponse.cs
+++ b/src/TeachingRecordSystem.Api/V3/V20250627/Responses/GetPersonResponse.cs
@@ -101,7 +101,9 @@ public record GetPersonResponseRouteToProfessionalStatus
         TrainingStartDate = source.TrainingStartDate,
         TrainingEndDate = source.TrainingEndDate,
         TrainingSubjects = source.TrainingSubjects.Select(s => TrainingSubject.Create(s)).AsReadOnly(),
-        TrainingAgeSpecialism = source.TrainingAgeSpecialism is { } ageSpecialism ? TrainingAgeSpecialism.Create(ageSpecialism) : null,
+        TrainingAgeSpecialism = source.TrainingAgeSpecialism is { } ageSpecialism
+            ? TrainingAgeSpecialism.Create(ageSpecialism, source.TrainingAgeSpecialismRangeFrom, source.TrainingAgeSpecialismRangeTo)
+            : null,
         TrainingCountry = source.TrainingCountry is { } country ? TrainingCountry.Create(country) : null,
         TrainingProvider = source.TrainingProvider is { } provider ? TrainingProvider.Create(provider) : null,
         DegreeType = source.DegreeType is { } degreeType ? DegreeType.Create(degreeType) : null,

--- a/src/TeachingRecordSystem.Core/ApiSchema/V3/V20250627/Dtos/TrainingAgeSpecialism.cs
+++ b/src/TeachingRecordSystem.Core/ApiSchema/V3/V20250627/Dtos/TrainingAgeSpecialism.cs
@@ -9,11 +9,11 @@ public record TrainingAgeSpecialism
     public required Option<int> From { get; init; }
     public required Option<int> To { get; init; }
 
-    public static TrainingAgeSpecialism Create(Models.TrainingAgeSpecialismType source) => new()
+    public static TrainingAgeSpecialism Create(Models.TrainingAgeSpecialismType source, int? from, int? to) => new()
     {
         Type = TeachingRecordSystem.Core.ApiSchema.V3.V20250425.Dtos.TrainingAgeSpecialismTypeExtensions
             .ConvertFromTrainingAgeSpecialismType(source),
-        From = default,
-        To = default
+        From = from is int f ? Option.Some(f) : Option.None<int>(),
+        To = to is int t ? Option.Some(t) : Option.None<int>()
     };
 }

--- a/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/GetPersonByTrnTests.cs
+++ b/tests/TeachingRecordSystem.Api.IntegrationTests/V3/V20250627/GetPersonByTrnTests.cs
@@ -1,4 +1,5 @@
 using TeachingRecordSystem.Api.V3.V20250627.Requests;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 
 namespace TeachingRecordSystem.Api.IntegrationTests.V3.V20250627;
 
@@ -345,6 +346,63 @@ public class GetPersonByTrnTests : TestBase
         var jsonResponse = await AssertEx.JsonResponseAsync(response);
         var responseRoutes = jsonResponse.RootElement.GetProperty("routesToProfessionalStatuses");
         Assert.True(responseRoutes.GetArrayLength() >= 1);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithRangeTrainingAgeSpecialism_ReturnsFromAndTo()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithRouteToProfessionalStatus(r => r
+                .WithRouteType(RouteToProfessionalStatusType.HeiProgrammeTypeId)
+                .WithStatus(RouteToProfessionalStatusStatus.InTraining)
+                .WithTrainingAgeSpecialismType(TrainingAgeSpecialismType.Range)
+                .WithTrainingAgeSpecialismRangeFrom(11)
+                .WithTrainingAgeSpecialismRangeTo(18)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=RoutesToProfessionalStatuses");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponseAsync(response);
+        var responseRoutes = jsonResponse.RootElement.GetProperty("routesToProfessionalStatuses");
+        var responseTrainingAgeSpecialism = responseRoutes.EnumerateArray().Single().GetProperty("trainingAgeSpecialism");
+
+        AssertEx.JsonObjectEquals(
+            new
+            {
+                type = "Range",
+                from = 11,
+                to = 18
+            },
+            responseTrainingAgeSpecialism);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithNonRangeTrainingAgeSpecialism_OmitsFromAndTo()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithRouteToProfessionalStatus(r => r
+                .WithRouteType(RouteToProfessionalStatusType.HeiProgrammeTypeId)
+                .WithStatus(RouteToProfessionalStatusStatus.InTraining)
+                .WithTrainingAgeSpecialismType(TrainingAgeSpecialismType.KeyStage1)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/v3/persons/{person.Trn}?include=RoutesToProfessionalStatuses");
+
+        // Act
+        var response = await GetHttpClientWithApiKey().SendAsync(request);
+
+        // Assert
+        var jsonResponse = await AssertEx.JsonResponseAsync(response);
+        var responseRoutes = jsonResponse.RootElement.GetProperty("routesToProfessionalStatuses");
+        var responseTrainingAgeSpecialism = responseRoutes.EnumerateArray().Single().GetProperty("trainingAgeSpecialism");
+
+        Assert.Equal("KeyStage1", responseTrainingAgeSpecialism.GetProperty("type").GetString());
+        Assert.False(responseTrainingAgeSpecialism.TryGetProperty("from", out _));
+        Assert.False(responseTrainingAgeSpecialism.TryGetProperty("to", out _));
     }
 
     [Fact]


### PR DESCRIPTION
https://github.com/DFE-Digital/teaching-record-team-project-board/issues/357

### Context

The 20250627 GET person mapping dropped the range values: the route result carried only the specialism type and the response DTO factory hardcoded From/To to Option.None, so trainingAgeSpecialism serialised as { "type": "Range" } with no from/to for every route. The SET path stores the values; they were only lost on read.

Check a teacher's record renders "<from> to <to> years" whenever the type is Range, so users saw "[Blank] to [Blank] years" (raised as teaching-record-team-project-board#357).

### Changes proposed in this pull request

- Update TrainingAgeSpecialism to accept From and To for age ranges.

### Guidance to review

- Verify specs are passing
- Check response against Swagger docs

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally