### PR TITLE
Derive resolved person attributes in the resolve services

### DIFF
--- a/src/TeachingRecordSystem.Core/Models/SupportTasks/PersonAttributeSource.cs
+++ b/src/TeachingRecordSystem.Core/Models/SupportTasks/PersonAttributeSource.cs
@@ -1,0 +1,69 @@
+namespace TeachingRecordSystem.Core.Models.SupportTasks;
+
+/// Where the value of a person attribute comes from when a TRN request is resolved to an existing record.
+public enum PersonAttributeSource
+{
+    ExistingRecord = 0,
+    TrnRequest = 1
+}
+
+/// <summary>
+/// The chosen source for each of a person's attributes when resolving a TRN request to an existing record.
+///
+/// A null source means no choice was made, which is what happens when the two values don't differ, or when
+/// the journey doesn't offer a choice for that attribute at all. Only <see cref="PersonAttributeSource.TrnRequest"/>
+/// updates the record, so any other source — including none — keeps the existing value.
+///
+/// The Teachers' Pensions journey has no email address to resolve and leaves <see cref="EmailAddress"/> unset.
+/// </summary>
+public record PersonAttributeSources
+{
+    public PersonAttributeSource? FirstName { get; init; }
+    public PersonAttributeSource? MiddleName { get; init; }
+    public PersonAttributeSource? LastName { get; init; }
+    public PersonAttributeSource? DateOfBirth { get; init; }
+    public PersonAttributeSource? EmailAddress { get; init; }
+    public PersonAttributeSource? NationalInsuranceNumber { get; init; }
+    public PersonAttributeSource? Gender { get; init; }
+
+    /// The attributes to be taken from the TRN request, i.e. the ones whose value on the record changes.
+    public IReadOnlyCollection<PersonMatchedAttribute> GetAttributesToUpdate() => Impl().AsReadOnly();
+
+    private IEnumerable<PersonMatchedAttribute> Impl()
+    {
+        if (FirstName is PersonAttributeSource.TrnRequest)
+        {
+            yield return PersonMatchedAttribute.FirstName;
+        }
+
+        if (MiddleName is PersonAttributeSource.TrnRequest)
+        {
+            yield return PersonMatchedAttribute.MiddleName;
+        }
+
+        if (LastName is PersonAttributeSource.TrnRequest)
+        {
+            yield return PersonMatchedAttribute.LastName;
+        }
+
+        if (DateOfBirth is PersonAttributeSource.TrnRequest)
+        {
+            yield return PersonMatchedAttribute.DateOfBirth;
+        }
+
+        if (EmailAddress is PersonAttributeSource.TrnRequest)
+        {
+            yield return PersonMatchedAttribute.EmailAddress;
+        }
+
+        if (NationalInsuranceNumber is PersonAttributeSource.TrnRequest)
+        {
+            yield return PersonMatchedAttribute.NationalInsuranceNumber;
+        }
+
+        if (Gender is PersonAttributeSource.TrnRequest)
+        {
+            yield return PersonMatchedAttribute.Gender;
+        }
+    }
+}

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/ResolveTeacherPensionsPotentialDuplicateWithMergeOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/ResolveTeacherPensionsPotentialDuplicateWithMergeOptions.cs
@@ -9,8 +9,9 @@ public record ResolveTeacherPensionsPotentialDuplicateWithMergeOptions
     /// The pre-existing record the task's record is merged into, and that the request resolves to
     public required Guid ExistingPersonId { get; init; }
 
