### PR TITLE
Page for support task zendesk tickets

### DIFF
--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
@@ -47,5 +47,9 @@ public class SupportTaskMapping : IEntityTypeConfiguration<SupportTask>
             .HasMethod("GIN")
             .UseCollation(Collations.CaseInsensitive)
             .IsCreatedConcurrently();
+        builder
+            .Property(x => x.ZendeskTickets)
+            .HasColumnType("varchar[]")
+            .HasDefaultValueSql("'{}'::varchar[]");
     }
 }

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260715082342_SupportTaskZendeskTickets.Designer.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260715082342_SupportTaskZendeskTickets.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeachingRecordSystem.Core.DataStore.Postgres;
@@ -13,9 +14,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(TrsDbContext))]
-    partial class TrsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715082342_SupportTaskZendeskTickets")]
+    partial class SupportTaskZendeskTickets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260715082342_SupportTaskZendeskTickets.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Migrations/20260715082342_SupportTaskZendeskTickets.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeachingRecordSystem.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SupportTaskZendeskTickets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string[]>(
+                name: "zendesk_tickets",
+                table: "support_tasks",
+                type: "varchar[]",
+                nullable: false,
+                defaultValueSql: "'{}'::varchar[]");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "zendesk_tickets",
+                table: "support_tasks");
+        }
+    }
+}

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Models/SupportTask.cs
@@ -28,6 +28,7 @@ public class SupportTask
     public required ISupportTaskData Data { get; set; }
     public SavedJourneyState? ResolveJourneySavedState { get; set; }
     public string? OutcomeLabel { get; set; }
+    public string[] ZendeskTickets { get; set; } = Array.Empty<string>();
 
     [Projectable]
     public bool IsOutstanding => Status != SupportTaskStatus.Closed;

--- a/src/TeachingRecordSystem.Core/Events/Models/SupportTask.cs
+++ b/src/TeachingRecordSystem.Core/Events/Models/SupportTask.cs
@@ -13,6 +13,7 @@ public record SupportTask
     public required SavedJourneyState? ResolveJourneySavedState { get; init; }
     public required Guid? AssignedToUserId { get; init; }
     public required string? OutcomeLabel { get; init; }
+    public required string[] ZendeskTickets { get; init; }
 
     public static SupportTask FromModel(DataStore.Postgres.Models.SupportTask model) => new()
     {
@@ -24,6 +25,7 @@ public record SupportTask
         Data = model.Data,
         ResolveJourneySavedState = model.ResolveJourneySavedState,
         AssignedToUserId = model.AssignedToUserId,
-        OutcomeLabel = model.OutcomeLabel
+        OutcomeLabel = model.OutcomeLabel,
+        ZendeskTickets = model.ZendeskTickets
     };
 }

--- a/src/TeachingRecordSystem.Core/Events/SupportTaskUpdatedEvent.cs
+++ b/src/TeachingRecordSystem.Core/Events/SupportTaskUpdatedEvent.cs
@@ -25,5 +25,6 @@ public enum SupportTaskUpdatedEventChanges
     Status = 1 << 0,
     Data = 1 << 1,
     ResolveJourneySavedState = 1 << 2,
-    AssignedToUserId = 1 << 3
+    AssignedToUserId = 1 << 3,
+    ZendeskTicketUrls = 1 << 4
 }

--- a/src/TeachingRecordSystem.Core/Models/ProcessType.cs
+++ b/src/TeachingRecordSystem.Core/Models/ProcessType.cs
@@ -62,5 +62,6 @@ public enum ProcessType
     ChangeOfDateOfBirthRequestCancelling = 60,
     SupportTaskNoteCreating = 61,
     SupportTaskAllocating = 62,
-    SupportTasksAssigning = 63
+    SupportTasksAssigning = 63,
+    SupportTaskZendeskUrlsUpdating = 64
 }

--- a/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0112_SupportTaskZendeskColumn.sql
+++ b/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0112_SupportTaskZendeskColumn.sql
@@ -1,0 +1,1 @@
+alter table trs_support_tasks add zendesk_tickets nvarchar(max)

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
@@ -302,6 +302,33 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
                 });
         }
     }
