### PR TITLE
Fix empty labels on search tabs

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
@@ -18,11 +18,8 @@
                         <div class="govuk-!-margin-bottom-4">
                             <govuk-input name="Search" data-testid="search-input" type="search" autocomplete="off">
                                 <govuk-input-label>
-                                    <span class="govuk-visually-hidden">Search</span>
-                                </govuk-input-label>
-                                <govuk-input-hint>
                                     Enter a name, email address, date of birth or TRN
-                                </govuk-input-hint>
+                                </govuk-input-label>
                                 <govuk-input-after-input>
                                     <govuk-button class="govuk-!-margin-bottom-0 govuk-!-margin-left-2 trs-!-height-full" type="submit">Search</govuk-button>
                                 </govuk-input-after-input>
@@ -42,13 +39,10 @@
                 <div class="govuk-!-margin-bottom-6">
                     <form action="@LinkGenerator.OneLogins.Index()" method="get" asp-antiforgery="false" data-testid="search-form-onelogin">
                         <div class="govuk-!-margin-bottom-4">
-                            <govuk-input name="Search" data-testid="search-input-onelogin" type="search" autocomplete="off">
+                            <govuk-input name="Search" id="OneLoginSearch" data-testid="search-input-onelogin" type="search" autocomplete="off">
                                 <govuk-input-label>
-                                    <span class="govuk-visually-hidden">Search</span>
-                                </govuk-input-label>
-                                <govuk-input-hint>
                                     Enter a GOV.UK One Login email address, name, date of birth or TRN
-                                </govuk-input-hint>
+                                </govuk-input-label>
                                 <govuk-input-after-input>
                                     <govuk-button class="govuk-!-margin-bottom-0 govuk-!-margin-left-2 trs-!-height-full" type="submit">Search</govuk-button>
                                 </govuk-input-after-input>


### PR DESCRIPTION
We shouldn't have empty labels.

Also fixes issue where both search inputs had the same ID, so clicking the label on the second tab wasn't focussing the correct input.