-    public IReadOnlyCollection<PersonMatchedAttribute> AttributesToUpdate { get; init; } = [];
-    public required TeacherPensionsPotentialDuplicateAttributes? ResolvedAttributes { get; init; }
-    public required TeacherPensionsPotentialDuplicateAttributes? SelectedPersonAttributes { get; init; }
+    /// Where each of the record's attributes takes its value from. This journey offers no email address or
+    /// middle name choice, so those are always unset and keep the existing record's value.
+    public PersonAttributeSources AttributeSources { get; init; } = new();
+
     public string? Comments { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/TeacherPensionsSupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/TeacherPensions/TeacherPensionsSupportTaskService.cs
@@ -41,6 +41,15 @@ public class TeacherPensionsSupportTaskService(
         await using var eventScope = eventPublisher.GetOrCreateEventScope(processContext);
 
         var supportTask = await GetOpenSupportTaskAsync(options.SupportTaskReference);
+        var trnRequest = await dbContext.TrnRequestMetadata.FindOrThrowAsync(
+            supportTask.TrnRequestApplicationUserId!.Value,
+            supportTask.TrnRequestId!);
+
+        var existingPerson = await dbContext.Persons.FindOrThrowAsync(options.ExistingPersonId);
+
+        // Snapshot the surviving record before the merge, which updates it.
+        var selectedPersonAttributes = GetPersonAttributes(existingPerson);
+        var resolvedAttributes = GetResolvedAttributes(options.AttributeSources, selectedPersonAttributes, trnRequest);
 
         await personService.DeactivatePersonViaMergeAsync(
             new DeactivatePersonViaMergeOptions(supportTask.PersonId!.Value, options.ExistingPersonId),
@@ -50,7 +59,7 @@ public class TeacherPensionsSupportTaskService(
             supportTask.TrnRequestApplicationUserId!.Value,
             supportTask.TrnRequestId!,
             options.ExistingPersonId,
-            options.AttributesToUpdate,
+            options.AttributeSources.GetAttributesToUpdate(),
             processContext);
 
         await supportTaskService.UpdateSupportTaskAsync<TeacherPensionsPotentialDuplicateData>(
@@ -59,14 +68,43 @@ public class TeacherPensionsSupportTaskService(
                 SupportTaskReference = options.SupportTaskReference,
                 UpdateData = data => data with
                 {
-                    ResolvedAttributes = options.ResolvedAttributes,
-                    SelectedPersonAttributes = options.SelectedPersonAttributes
+                    ResolvedAttributes = resolvedAttributes,
+                    SelectedPersonAttributes = selectedPersonAttributes
                 },
                 Status = SupportTaskStatus.Closed,
                 Comments = options.Comments
             },
             processContext);
     }
+
+    private static TeacherPensionsPotentialDuplicateAttributes GetPersonAttributes(Person person) =>
+        new()
+        {
+            FirstName = person.FirstName,
+            MiddleName = person.MiddleName,
+            LastName = person.LastName,
+            DateOfBirth = person.DateOfBirth,
+            NationalInsuranceNumber = person.NationalInsuranceNumber,
+            Gender = person.Gender,
+            Trn = person.Trn!
+        };
+
+    /// The attributes the surviving record ends up with: only a TrnRequest source changes a value, so anything
+    /// else keeps the existing one. The TRN is never resolvable — the surviving record's is always kept.
+    private static TeacherPensionsPotentialDuplicateAttributes GetResolvedAttributes(
+        PersonAttributeSources sources,
+        TeacherPensionsPotentialDuplicateAttributes existingAttributes,
+        TrnRequestMetadata trnRequest) =>
+        new()
+        {
+            FirstName = sources.FirstName is PersonAttributeSource.TrnRequest ? trnRequest.FirstName! : existingAttributes.FirstName,
+            MiddleName = sources.MiddleName is PersonAttributeSource.TrnRequest ? trnRequest.MiddleName ?? string.Empty : existingAttributes.MiddleName,
+            LastName = sources.LastName is PersonAttributeSource.TrnRequest ? trnRequest.LastName! : existingAttributes.LastName,
+            DateOfBirth = sources.DateOfBirth is PersonAttributeSource.TrnRequest ? trnRequest.DateOfBirth : existingAttributes.DateOfBirth,
+            NationalInsuranceNumber = sources.NationalInsuranceNumber is PersonAttributeSource.TrnRequest ? trnRequest.NationalInsuranceNumber : existingAttributes.NationalInsuranceNumber,
+            Gender = sources.Gender is PersonAttributeSource.TrnRequest ? trnRequest.Gender : existingAttributes.Gender,
+            Trn = existingAttributes.Trn
+        };
 
     // Both resolutions update the person and the request before closing the task, so check up-front that the task can
     // be closed rather than leaving those behind when it can't

--- a/src/TeachingRecordSystem.Core/Services/TrnRequests/ResolveTrnRequestOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/TrnRequests/ResolveTrnRequestOptions.cs
@@ -11,8 +11,9 @@ public record ResolveTrnRequestOptions
     /// The record the request resolves to, or null to resolve it with a newly created record
     public required Guid? PersonId { get; init; }
 
-    public IReadOnlyCollection<PersonMatchedAttribute> AttributesToUpdate { get; init; } = [];
-    public required TrnRequestDataPersonAttributes? ResolvedAttributes { get; init; }
-    public required TrnRequestDataPersonAttributes? SelectedPersonAttributes { get; init; }
+    /// Where each of the record's attributes takes its value from; ignored when creating a new record,
+    /// which takes every value from the request
+    public PersonAttributeSources AttributeSources { get; init; } = new();
+
     public string? Comments { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
+++ b/src/TeachingRecordSystem.Core/Services/TrnRequests/TrnRequestService.cs
@@ -347,17 +347,31 @@ public class TrnRequestService(
     {
         await using var eventScope = eventPublisher.GetOrCreateEventScope(processContext);
 
+        var trnRequest = await dbContext.TrnRequestMetadata.FindOrThrowAsync(options.ApplicationUserId, options.RequestId);
+
+        TrnRequestDataPersonAttributes? selectedPersonAttributes = null;
+        TrnRequestDataPersonAttributes resolvedAttributes;
+
         if (options.PersonId is Guid personId)
         {
+            var person = await dbContext.Persons.FindOrThrowAsync(personId);
+
+            // Snapshot the record before resolving, which updates it.
+            selectedPersonAttributes = GetPersonAttributes(person);
+            resolvedAttributes = GetResolvedAttributes(options.AttributeSources, selectedPersonAttributes, trnRequest);
+
             await ResolveTrnRequestWithMatchedPersonAsync(
                 options.ApplicationUserId,
                 options.RequestId,
                 personId,
-                options.AttributesToUpdate,
+                options.AttributeSources.GetAttributesToUpdate(),
                 processContext);
         }
         else
         {
+            // A new record takes every value from the request.
+            resolvedAttributes = GetRequestAttributes(trnRequest);
+
             await ResolveTrnRequestWithNewRecordAsync(options.ApplicationUserId, options.RequestId, processContext);
         }
 
@@ -365,15 +379,60 @@ public class TrnRequestService(
             new ResolveTrnRequestSupportTaskOptions
             {
                 SupportTaskReference = options.SupportTaskReference,
-                ResolvedAttributes = options.ResolvedAttributes,
-                SelectedPersonAttributes = options.SelectedPersonAttributes,
+                ResolvedAttributes = resolvedAttributes,
+                SelectedPersonAttributes = selectedPersonAttributes,
                 Comments = options.Comments
             },
             processContext);
 
-        var trnRequest = await dbContext.TrnRequestMetadata.FindOrThrowAsync(options.ApplicationUserId, options.RequestId);
+        // Resolving tracked the request's resolved record on the same entity.
         Debug.Assert(trnRequest.ResolvedPersonId is not null);
         return trnRequest.ResolvedPersonId.Value;
+    }
+
+    private static TrnRequestDataPersonAttributes GetPersonAttributes(Person person) =>
+        new()
+        {
+            FirstName = person.FirstName,
+            MiddleName = person.MiddleName,
+            LastName = person.LastName,
+            DateOfBirth = person.DateOfBirth,
+            EmailAddress = person.EmailAddress,
+            NationalInsuranceNumber = person.NationalInsuranceNumber,
+            Gender = person.Gender
+        };
+
+    private static TrnRequestDataPersonAttributes GetRequestAttributes(TrnRequestMetadata trnRequest) =>
+        new()
+        {
+            FirstName = trnRequest.FirstName!,
+            MiddleName = trnRequest.MiddleName ?? string.Empty,
+            LastName = trnRequest.LastName!,
+            DateOfBirth = trnRequest.DateOfBirth,
+            EmailAddress = trnRequest.EmailAddress,
+            NationalInsuranceNumber = trnRequest.NationalInsuranceNumber,
+            Gender = trnRequest.Gender
+        };
+
+    /// The attributes the record ends up with: only a TrnRequest source changes a value, so anything else
+    /// keeps the existing one.
+    private static TrnRequestDataPersonAttributes GetResolvedAttributes(
+        PersonAttributeSources sources,
+        TrnRequestDataPersonAttributes existingAttributes,
+        TrnRequestMetadata trnRequest)
+    {
+        var requestAttributes = GetRequestAttributes(trnRequest);
+
+        return new TrnRequestDataPersonAttributes()
+        {
+            FirstName = sources.FirstName is PersonAttributeSource.TrnRequest ? requestAttributes.FirstName : existingAttributes.FirstName,
+            MiddleName = sources.MiddleName is PersonAttributeSource.TrnRequest ? requestAttributes.MiddleName : existingAttributes.MiddleName,
+            LastName = sources.LastName is PersonAttributeSource.TrnRequest ? requestAttributes.LastName : existingAttributes.LastName,
+            DateOfBirth = sources.DateOfBirth is PersonAttributeSource.TrnRequest ? requestAttributes.DateOfBirth : existingAttributes.DateOfBirth,
+            EmailAddress = sources.EmailAddress is PersonAttributeSource.TrnRequest ? requestAttributes.EmailAddress : existingAttributes.EmailAddress,
+            NationalInsuranceNumber = sources.NationalInsuranceNumber is PersonAttributeSource.TrnRequest ? requestAttributes.NationalInsuranceNumber : existingAttributes.NationalInsuranceNumber,
+            Gender = sources.Gender is PersonAttributeSource.TrnRequest ? requestAttributes.Gender : existingAttributes.Gender
+        };
     }
 
     public async Task CompleteManualChecksNeededTrnRequestAsync(

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 using TeachingRecordSystem.SupportUi.Services;
@@ -129,16 +130,12 @@ public class CheckAnswersModel(
 
         var existingPersonId = JourneyInstance!.State.PersonId!.Value;
 
-        var selectedPersonAttributes = await GetPersonAttributesAsync(existingPersonId);
-
         await teacherPensionsSupportTaskService.ResolveWithMergeAsync(
             new()
             {
                 SupportTaskReference = SupportTaskReference,
                 ExistingPersonId = existingPersonId,
-                AttributesToUpdate = GetAttributesToUpdate(),
-                ResolvedAttributes = GetResolvedPersonAttributes(selectedPersonAttributes),
-                SelectedPersonAttributes = selectedPersonAttributes,
+                AttributeSources = GetPersonAttributeSources(),
                 Comments = MergeComments
             },
             processContext);

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml
@@ -1,5 +1,6 @@
 @page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/merge/{handler?}"
 @using TeachingRecordSystem.SupportUi.Pages.Shared
+@using TeachingRecordSystem.Core.Models.SupportTasks
 @using TeachingRecordSystem.SupportUi.Services
 @using static ResolveTeacherPensionsPotentialDuplicateState
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.MergeModel

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
-using TeachingRecordSystem.SupportUi.Services;
 using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.ResolveTeacherPensionsPotentialDuplicateState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
@@ -1,11 +1,8 @@
-using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.SupportUi.Services;
-using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.ResolveTeacherPensionsPotentialDuplicateState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
@@ -27,7 +24,9 @@ public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(TrsDbCon
         return supportTask;
     }
 
-    protected IReadOnlyCollection<PersonMatchedAttribute> GetAttributesToUpdate()
+    /// This journey offers no middle name choice, so that source is always unset and the existing record's
+    /// middle name is kept.
+    protected PersonAttributeSources GetPersonAttributeSources()
     {
         var state = JourneyInstance!.State;
 
@@ -36,53 +35,16 @@ public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(TrsDbCon
             throw new InvalidOperationException("Attribute sources not set.");
         }
 
-        return Impl().AsReadOnly();
-
-        IEnumerable<PersonMatchedAttribute> Impl()
+        return new PersonAttributeSources()
         {
-            if (state.FirstNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.FirstName;
-            }
-
-            if (state.MiddleNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.MiddleName;
-            }
-
-            if (state.LastNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.LastName;
-            }
-
-            if (state.DateOfBirthSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.DateOfBirth;
-            }
-
-            if (state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.NationalInsuranceNumber;
-            }
-
-            if (state.GenderSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.Gender;
-            }
-        }
-    }
-
-    protected TeacherPensionsPotentialDuplicateAttributes GetPersonAttributes(Person person) =>
-        new()
-        {
-            FirstName = person.FirstName,
-            MiddleName = person.MiddleName,
-            LastName = person.LastName,
-            DateOfBirth = person.DateOfBirth,
-            NationalInsuranceNumber = person.NationalInsuranceNumber,
-            Gender = person.Gender,
-            Trn = person.Trn
+            FirstName = state.FirstNameSource,
+            MiddleName = state.MiddleNameSource,
+            LastName = state.LastNameSource,
+            DateOfBirth = state.DateOfBirthSource,
+            NationalInsuranceNumber = state.NationalInsuranceNumberSource,
+            Gender = state.GenderSource
         };
+    }
 
     protected async Task<TeacherPensionsPotentialDuplicateAttributes> GetPersonAttributesAsync(Guid personId)
     {
@@ -113,52 +75,5 @@ public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(TrsDbCon
         };
     }
 
-    protected TeacherPensionsPotentialDuplicateAttributes GetPersonAttributesFromRequestData()
-    {
-        var supportTask = GetSupportTask();
-        var person = DbContext.Persons.Single(x => x.PersonId == supportTask.PersonId);
-        var requestData = supportTask.TrnRequestMetadata!;
-
-        return new TeacherPensionsPotentialDuplicateAttributes()
-        {
-            FirstName = requestData.FirstName!,
-            MiddleName = requestData.MiddleName ?? string.Empty,
-            LastName = requestData.LastName!,
-            DateOfBirth = requestData.DateOfBirth,
-            NationalInsuranceNumber = requestData.NationalInsuranceNumber,
-            Gender = requestData.Gender,
-            Trn = person.Trn
-        };
-    }
-
-    protected TeacherPensionsPotentialDuplicateAttributes GetResolvedPersonAttributes(
-        TeacherPensionsPotentialDuplicateAttributes? selectedPersonAttributes)
-    {
-        var state = JourneyInstance!.State;
-        var trnRequestPersonAttributes = GetPersonAttributesFromRequestData();
-
-        if (state.PersonId == CreateNewRecordPersonIdSentinel)
-        {
-            Debug.Assert(selectedPersonAttributes is null);
-            return trnRequestPersonAttributes;
-        }
-        else
-        {
-            Debug.Assert(selectedPersonAttributes is not null);
-
-            // Only a TrnRequest source updates the person (see GetAttributesToUpdate), so anything else —
-            // including MiddleName, which this journey never offers a choice for — keeps the existing value.
-            return new TeacherPensionsPotentialDuplicateAttributes()
-            {
-                FirstName = state.FirstNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.FirstName : selectedPersonAttributes.FirstName,
-                MiddleName = state.MiddleNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.MiddleName : selectedPersonAttributes.MiddleName,
-                LastName = state.LastNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.LastName : selectedPersonAttributes.LastName,
-                DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.DateOfBirth : selectedPersonAttributes.DateOfBirth,
-                NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.NationalInsuranceNumber : selectedPersonAttributes.NationalInsuranceNumber,
-                Gender = state.GenderSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.Gender : selectedPersonAttributes.Gender,
-                Trn = selectedPersonAttributes.Trn
-            };
-        }
-    }
 }
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateState.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
-using TeachingRecordSystem.SupportUi.Services;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -72,17 +72,16 @@ public class CheckAnswers(
         var processContext = new ProcessContext(ProcessType.TrnRequestResolving, timeProvider.UtcNow, User.GetUserId());
 
         Guid? existingPersonId = null;
-        TrnRequestDataPersonAttributes? selectedPersonAttributes = null;
-        IReadOnlyCollection<PersonMatchedAttribute> attributesToUpdate = [];
+
+        // A new record takes every value from the request, so it has no sources to choose and never visits
+        // the page that sets them.
+        var attributeSources = new PersonAttributeSources();
 
         if (!CreatingNewRecord)
         {
             Debug.Assert(state.PersonId is not null);
             existingPersonId = state.PersonId!.Value;
-            var selectedPerson = await DbContext.Persons.SingleAsync(p => p.PersonId == existingPersonId);
-
-            selectedPersonAttributes = GetPersonAttributes(selectedPerson);
-            attributesToUpdate = GetAttributesToUpdate();
+            attributeSources = GetPersonAttributeSources();
         }
 
         var resolvedPersonId = await trnRequestService.ResolveTrnRequestAsync(
@@ -92,9 +91,7 @@ public class CheckAnswers(
                 RequestId = trnRequest.RequestId,
                 SupportTaskReference = supportTask.SupportTaskReference,
                 PersonId = existingPersonId,
-                AttributesToUpdate = attributesToUpdate,
-                ResolvedAttributes = GetResolvedPersonAttributes(selectedPersonAttributes),
-                SelectedPersonAttributes = selectedPersonAttributes,
+                AttributeSources = attributeSources,
                 Comments = state.Comments
             },
             processContext);

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml
@@ -1,5 +1,6 @@
 @page "/support-tasks/trn-requests/{supportTaskReference}/resolve/merge/{handler?}"
 @using TeachingRecordSystem.SupportUi.Pages.Shared
+@using TeachingRecordSystem.Core.Models.SupportTasks
 @using TeachingRecordSystem.SupportUi.Services
 @using static ResolveTrnRequestState
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.Merge

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
-using TeachingRecordSystem.SupportUi.Services;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.ResolveTrnRequestState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestPageModel.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestPageModel.cs
@@ -1,10 +1,7 @@
-using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.SupportUi.Services;
-using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.ResolveTrnRequestState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
@@ -20,7 +17,7 @@ public abstract class ResolveTrnRequestPageModel(TrsDbContext dbContext) : PageM
         return supportTask.TrnRequestMetadata!;
     }
 
-    protected IReadOnlyCollection<PersonMatchedAttribute> GetAttributesToUpdate()
+    protected PersonAttributeSources GetPersonAttributeSources()
     {
         var state = JourneyInstance!.State;
 
@@ -29,58 +26,17 @@ public abstract class ResolveTrnRequestPageModel(TrsDbContext dbContext) : PageM
             throw new InvalidOperationException("Attribute sources not set.");
         }
 
-        return Impl().AsReadOnly();
-
-        IEnumerable<PersonMatchedAttribute> Impl()
+        return new PersonAttributeSources()
         {
-            if (state.FirstNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.FirstName;
-            }
-
-            if (state.MiddleNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.MiddleName;
-            }
-
-            if (state.LastNameSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.LastName;
-            }
-
-            if (state.DateOfBirthSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.DateOfBirth;
-            }
-
-            if (state.EmailAddressSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.EmailAddress;
-            }
-
-            if (state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.NationalInsuranceNumber;
-            }
-
-            if (state.GenderSource is PersonAttributeSource.TrnRequest)
-            {
-                yield return PersonMatchedAttribute.Gender;
-            }
-        }
-    }
-
-    protected TrnRequestDataPersonAttributes GetPersonAttributes(Person person) =>
-        new()
-        {
-            FirstName = person.FirstName,
-            MiddleName = person.MiddleName,
-            LastName = person.LastName,
-            DateOfBirth = person.DateOfBirth,
-            EmailAddress = person.EmailAddress,
-            NationalInsuranceNumber = person.NationalInsuranceNumber,
-            Gender = person.Gender
+            FirstName = state.FirstNameSource,
+            MiddleName = state.MiddleNameSource,
+            LastName = state.LastNameSource,
+            DateOfBirth = state.DateOfBirthSource,
+            EmailAddress = state.EmailAddressSource,
+            NationalInsuranceNumber = state.NationalInsuranceNumberSource,
+            Gender = state.GenderSource
         };
+    }
 
     protected async Task<TrnRequestDataPersonAttributes> GetPersonAttributesAsync(Guid personId)
     {
@@ -110,50 +66,5 @@ public abstract class ResolveTrnRequestPageModel(TrsDbContext dbContext) : PageM
         };
     }
 
-    protected TrnRequestDataPersonAttributes GetPersonAttributesFromRequestData()
-    {
-        var requestData = GetRequestData();
-
-        return new TrnRequestDataPersonAttributes()
-        {
-            FirstName = requestData.FirstName!,
-            MiddleName = requestData.MiddleName ?? string.Empty,
-            LastName = requestData.LastName!,
-            DateOfBirth = requestData.DateOfBirth,
-            EmailAddress = requestData.EmailAddress,
-            NationalInsuranceNumber = requestData.NationalInsuranceNumber,
-            Gender = requestData.Gender
-        };
-    }
-
-    protected TrnRequestDataPersonAttributes GetResolvedPersonAttributes(
-        TrnRequestDataPersonAttributes? selectedPersonAttributes)
-    {
-        var state = JourneyInstance!.State;
-        var trnRequestPersonAttributes = GetPersonAttributesFromRequestData();
-
-        if (state.PersonId == CreateNewRecordPersonIdSentinel)
-        {
-            Debug.Assert(selectedPersonAttributes is null);
-            return trnRequestPersonAttributes;
-        }
-        else
-        {
-            Debug.Assert(selectedPersonAttributes is not null);
-
-            // Only a TrnRequest source updates the person (see GetAttributesToUpdate), so anything else —
-            // including a source left unset because the page didn't offer a choice — keeps the existing value.
-            return new TrnRequestDataPersonAttributes()
-            {
-                FirstName = state.FirstNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.FirstName : selectedPersonAttributes.FirstName,
-                MiddleName = state.MiddleNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.MiddleName : selectedPersonAttributes.MiddleName,
-                LastName = state.LastNameSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.LastName : selectedPersonAttributes.LastName,
-                DateOfBirth = state.DateOfBirthSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.DateOfBirth : selectedPersonAttributes.DateOfBirth,
-                EmailAddress = state.EmailAddressSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.EmailAddress : selectedPersonAttributes.EmailAddress,
-                NationalInsuranceNumber = state.NationalInsuranceNumberSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.NationalInsuranceNumber : selectedPersonAttributes.NationalInsuranceNumber,
-                Gender = state.GenderSource is PersonAttributeSource.TrnRequest ? trnRequestPersonAttributes.Gender : selectedPersonAttributes.Gender
-            };
-        }
-    }
 }
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestState.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
-using TeachingRecordSystem.SupportUi.Services;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 

