### PR TITLE
Migrate Close Alert journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/alerts/{alertId}/close/check-answers/{handler?}"
+@page "/alerts/{alertId}/close/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before confirming change";
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Alerts.CloseAlert.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -44,7 +49,7 @@
                     <key>End date</key>
                     <value data-testid="end-date">@Model.EndDate!.Value.ToString(WebConstants.DateDisplayFormat)</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.CloseAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="end date">Change</action>
+                        <action href="@LinkGenerator.Alerts.CloseAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="end date">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
@@ -56,7 +61,7 @@
                     <key>Reason</key>
                     <value>@Model.ChangeReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.CloseAlert.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</action>
+                        <action href="@LinkGenerator.Alerts.CloseAlert.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for change">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -72,7 +77,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.CloseAlert.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.CloseAlert.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -81,7 +86,7 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.CloseAlert.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Alerts.CloseAlert.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
@@ -89,7 +94,7 @@
             <h2 class="govuk-heading-m">Are you sure you want to close this alert?</h2>
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and close alert</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.CloseAlert.CheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -8,20 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.CloseAlert), RequireJourneyInstance]
+[Journey(JourneyNames.CloseAlert)]
 public class CheckAnswersModel(
+    CloseAlertJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager,
     AlertService alertService,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<CloseAlertState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -47,11 +50,13 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
+        if (!journey.State.IsComplete)
         {
-            context.Result = Redirect(linkGenerator.Alerts.CloseAlert.Index(AlertId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.Alerts.CloseAlert.Index(journey.InstanceId));
             return;
         }
+
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
@@ -63,14 +68,19 @@ public class CheckAnswersModel(
         Link = alertInfo.Alert.ExternalLink;
         LinkUri = TrsUriHelper.TryCreateWebsiteUri(Link, out var linkUri) ? linkUri : null;
         StartDate = alertInfo.Alert.StartDate;
-        EndDate = JourneyInstance!.State.EndDate;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        EndDate = journey.State.EndDate;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var alert = HttpContext.GetCurrentAlertFeature().Alert;
         var processContext = new ProcessContext(
             ProcessType.AlertUpdating,
@@ -92,17 +102,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Alert closed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }
-

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertJourneyCoordinator.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
+
+[JourneyCoordinator(JourneyNames.CloseAlert, routeValueKeys: ["alertId"])]
+public class CloseAlertJourneyCoordinator : JourneyCoordinator<CloseAlertState>
+{
+    public override CloseAlertState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertLinkGenerator.cs
@@ -2,21 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 
 public class CloseAlertLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/CloseAlert/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid alertId) =>
+        linkGenerator.GetRequiredPathByPage("/Alerts/CloseAlert/Index", routeValues: new { alertId });
 
-    public string Cancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/CloseAlert/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/CloseAlert/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/CloseAlert/Reason", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/CloseAlert/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/CloseAlert/Reason", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/CloseAlert/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/CloseAlert/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Alerts/CloseAlert/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
@@ -4,14 +4,8 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 
-public class CloseAlertState : IRegisterJourney
+public class CloseAlertState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.CloseAlert,
-        typeof(CloseAlertState),
-        requestDataKeys: ["alertId"],
-        appendUniqueKey: true);
-
     public DateOnly? EndDate { get; set; }
 
     public CloseAlertReasonOption? ChangeReason { get; set; }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml
@@ -1,10 +1,13 @@
-@page "/alerts/{alertId}/close/{handler?}"
+@page "/alerts/{alertId}/close"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.IndexModel
 @{
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Alerts.CloseAlert.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Persons.PersonDetail.Alerts(Model.PersonId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -23,7 +26,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.CloseAlert.Cancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Index.cshtml.cs
@@ -5,19 +5,31 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.CloseAlert), ActivatesJourney, RequireJourneyInstance]
+[Journey(JourneyNames.CloseAlert), StartsJourney]
 public class IndexModel(
+    CloseAlertJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<CloseAlertState>? JourneyInstance { get; set; }
+    private readonly InlineValidator<IndexModel> _validator = new()
+    {
+        v => v.RuleFor(m => m.EndDate)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Enter an end date")
+            .LessThanOrEqualTo(timeProvider.Today).WithMessage("End date cannot be in the future")
+            .GreaterThan(m => m.StartDate).WithMessage("End date must be after the start date")
+    };
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -30,40 +42,27 @@ public class IndexModel(
 
     public void OnGet()
     {
-        EndDate = JourneyInstance!.State.EndDate;
+        EndDate = journey.State.EndDate;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (EndDate is null)
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(EndDate), "Enter an end date");
-        }
-        else if (EndDate > timeProvider.Today)
-        {
-            ModelState.AddModelError(nameof(EndDate), "End date cannot be in the future");
-        }
-        else if (EndDate <= StartDate)
-        {
-            ModelState.AddModelError(nameof(EndDate), "End date must be after the start date");
+            return await CancelAsync();
         }
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
+        await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state => state.EndDate = EndDate);
-
-        return Redirect(FromCheckAnswers
-            ? linkGenerator.Alerts.CloseAlert.CheckAnswers(AlertId, JourneyInstance.InstanceId)
-            : linkGenerator.Alerts.CloseAlert.Reason(AlertId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.CloseAlert.Reason(journey.InstanceId),
+            state => state.EndDate = EndDate);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
@@ -75,6 +74,7 @@ public class IndexModel(
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         StartDate = alertInfo.Alert.StartDate;
-    }
 
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Alerts(PersonId);
+    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/close/reason/{handler?}"
+@page "/alerts/{alertId}/close/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert.ReasonModel
 @{
     ViewBag.Title = "Why are you adding an end date?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.Alerts.CloseAlert.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.CloseAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -52,7 +55,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.CloseAlert.ReasonCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/Reason.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.CloseAlert), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.CloseAlert)]
+public class ReasonModel(
+    CloseAlertJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -23,13 +26,15 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<CloseAlertState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -49,11 +54,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.EndDate is null)
+        if (journey.State.EndDate is null)
         {
-            context.Result = Redirect(linkGenerator.Alerts.CloseAlert.Index(AlertId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.Alerts.CloseAlert.Index(journey.InstanceId));
             return;
         }
+
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -63,37 +70,40 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance!.State.HasAdditionalReasonDetail;
-        ChangeReasonDetail = JourneyInstance?.State.ChangeReasonDetail;
-        Evidence = JourneyInstance!.State.Evidence;
+        ChangeReason = journey.State.ChangeReason;
+        HasAdditionalReasonDetail = journey.State.HasAdditionalReasonDetail;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        Evidence = journey.State.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
-            state.ChangeReasonDetail = ChangeReasonDetail;
-            state.Evidence = Evidence;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Alerts.CloseAlert.CheckAnswers(AlertId, JourneyInstance!.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.CloseAlert.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+                state.ChangeReasonDetail = ChangeReasonDetail;
+                state.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -98,7 +98,7 @@
                         @if (canWrite)
                         {
                             <row-actions>
-                                <action href="@LinkGenerator.Alerts.CloseAlert.Index(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="end date">Add</action>
+                                <action href="@LinkGenerator.Alerts.CloseAlert.Index(alert.AlertId)" visually-hidden-text="end date">Add</action>
                             </row-actions>
                         }
                     </row>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -181,6 +181,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : CloseAlertTestBase(hos
 
         EventObserver.Clear();
 
+        var state = journeyInstance.State;
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -196,7 +198,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : CloseAlertTestBase(hos
         await WithDbContextAsync(async dbContext =>
         {
             var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alert.AlertId);
-            Assert.Equal(journeyInstance.State.EndDate, updatedAlert!.EndDate);
+            Assert.Equal(state.EndDate, updatedAlert!.EndDate);
         });
 
         Events.AssertProcessesCreated(p =>
@@ -205,13 +207,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : CloseAlertTestBase(hos
             p.AssertProcessHasEvents<AlertUpdatedEvent>();
 
             var changeReason = Assert.IsType<ChangeReasonWithDetailsAndEvidence>(p.ProcessContext.Process.ChangeReason);
-            Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), changeReason.Reason);
-            Assert.Equal(populateOptional ? journeyInstance.State.ChangeReasonDetail : null, changeReason.Details);
-            Assert.Equal(populateOptional ? journeyInstance.State.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
+            Assert.Equal(state.ChangeReason!.GetDisplayName(), changeReason.Reason);
+            Assert.Equal(populateOptional ? state.ChangeReasonDetail : null, changeReason.Details);
+            Assert.Equal(populateOptional ? state.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -221,7 +222,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : CloseAlertTestBase(hos
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional: true);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -230,8 +234,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : CloseAlertTestBase(hos
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CloseAlertTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CloseAlertTestBase.cs
@@ -1,3 +1,4 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
 
@@ -5,10 +6,10 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.CloseAlert;
 
 public abstract class CloseAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected Task<JourneyInstance<CloseAlertState>> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
+    protected Task<CloseAlertJourneyCoordinator> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
         CreateJourneyInstanceAsync(alertId, new());
 
-    protected Task<JourneyInstance<CloseAlertState>> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
+    protected Task<CloseAlertJourneyCoordinator> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
         CreateJourneyInstanceAsync(alert.AlertId, new CloseAlertState
         {
             EndDate = alert.StartDate!.Value.AddDays(2),
@@ -27,7 +28,7 @@ public abstract class CloseAlertTestBase(HostFixture hostFixture) : TestBase(hos
             }
         });
 
-    protected Task<JourneyInstance<CloseAlertState>> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
+    protected Task<CloseAlertJourneyCoordinator> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
         step switch
         {
             JourneySteps.New =>
@@ -42,11 +43,25 @@ public abstract class CloseAlertTestBase(HostFixture hostFixture) : TestBase(hos
             _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
         };
 
-    private Task<JourneyInstance<CloseAlertState>> CreateJourneyInstanceAsync(Guid alertId, CloseAlertState state) =>
-        CreateJourneyInstance(
+    protected CloseAlertState? GetJourneyInstanceState(CloseAlertJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (CloseAlertState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<CloseAlertJourneyCoordinator> CreateJourneyInstanceAsync(Guid alertId, CloseAlertState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<CloseAlertJourneyCoordinator>(
             JourneyNames.CloseAlert,
-            state,
-            new KeyValuePair<string, object>("alertId", alertId));
+            new RouteValueDictionary { ["alertId"] = alertId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/alerts/{alertId}/close",
+                $"/alerts/{alertId}/close/reason",
+                $"/alerts/{alertId}/close/check-answers",
+            ]);
 
     public static class JourneySteps
     {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/IndexTests.cs
@@ -106,7 +106,7 @@ public class IndexTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtur
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.New, alert);
         var endDate = alert.StartDate!.Value.AddDays(5);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = CreatePostContent(endDate)
         };
@@ -214,7 +214,7 @@ public class IndexTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtur
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
         var newEndDate = alert.StartDate!.Value.AddDays(2);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = CreatePostContent(newEndDate)
         };
@@ -226,7 +226,6 @@ public class IndexTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtur
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/close/reason", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(newEndDate, journeyInstance.State.EndDate);
     }
 
@@ -237,7 +236,10 @@ public class IndexTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtur
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -246,8 +248,7 @@ public class IndexTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtur
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -264,7 +265,7 @@ public class IndexTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtur
         });
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/ReasonTests.cs
@@ -336,7 +336,6 @@ public class ReasonTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.True(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Equal(reasonDetail, journeyInstance.State.ChangeReasonDetail);
@@ -370,7 +369,6 @@ public class ReasonTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.False(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Null(journeyInstance.State.ChangeReasonDetail);
@@ -385,7 +383,10 @@ public class ReasonTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtu
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -394,8 +395,7 @@ public class ReasonTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -412,7 +412,7 @@ public class ReasonTests(HostFixture hostFixture) : CloseAlertTestBase(hostFixtu
         });
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/close?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/close?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);


### PR DESCRIPTION
Follows on from #3618 (Add Alert), now merged; rebased onto `main`.

## What

Migrates the **Close Alert** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the Add Alert migration, and converts its validation to FluentValidation.

## Changes

- Add `CloseAlertJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.CloseAlert, ["alertId"])]`); drop FormFlow's `IRegisterJourney` from `CloseAlertState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys, the library's `returnUrl` mechanism for "Change" links, and a form-field `Cancel` submit (so the cancel POST stays on a valid journey step).
- Rewrite `CloseAlertLinkGenerator` onto the shared `GetJourneyPage` extension; update the person-alerts page entry link.
- **Validation → FluentValidation:** Index's end-date rules move from manual `ModelState` into an `InlineValidator` validated via `ValidateAndThrowAsync`; Reason moves off the `ValidateAndThrow` + `PageWithErrors` mix. Reason uploads the evidence file *before* validating so it's retained when the form re-renders with errors (the `FluentValidationExceptionFilter` re-renders the current model).

## Notes

- The page-level prerequisite guards and `CloseAlertState.IsComplete` are **kept** here (as with the initial Add Alert conversion — guard removal for Add Alert was a separate step).
- Removed spurious `?personId=` query params from some test request URLs — harmless under FormFlow, but under the path model they'd pollute the step id (the page derives the person from the alert, not the query).

## Testing

- `just build` — solution builds with no errors (the only warnings are pre-existing `NU1903` transitive-dependency advisories on `main`, unrelated to this change).
- CloseAlert tests: **68 passed**; all Alerts tests: **564 passed**.
- Route paths preserved, so the existing end-to-end close-alert journey test remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)