### PR TITLE
Add support task detail view

### DIFF
--- a/docs/process-type-events.md
+++ b/docs/process-type-events.md
@@ -331,6 +331,13 @@ Support UI *Add note* (support task).
 | --- | --- | --- |
 | `SupportTaskNoteCreatedEvent` | Always | — |
 
+### `SupportTaskAllocating` (62)
+Support UI *Allocate* (support task) — sets the status and assigned user.
+
+| Event | Emitted | Scenario |
+| --- | --- | --- |
+| `SupportTaskUpdatedEvent` | Always | — |
+
 ---
 
 ## Notes

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -34,6 +34,9 @@ public class SupportTask
 
     public T GetData<T>() where T : ISupportTaskData => (T)Data;
 
+    public string GetSubject() => SubjectName ??
+        SubjectEmailAddress ?? throw new InvalidOperationException($"Subject has not been set.");
+
     public sealed record Subject
     {
         private Subject(string? name, string? emailAddress)

--- a/src/TeachingRecordSystem.Core/Events/SupportTaskUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/SupportTaskUpdatedEvent.cs
@@ -24,5 +24,6 @@ public enum SupportTaskUpdatedEventChanges
     None = 0,
     Status = 1 << 0,
     Data = 1 << 1,
-    ResolveJourneySavedState = 1 << 2
+    ResolveJourneySavedState = 1 << 2,
+    AssignedToUserId = 1 << 3
 }

--- a/src/TeachingRecordSystem.Core/Models/ProcessType.cs
+++ b/src/TeachingRecordSystem.Core/Models/ProcessType.cs
@@ -60,5 +60,6 @@ public enum ProcessType
     ChangeOfDateOfBirthRequestRejecting = 58,
     ChangeOfNameRequestCancelling = 59,
     ChangeOfDateOfBirthRequestCancelling = 60,
-    SupportTaskNoteCreating = 61
+    SupportTaskNoteCreating = 61,
+    SupportTaskAllocating = 62
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/AllocateSupportTaskOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/AllocateSupportTaskOptions.cs
@@ -1,0 +1,8 @@
+namespace TeachingRecordSystem.Core.Services.SupportTasks;
+
+public record AllocateSupportTaskOptions
+{
+    public required string SupportTaskReference { get; init; }
+    public required SupportTaskStatus Status { get; init; }
+    public required Guid? AssignToUserId { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
@@ -89,6 +89,50 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
             });
     }
 