--- a/src/TeachingRecordSystem.SupportUi/Services/PersonChangeableAttributesService.cs
+++ b/src/TeachingRecordSystem.SupportUi/Services/PersonChangeableAttributesService.cs
@@ -1,3 +1,5 @@
+using TeachingRecordSystem.Core.Models.SupportTasks;
+
 namespace TeachingRecordSystem.SupportUi.Services;
 
 public class PersonChangeableAttributesService
@@ -19,10 +21,3 @@ public class PersonChangeableAttributesService
 public record ResolvedAttribute(PersonMatchedAttribute Attribute, PersonAttributeSource? Source);
 public record ResolvedMergedAttribute(PersonMatchedAttribute Attribute, TeachingRecordSystem.SupportUi.Pages.Persons.MergePerson.PersonAttributeSource? Source);
 #pragma warning restore CA1711
-
-
-public enum PersonAttributeSource
-{
-    ExistingRecord = 0,
-    TrnRequest = 1
-}

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TeacherPensionsSupportTaskServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/TeacherPensionsSupportTaskServiceTests.cs
@@ -59,27 +59,16 @@ public class TeacherPensionsSupportTaskServiceTests(ServiceFixture fixture) : Se
             integrationTransactionId: 42);
         Debug.Assert(supportTask.Status is SupportTaskStatus.Open);
 
