### PR TITLE
Fix two flaky support-task tests

### DIFF
--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/MergePersonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/MergePersonTests.cs
@@ -49,10 +49,12 @@ public class MergePersonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task MergePerson_PersonsDifferOnAllFields()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Alice").WithMiddleName("Amelia").WithLastName("Anderson")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Bob").WithMiddleName("Brian").WithLastName("Baker")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
@@ -102,10 +104,12 @@ public class MergePersonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task MergePerson_NavigateBack()
     {
         var person1 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Alice").WithMiddleName("Amelia").WithLastName("Anderson")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Bob").WithMiddleName("Brian").WithLastName("Baker")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
@@ -168,10 +172,12 @@ public class MergePersonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task MergePerson_CYA_ClickChangeLink_RedirectsToMergePage(string testIdSelector)
     {
         var person1 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Alice").WithMiddleName("Amelia").WithLastName("Anderson")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()).WithGender(Gender.Male));
 
         var person2 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Bob").WithMiddleName("Brian").WithLastName("Baker")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()).WithGender(Gender.Female));
 
@@ -224,10 +230,12 @@ public class MergePersonTests(HostFixture hostFixture) : TestBase(hostFixture)
     public async Task MergePerson_CYA_ChangeDetails_ContinuesToCYA(string changeLink)
     {
         var person1 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Alice").WithMiddleName("Amelia").WithLastName("Anderson")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 
         var person2 = await TestData.CreatePersonAsync(p => p
+            .WithFirstName("Bob").WithMiddleName("Brian").WithLastName("Baker")
             .WithEmailAddress(TestData.GenerateUniqueEmail())
             .WithNationalInsuranceNumber(TestData.GenerateNationalInsuranceNumber()));
 

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserIdVerificationTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserIdVerificationTests.cs
@@ -33,7 +33,7 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches");
-        await page.ClickRadioByLabelAsync("Connect it to Record A");
+        await page.ClickRadioByLabelAsync("Connect it to Record A", exact: false);
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect");
@@ -170,7 +170,7 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches");
-        await page.ClickRadioByLabelAsync("Connect it to Record A");
+        await page.ClickRadioByLabelAsync("Connect it to Record A", exact: false);
         await page.ClickButtonAsync("Save and come back later");
 
 

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserRecordMatchingTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserRecordMatchingTests.cs
@@ -28,7 +28,7 @@ public class OneLoginUserRecordMatchingTests(HostFixture hostFixture) : TestBase
         await page.ClickAsync($".trs-task-link__name{TextIsSelector($"{firstName} {lastName}")}");
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches");
 
-        await page.ClickRadioByLabelAsync("Connect it to Record A");
+        await page.ClickRadioByLabelAsync("Connect it to Record A", exact: false);
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect");
@@ -121,7 +121,7 @@ public class OneLoginUserRecordMatchingTests(HostFixture hostFixture) : TestBase
         await page.ClickAsync($".trs-task-link__name{TextIsSelector($"{firstName} {lastName}")}");
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches");
 
-        await page.ClickRadioByLabelAsync("Connect it to Record A");
+        await page.ClickRadioByLabelAsync("Connect it to Record A", exact: false);
         await page.ClickButtonAsync("Save and come back later");
 
 

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/PageExtensions.cs
@@ -166,14 +166,13 @@ public static class PageExtensions
             .Locator("xpath=following-sibling::label")
             .ClickAsync();
 
-    public static async Task ClickRadioByLabelAsync(this IPage page, string labelText)
-    {
-        var label = page.Locator($"label:has-text('{labelText}')");
-        var forAttr = await label.GetAttributeAsync("for");
-
-        var radio = page.Locator($"input[id='{forAttr}']");
-        await radio.CheckAsync();
-    }
+    /// <param name="exact">
+    /// Match the whole label. Pass false only for a label that is deliberately identified by a
+    /// prefix; a substring match resolves to every label containing <paramref name="labelText"/>,
+    /// which is ambiguous when the label is a data value that may appear inside another label.
+    /// </param>
+    public static Task ClickRadioByLabelAsync(this IPage page, string labelText, bool exact = true) =>
+        page.GetByLabel(labelText, new() { Exact = exact }).CheckAsync();
 
     public static Task ClickChangeLinkAsync(this IPage page) =>
         page.GetByTestId("change-link").ClickAsync();

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/IndexTests.cs
@@ -97,11 +97,12 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var tasks = SupportTaskLookup.Create(new()
         {
             ["ST1"] = await TestData.CreateTrnRequestSupportTaskAsync(
-                configure: t => t.WithFirstName("Jim").WithLastName("Smith")
+                configure: t => t.WithFirstName("Jim").WithMiddleName("Alan").WithLastName("Smith")
                     .WithCreatedOn(new DateTime(2025, 1, 1))),
 
             ["ST2"] = await TestData.CreateTrnRequestSupportTaskAsync(
-                configure: t => t.WithEmailAddress("bob.jones@email.com")
+                configure: t => t.WithFirstName("Bob").WithMiddleName("Robert").WithLastName("Jones")
+                .WithEmailAddress("bob.jones@email.com")
                 .WithCreatedOn(new DateTime(2023, 10, 10))),
         });
 


### PR DESCRIPTION
## What

Fixes two pre-existing flaky tests that passed in isolation but failed intermittently under a full `just test-changed` run. Both were caused by random-value collisions in Faker-generated test data, not cross-test pollution.

### 1. `IndexTests.Get_Search_ShowsMatchingResult`

The theory creates two TRN request support tasks and asserts a search returns exactly one. ST1 pinned its names (`Jim … Smith`) but ST2's first/last names came from `TestData.GenerateFirstName()` / `GenerateLastName()`, which are Faker-random — so ST2 could itself generate "Jim" or "Smith" and match a search meant to return only ST1. Fixed by pinning ST2's names (`Bob Robert Jones`), mirroring ST1. Also pinned ST1's middle name, since the search matches on **all** name parts.

The sorting theory in the same class was checked and is already safe — it orders on decisive pinned values, so the random last names never affect ordering.

### 2. `MergePersonTests` (`MergePerson_CYA_*` theories)

Not actually load-dependent — reproduced on the first isolated filtered run. Root cause is the `ClickRadioByLabelAsync` helper, which matched labels with a case-insensitive **substring** selector (`label:has-text('X')`):

- **Substring bleed into emails:** Faker builds emails from names, so clicking the surname radio "Johnson" also matched the email label `art@beckerjohnson.biz` → Playwright strict-mode violation.
- **Highlighted labels:** fields that *differ* between the two records render with the `highlight` tag helper, which wraps the label text in `<mark><strong>…</strong></mark>`, defeating a naive `:text-is()` on the label.

Fixed by rewriting the helper to use Playwright's `GetByLabel(text, Exact = true)`, which resolves label→control correctly regardless of nesting. The four OneLogin callers that identify a radio by prefix (`"Connect it to Record A"` renders as `…A (TRN 1234567)`) opt into `exact: false`. Also pinned distinct names on the two merged people as defense-in-depth, since Faker draws first and middle names from the same pool.

## Verification

- `IndexTests`: 24/24 passing.
- `MergePersonTests`: 5 consecutive full E2E runs, 17/17 every time, 0 failures. OneLogin prefix callers still pass.
- `just build` clean (0 warnings, 0 errors); `just format-changed` made no changes.

## Note for reviewers

While running the full E2E project I saw `EditDetails_ChangeName_NavigateBack` time out once. It does **not** use the changed helper, so it's a separate, pre-existing flake unrelated to this PR — flagging for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)