### PR TITLE
Resolve unset attribute sources to the existing record

### DIFF
--- a/src/TeachingRecordSystem.Core/Jobs/BackfillResolvedAttributesJob.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/BackfillResolvedAttributesJob.cs
@@ -10,8 +10,8 @@ using SupportTaskUpdatedEvent = TeachingRecordSystem.Core.Events.SupportTaskUpda
 namespace TeachingRecordSystem.Core.Jobs;
 
 /// <summary>
-/// Corrects <c>ResolvedAttributes</c> on closed TRN request and Teachers' Pensions potential duplicate tasks
-/// that were resolved by merging into an existing record.
+/// Corrects <c>ResolvedAttributes</c> on closed TRN request, NPQ TRN request and Teachers' Pensions potential
+/// duplicate tasks that were resolved by merging into an existing record.
 ///
 /// The resolve journeys recorded the TRN request's value for any attribute whose source was left unset, even
 /// though an unset source means the person was never updated and kept its existing value — so the task's
@@ -19,13 +19,16 @@ namespace TeachingRecordSystem.Core.Jobs;
 ///
 /// A source was only ever left unset where the merge page didn't offer a choice, and it offered one exactly
 /// when the two values differed. So wherever the request and the pre-merge snapshot agree, the resolved value
-/// should be the snapshot's. The Teachers' Pensions journey additionally never offered a middle name choice at
-/// all, so its middle name is always taken from the snapshot regardless.
+/// should be the snapshot's. Two journeys go further and never offered a choice for some attributes at all, so
+/// those always come from the snapshot: Teachers' Pensions for the middle name, and NPQ for all three names.
 ///
 /// <c>SelectedPersonAttributes</c> is that pre-merge snapshot, which makes the correct value recoverable.
 /// Tasks resolved by creating a new record have no snapshot and are left alone.
 ///
 /// The closing event's payload embeds the same task data, so it's corrected alongside the task itself.