-        var existingPerson = await TestData.CreatePersonAsync();
+        var existingPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());
 
-        var resolvedAttributes = new TeacherPensionsPotentialDuplicateAttributes
+        // Every attribute keeps the existing record's value, so the record itself doesn't change.
+        var attributeSources = new PersonAttributeSources
         {
-            FirstName = "Resolved",
-            MiddleName = "Resolved Middle",
-            LastName = "Resolved Last",
-            DateOfBirth = new DateOnly(1990, 1, 1),
-            NationalInsuranceNumber = "AB123456C",
-            Gender = null,
-            Trn = "1000000"
-        };
-        var selectedPersonAttributes = new TeacherPensionsPotentialDuplicateAttributes
-        {
-            FirstName = "Selected",
-            MiddleName = "Selected Middle",
-            LastName = "Selected Last",
-            DateOfBirth = new DateOnly(1991, 2, 2),
-            NationalInsuranceNumber = "CD654321B",
-            Gender = null,
-            Trn = "2000000"
+            FirstName = PersonAttributeSource.ExistingRecord,
+            LastName = PersonAttributeSource.ExistingRecord,
+            DateOfBirth = PersonAttributeSource.ExistingRecord,
+            NationalInsuranceNumber = PersonAttributeSource.ExistingRecord,
+            Gender = PersonAttributeSource.ExistingRecord
         };
         var comments = Faker.Lorem.Paragraph();
 
