### PR TITLE
Move TPS support task creation into TeacherPensionsSupportTaskService

### DIFF
--- a/docs/process-type-events.md
+++ b/docs/process-type-events.md
@@ -73,6 +73,7 @@ Support UI *Merge person*.
 | Event | Emitted | Scenario |
 | --- | --- | --- |
 | `PersonCreatedEvent` | Sometimes | The imported TPS record does not already exist in TRS, so a new person is created. |
+| `SupportTaskCreatedEvent` | Sometimes | The newly created person potentially matches an existing record (a `TeacherPensionsPotentialDuplicate` task). |
 
 ---
 

--- a/src/TeachingRecordSystem.Cli/Commands.ImportCapitaFile.cs
+++ b/src/TeachingRecordSystem.Cli/Commands.ImportCapitaFile.cs
@@ -54,7 +54,7 @@ public static partial class Commands
                 .AddWebhookMessageFactory()
                 .AddEventPublisher()
                 .AddPersonService()
-                .AddSupportTaskService()
+                .AddSupportTaskServices()
                 .AddTrnRequestService(configuration)
                 .BuildServiceProvider();
 

--- a/src/TeachingRecordSystem.Core/Jobs/BackfillTeacherPensionsSupportTaskProcessesJob.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/BackfillTeacherPensionsSupportTaskProcessesJob.cs
@@ -1,0 +1,146 @@
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using LegacySupportTaskCreatedEvent = TeachingRecordSystem.Core.Events.Legacy.SupportTaskCreatedEvent;
+using Process = TeachingRecordSystem.Core.DataStore.Postgres.Models.Process;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+/// <summary>
+/// Back-fills <see cref="ProcessEvent"/> records for the TPS potential duplicate support tasks raised by
+/// <see cref="CapitaImportJob"/>. Historically the job wrote the legacy <c>SupportTaskCreatedEvent</c> straight
+/// to the <c>events</c> table rather than going through the event pipeline, so the task's creation was never
+/// recorded against a process.
+///
+/// The import creates the person and raises the task within a single row, under one
+/// <see cref="ProcessType.TeacherPensionsRecordImporting"/> process, so — as with the current code — the
+/// back-filled event is attached to that same process. A process is only created for the rare event that no
+/// matching one is found.
+/// </summary>
+public class BackfillTeacherPensionsSupportTaskProcessesJob(TrsDbContext dbContext)
+{
+    // This matches the EventName value stored in the events table for the legacy event.
+    private static readonly string _legacyEventName = typeof(LegacySupportTaskCreatedEvent).Name;
+
+    public async Task ExecuteAsync(bool dryRun, CancellationToken cancellationToken)
+    {
+        dbContext.Database.SetCommandTimeout(0);
+
+        await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        // Only migrate events that haven't already been back-filled so the job is idempotent.
+        var legacyEvents = await dbContext.Events
+            .FromSql($"""
+                select e.* from events e
+                join support_tasks st on st.support_task_reference = (e.payload -> 'SupportTask' ->> 'SupportTaskReference')
+                where e.event_name = {_legacyEventName}
+                and st.support_task_type = {(int)SupportTaskType.TeacherPensionsPotentialDuplicate}
+                and not exists (select 1 from process_events pe where pe.process_event_id = e.event_id)
+                order by e.created
+                """)
+            .ToListAsync(cancellationToken);
+
+        foreach (var legacyEvent in legacyEvents)
+        {
+            var legacyEventData = (LegacySupportTaskCreatedEvent)legacyEvent.ToEventBase();
+
+            IEvent newEvent = new SupportTaskCreatedEvent
+            {
+                EventId = legacyEventData.EventId,
+                SupportTask = legacyEventData.SupportTask
+            };
+
+            var process =
+                await FindImportProcessAsync(legacyEventData, legacyEvent.Created, cancellationToken) ??
+                CreateProcess(legacyEventData, legacyEvent.Created);
+
+            AddProcessEvent(process, newEvent, legacyEvent.Created);
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        if (dryRun)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+        }
+        else
+        {
+            await transaction.CommitAsync(cancellationToken);
+        }
+    }
+
+    private async Task<Process?> FindImportProcessAsync(
+        LegacySupportTaskCreatedEvent legacyEventData,
+        DateTime created,
+        CancellationToken cancellationToken)
+    {
+        if (legacyEventData.SupportTask.PersonId is not { } personId)
+        {
+            return null;
+        }
+
+        var candidates = await dbContext.Processes
+            .Where(p => p.ProcessType == ProcessType.TeacherPensionsRecordImporting && p.PersonIds.Contains(personId))
+            .OrderBy(p => p.CreatedOn)
+            .ToListAsync(cancellationToken);
+
+        // The import only ever creates a person once, so a person should appear in a single import process.
+        // Should a person somehow appear in several, the timestamp the events in a file share picks out the right one.
+        return candidates.Count <= 1
+            ? candidates.SingleOrDefault()
+            : candidates.FirstOrDefault(p => p.CreatedOn == created);
+    }
+
+    private Process CreateProcess(LegacySupportTaskCreatedEvent legacyEventData, DateTime created)
+    {
+        var process = new Process
+        {
+            ProcessId = Guid.NewGuid(),
+            ProcessType = ProcessType.TeacherPensionsRecordImporting,
+            CreatedOn = created,
+            UpdatedOn = created,
+            UserId = legacyEventData.RaisedBy.UserId,
+            DqtUserId = legacyEventData.RaisedBy.DqtUserId,
+            DqtUserName = legacyEventData.RaisedBy.DqtUserName,
+            PersonIds = [],
+            OneLoginUserSubjects = [],
+            SupportTaskReferences = [],
+            ChangeReason = null
+        };
+
+        dbContext.Processes.Add(process);
+
+        return process;
+    }
+
+    private void AddProcessEvent(Process process, IEvent newEvent, DateTime created)
+    {
+        process.UpdatedOn = created;
+
+        foreach (var personId in newEvent.PersonIds.Except(process.PersonIds))
+        {
+            process.PersonIds.Add(personId);
+        }
+
+        foreach (var oneLoginUserSubject in newEvent.OneLoginUserSubjects.Except(process.OneLoginUserSubjects))
+        {
+            process.OneLoginUserSubjects.Add(oneLoginUserSubject);
+        }
+
+        foreach (var supportTaskReference in newEvent.SupportTaskReferences.Except(process.SupportTaskReferences))
+        {
+            process.SupportTaskReferences.Add(supportTaskReference);
+        }
+
+        dbContext.ProcessEvents.Add(new ProcessEvent
+        {
+            ProcessEventId = newEvent.EventId,
+            ProcessId = process.ProcessId,
+            EventName = newEvent.GetType().Name,
+            Payload = newEvent,
+            PersonIds = newEvent.PersonIds,
+            OneLoginUserSubjects = newEvent.OneLoginUserSubjects,
+            SupportTaskReferences = newEvent.SupportTaskReferences,
+            CreatedOn = created
+        });
+    }
+}

--- a/src/TeachingRecordSystem.Core/Jobs/BackfillTeacherPensionsSupportTaskProcessesJob.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/BackfillTeacherPensionsSupportTaskProcessesJob.cs
@@ -13,8 +13,8 @@ namespace TeachingRecordSystem.Core.Jobs;
 ///
 /// The import creates the person and raises the task within a single row, under one
 /// <see cref="ProcessType.TeacherPensionsRecordImporting"/> process, so — as with the current code — the
-/// back-filled event is attached to that same process. A process is only created for the rare event that no
-/// matching one is found.
+/// back-filled event is attached to that same process. Every task is expected to have one; the job throws if
+/// no matching process is found.
 /// </summary>
 public class BackfillTeacherPensionsSupportTaskProcessesJob(TrsDbContext dbContext)
 {
@@ -51,7 +51,9 @@ public class BackfillTeacherPensionsSupportTaskProcessesJob(TrsDbContext dbConte
 
             var process =
                 await FindImportProcessAsync(legacyEventData, legacyEvent.Created, cancellationToken) ??
-                CreateProcess(legacyEventData, legacyEvent.Created);
+                throw new InvalidOperationException(
+                    $"No {ProcessType.TeacherPensionsRecordImporting} process found for support task " +
+                    $"'{legacyEventData.SupportTask.SupportTaskReference}'.");
 
             AddProcessEvent(process, newEvent, legacyEvent.Created);
 
@@ -88,28 +90,6 @@ public class BackfillTeacherPensionsSupportTaskProcessesJob(TrsDbContext dbConte
         return candidates.Count <= 1
             ? candidates.SingleOrDefault()
             : candidates.FirstOrDefault(p => p.CreatedOn == created);
-    }
-
-    private Process CreateProcess(LegacySupportTaskCreatedEvent legacyEventData, DateTime created)
-    {
-        var process = new Process
-        {
-            ProcessId = Guid.NewGuid(),
-            ProcessType = ProcessType.TeacherPensionsRecordImporting,
-            CreatedOn = created,
-            UpdatedOn = created,
-            UserId = legacyEventData.RaisedBy.UserId,
-            DqtUserId = legacyEventData.RaisedBy.DqtUserId,
-            DqtUserName = legacyEventData.RaisedBy.DqtUserName,
-            PersonIds = [],
-            OneLoginUserSubjects = [],
-            SupportTaskReferences = [],
-            ChangeReason = null
-        };
-
-        dbContext.Processes.Add(process);
-
-        return process;
     }
 
     private void AddProcessEvent(Process process, IEvent newEvent, DateTime created)

--- a/src/TeachingRecordSystem.Core/Jobs/CapitaImportJob.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/CapitaImportJob.cs
@@ -11,6 +11,7 @@ using Optional;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.Persons;
+using TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 
 namespace TeachingRecordSystem.Core.Jobs;
@@ -22,6 +23,7 @@ public class CapitaImportJob(
     TimeProvider timeProvider,
     TrnRequestService trnRequestService,
     PersonService personService,
+    TeacherPensionsSupportTaskService teacherPensionsSupportTaskService,
     IOptions<CapitaTpsUserOption> capitaUser)
 {
     public const string JobSchedule = "0 4 * * *";
@@ -195,35 +197,15 @@ public class CapitaImportJob(
                         {
                             potentialDuplicate = true;
 
-                            var subject = SupportTask.Subject.FromTrnRequest(trnRequestMetadata);
-
-                            var supportTask = new SupportTask()
-                            {
-                                SupportTaskType = SupportTaskType.TeacherPensionsPotentialDuplicate,
-                                Data = new Models.SupportTasks.TeacherPensionsPotentialDuplicateData()
+                            await teacherPensionsSupportTaskService.CreatePotentialDuplicateAsync(
+                                new CreateTeacherPensionsPotentialDuplicateOptions
                                 {
+                                    PersonId = personId.Value,
+                                    TrnRequest = trnRequestMetadata,
                                     FileName = fileName,
                                     IntegrationTransactionId = integrationJob.IntegrationTransactionId
                                 },
-                                PersonId = personId.Value,
-                                TrnRequestApplicationUserId = capitaUser.Value.CapitaTpsUserId,
-                                TrnRequestId = trnRequestMetadata.RequestId,
-                                SubjectName = subject.Name,
-                                SubjectEmailAddress = subject.EmailAddress,
-                                CreatedOn = now,
-                                UpdatedOn = now
-                            };
-
-                            var supportTaskCreatedEvent = new LegacyEvents.SupportTaskCreatedEvent
-                            {
-                                SupportTask = EventModels.SupportTask.FromModel(supportTask),
-                                EventId = Guid.NewGuid(),
-                                CreatedUtc = now,
-                                RaisedBy = capitaUser.Value.CapitaTpsUserId
-                            };
-
-                            dbContext.SupportTasks.Add(supportTask);
-                            dbContext.AddEventWithoutBroadcast(supportTaskCreatedEvent);
+                                processContext);
 
                             duplicateRowCount++;
                         }

--- a/src/TeachingRecordSystem.Core/Jobs/Extensions.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/Extensions.cs
@@ -238,6 +238,16 @@ public static class Extensions
                 job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None),
                 Cron.Never);
 
+            recurringJobManager.AddOrUpdate<BackfillTeacherPensionsSupportTaskProcessesJob>(
+                $"{nameof(BackfillTeacherPensionsSupportTaskProcessesJob)} (dry-run)",
+                job => job.ExecuteAsync(/*dryRun: */true, CancellationToken.None),
+                Cron.Never);
+
+            recurringJobManager.AddOrUpdate<BackfillTeacherPensionsSupportTaskProcessesJob>(
+                nameof(BackfillTeacherPensionsSupportTaskProcessesJob),
+                job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None),
+                Cron.Never);
+
             recurringJobManager.AddOrUpdate<BackfillSupportTasksInReportingDb>(
                 nameof(BackfillSupportTasksInReportingDb),
                 job => job.ExecuteAsync(CancellationToken.None),

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/CreateTeacherPensionsPotentialDuplicateOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/CreateTeacherPensionsPotentialDuplicateOptions.cs
@@ -1,0 +1,11 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
+
+public record CreateTeacherPensionsPotentialDuplicateOptions
+{
+    public required Guid PersonId { get; init; }
+    public required TrnRequestMetadata TrnRequest { get; init; }
+    public required string FileName { get; init; }
+    public required long IntegrationTransactionId { get; init; }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/TeacherPensionsSupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/TeacherPensionsSupportTaskService.cs
@@ -1,9 +1,29 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 
 namespace TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
 
 public class TeacherPensionsSupportTaskService(SupportTaskService supportTaskService)
 {
+    public Task<SupportTask> CreatePotentialDuplicateAsync(
+        CreateTeacherPensionsPotentialDuplicateOptions options,
+        ProcessContext processContext) =>
+        supportTaskService.CreateSupportTaskAsync(
+            new CreateSupportTaskOptions
+            {
+                SupportTaskType = SupportTaskType.TeacherPensionsPotentialDuplicate,
+                Data = new TeacherPensionsPotentialDuplicateData
+                {
+                    FileName = options.FileName,
+                    IntegrationTransactionId = options.IntegrationTransactionId
+                },
+                PersonId = options.PersonId,
+                OneLoginUserSubject = null,
+                TrnRequest = (options.TrnRequest.ApplicationUserId, options.TrnRequest.RequestId),
+                Subject = SupportTask.Subject.FromTrnRequest(options.TrnRequest)
+            },
+            processContext);
+
     public Task ResolveWithMergeAsync(
         ResolveTeacherPensionsPotentialDuplicateWithMergeOptions options,
         ProcessContext processContext) =>

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillTeacherPensionsSupportTaskProcessesJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillTeacherPensionsSupportTaskProcessesJobTests.cs
@@ -38,27 +38,26 @@ public class BackfillTeacherPensionsSupportTaskProcessesJobTests(JobFixture fixt
     }
 
     [Fact]
-    public async Task Execute_NoImportProcessExists_CreatesOne()
+    public async Task Execute_NoImportProcessExists_Throws()
     {
         // Arrange
         var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
         var legacyEvent = await AddLegacyCreatedEventAsync(supportTask);
 
         // Act
-        await WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
-            job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None));
+        var exception = await Record.ExceptionAsync(() =>
+            WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
+                job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None)));
 
         // Assert
+        Assert.NotNull(exception);
+        Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains(supportTask.SupportTaskReference, exception.Message);
+
         await WithDbContextAsync(async dbContext =>
         {
             var processEvent = await dbContext.ProcessEvents.SingleOrDefaultAsync(pe => pe.ProcessEventId == legacyEvent.EventId);
-            Assert.NotNull(processEvent);
-
-            var process = await dbContext.Processes.SingleAsync(p => p.ProcessId == processEvent.ProcessId);
-            Assert.Equal(ProcessType.TeacherPensionsRecordImporting, process.ProcessType);
-            Assert.Equal(legacyEvent.CreatedUtc, process.CreatedOn);
-            Assert.Contains(supportTask.SupportTaskReference, process.SupportTaskReferences);
-            Assert.Contains(supportTask.PersonId!.Value, process.PersonIds);
+            Assert.Null(processEvent);
         });
     }
 

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillTeacherPensionsSupportTaskProcessesJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillTeacherPensionsSupportTaskProcessesJobTests.cs
@@ -1,0 +1,175 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Jobs;
+using Process = TeachingRecordSystem.Core.DataStore.Postgres.Models.Process;
+
+namespace TeachingRecordSystem.Core.Tests.Jobs;
+
+public class BackfillTeacherPensionsSupportTaskProcessesJobTests(JobFixture fixture) : JobTestBase(fixture)
+{
+    [Fact]
+    public async Task Execute_AttachesEventToTheImportProcessThatCreatedThePerson()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
+        var legacyEvent = await AddLegacyCreatedEventAsync(supportTask);
+        var processId = await AddImportProcessAsync(supportTask.PersonId!.Value, legacyEvent.CreatedUtc);
+
+        // Act
+        await WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
+            job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var processEvent = await dbContext.ProcessEvents.SingleOrDefaultAsync(pe => pe.ProcessEventId == legacyEvent.EventId);
+            Assert.NotNull(processEvent);
+            Assert.Equal(processId, processEvent.ProcessId);
+            Assert.Equal(nameof(SupportTaskCreatedEvent), processEvent.EventName);
+
+            var createdEvent = Assert.IsType<SupportTaskCreatedEvent>(processEvent.Payload);
+            Assert.Equal(supportTask.SupportTaskReference, createdEvent.SupportTask.SupportTaskReference);
+
+            // No new process is created; the task reference is recorded against the existing one.
+            var process = Assert.Single(await dbContext.Processes.Where(p => p.ProcessType == ProcessType.TeacherPensionsRecordImporting).ToListAsync());
+            Assert.Equal(processId, process.ProcessId);
+            Assert.Contains(supportTask.SupportTaskReference, process.SupportTaskReferences);
+            Assert.Contains(supportTask.PersonId!.Value, process.PersonIds);
+        });
+    }
+
+    [Fact]
+    public async Task Execute_NoImportProcessExists_CreatesOne()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
+        var legacyEvent = await AddLegacyCreatedEventAsync(supportTask);
+
+        // Act
+        await WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
+            job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var processEvent = await dbContext.ProcessEvents.SingleOrDefaultAsync(pe => pe.ProcessEventId == legacyEvent.EventId);
+            Assert.NotNull(processEvent);
+
+            var process = await dbContext.Processes.SingleAsync(p => p.ProcessId == processEvent.ProcessId);
+            Assert.Equal(ProcessType.TeacherPensionsRecordImporting, process.ProcessType);
+            Assert.Equal(legacyEvent.CreatedUtc, process.CreatedOn);
+            Assert.Contains(supportTask.SupportTaskReference, process.SupportTaskReferences);
+            Assert.Contains(supportTask.PersonId!.Value, process.PersonIds);
+        });
+    }
+
+    [Fact]
+    public async Task Execute_RunTwice_DoesNotBackfillTwice()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
+        var legacyEvent = await AddLegacyCreatedEventAsync(supportTask);
+        await AddImportProcessAsync(supportTask.PersonId!.Value, legacyEvent.CreatedUtc);
+
+        await WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
+            job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None));
+
+        // Act
+        await WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
+            job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var processEvents = await dbContext.ProcessEvents.Where(pe => pe.ProcessEventId == legacyEvent.EventId).ToListAsync();
+            Assert.Single(processEvents);
+
+            var process = await dbContext.Processes.SingleAsync(p => p.ProcessId == processEvents[0].ProcessId);
+            Assert.Equal(supportTask.SupportTaskReference, Assert.Single(process.SupportTaskReferences));
+        });
+    }
+
+    [Fact]
+    public async Task Execute_DryRun_DoesNotCommitChanges()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
+        var legacyEvent = await AddLegacyCreatedEventAsync(supportTask);
+        await AddImportProcessAsync(supportTask.PersonId!.Value, legacyEvent.CreatedUtc);
+
+        // Act
+        await WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
+            job => job.ExecuteAsync(/*dryRun: */true, CancellationToken.None));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var processEvent = await dbContext.ProcessEvents.SingleOrDefaultAsync(pe => pe.ProcessEventId == legacyEvent.EventId);
+            Assert.Null(processEvent);
+        });
+    }
+
+    [Fact]
+    public async Task Execute_SupportTaskOfAnotherType_IsNotBackfilled()
+    {
+        // Arrange
+        var result = await TestData.CreateTrnRequestSupportTaskAsync();
+        var legacyEvent = await AddLegacyCreatedEventAsync(result.SupportTask);
+
+        // Act
+        await WithServiceAsync<BackfillTeacherPensionsSupportTaskProcessesJob>(
+            job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var processEvent = await dbContext.ProcessEvents.SingleOrDefaultAsync(pe => pe.ProcessEventId == legacyEvent.EventId);
+            Assert.Null(processEvent);
+        });
+    }
+
+    private async Task<LegacyEvents.SupportTaskCreatedEvent> AddLegacyCreatedEventAsync(SupportTask supportTask)
+    {
+        var legacyEvent = new LegacyEvents.SupportTaskCreatedEvent
+        {
+            EventId = Guid.NewGuid(),
+            CreatedUtc = supportTask.CreatedOn,
+            RaisedBy = ApplicationUser.CapitaTpsImportUser.UserId,
+            SupportTask = EventModels.SupportTask.FromModel(supportTask)
+        };
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            dbContext.AddEventWithoutBroadcast(legacyEvent);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return legacyEvent;
+    }
+
+    private async Task<Guid> AddImportProcessAsync(Guid personId, DateTime createdOn)
+    {
+        var processId = Guid.NewGuid();
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            dbContext.Processes.Add(new Process
+            {
+                ProcessId = processId,
+                ProcessType = ProcessType.TeacherPensionsRecordImporting,
+                CreatedOn = createdOn,
+                UpdatedOn = createdOn,
+                UserId = ApplicationUser.CapitaTpsImportUser.UserId,
+                DqtUserId = null,
+                DqtUserName = null,
+                PersonIds = [personId],
+                OneLoginUserSubjects = [],
+                SupportTaskReferences = [],
+                ChangeReason = null
+            });
+
+            await dbContext.SaveChangesAsync();
+        });
+
+        return processId;
+    }
+}

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaImportJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/CapitaImportJobTests.cs
@@ -977,6 +977,49 @@ public class CapitaImportJobTests(JobFixture fixture) : JobTestBase(fixture)
     }
 
     [Fact]