+///
+/// The NPQ journey's UI was removed in #3434, so those tasks are historical only — they're covered because the
+/// data it left behind has the same defect, not because anything still writes it.
 /// </summary>
 public class BackfillResolvedAttributesJob(TrsDbContext dbContext)
 {
@@ -34,7 +37,7 @@ public class BackfillResolvedAttributesJob(TrsDbContext dbContext)
         [.. LegacyEventBase.GetEventNamesForBaseType(typeof(LegacySupportTaskUpdatedEvent))];
 
     private static readonly SupportTaskType[] _supportTaskTypes =
-        [SupportTaskType.TrnRequest, SupportTaskType.TeacherPensionsPotentialDuplicate];
+        [SupportTaskType.TrnRequest, SupportTaskType.NpqTrnRequest, SupportTaskType.TeacherPensionsPotentialDuplicate];
 
     public async Task ExecuteAsync(bool dryRun, CancellationToken cancellationToken)
     {
@@ -89,10 +92,35 @@ public class BackfillResolvedAttributesJob(TrsDbContext dbContext)
         return supportTask.SupportTaskType switch
         {
             SupportTaskType.TrnRequest => GetCorrectedTrnRequestData(supportTask.GetData<TrnRequestData>(), requestData),
+            SupportTaskType.NpqTrnRequest => GetCorrectedNpqTrnRequestData(supportTask.GetData<NpqTrnRequestData>(), requestData),
             SupportTaskType.TeacherPensionsPotentialDuplicate =>
                 GetCorrectedTeacherPensionsData(supportTask.GetData<TeacherPensionsPotentialDuplicateData>(), requestData),
             _ => null
         };
+    }
+
+    private static ISupportTaskData? GetCorrectedNpqTrnRequestData(NpqTrnRequestData data, TrnRequestMetadata requestData)
+    {
+        // No snapshot means the request was resolved with a newly created record (or the task was rejected),
+        // neither of which resolves attributes against an existing record.
+        if (data is not { ResolvedAttributes: { } resolved, SelectedPersonAttributes: { } selected })
+        {
+            return null;
+        }
+
+        var corrected = resolved with
+        {
+            // This journey offered no name choices at all, so the existing record's names were always kept.
+            FirstName = selected.FirstName,
+            MiddleName = selected.MiddleName,
+            LastName = selected.LastName,
+            DateOfBirth = selected.DateOfBirth != requestData.DateOfBirth ? resolved.DateOfBirth : selected.DateOfBirth,
+            EmailAddress = DifferAllowingNullOrEmpty(selected.EmailAddress, requestData.EmailAddress) ? resolved.EmailAddress : selected.EmailAddress,
+            NationalInsuranceNumber = DifferAllowingNullOrEmpty(selected.NationalInsuranceNumber, requestData.NationalInsuranceNumber) ? resolved.NationalInsuranceNumber : selected.NationalInsuranceNumber,
+            Gender = selected.Gender != requestData.Gender ? resolved.Gender : selected.Gender
+        };
+
+        return corrected != resolved ? data with { ResolvedAttributes = corrected } : null;
     }
 
     private static ISupportTaskData? GetCorrectedTrnRequestData(TrnRequestData data, TrnRequestMetadata requestData)
@@ -209,6 +237,7 @@ public class BackfillResolvedAttributesJob(TrsDbContext dbContext)
     private static object? GetResolvedAttributes(ISupportTaskData data) => data switch
     {
         TrnRequestData d => d.ResolvedAttributes,
+        NpqTrnRequestData d => d.ResolvedAttributes,
         TeacherPensionsPotentialDuplicateData d => d.ResolvedAttributes,
         _ => null
     };

--- a/src/TeachingRecordSystem.Core/Jobs/BackfillResolvedAttributesJob.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/BackfillResolvedAttributesJob.cs
@@ -1,0 +1,218 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
+using LegacyEventBase = TeachingRecordSystem.Core.Events.Legacy.EventBase;
+using LegacySupportTaskUpdatedEvent = TeachingRecordSystem.Core.Events.Legacy.SupportTaskUpdatedEvent;
+using SupportTaskUpdatedEvent = TeachingRecordSystem.Core.Events.SupportTaskUpdatedEvent;
+
+namespace TeachingRecordSystem.Core.Jobs;
+
+/// <summary>
+/// Corrects <c>ResolvedAttributes</c> on closed TRN request and Teachers' Pensions potential duplicate tasks
+/// that were resolved by merging into an existing record.
+///
+/// The resolve journeys recorded the TRN request's value for any attribute whose source was left unset, even
+/// though an unset source means the person was never updated and kept its existing value — so the task's
+/// record of the outcome disagreed with the record it describes.
+///
+/// A source was only ever left unset where the merge page didn't offer a choice, and it offered one exactly
+/// when the two values differed. So wherever the request and the pre-merge snapshot agree, the resolved value
+/// should be the snapshot's. The Teachers' Pensions journey additionally never offered a middle name choice at
+/// all, so its middle name is always taken from the snapshot regardless.
+///
+/// <c>SelectedPersonAttributes</c> is that pre-merge snapshot, which makes the correct value recoverable.
+/// Tasks resolved by creating a new record have no snapshot and are left alone.
+///
+/// The closing event's payload embeds the same task data, so it's corrected alongside the task itself.
+/// </summary>
+public class BackfillResolvedAttributesJob(TrsDbContext dbContext)
+{
+    // Legacy events that carry the support task's before/after state, i.e. can represent a close.
+    private static readonly string[] _closingLegacyEventNames =
+        [.. LegacyEventBase.GetEventNamesForBaseType(typeof(LegacySupportTaskUpdatedEvent))];
+
+    private static readonly SupportTaskType[] _supportTaskTypes =
+        [SupportTaskType.TrnRequest, SupportTaskType.TeacherPensionsPotentialDuplicate];
+
+    public async Task ExecuteAsync(bool dryRun, CancellationToken cancellationToken)
+    {
+        dbContext.Database.SetCommandTimeout(0);
+
+        await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        var supportTasks = await dbContext.SupportTasks
+            .IgnoreQueryFilters()
+            .Include(t => t.TrnRequestMetadata)
+            .Where(t => _supportTaskTypes.Contains(t.SupportTaskType))
+            .Where(t => t.Status == SupportTaskStatus.Closed)
+            .ToListAsync(cancellationToken);
+
+        // The corrected data for each task we actually changed, keyed by reference, so the closing event's
+        // copy can be brought in line with it.
+        var correctedData = new Dictionary<string, ISupportTaskData>();
+
+        foreach (var supportTask in supportTasks)
+        {
+            if (GetCorrectedData(supportTask) is { } corrected)
+            {
+                supportTask.Data = corrected;
+                correctedData.Add(supportTask.SupportTaskReference, corrected);
+            }
+        }
+
+        await CorrectClosingEventsAsync(correctedData, cancellationToken);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        if (dryRun)
+        {
+            await transaction.RollbackAsync(cancellationToken);
+        }
+        else
+        {
+            await transaction.CommitAsync(cancellationToken);
+        }
+    }
+
+    /// Returns the task's data with corrected resolved attributes, or null if it needs no correction.
+    private static ISupportTaskData? GetCorrectedData(SupportTask supportTask)
+    {
+        var requestData = supportTask.TrnRequestMetadata;
+
+        if (requestData is null)
+        {
+            return null;
+        }
+
+        return supportTask.SupportTaskType switch
+        {
+            SupportTaskType.TrnRequest => GetCorrectedTrnRequestData(supportTask.GetData<TrnRequestData>(), requestData),
+            SupportTaskType.TeacherPensionsPotentialDuplicate =>
+                GetCorrectedTeacherPensionsData(supportTask.GetData<TeacherPensionsPotentialDuplicateData>(), requestData),
+            _ => null
+        };
+    }
+
+    private static ISupportTaskData? GetCorrectedTrnRequestData(TrnRequestData data, TrnRequestMetadata requestData)
+    {
+        // No snapshot means the request was resolved with a newly created record, which takes every value
+        // from the request and so was never affected.
+        if (data is not { ResolvedAttributes: { } resolved, SelectedPersonAttributes: { } selected })
+        {
+            return null;
+        }
+
+        var corrected = resolved with
+        {
+            FirstName = Differ(selected.FirstName, requestData.FirstName) ? resolved.FirstName : selected.FirstName,
+            MiddleName = DifferAllowingNullOrEmpty(selected.MiddleName, requestData.MiddleName) ? resolved.MiddleName : selected.MiddleName,
+            LastName = Differ(selected.LastName, requestData.LastName) ? resolved.LastName : selected.LastName,
+            DateOfBirth = selected.DateOfBirth != requestData.DateOfBirth ? resolved.DateOfBirth : selected.DateOfBirth,
+            EmailAddress = DifferAllowingNullOrEmpty(selected.EmailAddress, requestData.EmailAddress) ? resolved.EmailAddress : selected.EmailAddress,
+            NationalInsuranceNumber = DifferAllowingNullOrEmpty(selected.NationalInsuranceNumber, requestData.NationalInsuranceNumber) ? resolved.NationalInsuranceNumber : selected.NationalInsuranceNumber,
+            Gender = selected.Gender != requestData.Gender ? resolved.Gender : selected.Gender
+        };
+
+        return corrected != resolved ? data with { ResolvedAttributes = corrected } : null;
+    }
+
+    private static ISupportTaskData? GetCorrectedTeacherPensionsData(
+        TeacherPensionsPotentialDuplicateData data,
+        TrnRequestMetadata requestData)
+    {
+        // No snapshot means the task was resolved without a merge, which records no resolved attributes.
+        if (data is not { ResolvedAttributes: { } resolved, SelectedPersonAttributes: { } selected })
+        {
+            return null;
+        }
+
+        var corrected = resolved with
+        {
+            FirstName = Differ(selected.FirstName, requestData.FirstName) ? resolved.FirstName : selected.FirstName,
+            // This journey's merge page offers no middle name choice, so the source is always unset.
+            MiddleName = selected.MiddleName,
+            LastName = Differ(selected.LastName, requestData.LastName) ? resolved.LastName : selected.LastName,
+            DateOfBirth = selected.DateOfBirth != requestData.DateOfBirth ? resolved.DateOfBirth : selected.DateOfBirth,
+            NationalInsuranceNumber = DifferAllowingNullOrEmpty(selected.NationalInsuranceNumber, requestData.NationalInsuranceNumber) ? resolved.NationalInsuranceNumber : selected.NationalInsuranceNumber,
+            Gender = selected.Gender != requestData.Gender ? resolved.Gender : selected.Gender
+        };
+
+        return corrected != resolved ? data with { ResolvedAttributes = corrected } : null;
+    }
+
+    // The merge pages compare most values exactly...
+    private static bool Differ(string? existingValue, string? requestValue) => existingValue != requestValue;
+
+    // ...but treat null and empty as the same value for those a request can omit.
+    private static bool DifferAllowingNullOrEmpty(string? existingValue, string? requestValue) =>
+        !(existingValue == requestValue || (string.IsNullOrEmpty(existingValue) && string.IsNullOrEmpty(requestValue)));
+
+    private async Task CorrectClosingEventsAsync(
+        IReadOnlyDictionary<string, ISupportTaskData> correctedData,
+        CancellationToken cancellationToken)
+    {
+        if (correctedData.Count == 0)
+        {
+            return;
+        }
+
+        // New pipeline: the close is a SupportTaskUpdatedEvent in process_events.
+        var processEvents = await dbContext.ProcessEvents
+            .Where(e => e.EventName == nameof(SupportTaskUpdatedEvent))
+            .ToListAsync(cancellationToken);
+
+        foreach (var processEvent in processEvents)
+        {
+            if (processEvent.Payload is SupportTaskUpdatedEvent payload &&
+                correctedData.TryGetValue(payload.SupportTask.SupportTaskReference, out var corrected) &&
+                ClosesTask(payload.OldSupportTask.Status, payload.SupportTask.Status))
+            {
+                dbContext.Entry(processEvent).Property(e => e.Payload).CurrentValue = payload with
+                {
+                    SupportTask = payload.SupportTask with { Data = corrected }
+                };
+            }
+        }
+
+        // Legacy events are stored as JSON, so edit the payload in place rather than round-tripping it
+        // through the typed model.
+        var legacyEvents = await dbContext.Events
+            .Where(e => _closingLegacyEventNames.Contains(e.EventName))
+            .ToListAsync(cancellationToken);
+
+        foreach (var legacyEvent in legacyEvents)
+        {
+            if (legacyEvent.ToEventBase() is not LegacySupportTaskUpdatedEvent { SupportTask: var newTask, OldSupportTask: var oldTask } ||
+                !ClosesTask(oldTask.Status, newTask.Status) ||
+                !correctedData.TryGetValue(newTask.SupportTaskReference, out var corrected))
+            {
+                continue;
+            }
+
+            var payload = JsonNode.Parse(legacyEvent.Payload)!;
+
+            if (payload["SupportTask"]?["Data"] is not JsonObject dataNode)
+            {
+                continue;
+            }
+
+            dataNode["ResolvedAttributes"] = JsonSerializer.SerializeToNode(
+                GetResolvedAttributes(corrected),
+                LegacyEventBase.JsonSerializerOptions);
+
+            dbContext.Entry(legacyEvent).Property(e => e.Payload).CurrentValue = payload.ToJsonString();
+        }
+    }
+
+    private static object? GetResolvedAttributes(ISupportTaskData data) => data switch
+    {
+        TrnRequestData d => d.ResolvedAttributes,
+        TeacherPensionsPotentialDuplicateData d => d.ResolvedAttributes,
+        _ => null
+    };
+
+    private static bool ClosesTask(SupportTaskStatus oldStatus, SupportTaskStatus newStatus) =>
+        oldStatus is not SupportTaskStatus.Closed && newStatus is SupportTaskStatus.Closed;
+}

--- a/src/TeachingRecordSystem.Core/Jobs/Extensions.cs
+++ b/src/TeachingRecordSystem.Core/Jobs/Extensions.cs
@@ -263,6 +263,16 @@ public static class Extensions
                 job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None),
                 Cron.Never);
 