@@ -92,8 +81,7 @@ public class TeacherPensionsSupportTaskServiceTests(ServiceFixture fixture) : Se
                 {
                     SupportTaskReference = supportTask.SupportTaskReference,
                     ExistingPersonId = existingPerson.PersonId,
-                    ResolvedAttributes = resolvedAttributes,
-                    SelectedPersonAttributes = selectedPersonAttributes,
+                    AttributeSources = attributeSources,
                     Comments = comments
                 },
                 processContext));
@@ -104,8 +92,20 @@ public class TeacherPensionsSupportTaskServiceTests(ServiceFixture fixture) : Se
             var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
             Assert.Equal(SupportTaskStatus.Closed, dbTask.Status);
             var data = Assert.IsType<TeacherPensionsPotentialDuplicateData>(dbTask.Data);
-            Assert.Equal(resolvedAttributes, data.ResolvedAttributes);
-            Assert.Equal(selectedPersonAttributes, data.SelectedPersonAttributes);
+
+            var expectedAttributes = new TeacherPensionsPotentialDuplicateAttributes
+            {
+                FirstName = existingPerson.FirstName,
+                MiddleName = existingPerson.MiddleName,
+                LastName = existingPerson.LastName,
+                DateOfBirth = existingPerson.DateOfBirth,
+                NationalInsuranceNumber = existingPerson.NationalInsuranceNumber,
+                Gender = existingPerson.Gender,
+                Trn = existingPerson.Trn!
+            };
+            Assert.Equal(expectedAttributes, data.SelectedPersonAttributes);
+            Assert.Equal(expectedAttributes, data.ResolvedAttributes);
+
             // The rest of the data is preserved by the update.
             Assert.Equal("duplicates.csv", data.FileName);
             Assert.Equal(42, data.IntegrationTransactionId);