+
+    public async Task UpdateZendeskUrlsAsync(string supportTaskReference, string[] zendeskUrls, ProcessContext processContext)
+    {
+        var supportTask = await dbContext.SupportTasks.FindOrThrowAsync(supportTaskReference);
+
+        var oldSupportTaskEventModel = EventModels.SupportTask.FromModel(supportTask);
+
+        supportTask.UpdatedOn = processContext.Now;
+        supportTask.ZendeskTickets = zendeskUrls
+            .Where(ticket => !string.IsNullOrEmpty(ticket))
+            .ToArray();
+
+        await dbContext.SaveChangesAsync();
+
+        await eventPublisher.PublishSingleEventAsync(
+            new SupportTaskUpdatedEvent
+            {
+                EventId = Guid.NewGuid(),
+                SupportTaskReference = supportTaskReference,
+                Changes = SupportTaskUpdatedEventChanges.ZendeskTicketUrls,
+                SupportTask = EventModels.SupportTask.FromModel(supportTask),
+                OldSupportTask = oldSupportTaskEventModel,
+                Comments = null,
+                RejectionReason = null
+            },
+            processContext);
+    }
 }
 
 public record AssignableUserInfo(Guid UserId, string UserName);

--- a/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -125,6 +125,7 @@
     <None Remove="Services\DqtReporting\Migrations\0109_UserLastSignedInUtc.sql" />
     <None Remove="Services\DqtReporting\Migrations\0110_ProcessReferences.sql" />
     <None Remove="Services\DqtReporting\Migrations\0111_SupportTaskColumns.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0112_SupportTaskZendeskColumn.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -289,6 +290,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0109_UserLastSignedInUtc.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0110_ProcessReferences.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0111_SupportTaskColumns.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0112_SupportTaskZendeskColumn.sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml
@@ -1,0 +1,106 @@
+@page "/support-tasks/{supportTaskReference}/zendesk-tickets"
+@using TeachingRecordSystem.Core.DataStore.Postgres.Models
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.SupportTaskDetail.ZendeskTickets
+
+@{
+    ViewBag.Title = "Zendesk tickets";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <form method="post">
+            <span class="govuk-caption-l">@Model.SupportTaskTypeTitle</span>
+            <span class="govuk-caption-m">@Model.SupportTaskReference</span>
+
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+                Add a Zendesk ticket
+            </h1>
+
+            <table class="govuk-table trs-table-layout-fixed">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">
+                            Link to ticket
+                        </th>
+                        <th scope="col" class="govuk-table__header trs-!-width-200">
+                            Action
+                        </th>
+                    </tr>
+                </thead>
+
+                <tbody class="govuk-table__body">
+                    @if (Model.TicketUrls is null || Model.TicketUrls.Count == 0)
+                    {
+                        <tr class="govuk-table__row" data-testid="no-tickets">
+                            <td class="govuk-table__cell" colspan="2">
+                                No tickets added
+                            </td>
+                        </tr>
+                    }
+                    else
+                    {
+                        @for (var i = 0; i < Model.TicketUrls.Count; i++)
+                        {
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <govuk-input
+                                        data-testid="zendesk-ticket-@i"
+                                        for="TicketUrls[@i]"
+                                        type="url">
+                                        <govuk-input-label class="govuk-label--s">
+                                            <span class="govuk-visually-hidden">Zendesk URL</span>
+                                        </govuk-input-label>
+                                    </govuk-input>
+                                </td>
+
+                                <td class="govuk-table__cell govuk-!-text-align-right">
+                                    <govuk-button
+                                        type="submit"
+                                        asp-page-handler="RemoveTicket"
+                                        asp-route-removeIndex="@i"
+                                        class="govuk-button--secondary"
+                                        data-testid="remove-ticket-@i">
+                                        Remove
+                                    </govuk-button>
+
+                                    <span class="trs-link-separator" aria-hidden="true">｜</span>
+
+                                    <a
+                                        href="@Model.TicketUrls[i]"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="govuk-link">
+                                        View ticket
+                                    </a>
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+
+            <div class="govuk-!-margin-top-4">
+                <govuk-button
+                    type="submit"
+                    asp-page-handler="AddTicket"
+                    class="govuk-button--secondary">
+                    Add another
+                </govuk-button>
+            </div>
+
+            <div class="govuk-button-group govuk-!-margin-top-4">
+                <govuk-button
+                    type="submit"
+                    asp-page-handler="Save">
+                    Continue
+                </govuk-button>
+
+                <govuk-button-link
+                    href="@LinkGenerator.SupportTasks.SupportTaskDetail.Index(Model.SupportTaskReference)"
+                    class="govuk-button--secondary">
+                    Cancel
+                </govuk-button-link>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml.cs
@@ -1,0 +1,120 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.SupportTasks;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.SupportTaskDetail;
+
+public class ZendeskTickets(
+    TimeProvider timeProvider,
+    SupportUiLinkGenerator linkGenerator,
+    SupportTaskService supportTaskService) : PageModel
+{
+    private readonly InlineValidator<ZendeskTickets> _validator = new()
+    {
+        v => v.RuleForEach(m => m.TicketUrls!)
+            .Must(ticket =>
+                string.IsNullOrWhiteSpace(ticket) ||
+                IsValidZendeskUrl(ticket))
+            .WithMessage("Enter a valid Zendesk URL")
+            .When(m => m.TicketUrls is not null)
+    };
+
+    [FromRoute] public string SupportTaskReference { get; set; } = null!;
+
+    public string SupportTaskTypeTitle { get; set; } = null!;
+
+    public SupportTaskType SupportTaskType { get; set; }
+
+    [BindProperty] public List<string>? TicketUrls { get; set; }
+
+    private SupportTask? _supportTask { get; set; }
+
+    public void OnGet()
+    {
+        var supportTask = HttpContext
+            .GetCurrentSupportTaskFeature()
+            .SupportTask;
+
+        TicketUrls = supportTask.ZendeskTickets?.ToList() ?? [];
+    }
+
+    public override void OnPageHandlerExecuting(
+        PageHandlerExecutingContext context)
+    {
+        _supportTask = HttpContext
+            .GetCurrentSupportTaskFeature()
+            .SupportTask;
+
+        SupportTaskType = _supportTask.SupportTaskType;
+        SupportTaskTypeTitle = _supportTask.SupportTaskType.GetTitle();
+    }
+
+    public IActionResult OnPostAddTicket()
+    {
+        TicketUrls ??= [];
+        TicketUrls.Add(string.Empty);
+
+        return Page();
+    }
+
+    public IActionResult OnPostRemoveTicket(int removeIndex)
+    {
+        TicketUrls ??= [];
+
+        if (removeIndex >= 0 && removeIndex < TicketUrls.Count)
+        {
+            TicketUrls.RemoveAt(removeIndex);
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        await _validator.ValidateAndThrowAsync(this);
+
+        var processContext = new ProcessContext(ProcessType.SupportTaskZendeskUrlsUpdating, timeProvider.UtcNow, SystemUser.SystemUserId);
+
+        await supportTaskService.UpdateZendeskUrlsAsync(SupportTaskReference, TicketUrls?.ToArray() ?? [], processContext);
+
+        TempData.SetFlashNotificationBanner(
+            "Zendesk tickets updated");
+
+        return Redirect(
+            linkGenerator.SupportTasks.SupportTaskDetail.Index(
+                SupportTaskReference));
+    }
+
+    private static bool IsValidZendeskUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (!string.Equals(
+                uri.Scheme,
+                Uri.UriSchemeHttps,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!uri.Host.EndsWith(
+                "zendesk.com",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !string.IsNullOrEmpty(uri.AbsolutePath)
+               && uri.AbsolutePath != "/";
+    }
+}

--- a/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/SupportTaskEventPipelineTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/EventPipelineTests/SupportTaskEventPipelineTests.cs
@@ -22,6 +22,7 @@ public class SupportTaskEventPipelineTests(EventPipelineFixture fixture) : Event
                 Status = SupportTaskStatus.Open,
                 OneLoginUserSubject = null,
                 PersonId = Guid.NewGuid(),
+                ZendeskTickets = [],
                 Data = new ChangeDateOfBirthRequestData
                 {
                     DateOfBirth = new(2000, 1, 1),
@@ -32,7 +33,7 @@ public class SupportTaskEventPipelineTests(EventPipelineFixture fixture) : Event
                 },
                 ResolveJourneySavedState = null,
                 AssignedToUserId = null,
-                OutcomeLabel = null
+                OutcomeLabel = null,
             }
         };
 
@@ -48,7 +49,21 @@ public class SupportTaskEventPipelineTests(EventPipelineFixture fixture) : Event
             {
                 var legacyEvent = Assert.IsType<LegacyEvents.SupportTaskCreatedEvent>(e);
                 Assert.Equal(@event.EventId, legacyEvent.EventId);
-                Assert.Equal(@event.SupportTask, legacyEvent.SupportTask);
+                Assert.Equal(@event.EventId, legacyEvent.EventId);
+
+                Assert.Equal(@event.SupportTask.SupportTaskReference, legacyEvent.SupportTask.SupportTaskReference);
+                Assert.Equal(@event.SupportTask.SupportTaskType, legacyEvent.SupportTask.SupportTaskType);
+                Assert.Equal(@event.SupportTask.Status, legacyEvent.SupportTask.Status);
+                Assert.Equal(@event.SupportTask.OneLoginUserSubject, legacyEvent.SupportTask.OneLoginUserSubject);
+                Assert.Equal(@event.SupportTask.PersonId, legacyEvent.SupportTask.PersonId);
+                Assert.Equal(@event.SupportTask.Data, legacyEvent.SupportTask.Data);
+                Assert.Equal(@event.SupportTask.ResolveJourneySavedState, legacyEvent.SupportTask.ResolveJourneySavedState);
+                Assert.Equal(@event.SupportTask.AssignedToUserId, legacyEvent.SupportTask.AssignedToUserId);
+                Assert.Equal(@event.SupportTask.OutcomeLabel, legacyEvent.SupportTask.OutcomeLabel);
+                Assert.Equal(@event.SupportTask.ZendeskTickets, legacyEvent.SupportTask.ZendeskTickets);
+                Assert.Equal(processContext.Now, legacyEvent.CreatedUtc);
+                Assert.Equal(@event.PersonId, legacyEvent.PersonId.ToNullable());
+
                 Assert.Equal(processContext.Now, legacyEvent.CreatedUtc);
                 Assert.Equal(@event.PersonId, legacyEvent.PersonId.ToNullable());
             });

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogApiTrnRequestSupportTaskUpdatedEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogApiTrnRequestSupportTaskUpdatedEventTests.cs
@@ -257,7 +257,8 @@ public class ChangeLogApiTrnRequestSupportTaskUpdatedEventTests : TestBase
             Data = new TrnRequestData(),
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = "Resolved"
+            OutcomeLabel = "Resolved",
+            ZendeskTickets = []
         };
 
         var oldSupportTask = new EventModels.SupportTask
@@ -270,7 +271,8 @@ public class ChangeLogApiTrnRequestSupportTaskUpdatedEventTests : TestBase
             Data = new TrnRequestData(),
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = null
+            OutcomeLabel = null,
+            ZendeskTickets = []
         };
 
         var requestData = new EventModels.TrnRequestMetadata

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogChangeNameOrDobRequestEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogChangeNameOrDobRequestEventTests.cs
@@ -37,7 +37,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeNameRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = null
+            OutcomeLabel = null,
+            ZendeskTickets = []
         };
         var supportTask = new SupportTask
         {
@@ -49,7 +50,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeNameRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = "Approved"
+            OutcomeLabel = "Approved",
+            ZendeskTickets = []
         };
 
         var updatedEvent = new ChangeNameRequestSupportTaskApprovedEvent()