+            recurringJobManager.AddOrUpdate<BackfillResolvedAttributesJob>(
+                $"{nameof(BackfillResolvedAttributesJob)} (dry-run)",
+                job => job.ExecuteAsync(/*dryRun: */true, CancellationToken.None),
+                Cron.Never);
+
+            recurringJobManager.AddOrUpdate<BackfillResolvedAttributesJob>(
+                nameof(BackfillResolvedAttributesJob),
+                job => job.ExecuteAsync(/*dryRun: */false, CancellationToken.None),
+                Cron.Never);
+
             recurringJobManager.AddOrUpdate<ScheduleTrnRecipientEmailsJob>(
                 nameof(ScheduleTrnRecipientEmailsJob),
                 job => job.ExecuteAsync(CancellationToken.None),

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
@@ -93,12 +93,13 @@ public class CheckAnswersModel(
             })
             .SingleAsync();
 
-        FirstName = state.FirstNameSource == PersonAttributeSource.ExistingRecord ? selectedPerson.FirstName : requestData.FirstName;
-        MiddleName = state.MiddleNameSource == PersonAttributeSource.ExistingRecord ? selectedPerson.MiddleName : requestData.MiddleName;
-        LastName = state.LastNameSource == PersonAttributeSource.ExistingRecord ? selectedPerson.LastName : requestData.LastName;
-        DateOfBirth = state.DateOfBirthSource == PersonAttributeSource.ExistingRecord ? selectedPerson.DateOfBirth : requestData.DateOfBirth;
-        NationalInsuranceNumber = state.NationalInsuranceNumberSource == PersonAttributeSource.ExistingRecord ? selectedPerson.NationalInsuranceNumber : requestData.NationalInsuranceNumber;
-        Gender = state.GenderSource == PersonAttributeSource.ExistingRecord ? selectedPerson.Gender : requestData.Gender;
+        // Mirrors GetResolvedPersonAttributes: only a TrnRequest source changes the record.
+        FirstName = state.FirstNameSource is PersonAttributeSource.TrnRequest ? requestData.FirstName : selectedPerson.FirstName;
+        MiddleName = state.MiddleNameSource is PersonAttributeSource.TrnRequest ? requestData.MiddleName : selectedPerson.MiddleName;
+        LastName = state.LastNameSource is PersonAttributeSource.TrnRequest ? requestData.LastName : selectedPerson.LastName;
+        DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.TrnRequest ? requestData.DateOfBirth : selectedPerson.DateOfBirth;
+        NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest ? requestData.NationalInsuranceNumber : selectedPerson.NationalInsuranceNumber;
+        Gender = state.GenderSource is PersonAttributeSource.TrnRequest ? requestData.Gender : selectedPerson.Gender;
         Trn = selectedPerson.Trn; //trn cannot be changed, it'll always be the existing trn that is kept
 
         MergeComments = state.MergeComments;

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
@@ -146,14 +146,16 @@ public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(TrsDbCon
         {
             Debug.Assert(selectedPersonAttributes is not null);
 
+            // Only a TrnRequest source updates the person (see GetAttributesToUpdate), so anything else —
+            // including MiddleName, which this journey never offers a choice for — keeps the existing value.
             return new TeacherPensionsPotentialDuplicateAttributes()
             {
-                FirstName = state.FirstNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.FirstName : trnRequestPersonAttributes.FirstName,
-                MiddleName = state.MiddleNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.MiddleName : trnRequestPersonAttributes.MiddleName,
-                LastName = state.LastNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.LastName : trnRequestPersonAttributes.LastName,
-                DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.DateOfBirth : trnRequestPersonAttributes.DateOfBirth,
-                NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.NationalInsuranceNumber : trnRequestPersonAttributes.NationalInsuranceNumber,
-                Gender = state.GenderSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.Gender : trnRequestPersonAttributes.Gender,
+                FirstName = state.FirstNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.FirstName : selectedPersonAttributes.FirstName,
+                MiddleName = state.MiddleNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.MiddleName : selectedPersonAttributes.MiddleName,
+                LastName = state.LastNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.LastName : selectedPersonAttributes.LastName,
+                DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.DateOfBirth : selectedPersonAttributes.DateOfBirth,
+                NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.NationalInsuranceNumber : selectedPersonAttributes.NationalInsuranceNumber,
+                Gender = state.GenderSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.Gender : selectedPersonAttributes.Gender,
                 Trn = selectedPersonAttributes.Trn
             };
         }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -162,13 +162,14 @@ public class CheckAnswers(
                 .SingleAsync();
 
             CreatingNewRecord = false;
-            FirstName = state.FirstNameSource == PersonAttributeSource.ExistingRecord ? selectedPerson.FirstName : requestData.FirstName;
-            MiddleName = state.MiddleNameSource == PersonAttributeSource.ExistingRecord ? selectedPerson.MiddleName : requestData.MiddleName;
-            LastName = state.LastNameSource == PersonAttributeSource.ExistingRecord ? selectedPerson.LastName : requestData.LastName;
-            DateOfBirth = state.DateOfBirthSource == PersonAttributeSource.ExistingRecord ? selectedPerson.DateOfBirth : requestData.DateOfBirth;
-            EmailAddress = state.EmailAddressSource == PersonAttributeSource.ExistingRecord ? selectedPerson.EmailAddress : requestData.EmailAddress;
-            NationalInsuranceNumber = state.NationalInsuranceNumberSource == PersonAttributeSource.ExistingRecord ? selectedPerson.NationalInsuranceNumber : requestData.NationalInsuranceNumber;
-            Gender = state.GenderSource == PersonAttributeSource.ExistingRecord ? selectedPerson.Gender : requestData.Gender;
+            // Mirrors GetResolvedPersonAttributes: only a TrnRequest source changes the record.
+            FirstName = state.FirstNameSource is PersonAttributeSource.TrnRequest ? requestData.FirstName : selectedPerson.FirstName;
+            MiddleName = state.MiddleNameSource is PersonAttributeSource.TrnRequest ? requestData.MiddleName : selectedPerson.MiddleName;
+            LastName = state.LastNameSource is PersonAttributeSource.TrnRequest ? requestData.LastName : selectedPerson.LastName;
+            DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.TrnRequest ? requestData.DateOfBirth : selectedPerson.DateOfBirth;
+            EmailAddress = state.EmailAddressSource is PersonAttributeSource.TrnRequest ? requestData.EmailAddress : selectedPerson.EmailAddress;
+            NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest ? requestData.NationalInsuranceNumber : selectedPerson.NationalInsuranceNumber;
+            Gender = state.GenderSource is PersonAttributeSource.TrnRequest ? requestData.Gender : selectedPerson.Gender;
             Trn = selectedPerson.Trn;
         }
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestPageModel.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestPageModel.cs
@@ -141,15 +141,17 @@ public abstract class ResolveTrnRequestPageModel(TrsDbContext dbContext) : PageM
         {
             Debug.Assert(selectedPersonAttributes is not null);
 
+            // Only a TrnRequest source updates the person (see GetAttributesToUpdate), so anything else —
+            // including a source left unset because the page didn't offer a choice — keeps the existing value.
             return new TrnRequestDataPersonAttributes()
             {
-                FirstName = state.FirstNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.FirstName : trnRequestPersonAttributes.FirstName,
-                MiddleName = state.MiddleNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.MiddleName : trnRequestPersonAttributes.MiddleName,
-                LastName = state.LastNameSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.LastName : trnRequestPersonAttributes.LastName,
-                DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.DateOfBirth : trnRequestPersonAttributes.DateOfBirth,
-                EmailAddress = state.EmailAddressSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.EmailAddress : trnRequestPersonAttributes.EmailAddress,
-                NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.NationalInsuranceNumber : trnRequestPersonAttributes.NationalInsuranceNumber,
-                Gender = state.GenderSource is PersonAttributeSource.ExistingRecord ? selectedPersonAttributes.Gender : trnRequestPersonAttributes.Gender
+                FirstName = state.FirstNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.FirstName : selectedPersonAttributes.FirstName,
+                MiddleName = state.MiddleNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.MiddleName : selectedPersonAttributes.MiddleName,
+                LastName = state.LastNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.LastName : selectedPersonAttributes.LastName,
+                DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.DateOfBirth : selectedPersonAttributes.DateOfBirth,
+                EmailAddress = state.EmailAddressSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.EmailAddress : selectedPersonAttributes.EmailAddress,
+                NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.NationalInsuranceNumber : selectedPersonAttributes.NationalInsuranceNumber,
+                Gender = state.GenderSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.Gender : selectedPersonAttributes.Gender
             };
         }
     }

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillResolvedAttributesJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillResolvedAttributesJobTests.cs
@@ -1,0 +1,213 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Jobs;
+using TeachingRecordSystem.Core.Models.SupportTasks;
+
+namespace TeachingRecordSystem.Core.Tests.Jobs;
+
+public class BackfillResolvedAttributesJobTests(JobFixture fixture) : JobTestBase(fixture)
+{
+    [Fact]
+    public async Task ExecuteAsync_MiddleNameTakenFromRequest_CorrectsResolvedMiddleNameToSelectedPerson()
+    {
+        // Arrange
+        var existingMiddleName = "Existing";
+        var requestMiddleName = "Different";
+
+        var supportTask = await CreateResolvedTeacherPensionsTaskAsync(
+            requestMiddleName,
+            selected => selected with { MiddleName = existingMiddleName },
+            // The bug: the request's middle name was recorded even though the person kept its own.
+            resolved => resolved with { MiddleName = requestMiddleName });
+
+        // Act
+        await WithDbContextAsync(dbContext =>
+            new BackfillResolvedAttributesJob(dbContext).ExecuteAsync(dryRun: false, CancellationToken.None));
+
+        // Assert
+        var data = await GetTeacherPensionsDataAsync(supportTask);
+        Assert.Equal(existingMiddleName, data.ResolvedAttributes!.MiddleName);
+        Assert.Equal(existingMiddleName, data.SelectedPersonAttributes!.MiddleName);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AttributeDifferedFromRequest_LeavesCaseworkersChoiceUnchanged()
+    {
+        // Arrange
+        // The merge page forces a choice whenever the values differ, so a differing resolved value is the
+        // caseworker's selection and must survive.
+        var requestFirstName = "Chosen";
+
+        var supportTask = await CreateResolvedTeacherPensionsTaskAsync(
+            requestMiddleName: null,
+            selected => selected with { FirstName = "NotChosen" },
+            resolved => resolved with { FirstName = requestFirstName },
+            configureRequest: s => s.WithFirstName(requestFirstName));
+
+        // Act
+        await WithDbContextAsync(dbContext =>
+            new BackfillResolvedAttributesJob(dbContext).ExecuteAsync(dryRun: false, CancellationToken.None));
+
+        // Assert
+        var data = await GetTeacherPensionsDataAsync(supportTask);
+        Assert.Equal(requestFirstName, data.ResolvedAttributes!.FirstName);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TaskWithNoSelectedPersonAttributes_IsLeftUnchanged()
+    {
+        // Arrange
+        // A task resolved without a merge records no attributes at all.
+        var person = await TestData.CreatePersonAsync();
+        var user = await TestData.CreateUserAsync();
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(
+            person.PersonId,
+            user.UserId,
+            s =>
+            {
+                s.WithSupportTaskData("test.csv", 1);
+                s.WithStatus(SupportTaskStatus.Closed);
+            });
+
+        // Act
+        await WithDbContextAsync(dbContext =>
+            new BackfillResolvedAttributesJob(dbContext).ExecuteAsync(dryRun: false, CancellationToken.None));
+
+        // Assert
+        var data = await GetTeacherPensionsDataAsync(supportTask);
+        Assert.Null(data.ResolvedAttributes);
+        Assert.Null(data.SelectedPersonAttributes);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DryRun_DoesNotPersistCorrections()
+    {
+        // Arrange
+        var requestMiddleName = "Different";
+
+        var supportTask = await CreateResolvedTeacherPensionsTaskAsync(
+            requestMiddleName,
+            selected => selected with { MiddleName = "Existing" },
+            resolved => resolved with { MiddleName = requestMiddleName });
+
+        // Act
+        await WithDbContextAsync(dbContext =>
+            new BackfillResolvedAttributesJob(dbContext).ExecuteAsync(dryRun: true, CancellationToken.None));
+
+        // Assert
+        var data = await GetTeacherPensionsDataAsync(supportTask);
+        Assert.Equal(requestMiddleName, data.ResolvedAttributes!.MiddleName);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ClosedTaskWithLegacyClosingEvent_CorrectsResolvedAttributesOnEventPayload()
+    {
+        // Arrange
+        var existingMiddleName = "Existing";
+        var requestMiddleName = "Different";
+        var closingEventId = Guid.NewGuid();
+
+        var supportTask = await CreateResolvedTeacherPensionsTaskAsync(
+            requestMiddleName,
+            selected => selected with { MiddleName = existingMiddleName },
+            resolved => resolved with { MiddleName = requestMiddleName });
+
+        // The closing event embeds a copy of the task data, carrying the same wrong middle name.
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbSupportTask = await dbContext.SupportTasks
+                .Include(t => t.TrnRequestMetadata)
+                .Include(t => t.Person)
+                .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+
+            var newSupportTask = EventModels.SupportTask.FromModel(dbSupportTask);
+            var oldSupportTask = newSupportTask with { Status = SupportTaskStatus.Open };
+
+            dbContext.AddEventWithoutBroadcast(new LegacyEvents.TeacherPensionsPotentialDuplicateSupportTaskResolvedEvent
+            {
+                EventId = closingEventId,
+                CreatedUtc = TimeProvider.UtcNow,
+                RaisedBy = SystemUser.SystemUserId,
+                PersonId = dbSupportTask.PersonId!.Value,
+                RequestData = EventModels.TrnRequestMetadata.FromModel(dbSupportTask.TrnRequestMetadata!),
+                ChangeReason = LegacyEvents.TeacherPensionsPotentialDuplicateSupportTaskResolvedReason.RecordMerged,
+                Changes = LegacyEvents.TeacherPensionsPotentialDuplicateSupportTaskResolvedEventChanges.Status,
+                PersonAttributes = EventModels.PersonDetails.FromModel(dbSupportTask.Person!),
+                OldPersonAttributes = null,
+                Comments = null,
+                SupportTask = newSupportTask,
+                OldSupportTask = oldSupportTask
+            });
+
+            await dbContext.SaveChangesAsync();
+        });
+
+        // Act
+        await WithDbContextAsync(dbContext =>
+            new BackfillResolvedAttributesJob(dbContext).ExecuteAsync(dryRun: false, CancellationToken.None));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var closingEvent = await dbContext.Events.SingleAsync(e => e.EventId == closingEventId);
+            var eventBase = Assert.IsType<LegacyEvents.TeacherPensionsPotentialDuplicateSupportTaskResolvedEvent>(closingEvent.ToEventBase());
+            var data = Assert.IsType<TeacherPensionsPotentialDuplicateData>(eventBase.SupportTask.Data);
+
+            Assert.Equal(existingMiddleName, data.ResolvedAttributes!.MiddleName);
+        });
+    }
+
+    private async Task<SupportTask> CreateResolvedTeacherPensionsTaskAsync(
+        string? requestMiddleName,
+        Func<TeacherPensionsPotentialDuplicateAttributes, TeacherPensionsPotentialDuplicateAttributes> configureSelected,
+        Func<TeacherPensionsPotentialDuplicateAttributes, TeacherPensionsPotentialDuplicateAttributes> configureResolved,
+        Action<TestData.CreateTeacherPensionsPotentialDuplicateTaskBuilder>? configureRequest = null)
+    {
+        var person = await TestData.CreatePersonAsync();
+        var user = await TestData.CreateUserAsync();
+
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(
+            person.PersonId,
+            user.UserId,
+            s =>
+            {
+                s.WithMiddleName(requestMiddleName);
+                s.WithSupportTaskData("test.csv", 1);
+                s.WithStatus(SupportTaskStatus.Closed);
+                configureRequest?.Invoke(s);
+            });
+
+        // The request's remaining attributes stand in for the merged-away record; the snapshot and resolved
+        // attributes are what the resolve journey would have written.
+        var baseline = new TeacherPensionsPotentialDuplicateAttributes
+        {
+            FirstName = person.FirstName,
+            MiddleName = person.MiddleName,
+            LastName = person.LastName,
+            DateOfBirth = person.DateOfBirth,
+            NationalInsuranceNumber = person.NationalInsuranceNumber,
+            Gender = person.Gender,
+            Trn = person.Trn!
+        };
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            dbContext.Attach(supportTask);
+            supportTask.Data = supportTask.GetData<TeacherPensionsPotentialDuplicateData>() with
+            {
+                SelectedPersonAttributes = configureSelected(baseline),
+                ResolvedAttributes = configureResolved(baseline)
+            };
+            await dbContext.SaveChangesAsync();
+        });
+
+        return supportTask;
+    }
+
+    private Task<TeacherPensionsPotentialDuplicateData> GetTeacherPensionsDataAsync(SupportTask supportTask) =>
+        WithDbContextAsync(async dbContext =>
+        {
+            var dbSupportTask = await dbContext.SupportTasks
+                .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            return dbSupportTask.GetData<TeacherPensionsPotentialDuplicateData>();
+        });
+}

