### PR TITLE
Move task creation and updates into type-specific services

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/Extensions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/Extensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using TeachingRecordSystem.Core.Services.SupportTasks.ChangeRequests;
 using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
+using TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
+using TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
 
 namespace TeachingRecordSystem.Core.Services.SupportTasks;
 
@@ -9,6 +11,8 @@ public static class Extensions
     public static IServiceCollection AddSupportTaskService(this IServiceCollection services)
     {
         services.AddTransient<SupportTaskService>();
+        // TrnRequestService depends on this, so it must be registered wherever SupportTaskService is.
+        services.AddTransient<TrnRequestSupportTaskService>();
 
         return services;
     }
@@ -18,6 +22,7 @@ public static class Extensions
         services.AddSupportTaskService();
         services.AddTransient<OneLoginUserMatchingSupportTaskService>();
         services.AddTransient<ChangeRequestSupportTaskService>();
+        services.AddTransient<TeacherPensionsSupportTaskService>();
 
         return services;
     }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/SaveSupportTaskProgressOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/SaveSupportTaskProgressOptions.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Services.SupportTasks;
+
+public record SaveSupportTaskProgressOptions
+{
+    public required string SupportTaskReference { get; init; }
+    public required SavedJourneyState SavedJourneyState { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
@@ -1,3 +1,4 @@
+using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
@@ -54,7 +55,7 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
         return note;
     }
 
-    public async Task<SupportTask> CreateSupportTaskAsync(CreateSupportTaskOptions options, ProcessContext processContext)
+    internal async Task<SupportTask> CreateSupportTaskAsync(CreateSupportTaskOptions options, ProcessContext processContext)
     {
         if (options.SupportTaskType.GetDataType() != options.Data.GetType())
         {
@@ -195,12 +196,12 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
         }
     }
 
-    public Task UpdateSupportTaskAsync(UpdateSupportTaskOptions options, ProcessContext processContext)
+    internal Task UpdateSupportTaskAsync(UpdateSupportTaskOptions options, ProcessContext processContext)
     {
         return UpdateSupportTaskCoreAsync(options, updateAction: null, processContext);
     }
 
-    public Task UpdateSupportTaskAsync<TData>(UpdateSupportTaskOptions<TData> options, ProcessContext processContext)
+    internal Task UpdateSupportTaskAsync<TData>(UpdateSupportTaskOptions<TData> options, ProcessContext processContext)
         where TData : ISupportTaskData, IEquatable<TData>
     {
         return UpdateSupportTaskCoreAsync(
@@ -221,7 +222,20 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
             processContext);
     }
 
-    public async Task UpdateSupportTaskCoreAsync(
+    public Task SaveProgressAsync(SaveSupportTaskProgressOptions options, ProcessContext processContext)
+    {
+        return UpdateSupportTaskCoreAsync(
+            new UpdateSupportTaskOptions
+            {
+                SupportTaskReference = options.SupportTaskReference,
+                Status = SupportTaskStatus.InProgress,
+                SavedJourneyState = Option.Some(options.SavedJourneyState)!
+            },
+            updateAction: null,
+            processContext);
+    }
+
+    private async Task UpdateSupportTaskCoreAsync(
         UpdateSupportTaskOptions options,
         Func<SupportTask, SupportTaskUpdatedEventChanges, SupportTaskUpdatedEventChanges>? updateAction,
         ProcessContext processContext)

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/ResolveTeacherPensionsPotentialDuplicateWithMergeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/ResolveTeacherPensionsPotentialDuplicateWithMergeOptions.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.Models.SupportTasks;
+
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
+
+public record ResolveTeacherPensionsPotentialDuplicateWithMergeOptions
+{
+    public required string SupportTaskReference { get; init; }
+    public required TeacherPensionsPotentialDuplicateAttributes? ResolvedAttributes { get; init; }
+    public required TeacherPensionsPotentialDuplicateAttributes? SelectedPersonAttributes { get; init; }
+    public string? Comments { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/ResolveTeacherPensionsPotentialDuplicateWithoutMergeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/ResolveTeacherPensionsPotentialDuplicateWithoutMergeOptions.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
+
+public record ResolveTeacherPensionsPotentialDuplicateWithoutMergeOptions
+{
+    public required string SupportTaskReference { get; init; }
+    public string? Comments { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/TeacherPensionsSupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/TeacherPensionsSupportTaskService.cs
@@ -1,0 +1,40 @@
+using TeachingRecordSystem.Core.Models.SupportTasks;
+
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
+
+public class TeacherPensionsSupportTaskService(SupportTaskService supportTaskService)
+{
+    public Task ResolveWithMergeAsync(
+        ResolveTeacherPensionsPotentialDuplicateWithMergeOptions options,
+        ProcessContext processContext) =>
+        supportTaskService.UpdateSupportTaskAsync<TeacherPensionsPotentialDuplicateData>(
+            new UpdateSupportTaskOptions<TeacherPensionsPotentialDuplicateData>
+            {
+                SupportTaskReference = options.SupportTaskReference,
+                UpdateData = data => data with
+                {
+                    ResolvedAttributes = options.ResolvedAttributes,
+                    SelectedPersonAttributes = options.SelectedPersonAttributes
+                },
+                Status = SupportTaskStatus.Closed,
+                Comments = options.Comments
+            },
+            processContext);
+
+    public Task ResolveWithoutMergeAsync(
+        ResolveTeacherPensionsPotentialDuplicateWithoutMergeOptions options,
+        ProcessContext processContext) =>
+        supportTaskService.UpdateSupportTaskAsync<TeacherPensionsPotentialDuplicateData>(
+            new UpdateSupportTaskOptions<TeacherPensionsPotentialDuplicateData>
+            {
+                SupportTaskReference = options.SupportTaskReference,
+                UpdateData = data => data with
+                {
+                    ResolvedAttributes = null,
+                    SelectedPersonAttributes = null
+                },
+                Status = SupportTaskStatus.Closed,
+                Comments = options.Comments
+            },
+            processContext);
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/CompleteManualChecksNeededSupportTaskOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/CompleteManualChecksNeededSupportTaskOptions.cs
@@ -1,0 +1,6 @@
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
+
+public record CompleteManualChecksNeededSupportTaskOptions
+{
+    public required string SupportTaskReference { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/CreateManualChecksNeededSupportTaskOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/CreateManualChecksNeededSupportTaskOptions.cs
@@ -1,0 +1,9 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
+
+public record CreateManualChecksNeededSupportTaskOptions
+{
+    public required Person Person { get; init; }
+    public required TrnRequestMetadata TrnRequest { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/CreateTrnRequestSupportTaskOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/CreateTrnRequestSupportTaskOptions.cs
@@ -1,0 +1,8 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
+
+public record CreateTrnRequestSupportTaskOptions
+{
+    public required TrnRequestMetadata TrnRequest { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/ResolveTrnRequestSupportTaskOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/ResolveTrnRequestSupportTaskOptions.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.Models.SupportTasks;
+
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
+
+public record ResolveTrnRequestSupportTaskOptions
+{
+    public required string SupportTaskReference { get; init; }
+    public required TrnRequestDataPersonAttributes? ResolvedAttributes { get; init; }
+    public required TrnRequestDataPersonAttributes? SelectedPersonAttributes { get; init; }
+    public string? Comments { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/TrnRequestSupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TrnRequests/TrnRequestSupportTaskService.cs
@@ -1,0 +1,66 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
+
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
+
+public class TrnRequestSupportTaskService(SupportTaskService supportTaskService)
+{
+    public Task<SupportTask> CreateTrnRequestSupportTaskAsync(
+        CreateTrnRequestSupportTaskOptions options,
+        ProcessContext processContext) =>
+        supportTaskService.CreateSupportTaskAsync(
+            new CreateSupportTaskOptions
+            {
+                SupportTaskType = SupportTaskType.TrnRequest,
+                Data = new TrnRequestData(),
+                PersonId = null,
+                OneLoginUserSubject = null,
+                TrnRequest = (options.TrnRequest.ApplicationUserId, options.TrnRequest.RequestId),
+                Subject = SupportTask.Subject.FromTrnRequest(options.TrnRequest)
+            },
+            processContext);
+
+    public Task<SupportTask> CreateManualChecksNeededSupportTaskAsync(
+        CreateManualChecksNeededSupportTaskOptions options,
+        ProcessContext processContext) =>
+        supportTaskService.CreateSupportTaskAsync(
+            new CreateSupportTaskOptions
+            {
+                SupportTaskType = SupportTaskType.TrnRequestManualChecksNeeded,
+                Data = new TrnRequestManualChecksNeededData(),
+                PersonId = options.Person.PersonId,
+                OneLoginUserSubject = null,
+                TrnRequest = (options.TrnRequest.ApplicationUserId, options.TrnRequest.RequestId),
+                Subject = SupportTask.Subject.FromPerson(options.Person)
+            },
+            processContext);
+
+    public Task ResolveTrnRequestSupportTaskAsync(
+        ResolveTrnRequestSupportTaskOptions options,
+        ProcessContext processContext) =>
+        supportTaskService.UpdateSupportTaskAsync<TrnRequestData>(
+            new UpdateSupportTaskOptions<TrnRequestData>
+            {
+                SupportTaskReference = options.SupportTaskReference,
+                UpdateData = data => data with
+                {
+                    ResolvedAttributes = options.ResolvedAttributes,
+                    SelectedPersonAttributes = options.SelectedPersonAttributes
+                },
+                Status = SupportTaskStatus.Closed,
+                Comments = options.Comments
+            },
+            processContext);
+
+    public Task CompleteManualChecksNeededSupportTaskAsync(
+        CompleteManualChecksNeededSupportTaskOptions options,
+        ProcessContext processContext) =>
+        supportTaskService.UpdateSupportTaskAsync<TrnRequestManualChecksNeededData>(
+            new UpdateSupportTaskOptions<TrnRequestManualChecksNeededData>
+            {
+                SupportTaskReference = options.SupportTaskReference,
+                UpdateData = data => data,
+                Status = SupportTaskStatus.Closed
+            },
+            processContext);
+}

--- a/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
+++ b/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
@@ -6,10 +6,9 @@ using NpgsqlTypes;
 using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.Core.Services.Persons;
-using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
 
 namespace TeachingRecordSystem.Core.Services.TrnRequests;
 
@@ -19,7 +18,7 @@ public class TrnRequestService(
     TrsDbContext dbContext,
     IEventPublisher eventPublisher,
     OneLoginService oneLoginService,
-    SupportTaskService supportTaskService,
+    TrnRequestSupportTaskService trnRequestSupportTaskService,
     PersonService personService,
     IOptions<AccessYourTeachingQualificationsOptions> aytqOptionsAccessor,
     IOptions<TrnRequestOptions> trnRequestOptionsAccessor)
@@ -216,15 +215,11 @@ public class TrnRequestService(
 
         if (furtherChecksNeeded)
         {
-            await supportTaskService.CreateSupportTaskAsync(
-                new CreateSupportTaskOptions
+            await trnRequestSupportTaskService.CreateManualChecksNeededSupportTaskAsync(
+                new CreateManualChecksNeededSupportTaskOptions
                 {
-                    SupportTaskType = SupportTaskType.TrnRequestManualChecksNeeded,
-                    Data = new TrnRequestManualChecksNeededData(),
-                    PersonId = person.PersonId,
-                    OneLoginUserSubject = null,
-                    TrnRequest = (trnRequest.ApplicationUserId, trnRequest.RequestId),
-                    Subject = SupportTask.Subject.FromPerson(person)
+                    Person = person,
+                    TrnRequest = trnRequest
                 },
                 processContext);
         }
@@ -750,15 +745,10 @@ public class TrnRequestService(
         {
             Debug.Assert(matchResult.Outcome is MatchPersonsResultOutcome.PotentialMatches);
 
-            await supportTaskService.CreateSupportTaskAsync(
-                new CreateSupportTaskOptions
+            await trnRequestSupportTaskService.CreateTrnRequestSupportTaskAsync(
+                new CreateTrnRequestSupportTaskOptions
                 {
-                    SupportTaskType = SupportTaskType.TrnRequest,
-                    Data = new TrnRequestData(),
-                    PersonId = null,
-                    OneLoginUserSubject = null,
-                    TrnRequest = (trnRequest.ApplicationUserId, trnRequest.RequestId),
-                    Subject = SupportTask.Subject.FromTrnRequest(trnRequest)
+                    TrnRequest = trnRequest
                 },
                 processContext);
         }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
@@ -93,12 +92,11 @@ public class Matches(
 
         var processContext = new ProcessContext(processType, timeProvider.UtcNow, User.GetUserId());
 
-        await supportTaskService.UpdateSupportTaskAsync(
+        await supportTaskService.SaveProgressAsync(
             new()
             {
                 SupportTaskReference = _supportTask.SupportTaskReference,
-                Status = SupportTaskStatus.InProgress,
-                SavedJourneyState = Option.Some(savedJourneyState)!
+                SavedJourneyState = savedJourneyState
             },
             processContext);
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
@@ -3,9 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using TeachingRecordSystem.Core.DataStore.Postgres;
-using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.Persons;
-using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 using TeachingRecordSystem.SupportUi.Services;
@@ -19,7 +18,7 @@ public class CheckAnswersModel(
     SupportUiLinkGenerator linkGenerator,
     TrnRequestService trnRequestService,
     PersonService personService,
-    SupportTaskService supportTaskService,
+    TeacherPensionsSupportTaskService teacherPensionsSupportTaskService,
     EvidenceUploadManager evidenceController,
     TimeProvider timeProvider,
     PersonChangeableAttributesService changedService) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
@@ -152,16 +151,12 @@ public class CheckAnswersModel(
             attributesToUpdate,
             processContext);
 
-        await supportTaskService.UpdateSupportTaskAsync(
-            new UpdateSupportTaskOptions<TeacherPensionsPotentialDuplicateData>
+        await teacherPensionsSupportTaskService.ResolveWithMergeAsync(
+            new()
             {
                 SupportTaskReference = SupportTaskReference,
-                UpdateData = data => data with
-                {
-                    ResolvedAttributes = resolvedPersonAttributes,
-                    SelectedPersonAttributes = selectedPersonAttributes
-                },
-                Status = SupportTaskStatus.Closed,
+                ResolvedAttributes = resolvedPersonAttributes,
+                SelectedPersonAttributes = selectedPersonAttributes,
                 Comments = MergeComments
             },
             processContext);

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason.cshtml.cs
@@ -1,8 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
-using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
@@ -12,7 +11,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Reso
 public class ConfirmKeepRecordSeparateReasonModel(
     TrsDbContext dbContext,
     TrnRequestService trnRequestService,
-    SupportTaskService supportTaskService,
+    TeacherPensionsSupportTaskService teacherPensionsSupportTaskService,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     TimeProvider timeProvider) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
@@ -48,16 +47,10 @@ public class ConfirmKeepRecordSeparateReasonModel(
 
         await trnRequestService.ResolveTrnRequestWithMatchedPersonAsync(trnRequest, supportTask.PersonId!.Value, processContext);
 
-        await supportTaskService.UpdateSupportTaskAsync(
-            new UpdateSupportTaskOptions<TeacherPensionsPotentialDuplicateData>
+        await teacherPensionsSupportTaskService.ResolveWithoutMergeAsync(
+            new()
             {
                 SupportTaskReference = SupportTaskReference,
-                UpdateData = data => data with
-                {
-                    ResolvedAttributes = null,
-                    SelectedPersonAttributes = null
-                },
-                Status = SupportTaskStatus.Closed,
                 Comments = Reason
             },
             processContext);

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequestManualChecksNeeded/Resolve/Confirm.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequestManualChecksNeeded/Resolve/Confirm.cshtml.cs
@@ -1,12 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequestManualChecksNeeded.Resolve;
 
-public class Confirm(TrnRequestService trnRequestService, SupportTaskService supportTaskService, TimeProvider timeProvider, SupportUiLinkGenerator linkGenerator) : PageModel
+public class Confirm(TrnRequestService trnRequestService, TrnRequestSupportTaskService trnRequestSupportTaskService, TimeProvider timeProvider, SupportUiLinkGenerator linkGenerator) : PageModel
 {
     [FromRoute]
     public string? SupportTaskReference { get; set; }
@@ -24,12 +23,10 @@ public class Confirm(TrnRequestService trnRequestService, SupportTaskService sup
 
         await trnRequestService.CompleteResolvedTrnRequestAsync(trnRequest, processContext);
 
-        await supportTaskService.UpdateSupportTaskAsync(
-            new UpdateSupportTaskOptions<TrnRequestManualChecksNeededData>
+        await trnRequestSupportTaskService.CompleteManualChecksNeededSupportTaskAsync(
+            new()
             {
-                SupportTaskReference = SupportTaskReference!,
-                UpdateData = data => data,
-                Status = SupportTaskStatus.Closed
+                SupportTaskReference = SupportTaskReference!
             },
             processContext);
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Services;
 using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.ResolveTrnRequestState;
@@ -14,7 +14,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 public class CheckAnswers(
     TrsDbContext dbContext,
     TrnRequestService trnRequestService,
-    SupportTaskService supportTaskService,
+    TrnRequestSupportTaskService trnRequestSupportTaskService,
     SupportUiLinkGenerator linkGenerator,
     TimeProvider timeProvider,
     PersonChangeableAttributesService changedService) :
@@ -101,18 +101,13 @@ public class CheckAnswers(
 
         var resolvedPersonAttributes = GetResolvedPersonAttributes(selectedPersonAttributes);
 
-        await supportTaskService.UpdateSupportTaskAsync<TrnRequestData>(
+        await trnRequestSupportTaskService.ResolveTrnRequestSupportTaskAsync(
             new()
             {
                 SupportTaskReference = supportTask.SupportTaskReference,
-                UpdateData = data => data with
-                {
-                    ResolvedAttributes = resolvedPersonAttributes,
-                    SelectedPersonAttributes = selectedPersonAttributes
-                },
-                Status = SupportTaskStatus.Closed,
-                Comments = state.Comments,
-                RejectionReason = null
+                ResolvedAttributes = resolvedPersonAttributes,
+                SelectedPersonAttributes = selectedPersonAttributes,
+                Comments = state.Comments
             },
             processContext);
 

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/SupportTaskServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/SupportTaskServiceTests.cs
@@ -536,6 +536,82 @@ public class SupportTaskServiceTests(ServiceFixture fixture) : ServiceTestBase(f
     }
 
     [Fact]
+    public async Task SaveProgressAsync_ValidRequest_SetsStatusToInProgressAndSavesJourneyStateAndPublishesEvent()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(person.PersonId);
+        Debug.Assert(supportTask.Status is SupportTaskStatus.Open);
+
+        var savedJourneyState = new SavedJourneyState(
+            "Page",
+            new Dictionary<string, string?>(),
+            new DummyJourneyState(),
+            typeof(DummyJourneyState));
+
+        var options = new SaveSupportTaskProgressOptions
+        {
+            SupportTaskReference = supportTask.SupportTaskReference,
+            SavedJourneyState = savedJourneyState
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync<SupportTaskService>(service => service.SaveProgressAsync(options, processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbSupportTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskStatus.InProgress, dbSupportTask.Status);
+            Assert.Equal(savedJourneyState, dbSupportTask.ResolveJourneySavedState);
+        });
+
+        Events.AssertEventsPublished(e =>
+        {
+            var supportTaskUpdatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+            Assert.Equal(supportTask.SupportTaskReference, supportTaskUpdatedEvent.SupportTaskReference);
+            Assert.Equal(TimeProvider.UtcNow, supportTask.UpdatedOn);
+            Assert.Equal(
+                SupportTaskUpdatedEventChanges.Status | SupportTaskUpdatedEventChanges.ResolveJourneySavedState,
+                supportTaskUpdatedEvent.Changes);
+        });
+    }
+
+    [Fact]
+    public async Task SaveProgressAsync_TaskIsAlreadyClosed_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            person.PersonId,
+            t => t.WithStatus(SupportTaskStatus.Closed));
+
+        var savedJourneyState = new SavedJourneyState(
+            "Page",
+            new Dictionary<string, string?>(),
+            new DummyJourneyState(),
+            typeof(DummyJourneyState));
+
+        var options = new SaveSupportTaskProgressOptions
+        {
+            SupportTaskReference = supportTask.SupportTaskReference,
+            SavedJourneyState = savedJourneyState
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => WithServiceAsync<SupportTaskService>(
+            service => service.SaveProgressAsync(options, processContext)));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(ex);
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
     public async Task AllocateSupportTaskAsync_TaskDoesNotExist_ReturnsNotFoundAndDoesNotPublishEvent()
     {
         // Arrange

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TeacherPensionsSupportTaskServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TeacherPensionsSupportTaskServiceTests.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
+using TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
+
+namespace TeachingRecordSystem.Core.Tests.Services.SupportTasks;
+
+public class TeacherPensionsSupportTaskServiceTests(ServiceFixture fixture) : ServiceTestBase(fixture)
+{
+    [Fact]
+    public async Task ResolveWithMergeAsync_ClosesTaskWithAttributesAndPublishesEvent()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(
+            fileName: "duplicates.csv",
+            integrationTransactionId: 42);
+        Debug.Assert(supportTask.Status is SupportTaskStatus.Open);
+
+        var resolvedAttributes = new TeacherPensionsPotentialDuplicateAttributes
+        {
+            FirstName = "Resolved",
+            MiddleName = "Resolved Middle",
+            LastName = "Resolved Last",
+            DateOfBirth = new DateOnly(1990, 1, 1),
+            NationalInsuranceNumber = "AB123456C",
+            Gender = null,
+            Trn = "1000000"
+        };
+        var selectedPersonAttributes = new TeacherPensionsPotentialDuplicateAttributes
+        {
+            FirstName = "Selected",
+            MiddleName = "Selected Middle",
+            LastName = "Selected Last",
+            DateOfBirth = new DateOnly(1991, 2, 2),
+            NationalInsuranceNumber = "CD654321B",
+            Gender = null,
+            Trn = "2000000"
+        };
+        var comments = Faker.Lorem.Paragraph();
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync<TeacherPensionsSupportTaskService>(
+            service => service.ResolveWithMergeAsync(
+                new ResolveTeacherPensionsPotentialDuplicateWithMergeOptions
+                {
+                    SupportTaskReference = supportTask.SupportTaskReference,
+                    ResolvedAttributes = resolvedAttributes,
+                    SelectedPersonAttributes = selectedPersonAttributes,
+                    Comments = comments
+                },
+                processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskStatus.Closed, dbTask.Status);
+            var data = Assert.IsType<TeacherPensionsPotentialDuplicateData>(dbTask.Data);
+            Assert.Equal(resolvedAttributes, data.ResolvedAttributes);
+            Assert.Equal(selectedPersonAttributes, data.SelectedPersonAttributes);
+            // The rest of the data is preserved by the update.
+            Assert.Equal("duplicates.csv", data.FileName);
+            Assert.Equal(42, data.IntegrationTransactionId);
+        });
+
+        Events.AssertEventsPublished(e =>
+        {
+            var updatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+            Assert.Equal(supportTask.SupportTaskReference, updatedEvent.SupportTaskReference);
+            Assert.Equal(comments, updatedEvent.Comments);
+            Assert.Equal(
+                SupportTaskUpdatedEventChanges.Status | SupportTaskUpdatedEventChanges.Data,
+                updatedEvent.Changes);
+        });
+    }
+
+    [Fact]
+    public async Task ResolveWithMergeAsync_TaskIsAlreadyClosed_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var user = await TestData.CreateUserAsync();
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(
+            person.PersonId,
+            user.UserId,
+            t => t.WithStatus(SupportTaskStatus.Closed));
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => WithServiceAsync<TeacherPensionsSupportTaskService>(
+            service => service.ResolveWithMergeAsync(
+                new ResolveTeacherPensionsPotentialDuplicateWithMergeOptions
+                {
+                    SupportTaskReference = supportTask.SupportTaskReference,
+                    ResolvedAttributes = null,
+                    SelectedPersonAttributes = null
+                },
+                processContext)));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(ex);
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task ResolveWithoutMergeAsync_ClosesTaskAndPublishesEvent()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
+        Debug.Assert(supportTask.Status is SupportTaskStatus.Open);
+
+        var comments = Faker.Lorem.Paragraph();
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync<TeacherPensionsSupportTaskService>(
+            service => service.ResolveWithoutMergeAsync(
+                new ResolveTeacherPensionsPotentialDuplicateWithoutMergeOptions
+                {
+                    SupportTaskReference = supportTask.SupportTaskReference,
+                    Comments = comments
+                },
+                processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskStatus.Closed, dbTask.Status);
+            var data = Assert.IsType<TeacherPensionsPotentialDuplicateData>(dbTask.Data);
+            Assert.Null(data.ResolvedAttributes);
+            Assert.Null(data.SelectedPersonAttributes);
+        });
+
+        Events.AssertEventsPublished(e =>
+        {
+            var updatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+            Assert.Equal(supportTask.SupportTaskReference, updatedEvent.SupportTaskReference);
+            Assert.Equal(comments, updatedEvent.Comments);
+            Assert.Equal(SupportTaskUpdatedEventChanges.Status, updatedEvent.Changes);
+        });
+    }
+}

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TrnRequestSupportTaskServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TrnRequestSupportTaskServiceTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
+using TeachingRecordSystem.Core.Services.SupportTasks.TrnRequests;
+
+namespace TeachingRecordSystem.Core.Tests.Services.SupportTasks;
+
+public class TrnRequestSupportTaskServiceTests(ServiceFixture fixture) : ServiceTestBase(fixture)
+{
+    [Fact]
+    public async Task CreateTrnRequestSupportTaskAsync_CreatesTaskAndPublishesEvent()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequest = await TestData.CreateDormantTrnRequestAsync(applicationUser.UserId);
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var result = await WithServiceAsync<TrnRequestSupportTaskService, SupportTask>(
+            service => service.CreateTrnRequestSupportTaskAsync(
+                new CreateTrnRequestSupportTaskOptions { TrnRequest = trnRequest },
+                processContext));
+
+        // Assert
+        Assert.Equal(SupportTaskType.TrnRequest, result.SupportTaskType);
+        Assert.IsType<TrnRequestData>(result.Data);
+        Assert.Equal(SupportTaskStatus.Open, result.Status);
+        Assert.Null(result.PersonId);
+        Assert.Equal(trnRequest.ApplicationUserId, result.TrnRequestApplicationUserId);
+        Assert.Equal(trnRequest.RequestId, result.TrnRequestId);
+
+        Events.AssertEventsPublished(e =>
+        {
+            var createdEvent = Assert.IsType<SupportTaskCreatedEvent>(e);
+            Assert.Equal(result.SupportTaskReference, createdEvent.SupportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskType.TrnRequest, createdEvent.SupportTask.SupportTaskType);
+        });
+    }
+
+    [Fact]
+    public async Task CreateManualChecksNeededSupportTaskAsync_CreatesTaskAndPublishesEvent()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequest = await TestData.CreateDormantTrnRequestAsync(applicationUser.UserId);
+        var person = await TestData.CreatePersonAsync();
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var result = await WithServiceAsync<TrnRequestSupportTaskService, SupportTask>(
+            service => service.CreateManualChecksNeededSupportTaskAsync(
+                new CreateManualChecksNeededSupportTaskOptions
+                {
+                    Person = person.Person,
+                    TrnRequest = trnRequest
+                },
+                processContext));
+
+        // Assert
+        Assert.Equal(SupportTaskType.TrnRequestManualChecksNeeded, result.SupportTaskType);
+        Assert.IsType<TrnRequestManualChecksNeededData>(result.Data);
+        Assert.Equal(SupportTaskStatus.Open, result.Status);
+        Assert.Equal(person.PersonId, result.PersonId);
+        Assert.Equal(trnRequest.ApplicationUserId, result.TrnRequestApplicationUserId);
+        Assert.Equal(trnRequest.RequestId, result.TrnRequestId);
+        Assert.Equal(string.JoinNonEmpty(' ', person.FirstName, person.MiddleName, person.LastName), result.SubjectName);
+
+        Events.AssertEventsPublished(e =>
+        {
+            var createdEvent = Assert.IsType<SupportTaskCreatedEvent>(e);
+            Assert.Equal(result.SupportTaskReference, createdEvent.SupportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskType.TrnRequestManualChecksNeeded, createdEvent.SupportTask.SupportTaskType);
+        });
+    }
+
+    [Fact]
+    public async Task ResolveTrnRequestSupportTaskAsync_ClosesTaskWithAttributesAndPublishesEvent()
+    {
+        // Arrange
+        var createResult = await TestData.CreateTrnRequestSupportTaskAsync();
+        var supportTask = createResult.SupportTask;
+        Debug.Assert(supportTask.Status is SupportTaskStatus.Open);
+
+        var resolvedAttributes = new TrnRequestDataPersonAttributes
+        {
+            FirstName = "Resolved",
+            MiddleName = "Resolved Middle",
+            LastName = "Resolved Last",
+            DateOfBirth = new DateOnly(1990, 1, 1),
+            EmailAddress = "resolved@example.com",
+            NationalInsuranceNumber = "AB123456C",
+            Gender = null
+        };
+        var selectedPersonAttributes = new TrnRequestDataPersonAttributes
+        {
+            FirstName = "Selected",
+            MiddleName = "Selected Middle",
+            LastName = "Selected Last",
+            DateOfBirth = new DateOnly(1991, 2, 2),
+            EmailAddress = "selected@example.com",
+            NationalInsuranceNumber = "CD654321B",
+            Gender = null
+        };
+        var comments = Faker.Lorem.Paragraph();
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync<TrnRequestSupportTaskService>(
+            service => service.ResolveTrnRequestSupportTaskAsync(
+                new ResolveTrnRequestSupportTaskOptions
+                {
+                    SupportTaskReference = supportTask.SupportTaskReference,
+                    ResolvedAttributes = resolvedAttributes,
+                    SelectedPersonAttributes = selectedPersonAttributes,
+                    Comments = comments
+                },
+                processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskStatus.Closed, dbTask.Status);
+            var data = Assert.IsType<TrnRequestData>(dbTask.Data);
+            Assert.Equal(resolvedAttributes, data.ResolvedAttributes);
+            Assert.Equal(selectedPersonAttributes, data.SelectedPersonAttributes);
+        });
+
+        Events.AssertEventsPublished(e =>
+        {
+            var updatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+            Assert.Equal(supportTask.SupportTaskReference, updatedEvent.SupportTaskReference);
+            Assert.Equal(comments, updatedEvent.Comments);
+            Assert.Equal(
+                SupportTaskUpdatedEventChanges.Status | SupportTaskUpdatedEventChanges.Data,
+                updatedEvent.Changes);
+        });
+    }
+
+    [Fact]
+    public async Task ResolveTrnRequestSupportTaskAsync_TaskIsAlreadyClosed_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var createResult = await TestData.CreateTrnRequestSupportTaskAsync(
+            configure: t => t.WithStatus(SupportTaskStatus.Closed));
+        var supportTask = createResult.SupportTask;
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => WithServiceAsync<TrnRequestSupportTaskService>(
+            service => service.ResolveTrnRequestSupportTaskAsync(
+                new ResolveTrnRequestSupportTaskOptions
+                {
+                    SupportTaskReference = supportTask.SupportTaskReference,
+                    ResolvedAttributes = null,
+                    SelectedPersonAttributes = null
+                },
+                processContext)));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(ex);
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task CompleteManualChecksNeededSupportTaskAsync_ClosesTaskAndPublishesEvent()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTrnRequestManualChecksNeededSupportTaskAsync();
+        Debug.Assert(supportTask.Status is SupportTaskStatus.Open);
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync<TrnRequestSupportTaskService>(
+            service => service.CompleteManualChecksNeededSupportTaskAsync(
+                new CompleteManualChecksNeededSupportTaskOptions
+                {
+                    SupportTaskReference = supportTask.SupportTaskReference
+                },
+                processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskStatus.Closed, dbTask.Status);
+        });
+
+        Events.AssertEventsPublished(e =>
+        {
+            var updatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+            Assert.Equal(supportTask.SupportTaskReference, updatedEvent.SupportTaskReference);
+            Assert.Equal(SupportTaskUpdatedEventChanges.Status, updatedEvent.Changes);
+        });
+    }
+}


### PR DESCRIPTION
We currently have a mix of approaches when it comes to where support tasks are created and updated. For some task types we have dedicated services and creations and/or updates go through there. In some places we go direct to `SupportTaskService`. This removes the latter usage and puts all task creations and updates through the type-specific services.

There's one remaining place where we're not using a service at all to create the task - TPS TRN requests. A separate PR will follow to fix that up, as it also requires a data fix.