@@ -143,6 +143,64 @@ public class TeacherPensionsSupportTaskServiceTests(ServiceFixture fixture) : Se
     }
 
     [Fact]
+    public async Task ResolveWithMergeAsync_AttributeSourcedFromRequest_UpdatesRecordAndSnapshotsItAsItWasBeforehand()
+    {
+        // Arrange
+        var supportTask = await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync();
+        var existingPerson = await TestData.CreatePersonAsync();
+
+        var trnRequest = await WithDbContextAsync(dbContext =>
+            dbContext.TrnRequestMetadata.SingleAsync(r => r.RequestId == supportTask.TrnRequestId));
+
+        // Take the first name from the request; everything else keeps the existing record's value.
+        var attributeSources = new PersonAttributeSources
+        {
+            FirstName = PersonAttributeSource.TrnRequest,
+            LastName = PersonAttributeSource.ExistingRecord,
+            DateOfBirth = PersonAttributeSource.ExistingRecord,
+            NationalInsuranceNumber = PersonAttributeSource.ExistingRecord,
+            Gender = PersonAttributeSource.ExistingRecord
+        };
+
+        var processContext = new ProcessContext(default, TimeProvider.UtcNow, SystemUser.SystemUserId);
+
+        // Act
+        await WithServiceAsync<TeacherPensionsSupportTaskService>(
+            service => service.ResolveWithMergeAsync(
+                new ResolveTeacherPensionsPotentialDuplicateWithMergeOptions
+                {
+                    SupportTaskReference = supportTask.SupportTaskReference,
+                    ExistingPersonId = existingPerson.PersonId,
+                    AttributeSources = attributeSources
+                },
+                processContext));
+
+        // Assert
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updatedPerson = await dbContext.Persons.SingleAsync(p => p.PersonId == existingPerson.PersonId);
+            Assert.Equal(trnRequest.FirstName, updatedPerson.FirstName);
+            Assert.Equal(existingPerson.LastName, updatedPerson.LastName);
+
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            var data = Assert.IsType<TeacherPensionsPotentialDuplicateData>(dbTask.Data);
+
+            // The snapshot is the record as it was before the merge, not after.
+            Assert.Equal(existingPerson.FirstName, data.SelectedPersonAttributes!.FirstName);
+
+            // The resolved attributes are the record as it is after the merge.
+            Assert.Equal(trnRequest.FirstName, data.ResolvedAttributes!.FirstName);
+            Assert.Equal(existingPerson.LastName, data.ResolvedAttributes.LastName);
+
+            // The middle name has no choice on this journey, so the existing record's is kept.
+            Assert.Equal(existingPerson.MiddleName, data.ResolvedAttributes.MiddleName);
+
+            // The TRN is never resolvable; the surviving record keeps its own.
+            Assert.Equal(existingPerson.Trn, data.ResolvedAttributes.Trn);
+        });
+    }
+
+    [Fact]
     public async Task ResolveWithMergeAsync_TaskIsAlreadyClosed_ThrowsInvalidOperationException()
     {
         // Arrange
@@ -163,9 +221,7 @@ public class TeacherPensionsSupportTaskServiceTests(ServiceFixture fixture) : Se
                 new ResolveTeacherPensionsPotentialDuplicateWithMergeOptions
                 {
                     SupportTaskReference = supportTask.SupportTaskReference,
-                    ExistingPersonId = existingPerson.PersonId,
-                    ResolvedAttributes = null,
-                    SelectedPersonAttributes = null
+                    ExistingPersonId = existingPerson.PersonId
                 },
                 processContext)));
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
@@ -3,7 +3,6 @@ using TeachingRecordSystem.Core.Events.Legacy;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
-using TeachingRecordSystem.SupportUi.Services;
 using PersonDetailsUpdatedEvent = TeachingRecordSystem.Core.Events.PersonDetailsUpdatedEvent;
 using SupportTaskUpdatedEvent = TeachingRecordSystem.Core.Events.SupportTaskUpdatedEvent;
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MergeTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MergeTests.cs
@@ -1,9 +1,9 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
-using TeachingRecordSystem.SupportUi.Services;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
@@ -4,7 +4,6 @@ using TeachingRecordSystem.Core.Events.Legacy;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
-using TeachingRecordSystem.SupportUi.Services;
 using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.ResolveTrnRequestState;
 using PersonCreatedEvent = TeachingRecordSystem.Core.Events.PersonCreatedEvent;
 using PersonDetailsUpdatedEvent = TeachingRecordSystem.Core.Events.PersonDetailsUpdatedEvent;

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MatchesTests.cs
@@ -1,8 +1,8 @@
 using AngleSharp.Dom;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
