### PR TITLE
Allow support task searches to match on task reference

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/SupportTaskSearchService.cs
+++ b/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/SupportTaskSearchService.cs
@@ -41,6 +41,11 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
                 t.TrnRequest.EmailAddress != null &&
                 EF.Functions.Collate(t.TrnRequest.EmailAddress, Collations.CaseInsensitive) == email);
         }
+        else if (SearchTextHelper.IsSupportTaskReference(search))
+        {
+            tasks = tasks.Where(t =>
+                EF.Functions.Collate(t.Task.SupportTaskReference, Collations.CaseInsensitive) == search);
+        }
         else if (SearchTextIsName(search, out var nameParts))
         {
             tasks = tasks.Where(t =>
@@ -117,7 +122,12 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
 
         tasks = tasks.Where(t => changeRequestTypes.Contains(t.SupportTaskType));
 
-        if (SearchTextIsName(search, out var nameParts))
+        if (SearchTextHelper.IsSupportTaskReference(search))
+        {
+            tasks = tasks.Where(t =>
+                EF.Functions.Collate(t.SupportTaskReference, Collations.CaseInsensitive) == search);
+        }
+        else if (SearchTextIsName(search, out var nameParts))
         {
             tasks = tasks.Where(t =>
                 nameParts.All(n => EF.Property<string[]>(t.Person!, "names").Contains(n)));
@@ -187,7 +197,12 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
 
         tasks = tasks.Where(t => sources.Contains(t.Task.TrnRequestMetadata!.ApplicationUserId));
 
-        if (SearchTextIsName(search, out var nameParts))
+        if (SearchTextHelper.IsSupportTaskReference(search))
+        {
+            tasks = tasks.Where(t =>
+                EF.Functions.Collate(t.Task.SupportTaskReference, Collations.CaseInsensitive) == search);
+        }
+        else if (SearchTextIsName(search, out var nameParts))
         {
             tasks = tasks.Where(t =>
                 nameParts.All(n => t.Task.TrnRequestMetadata!.Name.Select(m => EF.Functions.Collate(m, Collations.CaseInsensitive)).Contains(n)));
@@ -261,11 +276,18 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
         {
             unorderedResults = unorderedResults.Where(t => t.CreatedOn >= minDate && t.CreatedOn < maxDate);
         }
+        else if (SearchTextHelper.IsSupportTaskReference(search))
+        {
+            unorderedResults = unorderedResults.Where(t =>
+                string.Equals(t.SupportTaskReference, search, StringComparison.OrdinalIgnoreCase));
+        }
         else if (SearchTextIsName(search, out var name))
         {
             unorderedResults = unorderedResults.Where(t =>
                 name.All(n => t.NameParts!.Any(m => string.Equals(m, n, StringComparison.OrdinalIgnoreCase))));
         }
+
+        var totalFilteredTaskCount = unorderedResults.Count();
 
         var searchResults = (sortBy switch
         {
@@ -277,7 +299,7 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
                 .OrderBy(r => r.IntegrationTransactionId, sortDirection),
             _ => unorderedResults
                 .OrderBy(r => r.CreatedOn, sortDirection),
-        }).GetPage(paginationOptions.PageNumber, paginationOptions.PageSize, tasks.Count);
+        }).GetPage(paginationOptions.PageNumber, paginationOptions.PageSize, totalFilteredTaskCount);
 
         return new()
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchChangeRequestsAsync.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchChangeRequestsAsync.cs
@@ -138,6 +138,40 @@ public partial class SupportTaskSearchServiceTests
         Assert.Equal(expectedTaskKeys, tasks.GetKeysFor(result.SearchResults));
     }
 
+    [Fact]
+    public async Task SearchChangeRequestsAsync_SearchTextIsSupportTaskReference_ReturnsTaskWithMatchingReference()
+    {
+        // Arrange
+        var tasks = new SupportTaskLookup
+        {
+            ["ST1"] = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync(),
+            ["ST2"] = await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync()
+        };
+
+        // Act
+        var result = await SearchChangeRequestsAsync(new(Search: tasks["ST2"].SupportTaskReference.ToLowerInvariant()), new());
+
+        // Assert
+        Assert.Equal(2, result.TotalRequestCount);
+        Assert.Equal(1, result.SearchResults.TotalItemCount);
+        Assert.Equal(["ST2"], tasks.GetKeysFor(result.SearchResults));
+    }
+
+    [Fact]
+    public async Task SearchChangeRequestsAsync_SearchTextIsUnusedSupportTaskReference_ReturnsNoTasks()
+    {
+        // Arrange
+        await TestData.CreateChangeDateOfBirthRequestSupportTaskAsync();
+
+        // Act
+        var result = await SearchChangeRequestsAsync(new(Search: "TRS-0"), new());
+
+        // Assert
+        Assert.Equal(1, result.TotalRequestCount);
+        Assert.Equal(0, result.SearchResults.TotalItemCount);
+        Assert.Empty(result.SearchResults);
+    }
+
     [Theory]
     [InlineData(new[] { SupportTaskType.ChangeNameRequest }, new[] { "ST1" })]
     [InlineData(new[] { SupportTaskType.ChangeDateOfBirthRequest }, new[] { "ST2" })]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchTeachersPensionsPotentialDuplicatesAsync.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchTeachersPensionsPotentialDuplicatesAsync.cs
@@ -72,6 +72,40 @@ public partial class SupportTaskSearchServiceTests
         });
     }
 