--- a/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillResolvedAttributesJobTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Jobs/BackfillResolvedAttributesJobTests.cs
@@ -156,6 +156,101 @@ public class BackfillResolvedAttributesJobTests(JobFixture fixture) : JobTestBas
         });
     }
 
+    // The NPQ journey's UI is gone, but the data it left behind has the same defect. It offered no name
+    // choices, so a differing email address with no source selected is the equivalent case.
+    [Fact]
+    public async Task ExecuteAsync_NpqTaskWithEmailAddressTakenFromRequest_CorrectsResolvedEmailToSelectedPerson()
+    {
+        // Arrange
+        // The request holds an empty email address and the record holds none, which the merge page treated as
+        // not different, so no source was selected and the request's value was recorded regardless.
+        var supportTask = await CreateResolvedNpqTaskAsync(
+            requestEmailAddress: string.Empty,
+            configureSelected: a => a with { EmailAddress = null },
+            configureResolved: a => a with { EmailAddress = string.Empty });
+
+        // Act
+        await WithDbContextAsync(dbContext =>
+            new BackfillResolvedAttributesJob(dbContext).ExecuteAsync(dryRun: false, CancellationToken.None));
+
+        // Assert
+        var data = await WithDbContextAsync(async dbContext =>
+        {
+            var dbSupportTask = await dbContext.SupportTasks
+                .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            return dbSupportTask.GetData<NpqTrnRequestData>();
+        });
+
+        Assert.Null(data.ResolvedAttributes!.EmailAddress);
+    }
+
+    private async Task<SupportTask> CreateResolvedNpqTaskAsync(
+        string? requestEmailAddress,
+        Func<NpqTrnRequestDataPersonAttributes, NpqTrnRequestDataPersonAttributes> configureSelected,
+        Func<NpqTrnRequestDataPersonAttributes, NpqTrnRequestDataPersonAttributes> configureResolved)
+    {
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var person = await TestData.CreatePersonAsync();
+
+        var metadata = new TrnRequestMetadata
+        {
+            ApplicationUserId = applicationUser.UserId,
+            RequestId = Guid.NewGuid().ToString(),
+            CreatedOn = TimeProvider.UtcNow,
+            IdentityVerified = null,
+            OneLoginUserSubject = null,
+            Name = [person.FirstName, person.LastName],
+            FirstName = person.FirstName,
+            MiddleName = person.MiddleName,
+            LastName = person.LastName,
+            DateOfBirth = person.DateOfBirth,
+            EmailAddress = requestEmailAddress,
+            NationalInsuranceNumber = person.NationalInsuranceNumber,
+            Gender = person.Gender,
+            PotentialDuplicate = false
+        };
+
+        var baseline = new NpqTrnRequestDataPersonAttributes
+        {
+            FirstName = person.FirstName,
+            MiddleName = person.MiddleName,
+            LastName = person.LastName,
+            DateOfBirth = person.DateOfBirth,
+            EmailAddress = person.EmailAddress,
+            NationalInsuranceNumber = person.NationalInsuranceNumber,
+            Gender = person.Gender
+        };
+
+        var subject = SupportTask.Subject.FromTrnRequest(metadata);
+
+        var supportTask = new SupportTask
+        {
+            CreatedOn = TimeProvider.UtcNow,
+            UpdatedOn = TimeProvider.UtcNow,
+            SupportTaskType = SupportTaskType.NpqTrnRequest,
+            Status = SupportTaskStatus.Closed,
+            Data = new NpqTrnRequestData
+            {
+                SupportRequestOutcome = SupportRequestOutcome.Approved,
+                SelectedPersonAttributes = configureSelected(baseline),
+                ResolvedAttributes = configureResolved(baseline)
+            },
+            PersonId = person.PersonId,
+            TrnRequestApplicationUserId = applicationUser.UserId,
+            TrnRequestId = metadata.RequestId,
+            SubjectName = subject.Name,
+            SubjectEmailAddress = subject.EmailAddress
+        };
+
+        return await WithDbContextAsync(async dbContext =>
+        {
+            dbContext.TrnRequestMetadata.Add(metadata);
+            dbContext.SupportTasks.Add(supportTask);
+            await dbContext.SaveChangesAsync();
+            return supportTask;
+        });
+    }
+
     private async Task<SupportTask> CreateResolvedTeacherPensionsTaskAsync(
         string? requestMiddleName,
         Func<TeacherPensionsPotentialDuplicateAttributes, TeacherPensionsPotentialDuplicateAttributes> configureSelected,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
@@ -1,5 +1,6 @@
 using Optional;
 using TeachingRecordSystem.Core.Events.Legacy;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 using TeachingRecordSystem.SupportUi.Services;
@@ -470,6 +471,79 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
 
         journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.True(journeyInstance.Completed);
+    }
+
+    // This journey's merge page offers no middle name choice, so MiddleNameSource is always unset. An unset
+    // source must resolve to the existing record's value, matching the fact that the person isn't updated.
+    [Fact]
+    public async Task Post_MiddleNameSourceNotSet_ResolvesMiddleNameToExistingRecordAndLeavesPersonUnchanged()
+    {
+        // Arrange
+        var existingMiddleName = "Existing";
+        var requestMiddleName = "Different";
+
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber().WithGender(Gender.Male));
+        var duplicatePerson1 = await TestData.CreatePersonAsync(x =>
+            x.WithMiddleName(existingMiddleName).WithNationalInsuranceNumber().WithGender(Gender.Female));
+        var user = await TestData.CreateUserAsync();
+
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(
+            person.PersonId,
+            user.UserId,
+            s =>
+            {
+                s.WithMatchedPersons(duplicatePerson1.PersonId);
+                s.WithFirstName(person.FirstName);
+                s.WithMiddleName(requestMiddleName);
+                s.WithLastName(person.LastName);
+                s.WithNationalInsuranceNumber(person.NationalInsuranceNumber);
+                s.WithGender(person.Gender);
+                s.WithDateOfBirth(person.DateOfBirth);
+                s.WithSupportTaskData("test.txt", 1);
+                s.WithCreatedOn(TimeProvider.UtcNow);
+                s.WithStatus(SupportTaskStatus.Open);
+            });
+
+        var state = new ResolveTeacherPensionsPotentialDuplicateState
+        {
+            MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            TeachersPensionPersonId = person.PersonId,
+            FirstNameSource = PersonAttributeSource.ExistingRecord,
+            MiddleNameSource = null,
+            LastNameSource = PersonAttributeSource.ExistingRecord,
+            DateOfBirthSource = PersonAttributeSource.ExistingRecord,
+            GenderSource = PersonAttributeSource.ExistingRecord,
+            NationalInsuranceNumberSource = PersonAttributeSource.ExistingRecord,
+            PersonId = duplicatePerson1.PersonId,
+            PersonAttributeSourcesSet = true,
+            Evidence = new() { UploadEvidence = false }
+        };
+
+        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updatedPersonRecord = await dbContext.Persons.SingleAsync(x => x.PersonId == duplicatePerson1.PersonId);
+            Assert.Equal(existingMiddleName, updatedPersonRecord.MiddleName);
+
+            var updatedSupportTask = await dbContext.SupportTasks
+                .SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            var supportTaskData = updatedSupportTask.GetData<TeacherPensionsPotentialDuplicateData>();
+
+            Assert.NotNull(supportTaskData.ResolvedAttributes);
+            Assert.Equal(existingMiddleName, supportTaskData.ResolvedAttributes.MiddleName);
+            Assert.NotNull(supportTaskData.SelectedPersonAttributes);
+            Assert.Equal(existingMiddleName, supportTaskData.SelectedPersonAttributes.MiddleName);
+        });
     }
 
     private Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