+    public async Task Import_CreatesPotentialDuplicateSupportTask_RaisesProcessEventOnImportProcessAndLegacyEvent()
+    {
+        // Arrange
+        var existingPerson = await TestData.CreatePersonAsync(p => p
+            .WithGender(Gender.Male)
+            .WithDateOfBirth(new DateOnly(1981, 08, 20)));
+
+        var newTrn = "1234567";
+        var newNino = Faker.Identification.UkNationalInsuranceNumber();
+        (var reader, _) = BuildSingleRowCsv(newTrn, existingPerson.Gender, existingPerson.LastName, existingPerson.FirstName, existingPerson.DateOfBirth, newNino);
+
+        // Act
+        await WithServiceAsync<CapitaImportJob, long>(job => job.ImportAsync(reader, "SingleFile.txt"));
+
+        // Assert
+        var newPerson = await AssertSinglePersonAsync(newTrn);
+        var task = await AssertSingleSupportTaskAsync(SupportTaskType.TeacherPensionsPotentialDuplicate, newPerson.PersonId);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var processEvent = await dbContext.ProcessEvents.SingleOrDefaultAsync(pe =>
+                pe.EventName == nameof(SupportTaskCreatedEvent) &&
+                pe.SupportTaskReferences.Contains(task.SupportTaskReference));
+            Assert.NotNull(processEvent);
+
+            var process = await dbContext.Processes.SingleAsync(p => p.ProcessId == processEvent.ProcessId);
+            Assert.Equal(ProcessType.TeacherPensionsRecordImporting, process.ProcessType);
+            Assert.Contains(task.SupportTaskReference, process.SupportTaskReferences);
+
+            // The person and the task come from the same import row, so they share a process.
+            var personCreatedProcessEvent = await dbContext.ProcessEvents.SingleAsync(pe =>
+                pe.EventName == nameof(PersonCreatedEvent) &&
+                pe.PersonIds.Contains(newPerson.PersonId));
+            Assert.Equal(personCreatedProcessEvent.ProcessId, processEvent.ProcessId);
+        });
+
+        // The legacy event is still written, now by the event handler rather than the job itself.
+        var legacyEvent = await AssertSingleEventAsync<LegacyEvents.SupportTaskCreatedEvent>(newPerson.PersonId);
+        Assert.Equal(task.SupportTaskReference, legacyEvent.SupportTask.SupportTaskReference);
+        Assert.Equal(ApplicationUser.CapitaTpsImportUser.UserId, legacyEvent.RaisedBy.UserId);
+    }
+
+    [Fact]
     public async Task Import_MatchesExistingPersonWithNinoOnFirstNameAndLastNameAndDob_CreatesPersonAndCreatesPotentialDuplicateSupportTask_ReportsDuplicate()
     {
         // Arrange

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/JobFixture.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/JobFixture.cs
@@ -29,7 +29,7 @@ public class JobFixture : ServiceProviderFixture
             .AddWebhookMessageFactory()
             .AddOneLoginService()
             .AddPersonService()
-            .AddSupportTaskService()
+            .AddSupportTaskServices()
             .AddTrnRequestService(configuration)
             .AddSingleton<IBackgroundJobScheduler>(_ => Mock.Of<IBackgroundJobScheduler>())
             .AddSingleton(Options.Create(new AccessYourTeachingQualificationsOptions { BaseAddress = "https://aytq.example.com/" }))

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TeacherPensionsSupportTaskServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TeacherPensionsSupportTaskServiceTests.cs
@@ -8,6 +8,49 @@ namespace TeachingRecordSystem.Core.Tests.Services.SupportTasks;
 public class TeacherPensionsSupportTaskServiceTests(ServiceFixture fixture) : ServiceTestBase(fixture)
 {
     [Fact]
+    public async Task CreatePotentialDuplicateAsync_CreatesTaskAndPublishesEvent()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var trnRequest = await TestData.CreateDormantTrnRequestAsync(applicationUser.UserId);
+        var person = await TestData.CreatePersonAsync();
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        var result = await WithServiceAsync<TeacherPensionsSupportTaskService, SupportTask>(
+            service => service.CreatePotentialDuplicateAsync(
+                new CreateTeacherPensionsPotentialDuplicateOptions
+                {
+                    PersonId = person.PersonId,
+                    TrnRequest = trnRequest,
+                    FileName = "duplicates.csv",
+                    IntegrationTransactionId = 42
+                },
+                processContext));
+
+        // Assert
+        Assert.Equal(SupportTaskType.TeacherPensionsPotentialDuplicate, result.SupportTaskType);
+        Assert.Equal(SupportTaskStatus.Open, result.Status);
+        Assert.Equal(person.PersonId, result.PersonId);
+        Assert.Equal(trnRequest.ApplicationUserId, result.TrnRequestApplicationUserId);
+        Assert.Equal(trnRequest.RequestId, result.TrnRequestId);
+
+        var data = Assert.IsType<TeacherPensionsPotentialDuplicateData>(result.Data);
+        Assert.Equal("duplicates.csv", data.FileName);
+        Assert.Equal(42, data.IntegrationTransactionId);
+        Assert.Null(data.ResolvedAttributes);
+        Assert.Null(data.SelectedPersonAttributes);
+
+        Events.AssertEventsPublished(e =>
+        {
+            var createdEvent = Assert.IsType<SupportTaskCreatedEvent>(e);
+            Assert.Equal(result.SupportTaskReference, createdEvent.SupportTask.SupportTaskReference);
+            Assert.Equal(SupportTaskType.TeacherPensionsPotentialDuplicate, createdEvent.SupportTask.SupportTaskType);
+        });
+    }
+
+    [Fact]
     public async Task ResolveWithMergeAsync_ClosesTaskWithAttributesAndPublishesEvent()
     {
         // Arrange


### PR DESCRIPTION
### Context

Follow-up to #3598, which moved all support task creations and updates into type-specific services except one: TPS TRN requests. `CapitaImportJob` built the `SupportTask` by hand and wrote a legacy `SupportTaskCreatedEvent` straight to the `events` table via `AddEventWithoutBroadcast`, so the task's creation was never recorded against a process. As #3598 noted, fixing this also needs a data fix.

### Changes proposed in this pull request

- Add `CreatePotentialDuplicateAsync` to `TeacherPensionsSupportTaskService` (plus a `CreateTeacherPensionsPotentialDuplicateOptions` record), following the shape of `TrnRequestSupportTaskService`.
- `CapitaImportJob` now calls it with the import row's existing `processContext`, so the person and the task it raises share one `TeacherPensionsRecordImporting` process. This drops ~30 lines of hand-rolled task and legacy-event construction.
- Add `BackfillTeacherPensionsSupportTaskProcessesJob` to back-fill `ProcessEvent` records for tasks raised before this change, registered with the usual dry-run/live `Cron.Never` pair.
- Widen two DI registrations from `AddSupportTaskService()` to `AddSupportTaskServices()` — see below.
- Document the newly-emitted event in `docs/process-type-events.md`.

### Guidance to review

**No new event handler was needed.** The description of this work assumed one would be, but `CreateLegacySupportTaskEvents` already handles `SupportTaskCreatedEvent` unconditionally for every task type (added in #3567), so routing TPS through the service emits the legacy event for free. Rather than take that on trust, `Import_CreatesPotentialDuplicateSupportTask_RaisesProcessEventOnImportProcessAndLegacyEvent` asserts the legacy event still lands with the same `RaisedBy` and task reference. The emitted legacy data is unchanged.

**The backfill attaches to the existing process rather than minting a new one.** This differs from the `BackfillChangeRequestProcessesJob` precedent, and is the main thing worth a second opinion. Unlike the change-request case, a process genuinely already exists for every historic row here: task creation only happens in the `person is null` branch, immediately after `CreatePersonAsync` runs under the row's `processContext`. Creating a second process would split one real import row across two, and wouldn't match what the new code path now writes. The job matches on `ProcessType` + `PersonIds`, falls back to the shared per-file `created` timestamp if a person somehow appears in several import processes, and throws if no match is found — a missing process contradicts the reasoning above, so the run should fail rather than paper over it by minting one. Everything runs in a transaction, so a throw part-way leaves the run rolled back rather than half-backfilled.

**Two DI registrations had to be widened.** `TeacherPensionsSupportTaskService` is only in the plural `AddSupportTaskServices()`, so `Commands.ImportCapitaFile.cs` (which constructs `CapitaImportJob`) would have thrown at runtime. The job test fixture needed the same.

**Note on `just test-changed`:** it selects nothing on this branch, because `incrementalist` diffs committed changes against `main`. I ran `Core.Tests` (1026 passed) and `Cli.Tests` (31 passed) directly. Build is clean with 0 warnings.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