+    [Fact]
+    public async Task SearchTeachersPensionsPotentialDuplicatesAsync_SearchTextIsSupportTaskReference_ReturnsTaskWithMatchingReference()
+    {
+        // Arrange
+        var tasks = new SupportTaskLookup
+        {
+            ["ST1"] = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(),
+            ["ST2"] = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync()
+        };
+
+        // Act
+        var result = await SearchTeachersPensionsPotentialDuplicatesAsync(new(Search: tasks["ST2"].SupportTaskReference.ToLowerInvariant()), new());
+
+        // Assert
+        Assert.Equal(2, result.TotalTaskCount);
+        Assert.Equal(1, result.SearchResults.TotalItemCount);
+        Assert.Equal(["ST2"], tasks.GetKeysFor(result.SearchResults));
+    }
+
+    [Fact]
+    public async Task SearchTeachersPensionsPotentialDuplicatesAsync_SearchTextIsUnusedSupportTaskReference_ReturnsNoTasks()
+    {
+        // Arrange
+        await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
+
+        // Act
+        var result = await SearchTeachersPensionsPotentialDuplicatesAsync(new(Search: "TRS-0"), new());
+
+        // Assert
+        Assert.Equal(1, result.TotalTaskCount);
+        Assert.Equal(0, result.SearchResults.TotalItemCount);
+        Assert.Empty(result.SearchResults);
+    }
+
     [Theory]
     [InlineData(SortDirection.Ascending)]
     [InlineData(SortDirection.Descending)]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchTrnRequestManualChecksAsync.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchTrnRequestManualChecksAsync.cs
@@ -137,6 +137,40 @@ public partial class SupportTaskSearchServiceTests
         Assert.Equal(expectedTaskKeys, tasks.GetKeysFor(result.SearchResults));
     }
 
+    [Fact]
+    public async Task SearchTrnRequestManualChecksAsync_SearchTextIsSupportTaskReference_ReturnsTaskWithMatchingReference()
+    {
+        // Arrange
+        var tasks = new SupportTaskLookup
+        {
+            ["ST1"] = await TestData.CreateTrnRequestManualChecksNeededSupportTaskAsync(createdOn: new DateTime(2025, 1, 20)),
+            ["ST2"] = await TestData.CreateTrnRequestManualChecksNeededSupportTaskAsync(createdOn: new DateTime(2025, 1, 21))
+        };
+
+        // Act
+        var result = await SearchTrnRequestManualChecksAsync(new(Search: tasks["ST2"].SupportTaskReference.ToLowerInvariant()), new());
+
+        // Assert
+        Assert.Equal(2, result.TotalTaskCount);
+        Assert.Equal(1, result.SearchResults.TotalItemCount);
+        Assert.Equal(["ST2"], tasks.GetKeysFor(result.SearchResults));
+    }
+
+    [Fact]
+    public async Task SearchTrnRequestManualChecksAsync_SearchTextIsUnusedSupportTaskReference_ReturnsNoTasks()
+    {
+        // Arrange
+        await TestData.CreateTrnRequestManualChecksNeededSupportTaskAsync(createdOn: new DateTime(2025, 1, 20));
+
+        // Act
+        var result = await SearchTrnRequestManualChecksAsync(new(Search: "TRS-0"), new());
+
+        // Assert
+        Assert.Equal(1, result.TotalTaskCount);
+        Assert.Equal(0, result.SearchResults.TotalItemCount);
+        Assert.Empty(result.SearchResults);
+    }
+
     [Theory]
     [InlineData(new[] { "A application" }, new[] { "ST1", "ST3" })]
     [InlineData(new[] { "B application" }, new[] { "ST2", "ST4" })]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchTrnRequestsAsync.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchTrnRequestsAsync.cs