@@ -861,6 +861,56 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         Assert.Contains(expectedPersonId.ToString(), viewRecordLink.GetAttribute("href"));
     }
 
+    // An attribute with no source selected isn't written to the person, so the resolved attributes must
+    // record the existing record's value rather than the request's.
+    [Fact]
+    public async Task Post_UpdatingExistingRecordWithNoSourceSelected_ResolvesAttributeToExistingRecord()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var (supportTask, matchedPerson) = await CreateSupportTaskWithSingleDifferenceToMatch(
+            applicationUser.UserId,
+            PersonMatchedAttribute.MiddleName);
+
+        var journeyInstance = await CreateJourneyInstance(
+            supportTask.SupportTaskReference,
+            new ResolveTrnRequestState
+            {
+                MatchedPersons = [new MatchPersonsResultPerson(
+                    matchedPerson.PersonId,
+                    [
+                        PersonMatchedAttribute.FirstName,
+                        PersonMatchedAttribute.LastName,
+                        PersonMatchedAttribute.DateOfBirth,
+                        PersonMatchedAttribute.EmailAddress,
+                        PersonMatchedAttribute.NationalInsuranceNumber,
+                        PersonMatchedAttribute.Gender
+                    ])],
+                PersonId = matchedPerson.PersonId,
+                PersonAttributeSourcesSet = true,
+                MiddleNameSource = null
+            });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var person = await WithDbContextAsync(dbContext => dbContext.Persons.SingleAsync(p => p.PersonId == matchedPerson.PersonId));
+        Assert.Equal(matchedPerson.Person.MiddleName, person.MiddleName);
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext => dbContext
+            .SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference));
+        var supportTaskData = updatedSupportTask.GetData<TrnRequestData>();
+        AssertPersonAttributesMatchPerson(supportTaskData.ResolvedAttributes, person);
+    }
+
     private void AssertPersonAttributesMatchPerson(
         TrnRequestDataPersonAttributes? personAttributes,
         Person person)


### PR DESCRIPTION
Stacked on #3603 — review that first, and this PR's diff will narrow to a single commit once it merges.

## The bug

An attribute's source being unset meant two contradictory things:

- `GetAttributesToUpdate` tested `is PersonAttributeSource.TrnRequest`, so an unset source meant **don't touch the person**.
- `GetResolvedPersonAttributes` tested `is PersonAttributeSource.ExistingRecord ? existing : request` — a two-branch ternary for three possible values, so an unset source fell into the `else` and recorded the **TRN request's** value.

The support task's record of the outcome therefore disagreed with the record it describes.

This normally hides, because a source is only unset when the merge page didn't offer a choice, and it only offers one when the values differ — so the two reads usually produce the same value anyway.

The Teachers' Pensions journey makes it reachable. Its merge page renders no middle name control and never writes `MiddleNameSource`, so the source is **always** unset, even when the middle names genuinely differ. Those merges recorded the request's middle name, kept the person's, and showed the caseworker the value that was never applied.

## The fix

Both `GetResolvedPersonAttributes` methods now read `is TrnRequest ? request : existing`, aligning them with what actually gets written to the person. The check answers pages previewed the outcome with the same defect, so they're fixed too.

## The backfill

`BackfillResolvedAttributesJob` corrects tasks that are already closed. The correct value is recoverable from what's stored:

- `SelectedPersonAttributes` is the pre-merge snapshot of the person, so for any unset-source attribute **that snapshot is the right answer**.
- A source was only unset where the merge page offered no choice, which it did exactly when the values differed — so wherever the request and the snapshot agree, the resolved value should be the snapshot's. Teachers' Pensions middle names are corrected unconditionally.
- Tasks resolved by creating a new record have no snapshot and are skipped.

The closing event payloads embed the same task data, so they're corrected alongside the task — otherwise a reporting DB rebuild could reintroduce the bad values. Follows `BackfillSupportTaskColumnsJob`'s shape and is registered at `Cron.Never` with dry-run and live variants.

## Notes for review

- **The TrnRequests arm of the job is close to a no-op in practice.** `Person.MiddleName` is non-nullable and that journey forces a choice whenever values differ, so its only reachable damage is `null` vs `""` on email/NINO — possibly zero rows in prod. Kept because it's the same code path and provably safe; happy to drop it.
- Every new test was checked to actually fail against the old logic, not just pass against the new one.
- No new events are emitted (existing ones are corrected in place), so `docs/process-type-events.md` is unchanged.

## Testing

`just build` clean at 0 warnings. Resolve-journey and job suites green (177 + 5). Two pre-existing failures are unrelated and confirmed to fail identically without these changes: the known-broken `RefreshTrainingProvidersJobTests`, and an E2E training-provider test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)