### PR TITLE
Give each git worktree its own test database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,6 +404,8 @@ FodyWeavers.xsd
 
 **/.DS_Store
 
+.tests-schema-version.txt
+
 terraform/domains/environment_domains/vendor/
 terraform/domains/infrastructure/vendor/
 terraform/aks/vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,24 @@ Assert.IsType<ArgumentException>(exception);
 
 Assume that dependencies for running tests (a local postgres database, Playwright etc.) are already configured.
 
+### Running tests in a git worktree
+
+Each worktree must use its own test database; sharing one with other worktrees will cause tests to interfere with each other.
+When working in a git worktree, set the following environment variables before running tests:
+
+- `UseTestContainers` to `true`, so the tests spin up their own postgres container.
+- `TestContainersPostgresPort` to a random free port, so the container doesn't clash with the ones other worktrees are using.
+
+### Resetting the database schema and data
+
+The test database schema is cached in a `.tests-schema-version.txt` file at the root of the repository (this file is git-ignored, so each
+worktree has its own). If the schema gets out of sync — tests fail with Postgres errors about missing tables or columns — remove the cache
+file to force the schema and data to be recreated on the next test run:
+
+```shell
+just remove-tests-schema-cache
+```
+
 ### Boolean Expressions
 
 - Prefer `!boolean-expression` over `boolean-expression == false`.

--- a/scripts/RemoveTestsSchemaCache.cs
+++ b/scripts/RemoveTestsSchemaCache.cs
@@ -1,4 +1,8 @@
 #!/usr/bin/env -S dotnet --
 
-var appDataDir = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TeachingRecordSystem.Tests");
-Directory.GetFiles(appDataDir, "*-dbversion.txt").ToList().ForEach(File.Delete);
+var schemaVersionFilePath = Path.Join(Environment.CurrentDirectory, ".tests-schema-version.txt");
+
+if (File.Exists(schemaVersionFilePath))
+{
+    File.Delete(schemaVersionFilePath);
+}

--- a/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
+++ b/tests/TeachingRecordSystem.TestCommon/DbHelper.cs
@@ -14,6 +14,9 @@ namespace TeachingRecordSystem.TestCommon;
 
 public sealed class DbHelper : IAsyncDisposable
 {
+    private const int DefaultTestContainersPostgresPort = 43007;
+    private const string SchemaVersionFileName = ".tests-schema-version.txt";
+
     private readonly IServiceProvider _serviceProvider;
     private readonly PostgreSqlContainer? _postgresContainer;
 
@@ -31,8 +34,11 @@ public sealed class DbHelper : IAsyncDisposable
 
     public IDbContextFactory<TrsDbContext> DbContextFactory => _serviceProvider.GetRequiredService<IDbContextFactory<TrsDbContext>>();
 
-    public static string GetTestContainersConnectionString() =>
-        "Host=localhost;Port=43007;Database=trs;Username=postgres;Password=postgres;";
+    public static string GetTestContainersConnectionString(int port) =>
+        $"Host=localhost;Port={port};Database=trs;Username=postgres;Password=postgres;";
+
+    public static int GetTestContainersPostgresPort(IConfiguration configuration) =>
+        configuration.GetValue<int?>("TestContainersPostgresPort") ?? DefaultTestContainersPostgresPort;
 
     private static DbHelper CreateInstance()
     {
@@ -47,7 +53,7 @@ public sealed class DbHelper : IAsyncDisposable
             postgresContainer = new PostgreSqlBuilder("postgres:17")
                 .WithDatabase("trs")
                 .WithReuse(true)
-                .WithPortBinding(43007, 5432)
+                .WithPortBinding(GetTestContainersPostgresPort(configuration), 5432)
                 .Build();
         }
 
@@ -114,12 +120,8 @@ public sealed class DbHelper : IAsyncDisposable
         using var dbContext = await DbContextFactory.CreateDbContextAsync();
 
         var connection = dbContext.Database.GetDbConnection();
-        var dbName = connection.Database;
 
-        var cachedMigrationsVersionPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "TeachingRecordSystem.Tests",
-            $"{dbName}-dbversion.txt");
+        var cachedMigrationsVersionPath = Path.Combine(GetRepositoryRootPath(), SchemaVersionFileName);
 
         var currentDbVersion = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(dbContext.Database.GenerateCreateScript())));
 