@@ -208,6 +208,40 @@ public partial class SupportTaskSearchServiceTests
         Assert.Equal(expectedTaskKeys, tasks.GetKeysFor(result.SearchResults));
     }
 
+    [Fact]
+    public async Task SearchTrnRequestsAsync_SearchTextIsSupportTaskReference_ReturnsTaskWithMatchingReference()
+    {
+        // Arrange
+        var tasks = SupportTaskLookup.Create(new()
+        {
+            ["ST1"] = await TestData.CreateTrnRequestSupportTaskAsync(),
+            ["ST2"] = await TestData.CreateTrnRequestSupportTaskAsync()
+        });
+
+        // Act
+        var result = await SearchTrnRequestsAsync(new(Search: tasks["ST2"].SupportTaskReference.ToLowerInvariant(), SourceApplicationUserIds: []), new());
+
+        // Assert
+        Assert.Equal(2, result.TotalTaskCount);
+        Assert.Equal(1, result.SearchResults.TotalItemCount);
+        Assert.Equal(["ST2"], tasks.GetKeysFor(result.SearchResults));
+    }
+
+    [Fact]
+    public async Task SearchTrnRequestsAsync_SearchTextIsUnusedSupportTaskReference_ReturnsNoTasks()
+    {
+        // Arrange
+        await TestData.CreateTrnRequestSupportTaskAsync();
+
+        // Act
+        var result = await SearchTrnRequestsAsync(new(Search: "TRS-0", SourceApplicationUserIds: []), new());
+
+        // Assert
+        Assert.Equal(1, result.TotalTaskCount);
+        Assert.Equal(0, result.SearchResults.TotalItemCount);
+        Assert.Empty(result.SearchResults);
+    }
+
     [Theory]
     [InlineData(SortDirection.Ascending)]
     [InlineData(SortDirection.Descending)]


### PR DESCRIPTION
### Context

Support task references are a single word prefixed with `TRS-`. Only the two One Login searches on `SupportTaskSearchService` handled them. On the other searches a `TRS-` search text fell through to the name branch, where it was split into name parts and matched nothing.

### Changes proposed in this pull request

Added a `SearchTextHelper.IsSupportTaskReference` branch to `SearchTrnRequestsAsync`, `SearchChangeRequestsAsync`, `SearchTrnRequestManualChecksAsync` and `SearchTeachersPensionsPotentialDuplicatesAsync`. Each does a case-insensitive exact match on `SupportTaskReference`, placed ahead of the name branch. The three database-backed searches use `EF.Functions.Collate(..., Collations.CaseInsensitive)` to match the surrounding style; the Teachers' Pensions one filters in memory, as the rest of that method does.

Each method gains two tests — a matching reference and an unused reference.

`SearchSupportTasksAsync` is untouched: it takes no `Search` parameter at all, only type, assignee and status filters. Adding reference search there means adding a field to `SupportTasksSearchOptions` and threading it through the callers, so it seemed better left to its own change. Happy to fold it in if you'd prefer.

### Guidance to review

One fix here is outside the headline change and worth a look. `SearchTeachersPensionsPotentialDuplicatesAsync` was passing the **unfiltered** task count to `GetPage`, unlike every other search method, which passes the filtered count. That meant a wrong `TotalItemCount` and a page number that could resolve past the end of the filtered results. The bug is pre-existing and already affected date and name searches, but the new reference filter reaches the same path, so it is fixed here. Say the word if you'd rather see it split out.

No dependencies. `just build` is clean and all 214 tests in `SupportTaskSearchServiceTests` pass, including the 8 new ones.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally