### PR TITLE
Stop error page masking the real error at /continue-to-application

### DIFF
--- a/src/TeachingRecordSystem.AuthorizeAccess/Pages/Cookies.cshtml
+++ b/src/TeachingRecordSystem.AuthorizeAccess/Pages/Cookies.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "/cookies"
 @inject IJourneyInstanceProvider JourneyInstanceProvider
 @model TeachingRecordSystem.AuthorizeAccess.Pages.CookiesModel
 @{

--- a/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/_Layout.cshtml
+++ b/src/TeachingRecordSystem.AuthorizeAccess/Pages/Shared/_Layout.cshtml
@@ -1,3 +1,5 @@
+@using Microsoft.AspNetCore.Diagnostics
+@using Microsoft.AspNetCore.Http.Features
 @inject Joonasw.AspNetCore.SecurityHeaders.Csp.ICspNonceService NonceService
 @inject IJourneyInstanceProvider JourneyInstanceProvider
 @inject AuthorizeAccessLinkGenerator LinkGenerator
@@ -5,7 +7,13 @@
 @{
     Layout = "_GovUkPageTemplate";
 
-    var coordinator = JourneyInstanceProvider.GetJourneyInstance(Context) as SignInJourneyCoordinator;
+    // Don't resolve journey chrome (service header, back link) when this shared layout is
+    // rendered for an error page re-execution. The request path is then '/error', which isn't
+    // a step in any journey, so GetBackLink() would throw "Current step not found in journey
+    // path." and mask the real error that triggered the error page in the first place.
+    var coordinator = IsErrorReExecute()
+        ? null
+        : JourneyInstanceProvider.GetJourneyInstance(Context) as SignInJourneyCoordinator;
 
     if (coordinator is not null)
     {
@@ -54,7 +62,8 @@
     {
         @await RenderSectionAsync("BeforeContent")
     }
-    else if (JourneyInstanceProvider.GetJourneyInstance(Context) is SignInJourneyCoordinator signInJourneyCoordinator &&
+    else if (!IsErrorReExecute() &&
+        JourneyInstanceProvider.GetJourneyInstance(Context) is SignInJourneyCoordinator signInJourneyCoordinator &&
         signInJourneyCoordinator.GetBackLink() is string backLink)
     {
         <govuk-back-link href="@backLink" />
@@ -68,12 +77,9 @@
         <govuk-footer-meta>
             <govuk-footer-meta-items>
                 <govuk-footer-meta-item href="https://accessibility-statements.education.gov.uk/s/78">Accessibility</govuk-footer-meta-item>
-                @{
-                    var journeyInstance = JourneyInstanceProvider.GetJourneyInstance(Context);
-                    if (journeyInstance is not null)
-                    {
-                        <govuk-footer-meta-item href="@LinkGenerator.Cookies(journeyInstance.InstanceId)">Cookies</govuk-footer-meta-item>
-                    }
+                @if (coordinator is not null)
+                {
+                    <govuk-footer-meta-item href="@LinkGenerator.Cookies(coordinator.InstanceId)">Cookies</govuk-footer-meta-item>
                 }
                 <govuk-footer-meta-item href="https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers">Privacy</govuk-footer-meta-item>
             </govuk-footer-meta-items>
@@ -87,4 +93,12 @@
     @Html.GovUkFrontendScriptImports(cspNonce: NonceService.GetNonce())
     <script src="~/one-login-service-header.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
+}
+
+@functions {
+    // True when the pipeline is re-executing to render the error page (via UseExceptionHandler
+    // or UseStatusCodePagesWithReExecute). In that case the current request path is '/error'.
+    private bool IsErrorReExecute() =>
+        Context.Features.Get<IExceptionHandlerPathFeature>() is not null ||
+        Context.Features.Get<IStatusCodeReExecuteFeature>() is not null;
 }


### PR DESCRIPTION
### Context

We were seeing intermittent `System.InvalidOperationException: Current step not found in journey path.` errors reported at the `/continue-to-application` endpoint in AuthorizeAccess, unreproducible in testing.

The exception is actually a **secondary failure from the error page**, not from `/continue-to-application`'s own logic:

1. Something errors on a journey request (e.g. the auto-submitting `/continue-to-application` form failing antiforgery validation after a timeout).
2. `UseExceptionHandler("/error")` re-executes the pipeline on the same `HttpContext`, with `Request.Path` rewritten to `/error`.
3. The error views (`GenericError` → `_ErrorLayout`) render through the shared `_Layout`, which — because the coordinator is still cached in `HttpContext.Items` from the original request — calls `coordinator.GetBackLink()`.
4. `GetBackLink()` computes the "current step" from the now-`/error` request path, which isn't a step in any journey, and throws `Current step not found in journey path.` (in the `GovUk.Questions.AspNetCore` library).

The real error is swallowed and replaced by this one. It only bites in production because the exception handler is registered behind `!IsTests()`, which is exactly why tests never hit it.

### Changes proposed in this pull request

- `_Layout.cshtml`: skip resolving journey chrome (service header state, back link, cookies footer link) when the layout is rendered for an error re-execution (detected via `IExceptionHandlerPathFeature` / `IStatusCodeReExecuteFeature`). This stops `GetBackLink()` from throwing so the error page renders and the real exception surfaces in logs.
- `_Layout.cshtml`: reuse the already-resolved `coordinator` in the footer instead of a second `GetJourneyInstance()` call.
- `Cookies.cshtml`: give the page an explicit `/cookies` route, matching the convention used by the other pages (`/found`, `/sign-out`, etc.).

### Guidance to review

- The core fix is the `IsErrorReExecute()` guard in `_Layout.cshtml`. On normal (non-error) requests it returns `false`, so behaviour is unchanged.
- The link generator resolves `Cookies` by page name (`/Cookies`), so the explicit `/cookies` route is picked up automatically and the `GetCurrentStep()` special-case in `SignInJourneyCoordinator` keeps working.
- No automated regression test is included: the test host runs under the `Tests` environment, which disables the exception handler entirely, so the re-execution path can't be exercised without dedicated host wiring. Happy to add a fixture that enables error handling if wanted.
- **Follow-up (separate):** now that masking is removed, the true primary error on `/continue-to-application` should appear in logs — most likely an antiforgery failure on the auto-submitting form. Worth watching after this deploys.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)