@@ -139,12 +141,24 @@ public sealed class DbHelper : IAsyncDisposable
         string? GetPreviousMigrationsVersion() =>
             File.Exists(cachedMigrationsVersionPath) ? File.ReadAllText(cachedMigrationsVersionPath) : null;
 
-        void WriteMigrationsVersion()
+        void WriteMigrationsVersion() => File.WriteAllText(cachedMigrationsVersionPath, currentDbVersion);
+    }
+
+    private static string GetRepositoryRootPath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
         {
-            var directory = Path.GetDirectoryName(cachedMigrationsVersionPath)!;
-            Directory.CreateDirectory(directory);
-            File.WriteAllText(cachedMigrationsVersionPath, currentDbVersion);
+            if (File.Exists(Path.Combine(directory.FullName, "TeachingRecordSystem.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
         }
+
+        throw new InvalidOperationException($"Could not find the repository root from '{AppContext.BaseDirectory}'.");
     }
 
     private async Task EnsureRespawnerAsync(DbConnection connection) =>

--- a/tests/TeachingRecordSystem.TestCommon/TestConfiguration.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestConfiguration.cs
@@ -16,7 +16,7 @@ public static class TestConfiguration
         var connectionString = configuration.GetConnectionString(TrsDbContext.ConnectionName);
         if (connectionString is null)
         {
-            connectionString = DbHelper.GetTestContainersConnectionString();
+            connectionString = DbHelper.GetTestContainersConnectionString(DbHelper.GetTestContainersPostgresPort(configuration));
 
             configuration.AddInMemoryCollection([
                 KeyValuePair.Create($"ConnectionStrings:{TrsDbContext.ConnectionName}", (string?)connectionString),


### PR DESCRIPTION
### Context

Working in a git worktree currently means sharing a test database with every other worktree, so tests running in one worktree trample the data another is relying on. Two things were tying them together: a schema cache keyed only on database name, and a hardcoded testcontainers port.

### Changes proposed in this pull request

**Schema cache moved into the repo.** `DbHelper` previously wrote its cached schema version to `%AppData%/TeachingRecordSystem.Tests/{dbName}-dbversion.txt`, which every worktree pointing at the same database name shared. It now writes `.tests-schema-version.txt` at the repository root, located by walking up from `AppContext.BaseDirectory` until `TeachingRecordSystem.slnx` is found. Each worktree is its own directory, so each gets its own cache. The file is git-ignored.

**Testcontainers port is configurable.** The container port now comes from a `TestContainersPostgresPort` configuration value when provided, falling back to the previously hardcoded 43007. `GetTestContainersConnectionString` takes the port as a parameter, and a new `GetTestContainersPostgresPort(IConfiguration)` resolves it — `TestConfiguration` was the only caller. Because `WithReuse(true)` hashes the container config, a distinct port yields a distinct container per worktree.

**`RemoveTestsSchemaCache.cs`** deletes the single file from the working directory instead of globbing `*-dbversion.txt` out of AppData. `just` runs recipes from the justfile directory, so the working directory is always the repository root.

**`AGENTS.md`** documents setting `UseTestContainers=true` plus a random `TestContainersPostgresPort` when working in a worktree, and how to reset the schema and data with `just remove-tests-schema-cache`.

### Guidance to review

Worth knowing: Docker wasn't running on the machine this was developed on, so the testcontainers path itself is unexercised. The passing test run used a local postgres via user secrets, which confirmed the schema cache file lands at the repository root and is picked up correctly. The port plumbing is straightforward but has not been observed starting a real container — worth a look from someone with Docker up.

Note that the schema cache filename no longer includes the database name. That's intentional: the worktree directory is now what separates caches, not the database name.

`just build` is clean and `dotnet test tests/TeachingRecordSystem.Cli.Tests` passes (31/31).

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)