+    public async Task<bool> AllocateSupportTaskAsync(AllocateSupportTaskOptions options, ProcessContext processContext)
+    {
+        await using var eventScope = eventPublisher.GetOrCreateEventScope(processContext);
+
+        var supportTask = await dbContext.SupportTasks.FindOrThrowAsync(options.SupportTaskReference);
+
+        if (supportTask.Status is SupportTaskStatus.Closed)
+        {
+            throw new InvalidOperationException("Support task is closed.");
+        }
+
+        var oldSupportTaskEventModel = EventModels.SupportTask.FromModel(supportTask);
+
+        supportTask.Status = options.Status;
+        supportTask.AssignedToUserId = options.AssignToUserId;
+
+        var changes = SupportTaskUpdatedEventChanges.None |
+            (supportTask.Status != oldSupportTaskEventModel.Status ? SupportTaskUpdatedEventChanges.Status : 0) |
+            (supportTask.AssignedToUserId != oldSupportTaskEventModel.AssignedToUserId ? SupportTaskUpdatedEventChanges.AssignedToUserId : 0);
+
+        if (changes is not SupportTaskUpdatedEventChanges.None)
+        {
+            supportTask.UpdatedOn = processContext.Now;
+
+            await dbContext.SaveChangesAsync();
+
+            await eventScope.PublishEventAsync(
+                new SupportTaskUpdatedEvent
+                {
+                    EventId = Guid.NewGuid(),
+                    SupportTaskReference = supportTask.SupportTaskReference,
+                    Changes = changes,
+                    OldSupportTask = oldSupportTaskEventModel,
+                    SupportTask = EventModels.SupportTask.FromModel(supportTask),
+                    Comments = null,
+                    RejectionReason = null
+                });
+
+            return true;
+        }
+
+        return false;
+    }
+
     public Task UpdateSupportTaskAsync(UpdateSupportTaskOptions options, ProcessContext processContext)
     {
         return UpdateSupportTaskCoreAsync(options, updateAction: null, processContext);

--- a/src/TeachingRecordSystem.SupportUi/AllowClosedSupportTaskAttribute.cs
+++ b/src/TeachingRecordSystem.SupportUi/AllowClosedSupportTaskAttribute.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace TeachingRecordSystem.SupportUi;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class AllowClosedSupportTaskAttribute : Attribute, IPageApplicationModelConvention
+{
+    public void Apply(PageApplicationModel model)
+    {
+        model.EndpointMetadata.Add(AllowClosedSupportTaskMetadata.Instance);
+    }
+}
+
+public sealed class AllowClosedSupportTaskMetadata
+{
+    private AllowClosedSupportTaskMetadata() { }
+
+    public static AllowClosedSupportTaskMetadata Instance { get; } = new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckSupportTaskExistsFilter.cs
+++ b/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckSupportTaskExistsFilter.cs
@@ -17,6 +17,11 @@ public class CheckSupportTaskExistsFilter(TrsDbContext dbContext, bool excludeCl
 
         _ = Transaction.Current ?? throw new InvalidOperationException("A TransactionScope is required.");
 
+        if (context.ActionDescriptor.EndpointMetadata.Any(e => e is AllowClosedSupportTaskMetadata))
+        {
+            excludeClosed = false;
+        }
+
         var currentSupportTaskQuery = dbContext.SupportTasks
             .FromSql($"select * from support_tasks where support_task_reference = {supportTaskReference} for update");  // https://github.com/dotnet/efcore/issues/26042
 
@@ -46,6 +51,10 @@ public class CheckSupportTaskExistsFilter(TrsDbContext dbContext, bool excludeCl
             currentSupportTaskQuery = currentSupportTaskQuery
                 .Include(t => t.Person);
         }
+
+        currentSupportTaskQuery = currentSupportTaskQuery
+            .Include(t => t.AssignedTo)
+            .Include(t => t.CompletedBy);
 
         var currentSupportTask = await currentSupportTaskQuery.SingleOrDefaultAsync();
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/AddNote.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/AddNote.cshtml.cs
@@ -26,6 +26,7 @@ public class AddNote(NoteService noteService, SupportUiLinkGenerator linkGenerat
                 .WithMessage($"The selected file {UiDefaults.MaxFileUploadSizeErrorMessage}")
                 .When(m => m.File is not null)
     };
+
     [FromRoute]
     public Guid PersonId { get; set; }
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/AddNote.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/AddNote.cshtml
@@ -11,15 +11,15 @@
             <span class="govuk-caption-l">@Model.SupportTaskTypeTitle</span>
             <span class="govuk-caption-m">@Model.SupportTaskReference</span>
 
-            <govuk-character-count for="Content" max-words="@SupportTaskNote.ContentMaxLength" data-testid="text">
-                <govuk-character-count-label class="govuk-label--l" is-page-heading="true">Add a note</govuk-character-count-label>
-            </govuk-character-count>
+            <govuk-textarea for="Content" max-length="@SupportTaskNote.ContentMaxLength" data-testid="text">
+                <govuk-textarea-label class="govuk-label--l" is-page-heading="true">Add a note</govuk-textarea-label>
+            </govuk-textarea>
 
             <p class="govuk-hint">Your note will be saved to the task.</p>
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Save note</govuk-button>
-                <govuk-button-link href="@LinkGenerator.SupportTaskDetail(Model.SupportTaskReference, Model.SupportTaskType)" class="govuk-button--secondary">Cancel</govuk-button-link>
+                <govuk-button-link href="@LinkGenerator.SupportTasks.SupportTaskDetail.Index(Model.SupportTaskReference)" class="govuk-button--secondary">Cancel</govuk-button-link>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/AddNote.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/AddNote.cshtml.cs
@@ -49,7 +49,9 @@ public class AddNote(
             },
             processContext);
 
-        return Redirect(linkGenerator.SupportTaskDetail(SupportTaskReference, SupportTaskType));
+        TempData.SetFlashNotificationBanner("Note added");
+
+        return Redirect(linkGenerator.SupportTasks.SupportTaskDetail.Index(SupportTaskReference, expandNotes: true));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml
@@ -1,0 +1,178 @@
+@page "/support-tasks/{supportTaskReference}"
+@using Microsoft.AspNetCore.Html
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.SupportTaskDetail.Index
+@{
+    ViewBag.Title = $"{Model.Subject} {Model.SupportTaskReference}";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="#TODO" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form method="post">
+            <span class="govuk-caption-m">Manage task</span>
+
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+                @Model.Subject<br/>
+                @Model.SupportTaskReference
+            </h1>
+
+            @{
+                var linksBuilder = new HtmlContentBuilder();
+            }
+
+            @if (Model.IsOutstanding)
+            {
+                <capture-content to="linksBuilder">
+                    <a href="@LinkGenerator.SupportTaskResolve(Model.SupportTaskReference, Model.SupportTaskType)" class="govuk-link">View task</a>
+                </capture-content>
+            }
+
+            @if (Model.Subject is not null)
+            {
+                if (linksBuilder.Count > 0)
+                {
+                    <capture-content to="linksBuilder">
+                        <span class="trs-link-separator" aria-hidden="true">｜</span>
+                    </capture-content>
+                }
+
+                <capture-content to="linksBuilder">
+                    <a href="@Model.SubjectLink" target="_blank" class="govuk-link">@Model.SubjectLinkText (opens in a new tab)</a>
+                </capture-content>
+            }
+
+            @if (linksBuilder.Count > 0)
+            {
+                <div class="govuk-!-margin-bottom-6">
+                    @linksBuilder
+                </div>
+            }
+        </form>
+    </div>
+
+    @if (Model.IsOutstanding)
+    {
+        <div class="govuk-grid-column-full">
+            <form method="post">
+                <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Overview</h2>
+
+                <div class="trs-support-task__overview-actions">
+                    <govuk-select for="AssignedToUserId">
+                        <govuk-select-label>Assigned to</govuk-select-label>
+                        <govuk-select-item value=""></govuk-select-item>
+                        @foreach (var option in Model.AssignToOptions!)
+                        {
+                            <govuk-select-item value="@option.UserId">@option.Name</govuk-select-item>
+                        }
+                    </govuk-select>
+
+                    <govuk-select for="Status">
+                        <govuk-select-label>Status</govuk-select-label>
+                        <govuk-select-item value="@SupportTaskStatus.Open">Not started</govuk-select-item>
+                        <govuk-select-item value="@SupportTaskStatus.InProgress">In progress</govuk-select-item>
+                    </govuk-select>
+                </div>
+
+                <div class="govuk-button-group">
+                    <govuk-button type="submit">Update details</govuk-button>
+                    <govuk-button-link href="@LinkGenerator.SupportTasks.SupportTaskDetail.Index(Model.SupportTaskReference)"
+                                       class="govuk-button--secondary">
+                        Cancel
+                    </govuk-button-link>
+                </div>
+            </form>
+        </div>
+
+        <div class="govuk-grid-column-full trs-task-detail__section">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Notes</h2>
+
+            <p class="govuk-body">View and add notes related to this task.</p>
+
+            <govuk-details open="@Model.ExpandNotes">
+                <govuk-details-summary>View notes</govuk-details-summary>
+                <govuk-details-text>
+                    <div class="moj-timeline">
+                        @foreach (var note in Model.Notes!)
+                        {
+                            <timeline-entry title="Note added" by="@note.CreatedBy" timestamp="@note.CreatedOn.ToGmt()">
+                                @note.Content
+                            </timeline-entry>
+                        }
+                    </div>
+                </govuk-details-text>
+            </govuk-details>
+
+            <govuk-button-link href="@LinkGenerator.SupportTasks.SupportTaskDetail.AddNote(Model.SupportTaskReference)"
+                               class="govuk-button--secondary">
+                Add a note
+            </govuk-button-link>
+        </div>
+
+        <div class="govuk-grid-column-full trs-task-detail__section">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Zendesk tickets</h2>
+
+            <p class="govuk-body">View and add Zendesk tickets related to this task.</p>
+
+            <govuk-details>
+                <govuk-details-summary>View tickets</govuk-details-summary>
+                <govuk-details-text>
+                    TODO
+                </govuk-details-text>
+            </govuk-details>
+
+            <govuk-button class="govuk-button--secondary">Add a Zendesk ticket</govuk-button>
+        </div>
+
+        <div class="govuk-grid-column-full trs-task-detail__section">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-2">History</h2>
+
+            <govuk-details>
+                <govuk-details-summary>View activity</govuk-details-summary>
+                <govuk-details-text>
+                    TODO
+                </govuk-details-text>
+            </govuk-details>
+        </div>
+    }
+    else
+    {
+        <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Key task details</h2>
+
+            <govuk-summary-list>
+                <row>
+                    <key>Outcome</key>
+                    <value>
+                        <govuk-tag class="govuk-tag--green">@Model.OutcomeLabel</govuk-tag>
+                    </value>
+                </row>
+                <row>
+                    <key>Type</key>
+                    <value>@Model.SupportTaskTypeTitle</value>
+                </row>
+                <row>
+                    <key>Completed on</key>
+                    <value>@Model.CompletedOn?.ToString(DateDisplayFormat)</value>
+                </row>
+                <row>
+                    <key>Completed by</key>
+                    <value>@Model.CompletedByUserName</value>
+                </row>
+                <row>
+                    <key>Zendesk tickets</key>
+                    <value>
+                        TODO
+                    </value>
+                </row>
+            </govuk-summary-list>
+
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Task history</h2>
+
+            <div class="moj-timeline">
+            </div>
+        </div>
+    }
+</div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml.cs
@@ -1,0 +1,128 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.SupportTasks;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.SupportTaskDetail;
+
+[AllowClosedSupportTask]
+public class Index(
+    SupportTaskService supportTaskService,
+    TrsDbContext dbContext,
+    TimeProvider timeProvider,
+    SupportUiLinkGenerator linkGenerator) :
+    PageModel
+{
+    private SupportTask? _supportTask;
+
+    [FromRoute]
+    public string SupportTaskReference { get; set; } = null!;
+
+    public string? Subject { get; set; }
+
+    public SupportTaskType SupportTaskType { get; set; }
+
+    public string? SupportTaskTypeTitle { get; set; }
+
+    public string? SubjectLink { get; set; }
+
+    public string? SubjectLinkText { get; set; }
+
+    public bool IsOutstanding { get; set; }
+
+    public string? OutcomeLabel { get; set; }
+
+    public DateTime? CompletedOn { get; set; }
+
+    public string? CompletedByUserName { get; set; }
+
+    public IReadOnlyCollection<Note>? Notes { get; set; }
+
+    [BindProperty]
+    public Guid? AssignedToUserId { get; set; }
+
+    [BindProperty]
+    public SupportTaskStatus Status { get; set; }
+
+    [FromQuery]
+    public bool ExpandNotes { get; set; }
+
+    public IReadOnlyCollection<AssignToOption>? AssignToOptions { get; set; }
+
+    public void OnGet()
+    {
+        AssignedToUserId = _supportTask!.AssignedToUserId;
+        Status = _supportTask.Status;
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!_supportTask!.IsOutstanding)
+        {
+            return BadRequest();
+        }
+
+        // Belt & braces check that status and user assignments are valid
+        if (Status is not SupportTaskStatus.InProgress and not SupportTaskStatus.Open ||
+            AssignedToUserId is not null && !AssignToOptions!.Any(o => o.UserId == AssignedToUserId))
+        {
+            return BadRequest();
+        }
+
+        var processContext = new ProcessContext(ProcessType.SupportTaskAllocating, timeProvider.UtcNow, User.GetUserId());
+
+        var updated = await supportTaskService.AllocateSupportTaskAsync(
+            new AllocateSupportTaskOptions
+            {
+                SupportTaskReference = SupportTaskReference,
+                Status = Status,
+                AssignToUserId = AssignedToUserId
+            },
+            processContext);
+
+        if (updated)
+        {
+            TempData.SetFlashNotificationBanner("Task updated");
+        }
+
+        return Redirect(linkGenerator.SupportTasks.SupportTaskDetail.Index(SupportTaskReference));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        _supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+
+        Subject = _supportTask.GetSubject();
+        SupportTaskType = _supportTask.SupportTaskType;
+        SupportTaskTypeTitle = _supportTask.SupportTaskType.GetTitle();
+        IsOutstanding = _supportTask.IsOutstanding;
+        OutcomeLabel = _supportTask.OutcomeLabel;
+        CompletedOn = _supportTask.CompletedOn;
+        CompletedByUserName = _supportTask.CompletedBy?.Name;
+
+        (SubjectLink, SubjectLinkText) = _supportTask.PersonId is Guid personId ? (linkGenerator.Persons.PersonDetail.Index(personId), "View record") :
+            _supportTask.TrnRequestMetadata?.ResolvedPersonId is Guid resolvedPersonId ? (linkGenerator.Persons.PersonDetail.Index(resolvedPersonId), "View record") :
+            _supportTask.OneLoginUserSubject is string oneLoginUserSubject ? (linkGenerator.OneLogins.OneLoginDetail.Index(oneLoginUserSubject), "View One Login") :
+            (null, null);
+
+        Notes = await dbContext.SupportTaskNotes
+            .Where(t => t.SupportTaskReference == SupportTaskReference)
+            .OrderByDescending(t => t.CreatedOn)
+            .Select(t => new Note(t.Content, t.CreatedOn, t.CreatedBy!.Name))
+            .ToArrayAsync();
+
+        AssignToOptions = await dbContext.Users
+            .Where(u => u.Role == UserRoles.AccessManager || u.Role == UserRoles.RecordManager)
+            .OrderBy(u => u.Name)
+            .Select(u => new AssignToOption(u.UserId, u.Name))
+            .ToArrayAsync();
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+    }
+
+    public record AssignToOption(Guid UserId, string Name);
+
+    public record Note(string Content, DateTime CreatedOn, string CreatedBy);
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/SupportTaskDetailLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/SupportTaskDetailLinkGenerator.cs
@@ -2,6 +2,9 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.SupportTaskDetail;
 
 public class SupportTaskDetailLinkGenerator(LinkGenerator linkGenerator)
 {
+    public string Index(string supportTaskReference, bool? expandNotes = null) =>
+        linkGenerator.GetRequiredPathByPage("/SupportTasks/SupportTaskDetail/Index", routeValues: new { supportTaskReference, expandNotes });
+
     public string Events(string supportTaskReference) =>
         linkGenerator.GetRequiredPathByPage("/SupportTasks/SupportTaskDetail/Events", routeValues: new { supportTaskReference });
 

--- a/src/TeachingRecordSystem.SupportUi/Styles/app.scss
+++ b/src/TeachingRecordSystem.SupportUi/Styles/app.scss
@@ -503,3 +503,37 @@
     }
   }
 }
+
+.trs-link-separator {
+  color: var(--govuk-link-colour, #1a65a6);
+  font-weight: bold;
+  user-select: none;
+  cursor: default;
+}
+
+.trs-task-detail__section {
+  @extend .govuk-\!-margin-top-6;
+  border-bottom: 1px solid var(--govuk-border-colour, #cecece);
+}
+
+.trs-support-task__overview-actions {
+  margin-bottom: 30px;
+
+  >* {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--govuk-border-colour, #cecece);
+    margin-bottom: 0 !important;
+
+    .govuk-label {
+      width: 30%;
+      margin-bottom: 5px;
+      font-weight: 700;
+      padding: 10px 20px 10px 0;
+    }
+
+    .govuk-select {
+      margin: 10px 20px 10px 0;
+    }
+  }
+}

--- a/src/TeachingRecordSystem.SupportUi/SupportUiLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/SupportUiLinkGenerator.cs
@@ -27,7 +27,7 @@ public class SupportUiLinkGenerator(LinkGenerator linkGenerator)
     public string SignedOut() =>
         linkGenerator.GetRequiredPathByPage("/SignedOut");
 
-    public string SupportTaskDetail(string supportTaskReference, SupportTaskType supportTaskType) =>
+    public string SupportTaskResolve(string supportTaskReference, SupportTaskType supportTaskType) =>
         supportTaskType switch
         {
             SupportTaskType.OneLoginUserRecordMatching => SupportTasks.OneLoginUserMatching.Resolve.Index(supportTaskReference),

--- a/src/TeachingRecordSystem.SupportUi/TagHelpers/CaptureContentTagHelper.cs
+++ b/src/TeachingRecordSystem.SupportUi/TagHelpers/CaptureContentTagHelper.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TeachingRecordSystem.SupportUi.TagHelpers;
+
+public class CaptureContentTagHelper : TagHelper
+{
+    public IHtmlContentBuilder? To { get; set; }
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        if (To is null)
+        {
+            throw new InvalidOperationException("To must be specified.");
+        }
+
+        var content = await output.GetChildContentAsync();
+
+        if (!content.IsEmptyOrWhiteSpace)
+        {
+            To.AppendHtml(content);
+        }
+
+        output.TagName = null;
+    }
+}

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/SupportTaskServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/SupportTaskServiceTests.cs
@@ -535,5 +535,131 @@ public class SupportTaskServiceTests(ServiceFixture fixture) : ServiceTestBase(f
         });
     }
 
+    [Fact]
+    public async Task AllocateSupportTaskAsync_TaskDoesNotExist_ReturnsNotFoundAndDoesNotPublishEvent()
+    {
+        // Arrange
+        var options = new AllocateSupportTaskOptions
+        {
+            SupportTaskReference = "ABC-123",
+            Status = SupportTaskStatus.InProgress,
+            AssignToUserId = null
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => WithServiceAsync<SupportTaskService>(
+            service => service.AllocateSupportTaskAsync(options, processContext)));
+
+        // Assert
+        Assert.IsType<NotFoundException>(ex);
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task AllocateSupportTaskAsync_TaskIsAlreadyClosed_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            person.PersonId,
+            t => t.WithStatus(SupportTaskStatus.Closed));
+
+        var options = new AllocateSupportTaskOptions
+        {
+            SupportTaskReference = supportTask.SupportTaskReference,
+            Status = SupportTaskStatus.InProgress,
+            AssignToUserId = null
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => WithServiceAsync<SupportTaskService>(
+            service => service.AllocateSupportTaskAsync(options, processContext)));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(ex);
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task AllocateSupportTaskAsync_ChangesStatusAndAssignedUser_UpdatesTaskAndPublishesEvent()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(person.PersonId);
+        Debug.Assert(supportTask.Status is SupportTaskStatus.Open);
+        Debug.Assert(supportTask.AssignedToUserId is null);
+        var user = await TestData.CreateUserAsync();
+
+        var options = new AllocateSupportTaskOptions
+        {
+            SupportTaskReference = supportTask.SupportTaskReference,
+            Status = SupportTaskStatus.InProgress,
+            AssignToUserId = user.UserId
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var result = await WithServiceAsync<SupportTaskService, bool>(service => service.AllocateSupportTaskAsync(options, processContext));
+
+        // Assert
+        Assert.True(result);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbSupportTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(options.Status, dbSupportTask.Status);
+            Assert.Equal(user.UserId, dbSupportTask.AssignedToUserId);
+            Assert.Equal(TimeProvider.UtcNow, dbSupportTask.UpdatedOn);
+        });
+
+        Events.AssertEventsPublished(e =>
+        {
+            var supportTaskUpdatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+            Assert.Equal(supportTask.SupportTaskReference, supportTaskUpdatedEvent.SupportTaskReference);
+            Assert.Equal(user.UserId, supportTaskUpdatedEvent.SupportTask.AssignedToUserId);
+            Assert.Equal(
+                SupportTaskUpdatedEventChanges.Status | SupportTaskUpdatedEventChanges.AssignedToUserId,
+                supportTaskUpdatedEvent.Changes);
+        });
+    }
+
+    [Fact]
+    public async Task AllocateSupportTaskAsync_NoChanges_DoesNotPublishEventOrSetUpdatedOn()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(person.PersonId);
+        Debug.Assert(supportTask.AssignedToUserId is null);
+        TimeProvider.Advance(TimeSpan.FromDays(1));
+
+        var options = new AllocateSupportTaskOptions
+        {
+            SupportTaskReference = supportTask.SupportTaskReference,
+            Status = supportTask.Status,
+            AssignToUserId = supportTask.AssignedToUserId
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var result = await WithServiceAsync<SupportTaskService, bool>(service => service.AllocateSupportTaskAsync(options, processContext));
+
+        // Assert
+        Assert.False(result);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbSupportTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(supportTask.CreatedOn, dbSupportTask.UpdatedOn);
+        });
+
+        Events.AssertNoEventsPublished();
+    }
+
     private record DummyJourneyState;
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/AddNoteTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/AddNoteTests.cs
@@ -103,6 +103,36 @@ public class AddNoteTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
+    public async Task Post_ValidContent_RedirectsToDetailWithNotesExpandedAndShowsFlashMessage()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTrnRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTask.SupportTaskReference}/notes/add")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "Content", Faker.Lorem.Paragraph() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var location = response.Headers.Location?.OriginalString;
+        Assert.NotNull(location);
+        Assert.StartsWith($"/support-tasks/{supportTask.SupportTask.SupportTaskReference}", location);
+        Assert.Contains("xpandNotes=True", location);
+
+        var nextPage = await response.FollowRedirectAsync(HttpClient);
+        var nextPageDoc = await nextPage.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, "Note added");
+    }
+
+    [Fact]
     public async Task Post_MaxLengthContent_CreatesNoteSuccessfully()
     {
         // Arrange

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/IndexTests.cs
@@ -1,0 +1,350 @@
+using AngleSharp.Html.Dom;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.SupportTaskDetail;
+
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_TaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/NON-EXISTENT");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_OutstandingTask_DisplaysOverviewFormAndNotesSection()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        Assert.NotNull(doc.GetElementById("AssignedToUserId"));
+        Assert.NotNull(doc.GetElementById("Status"));
+        Assert.Contains(supportTask.SupportTaskReference, doc.Body!.TextContent);
+        Assert.Contains(supportTask.GetSubject(), doc.Body!.TextContent);
+    }
+
+    [Fact]
+    public async Task Get_OutstandingTask_PreSelectsAssignedUserAndStatus()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            dbTask.AssignedToUserId = user.UserId;
+            dbTask.Status = SupportTaskStatus.InProgress;
+            await dbContext.SaveChangesAsync();
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var assignedToSelect = (IHtmlSelectElement)doc.GetElementById("AssignedToUserId")!;
+        Assert.Equal(user.UserId.ToString(), assignedToSelect.Value);
+
+        var statusSelect = (IHtmlSelectElement)doc.GetElementById("Status")!;
+        Assert.Equal(SupportTaskStatus.InProgress.ToString(), statusSelect.Value);
+    }
+
+    [Fact]
+    public async Task Get_AssignToOptions_OnlyIncludesAccessManagerAndRecordManagerUsers()
+    {
+        // Arrange
+        var recordManager = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        var accessManager = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
+        var administrator = await TestData.CreateUserAsync(role: UserRoles.Administrator);
+
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var optionValues = ((IHtmlSelectElement)doc.GetElementById("AssignedToUserId")!)
+            .Options
+            .Select(o => o.Value)
+            .ToArray();
+
+        Assert.Contains(recordManager.UserId.ToString(), optionValues);
+        Assert.Contains(accessManager.UserId.ToString(), optionValues);
+        Assert.DoesNotContain(administrator.UserId.ToString(), optionValues);
+    }
+
+    [Fact]
+    public async Task Get_OutstandingTask_DisplaysNotesInDescendingCreatedOrder()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var olderContent = "This is the older note";
+        var newerContent = "This is the newer note";
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            dbContext.SupportTaskNotes.Add(new SupportTaskNote
+            {
+                SupportTaskNoteId = Guid.NewGuid(),
+                SupportTaskReference = supportTask.SupportTaskReference,
+                Content = olderContent,
+                CreatedOn = TimeProvider.UtcNow,
+                CreatedByUserId = GetCurrentUserId()
+            });
+            dbContext.SupportTaskNotes.Add(new SupportTaskNote
+            {
+                SupportTaskNoteId = Guid.NewGuid(),
+                SupportTaskReference = supportTask.SupportTaskReference,
+                Content = newerContent,
+                CreatedOn = TimeProvider.UtcNow.AddMinutes(1),
+                CreatedByUserId = GetCurrentUserId()
+            });
+            await dbContext.SaveChangesAsync();
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        var bodyText = doc.Body!.TextContent;
+
+        Assert.Contains(olderContent, bodyText);
+        Assert.Contains(newerContent, bodyText);
+        Assert.True(bodyText.IndexOf(newerContent, StringComparison.Ordinal) < bodyText.IndexOf(olderContent, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_ExpandNotesQueryParameter_ControlsWhetherNotesAreExpanded(bool expandNotes)
+    {
+        // Arrange
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTaskReference}?ExpandNotes={expandNotes}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var details = doc.QuerySelector(".govuk-details");
+        Assert.NotNull(details);
+        Assert.Equal(expandNotes, details.HasAttribute("open"));
+    }
+
+    [Fact]
+    public async Task Get_ClosedTask_DisplaysKeyTaskDetailsAndNotOverviewForm()
+    {
+        // Arrange
+        var completedOn = TimeProvider.UtcNow;
+        var (supportTask, completedByUser) = await CreateClosedSupportTaskAsync(outcomeLabel: "Approved", completedOn: completedOn);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        // The overview form is only shown for outstanding tasks
+        Assert.Null(doc.GetElementById("Status"));
+        Assert.Null(doc.GetElementById("AssignedToUserId"));
+
+        var summaryList = doc.QuerySelector(".govuk-summary-list");
+        Assert.NotNull(summaryList);
+        Assert.Equal("Approved", summaryList.GetSummaryListValueByKey("Outcome"));
+        Assert.Equal(supportTask.SupportTaskType.GetTitle(), summaryList.GetSummaryListValueByKey("Type"));
+        Assert.Equal(completedOn.ToString(WebConstants.DateDisplayFormat), summaryList.GetSummaryListValueByKey("Completed on"));
+        Assert.Equal(completedByUser.Name, summaryList.GetSummaryListValueByKey("Completed by"));
+    }
+
+    [Fact]
+    public async Task Post_ValidChanges_UpdatesTaskPublishesEventAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignedToUserId", user.UserId.ToString() },
+                { "Status", SupportTaskStatus.InProgress.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/support-tasks/{supportTask.SupportTaskReference}", response.Headers.Location?.OriginalString);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskStatus.InProgress, dbTask.Status);
+            Assert.Equal(user.UserId, dbTask.AssignedToUserId);
+        });
+
+        Events.AssertProcessesCreated(p =>
+        {
+            Assert.Equal(ProcessType.SupportTaskAllocating, p.ProcessContext.ProcessType);
+            Assert.Collection(p.Events, e =>
+            {
+                var updatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.Equal(supportTask.SupportTaskReference, updatedEvent.SupportTaskReference);
+                Assert.Equal(user.UserId, updatedEvent.SupportTask.AssignedToUserId);
+                Assert.Equal(
+                    SupportTaskUpdatedEventChanges.Status | SupportTaskUpdatedEventChanges.AssignedToUserId,
+                    updatedEvent.Changes);
+            });
+        });
+
+        var nextPage = await response.FollowRedirectAsync(HttpClient);
+        var nextPageDoc = await nextPage.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, "Task updated");
+    }
+
+    [Fact]
+    public async Task Post_NoChanges_RedirectsWithoutPublishingEvent()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignedToUserId", "" },
+                { "Status", SupportTaskStatus.Open.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/support-tasks/{supportTask.SupportTaskReference}", response.Headers.Location?.OriginalString);
+
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task Post_ClosedTask_ReturnsBadRequest()
+    {
+        // Arrange
+        var (supportTask, _) = await CreateClosedSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignedToUserId", "" },
+                { "Status", SupportTaskStatus.InProgress.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task Post_InvalidStatus_ReturnsBadRequest()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignedToUserId", "" },
+                { "Status", SupportTaskStatus.Closed.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task Post_AssignedUserNotInOptions_ReturnsBadRequest()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignedToUserId", Guid.NewGuid().ToString() },
+                { "Status", SupportTaskStatus.InProgress.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        Events.AssertNoEventsPublished();
+    }
+
+    private async Task<(SupportTask SupportTask, User CompletedByUser)> CreateClosedSupportTaskAsync(string outcomeLabel = "Approved", DateTime? completedOn = null)
+    {
+        var completedByUser = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            configure: b => b.WithStatus(SupportTaskStatus.Closed));
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            dbTask.OutcomeLabel = outcomeLabel;
+            dbTask.CompletedOn = completedOn ?? TimeProvider.UtcNow;
+            dbTask.CompletedByUserId = completedByUser.UserId;
+            await dbContext.SaveChangesAsync();
+        });
+
+        return (supportTask, completedByUser);
+    }
+}


### PR DESCRIPTION
Also tweaks the Add Note page for tasks a little to redirect to this page, add a flash message and remove the character count UI.

There are some TODOs left here that are waiting on other pages being in place.

Closes https://github.com/DFE-Digital/teaching-record-team-project-board/issues/334