@@ -144,7 +146,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeNameRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = null
+            OutcomeLabel = null,
+            ZendeskTickets = []
         };
         var supportTask = new SupportTask
         {
@@ -156,7 +159,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeNameRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = "Rejected"
+            OutcomeLabel = "Rejected",
+            ZendeskTickets = []
         };
 
         var updatedEvent = new ChangeNameRequestSupportTaskRejectedEvent()
@@ -225,7 +229,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeDateOfBirthRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = null
+            OutcomeLabel = null,
+            ZendeskTickets = []
         };
         var supportTask = new SupportTask
         {
@@ -237,7 +242,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeDateOfBirthRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = "Approved"
+            OutcomeLabel = "Approved",
+            ZendeskTickets = []
         };
 
         var updatedEvent = new ChangeDateOfBirthRequestSupportTaskApprovedEvent()
@@ -323,7 +329,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeDateOfBirthRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = null
+            OutcomeLabel = null,
+            ZendeskTickets = []
         };
         var supportTask = new SupportTask
         {
@@ -335,7 +342,8 @@ public class ChangeLogChangeNameOrDobRequestEventTests(HostFixture hostFixture) 
             SupportTaskType = SupportTaskType.ChangeDateOfBirthRequest,
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = "Rejected"
+            OutcomeLabel = "Rejected",
+            ZendeskTickets = []
         };
 
         var updatedEvent = new ChangeDateOfBirthRequestSupportTaskRejectedEvent()

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogNpqTrnRequestSupportTaskUpdatedEventTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ChangeLogNpqTrnRequestSupportTaskUpdatedEventTests.cs
@@ -321,7 +321,8 @@ public class ChangeLogNpqTrnRequestSupportTaskResolvedEventTests : TestBase
             Data = new NpqTrnRequestData(),
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = "Resolved"
+            OutcomeLabel = "Resolved",
+            ZendeskTickets = []
         };
 
         var oldSupportTask = new EventModels.SupportTask