-using TeachingRecordSystem.SupportUi.Services;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TrnRequests.Resolve;
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MergeTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MergeTests.cs
@@ -1,9 +1,9 @@
 using AngleSharp.Dom;
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
-using TeachingRecordSystem.SupportUi.Services;
 using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.ResolveTrnRequestState;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TrnRequests.Resolve;


### PR DESCRIPTION
Stacked on #3604 (which is itself stacked on #3603) — review those first, and this PR's diff will narrow to a single commit as they merge.

## Why

The two resolve handlers each computed three overlapping views of the *same* per-attribute source choices and passed all three to their service:

- `AttributesToUpdate` — the attributes whose source is the TRN request
- `SelectedPersonAttributes` — a snapshot of the record taken *before* the update
- `ResolvedAttributes` — per attribute, the existing value or the request's

All three are derivable from the sources, the record and the request. The handlers only ever needed to say **where each attribute comes from** — the rest is the service's job.

## What changed

`PersonAttributeSource` moves to `Core.Models.SupportTasks`, alongside `ChangeRequestRejectReason` and `OneLoginUserNotConnectingReason` — the established home for source/reason enums that Razor radios bind directly. A new `PersonAttributeSources` record carries the per-attribute choices across the service boundary and knows how to derive `GetAttributesToUpdate()`.

Both options records shrink to sources plus comments, and `TrnRequestService.ResolveTrnRequestAsync` / `TeacherPensionsSupportTaskService.ResolveWithMergeAsync` derive the rest. Net −30 lines, with ~216 lines of duplicated derivation gone from the two page base classes.

## Design notes

**Sources shape: a record of nullable members, not a dictionary keyed by `PersonMatchedAttribute`.** A dictionary handles both journeys' differing attribute sets with one type, and since #3604 an unset source correctly means "keep existing" — so `GetValueOrDefault` returning `ExistingRecord` (`0`) for a missing key now happens to be right. I didn't want the API's correctness resting on that coincidence. A record is total and explicit, and mirrors the journey state so the handler mapping is mechanical. TeacherPensions leaves `EmailAddress` unset, documented on the type.

**`PersonChangeableAttributesService` stays in SupportUi.** Both its methods are `items.Where(x => x.Source is not null)` — it filters view rows so three check-answers pages can render, and has no meaning in Core.

**The MergePerson enum of the same name is untouched.** Different journey, different values (`PrimaryPerson`/`SecondaryPerson`), no Core service call to push logic into.

## Testing

The snapshot must be taken before the record is updated. Both services now do that explicitly, and I verified both are genuinely pinned by deliberately inverting the order and watching the tests fail — TeacherPensions read the post-update name, TrnRequests likewise — rather than trusting a green run. Added a Core test for the TeacherPensions derivation and snapshot ordering; the TrnRequests side was already covered end-to-end by `Post_UpdatingExistingRecord_...`.

`just build` clean at 0 warnings. SupportUi 3965 green, Core 1024 green. Two pre-existing failures are unrelated and present without these changes: the known-broken `RefreshTrainingProvidersJobTests`, and the flaky E2E `RoutesToProfessionalStatus` suite (a different test fails on each run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)