### PR TITLE
Add DqtReporting migration for new support task columns

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0111_SupportTaskColumns.sql
+++ b/src/TeachingRecordSystem.Core/Services/DqtReporting/Migrations/0111_SupportTaskColumns.sql
@@ -1,0 +1,7 @@
+alter table trs_support_tasks add assigned_to_user_id uniqueidentifier
+alter table trs_support_tasks add completed_by_user_id uniqueidentifier
+alter table trs_support_tasks add completed_on datetime
+alter table trs_support_tasks add outcome_label nvarchar(200)
+alter table trs_support_tasks add subject_email_address nvarchar(200)
+alter table trs_support_tasks add subject_name nvarchar(max)
+alter table trs_support_tasks add subject_names nvarchar(max)

--- a/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
+++ b/src/TeachingRecordSystem.Core/TeachingRecordSystem.Core.csproj
@@ -124,6 +124,7 @@
     <None Remove="Services\DqtReporting\Migrations\0108_UserAppContent.sql" />
     <None Remove="Services\DqtReporting\Migrations\0109_UserLastSignedInUtc.sql" />
     <None Remove="Services\DqtReporting\Migrations\0110_ProcessReferences.sql" />
+    <None Remove="Services\DqtReporting\Migrations\0111_SupportTaskColumns.sql" />
   </ItemGroup>
 
   <ItemGroup>
@@ -287,6 +288,7 @@
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0108_UserAppContent.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0109_UserLastSignedInUtc.sql" />
     <EmbeddedResource Include="Services\DqtReporting\Migrations\0110_ProcessReferences.sql" />
+    <EmbeddedResource Include="Services\DqtReporting\Migrations\0111_SupportTaskColumns.sql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Context

[#3580](https://github.com/DFE-Digital/teaching-record-system/pull/3580) added subject, assignment, completion and outcome columns to the `support_tasks` table. Those columns are replicated to the DQT reporting database via the `dqt_rep_sync` publication, which is declared `FOR TABLE support_tasks` with no column list — so **every** physical column (including the trigger-populated `subject_names` search column) is streamed. The `trs_support_tasks` table in the reporting DB was missing these columns, so the replication upsert would fail with an "invalid column name" error, breaking replication for the whole table.

### Changes proposed in this pull request

- Added DqtReporting migration `0111_SupportTaskColumns.sql`, adding the seven new columns to `trs_support_tasks`:

  | Column | Postgres type | Reporting type |
  |---|---|---|
  | `assigned_to_user_id` | `uuid` | `uniqueidentifier` |
  | `completed_by_user_id` | `uuid` | `uniqueidentifier` |
  | `completed_on` | `timestamptz` | `datetime` |
  | `outcome_label` | `varchar(200)` | `nvarchar(200)` |
  | `subject_email_address` | `varchar(200)` | `nvarchar(200)` |
  | `subject_name` | `text` | `nvarchar(max)` |
  | `subject_names` | `varchar[]` | `nvarchar(max)` |

- Registered the migration as an embedded resource in `TeachingRecordSystem.Core.csproj`.

### Guidance to review

- Types follow the existing conventions in the reporting migrations: `uuid` → `uniqueidentifier` (cf. `person_id`), `timestamptz` → `datetime` (cf. `created_on`/`deleted_on`), and Postgres arrays → `nvarchar(max)` since they're JSON-serialised during replication (cf. `trs_users.api_roles`, `trs_persons.names`).
- `subject_names` is intentionally included even though it's a search-only column — the publication streams all physical columns, so it must exist in the target table to keep replication working.
- Cross-checked against `TrsDbContextModelSnapshot`: all 19 physical `support_tasks` columns are now present in `trs_support_tasks` (12 pre-existing + 7 added here), no gaps or duplicates.
- The newer `BackfillSupportTasksInReportingDb` job reads all Postgres columns dynamically, so it will populate these columns once they exist — no backfill code change required.
- Not an events change, so `docs/process-type-events.md` is unaffected.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [ ] Tested by running locally