@@ -334,7 +335,8 @@ public class ChangeLogNpqTrnRequestSupportTaskResolvedEventTests : TestBase
             Data = new NpqTrnRequestData(),
             ResolveJourneySavedState = null,
             AssignedToUserId = null,
-            OutcomeLabel = null
+            OutcomeLabel = null,
+            ZendeskTickets = []
         };
 
         var requestData = new EventModels.TrnRequestMetadata

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/ZendeskTicketsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/ZendeskTicketsTests.cs
@@ -1,0 +1,410 @@
+using Optional;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.SupportTaskDetail;
+
+public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_ValidSupportTask_DisplaysForm()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTrnRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTask.SupportTaskReference}/zendesk-tickets");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_NoZendeskTickets_ShowsNoTicketsAdded()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(
+            personId: null,
+            email: Option.Some<string?>(TestData.GenerateUniqueEmail()),
+            verifiedInfo: null);
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var document = await AssertEx.HtmlResponseAsync(response);
+
+        var noTickets = document.GetElementByTestId("no-tickets");
+
+        Assert.NotNull(noTickets);
+        Assert.Equal("No tickets added", noTickets.TrimmedText());
+    }
+
+    [Fact]
+    public async Task Post_ZendeskTicketUrlIsEmpty_IsExcludedFromSave()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTrnRequestSupportTaskAsync();
+        var ticketUrl1 = "https://example.zendesk.com/agent/tickets/123";
+        var ticketUrl2 = "https://example.zendesk.com/agent/tickets/456";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls[0]", "" },
+                { "TicketUrls[1]", ticketUrl2 }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTask.SupportTaskReference));
+
+        Assert.NotNull(updatedSupportTask);
+        Assert.DoesNotContain(ticketUrl1, updatedSupportTask.ZendeskTickets);
+        Assert.Contains(ticketUrl2, updatedSupportTask.ZendeskTickets);
+    }
+
+    [Fact]
+    public async Task Post_AddTicket_AddsEmptyTicketInput()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTrnRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTask.SupportTaskReference}/zendesk-tickets?handler=AddTicket")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var document = await AssertEx.HtmlResponseAsync(response);
+
+        var ticketInput = document.QuerySelector(
+            "input[name='TicketUrls[0]']");
+
+        Assert.NotNull(ticketInput);
+    }
+
+    [Fact]
+    public async Task Post_ValidTickets_UpdatesSupportTask()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTrnRequestSupportTaskAsync();
+
+        var ticketUrl1 = "https://example.zendesk.com/agent/tickets/123";
+        var ticketUrl2 = "https://example.zendesk.com/agent/tickets/456";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls[0]", ticketUrl1 },
+                { "TicketUrls[1]", ticketUrl2 }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+        var redirectResponse = await response.FollowRedirectAsync(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocumentAsync();
+
+        // Assert
+        AssertEx.HtmlDocumentHasFlashNotificationBanner(redirectDoc, "Zendesk tickets updated");
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTask.SupportTaskReference));
+
+        Assert.Equal(
+            [ticketUrl1, ticketUrl2],
+            updatedSupportTask.ZendeskTickets);
+
+        Events.AssertProcessesCreated(x =>
+        {
+            Assert.Equal(ProcessType.SupportTaskZendeskUrlsUpdating, x.ProcessContext.ProcessType);
+            Assert.Collection(x.Events, e =>
+            {
+                var supportTaskZendeskEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.NotNull(supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.NotNull(supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+                Assert.Contains(ticketUrl1, supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.Contains(ticketUrl2, supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_ExistingTicketIsUpdated_UpdatesSupportTask()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(personId: null, email: Option.Some<string?>(TestData.GenerateUniqueEmail()), verifiedInfo: null);
+        var existingTicketUrl =
+            "https://example.zendesk.com/agent/tickets/123";
+
+        var updatedTicketUrl =
+            "https://example.zendesk.com/agent/tickets/456";
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser1.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId)
+                    .WithZendeskTickets(existingTicketUrl));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls[0]", updatedTicketUrl }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTaskReference));
+
+        Assert.Equal(
+            [updatedTicketUrl],
+            updatedSupportTask.ZendeskTickets);
+
+        Events.AssertProcessesCreated(x =>
+        {
+            Assert.Equal(ProcessType.SupportTaskZendeskUrlsUpdating, x.ProcessContext.ProcessType);
+            Assert.Collection(x.Events, e =>
+            {
+                var supportTaskZendeskEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.NotNull(supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.Contains(updatedTicketUrl, supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.NotNull(supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+                Assert.Contains(existingTicketUrl, supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_RemoveAllTickets_UpdatesSupportTask()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(
+            personId: null,
+            email: Option.Some<string?>(TestData.GenerateUniqueEmail()),
+            verifiedInfo: null);
+
+        var existingTicketUrl1 =
+            "https://example.zendesk.com/agent/tickets/123";
+        var existingTicketUrl2 =
+            "https://example.zendesk.com/agent/tickets/123";
+
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser1.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId)
+                    .WithZendeskTickets(existingTicketUrl1)
+                    .WithZendeskTickets(existingTicketUrl2));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls[0]", "" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTaskReference));
+
+        Assert.Empty(updatedSupportTask.ZendeskTickets);
+
+        Events.AssertProcessesCreated(x =>
+        {
+            Assert.Equal(ProcessType.SupportTaskZendeskUrlsUpdating, x.ProcessContext.ProcessType);
+            Assert.Collection(x.Events, e =>
+            {
+                var supportTaskZendeskEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.NotNull(supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.NotNull(supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+                Assert.Empty(supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.Contains(existingTicketUrl1, supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+                Assert.Contains(existingTicketUrl2, supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_ExistingTicketsAreUpdated_UpdatesSupportTask()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(
+            personId: null,
+            email: Option.Some<string?>(TestData.GenerateUniqueEmail()),
+            verifiedInfo: null);
+
+        var existingTicketUrl =
+            "https://example.zendesk.com/agent/tickets/123";
+
+        var updatedTicketUrl1 =
+            "https://example.zendesk.com/agent/tickets/456";
+
+        var updatedTicketUrl2 =
+            "https://example.zendesk.com/agent/tickets/789";
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser1.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId)
+                    .WithZendeskTickets(existingTicketUrl));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls[0]", updatedTicketUrl1 },
+                { "TicketUrls[1]", updatedTicketUrl2 }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTaskReference));
+
+        Assert.Equal(
+            [updatedTicketUrl1, updatedTicketUrl2],
+            updatedSupportTask.ZendeskTickets);
+
+        Events.AssertProcessesCreated(x =>
+        {
+            Assert.Equal(ProcessType.SupportTaskZendeskUrlsUpdating, x.ProcessContext.ProcessType);
+            Assert.Collection(x.Events, e =>
+            {
+                var supportTaskZendeskEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.NotNull(supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.NotNull(supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+                Assert.Contains(updatedTicketUrl1, supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.Contains(updatedTicketUrl2, supportTaskZendeskEvent.SupportTask.ZendeskTickets);
+                Assert.Contains(existingTicketUrl, supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_OneTicketIsInvalid_ReturnsError()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(
+            personId: null,
+            email: Option.Some<string?>(TestData.GenerateUniqueEmail()),
+            verifiedInfo: null);
+
+        var ticketUrl1 =
+            "https://example.zendesk.com/agent/tickets/123";
+
+        var ticketUrl2 =
+            "https://example.zendesk.com/agent/tickets/456";
+
+        var invalidTicketUrl =
+            "https://example.com/tickets/789";
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser1.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls[0]", ticketUrl1 },
+                { "TicketUrls[1]", ticketUrl2 },
+                { "TicketUrls[2]", invalidTicketUrl }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasErrorAsync(
+            response,
+            "TicketUrls_2_",
+            "Enter a valid Zendesk URL");
+    }
+}

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeDateOfBirthRequestSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeDateOfBirthRequestSupportTask.cs
@@ -37,6 +37,7 @@ public partial class TestData
         private Option<SupportTaskStatus> _status;
         private Option<DateTime> _createdOn;
         private bool _hasEmailAddress = true;
+        private Option<string[]> _zendeskTickets;
 
         public CreateChangeDateOfBirthRequestSupportTaskBuilder WithDateOfBirth(DateOnly dateOfBirth)
         {
@@ -85,6 +86,13 @@ public partial class TestData
             return this;
         }
 
+        public CreateChangeDateOfBirthRequestSupportTaskBuilder WithZendeskTickets(
+            params string[] zendeskTickets)
+        {
+            _zendeskTickets = Option.Some(zendeskTickets);
+            return this;
+        }
+
         public Task<SupportTask> ExecuteAsync(TestData testData) => testData.WithDbContextAsync(async dbContext =>
         {
             var dateOfBirth = _dateOfBirth.ValueOr(testData.GenerateDateOfBirth);
@@ -93,6 +101,7 @@ public partial class TestData
             var emailAddress = _hasEmailAddress ? _emailAddress.ValueOr(testData.GenerateUniqueEmail) : null;
             var status = _status.ValueOr(SupportTaskStatus.Open);
             var createdOn = _createdOn.ValueOr(testData.TimeProvider.UtcNow).ToUniversalTime();
+            var zendeskTickets = _zendeskTickets.ValueOr([]);
 
             var person = await dbContext.Persons.FindAsync(personId) ??
                 throw new InvalidOperationException("Person does not exist.");
@@ -115,7 +124,8 @@ public partial class TestData
                 },
                 PersonId = personId,
                 SubjectName = subject.Name,
-                SubjectEmailAddress = subject.EmailAddress
+                SubjectEmailAddress = subject.EmailAddress,
+                ZendeskTickets = zendeskTickets
             };
 
             dbContext.SupportTasks.Add(supportTask);

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeNameRequestSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateChangeNameRequestSupportTask.cs
@@ -39,6 +39,7 @@ public partial class TestData
         private Option<SupportTaskStatus> _status;
         private Option<DateTime> _createdOn;
         private bool _hasEmailAddress = true;
+        private Option<string[]> _zendeskTickets;
 
         public CreateChangeNameRequestSupportTaskBuilder WithFirstName(string firstName)
         {
@@ -103,6 +104,13 @@ public partial class TestData
             return this;
         }
 
+        public CreateChangeNameRequestSupportTaskBuilder WithZendeskTickets(
+            params string[] zendeskTickets)
+        {
+            _zendeskTickets = Option.Some(zendeskTickets);
+            return this;
+        }
+
         public Task<SupportTask> ExecuteAsync(TestData testData) => testData.WithDbContextAsync(async dbContext =>
         {
             var firstName = _firstName.ValueOr(testData.GenerateFirstName);
@@ -113,6 +121,7 @@ public partial class TestData
             var emailAddress = _hasEmailAddress ? _emailAddress.ValueOr(testData.GenerateUniqueEmail) : null;
             var status = _status.ValueOr(SupportTaskStatus.Open);
             var createdOn = _createdOn.ValueOr(testData.TimeProvider.UtcNow).ToUniversalTime();
+            var zendeskTickets = _zendeskTickets.ValueOr([]);
 
             var person = await dbContext.Persons.FindAsync(personId) ??
                 throw new InvalidOperationException("Person does not exist.");
@@ -137,7 +146,8 @@ public partial class TestData
                 },
                 PersonId = personId,
                 SubjectName = subject.Name,
-                SubjectEmailAddress = subject.EmailAddress
+                SubjectEmailAddress = subject.EmailAddress,
+                ZendeskTickets = zendeskTickets
             };
 
             dbContext.SupportTasks.Add(supportTask);

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUserRecordMatchingSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUserRecordMatchingSupportTask.cs
@@ -28,6 +28,7 @@ public partial class TestData
         private Option<SupportTaskStatus> _status;
         private Option<DateTime> _createdOn;
         private Option<string> _trnRequestId;
+        private Option<string[]> _zendeskTickets;
 
         public CreateOneLoginUserRecordMatchingSupportTaskBuilder WithEmailAddress(string emailAddress)
         {
@@ -89,6 +90,13 @@ public partial class TestData
             return this;
         }
 
+        public CreateOneLoginUserRecordMatchingSupportTaskBuilder WithZendeskTickets(
+            params string[] zendeskTickets)
+        {
+            _zendeskTickets = Option.Some(zendeskTickets);
+            return this;
+        }
+
         public Task<SupportTask> ExecuteAsync(TestData testData) =>
             testData.WithDbContextAsync(async dbContext =>
             {
@@ -100,6 +108,7 @@ public partial class TestData
                 var trnTokenTrn = _trnTokenTrn.ValueOrDefault();
                 var status = _status.ValueOr(SupportTaskStatus.Open);
                 var createdOn = _createdOn.ValueOr(testData.TimeProvider.UtcNow);
+                var zendeskTickets = _zendeskTickets.ValueOr([]);
 
                 Guid clientApplicationUserId;
                 string? trnRequestId = _trnRequestId.ValueOrDefault();
@@ -189,6 +198,7 @@ public partial class TestData
                     TrnRequestId = trnRequestId,
                     SubjectName = subject.Name,
                     SubjectEmailAddress = subject.EmailAddress,
+                    ZendeskTickets = zendeskTickets
                 };
 
                 dbContext.SupportTasks.Add(supportTask);

--- a/tests/TeachingRecordSystem.TestCommon/TestData.OneLoginUserIdVerificationSupportTask.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.OneLoginUserIdVerificationSupportTask.cs
@@ -31,6 +31,7 @@ public partial class TestData
         private Option<SupportTaskStatus> _status;
         private Option<DateTime> _createdOn;
         private Option<string> _trnRequestId;
+        private Option<string[]> _zendeskTickets;
 
         public CreateOneLoginUserIdVerificationSupportTaskBuilder WithEmailAddress(string emailAddress)
         {
@@ -110,6 +111,13 @@ public partial class TestData
             return this;
         }
 
+        public CreateOneLoginUserIdVerificationSupportTaskBuilder WithZendeskTickets(
+            params string[] zendeskTickets)
+        {
+            _zendeskTickets = Option.Some(zendeskTickets);
+            return this;
+        }
+
         public Task<SupportTask> ExecuteAsync(TestData testData) =>
             testData.WithDbContextAsync(async dbContext =>
             {
@@ -124,6 +132,7 @@ public partial class TestData
                 var trnTokenTrn = _trnTokenTrn.ValueOrDefault();
                 var status = _status.ValueOr(SupportTaskStatus.Open);
                 var createdOn = _createdOn.ValueOr(testData.TimeProvider.UtcNow);
+                var zendeskTickets = _zendeskTickets.ValueOr([]);
 
                 Guid clientApplicationUserId;
                 string? trnRequestId = _trnRequestId.ValueOrDefault();
@@ -212,7 +221,8 @@ public partial class TestData
                     },
                     OneLoginUserSubject = oneLoginUserSubject,
                     SubjectName = subject.Name,
-                    SubjectEmailAddress = subject.EmailAddress
+                    SubjectEmailAddress = subject.EmailAddress,
+                    ZendeskTickets = zendeskTickets
                 };
 
                 dbContext.SupportTasks.Add(supportTask);


### PR DESCRIPTION
### Context

new page to manage zendesk support urls

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/336

### Changes proposed in this pull request

-  Added new column to store array of zendesk urls to support tasks.
- Updated test helpers to seed a support task zendesk url
- added page
- added tests
- add column to reporting database.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally