### PR TITLE
Migrate Delete Alert journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CheckAnswers.cshtml.cs
@@ -50,12 +50,6 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!journey.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Alerts.CloseAlert.Index(journey.InstanceId));
-            return;
-        }
-
         BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/CloseAlert/CloseAlertState.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.CloseAlert;
@@ -15,12 +13,4 @@ public class CloseAlertState
     public string? ChangeReasonDetail { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(HasAdditionalReasonDetail))]
-    public bool IsComplete => EndDate is not null &&
-        ChangeReason.HasValue &&
-        HasAdditionalReasonDetail is bool hasDetail &&
-        (!hasDetail || ChangeReasonDetail is not null) &&
-        Evidence.IsComplete;
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/alerts/{alertId}/delete/check-answers/{handler?}"
+@page "/alerts/{alertId}/delete/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before deleting alert";
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -53,7 +58,7 @@
                     <key>Reason</key>
                     <value>@Model.DeleteReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</action>
+                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for change">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -62,7 +67,7 @@
                         @Html.ConvertNewlinesToLineBreaks(Model.DeleteReasonDetail)
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -71,7 +76,7 @@
                         @Html.ConvertNewlinesToLineBreaks(Model.AdditionalInformation)
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -80,7 +85,7 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
@@ -91,7 +96,7 @@
             </div>
             <div class="govuk-button-group">
                 <govuk-button class="govuk-button--warning" type="submit">Confirm and delete alert</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.DeleteAlert.CheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
@@ -51,12 +51,6 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!journey.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Alerts.DeleteAlert.Index(journey.InstanceId));
-            return;
-        }
-
         BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/CheckAnswers.cshtml.cs
@@ -7,17 +7,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DeleteAlert), RequireJourneyInstance]
+[Journey(JourneyNames.DeleteAlert)]
 public class CheckAnswersModel(
+    DeleteAlertJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager,
     AlertService alertService,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<DeleteAlertState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -45,11 +51,13 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
+        if (!journey.State.IsComplete)
         {
-            context.Result = Redirect(linkGenerator.Alerts.DeleteAlert.Index(AlertId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.Alerts.DeleteAlert.Index(journey.InstanceId));
             return;
         }
+
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
@@ -62,14 +70,19 @@ public class CheckAnswersModel(
         LinkUri = TrsUriHelper.TryCreateWebsiteUri(Link, out var linkUri) ? linkUri : null;
         StartDate = alertInfo.Alert.StartDate;
         EndDate = alertInfo.Alert.EndDate;
-        DeleteReason = JourneyInstance.State.DeleteReason!.Value;
-        DeleteReasonDetail = JourneyInstance.State.DeleteReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
+        DeleteReason = journey.State.DeleteReason!.Value;
+        DeleteReasonDetail = journey.State.DeleteReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = journey.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var alert = HttpContext.GetCurrentAlertFeature().Alert;
         var processContext = new ProcessContext(
             ProcessType.AlertDeleting,
@@ -90,16 +103,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Alert deleted");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(EndDate is null ? linkGenerator.Persons.PersonDetail.Alerts(PersonId) : linkGenerator.Alerts.AlertDetail(AlertId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertJourneyCoordinator.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert;
+
+[JourneyCoordinator(JourneyNames.DeleteAlert, routeValueKeys: ["alertId"])]
+public class DeleteAlertJourneyCoordinator : JourneyCoordinator<DeleteAlertState>
+{
+    public override DeleteAlertState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertLinkGenerator.cs
@@ -2,15 +2,12 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert;
 
 public class DeleteAlertLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/DeleteAlert/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid alertId) =>
+        linkGenerator.GetRequiredPathByPage("/Alerts/DeleteAlert/Index", routeValues: new { alertId });
 
-    public string Cancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/DeleteAlert/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/DeleteAlert/Index", journeyInstanceId, returnUrl);
 
-    public string CheckAnswers(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/DeleteAlert/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/DeleteAlert/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Alerts/DeleteAlert/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertState.cs
@@ -4,14 +4,8 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert;
 
-public class DeleteAlertState : IRegisterJourney
+public class DeleteAlertState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.DeleteAlert,
-        typeof(DeleteAlertState),
-        requestDataKeys: ["alertId"],
-        appendUniqueKey: true);
-
     public DeleteAlertReasonOption? DeleteReason { get; set; }
 
     public bool? ProvideAdditionalInformation { get; set; }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/DeleteAlertState.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert;
@@ -15,14 +13,4 @@ public class DeleteAlertState
     public string? AdditionalInformation { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(ProvideAdditionalInformation))]
-    public bool IsComplete =>
-        (DeleteReason.HasValue && DeleteReason == DeleteAlertReasonOption.AnotherReason && !string.IsNullOrEmpty(DeleteReasonDetail) ||
-         DeleteReason != DeleteAlertReasonOption.AnotherReason && string.IsNullOrEmpty(DeleteReasonDetail)) &&
-        (ProvideAdditionalInformation == true && !string.IsNullOrEmpty(AdditionalInformation) ||
-         ProvideAdditionalInformation == false && string.IsNullOrEmpty(AdditionalInformation)) &&
-        Evidence.IsComplete;
-
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/delete/{handler?}"
+@page "/alerts/{alertId}/delete"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert.IndexModel
 @{
     ViewBag.Title = "Why are you deleting this alert?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Alerts.DeleteAlert.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : Model.EndDate is null ? LinkGenerator.Persons.PersonDetail.Alerts(Model.PersonId) : LinkGenerator.Alerts.AlertDetail(Model.AlertId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -52,7 +55,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.DeleteAlert.Cancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/DeleteAlert/Index.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DeleteAlert), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.DeleteAlert), StartsJourney]
+public class IndexModel(
+    DeleteAlertJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<IndexModel> _validator = new()
     {
@@ -26,13 +29,15 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
             .When(m => m.DeleteReason == DeleteAlertReasonOption.AnotherReason),
     };
 
-    public JourneyInstance<DeleteAlertState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -59,40 +64,43 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        DeleteReason = JourneyInstance!.State.DeleteReason;
-        ProvideAdditionalInformation = JourneyInstance!.State.ProvideAdditionalInformation;
-        DeleteReasonDetail = JourneyInstance!.State.DeleteReasonDetail;
-        Evidence = JourneyInstance!.State.Evidence;
-        AdditionalInformation = JourneyInstance!.State.AdditionalInformation;
+        DeleteReason = journey.State.DeleteReason;
+        ProvideAdditionalInformation = journey.State.ProvideAdditionalInformation;
+        DeleteReasonDetail = journey.State.DeleteReasonDetail;
+        Evidence = journey.State.Evidence;
+        AdditionalInformation = journey.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<IndexModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.DeleteReason = DeleteReason;
-            state.AdditionalInformation = AdditionalInformation;
-            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
-            state.DeleteReasonDetail = DeleteReasonDetail;
-            state.Evidence = Evidence;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Alerts.DeleteAlert.CheckAnswers(AlertId, JourneyInstance!.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.DeleteAlert.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.DeleteReason = DeleteReason;
+                state.AdditionalInformation = AdditionalInformation;
+                state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+                state.DeleteReasonDetail = DeleteReasonDetail;
+                state.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(EndDate is null ? linkGenerator.Persons.PersonDetail.Alerts(PersonId) : linkGenerator.Alerts.AlertDetail(AlertId));
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
+        return Redirect(GetReturnToRecordLink());
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -104,5 +112,10 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         PersonName = personInfo.Name;
         AlertTypeName = alertInfo.Alert.AlertType!.Name;
         EndDate = alertInfo.Alert.EndDate;
+
+        BackLink = journey.GetBackLink() ?? GetReturnToRecordLink();
     }
+
+    private string GetReturnToRecordLink() =>
+        EndDate is null ? linkGenerator.Persons.PersonDetail.Alerts(PersonId) : linkGenerator.Alerts.AlertDetail(AlertId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -40,7 +40,7 @@
                 @if (canWrite)
                 {
                     <card-actions>
-                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="alert">Delete</action>
+                        <action href="@LinkGenerator.Alerts.DeleteAlert.Index(alert.AlertId)" visually-hidden-text="alert">Delete</action>
                     </card-actions>
                 }
                 <govuk-summary-list>
@@ -143,7 +143,7 @@
                         <td class="govuk-table__cell">
                             @if (canWrite)
                             {
-                                <a href="@LinkGenerator.Alerts.DeleteAlert.Index(alert.AlertId, journeyInstanceId: null)" class="govuk-link">Delete <span class="govuk-visually-hidden">alert</span></a>
+                                <a href="@LinkGenerator.Alerts.DeleteAlert.Index(alert.AlertId)" class="govuk-link">Delete <span class="govuk-visually-hidden">alert</span></a>
                             }
                         </td>
                     </tr>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/CloseAlert/CheckAnswersTests.cs
@@ -59,23 +59,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : CloseAlertTestBase(hos
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/close", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -151,23 +134,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : CloseAlertTestBase(hos
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/close/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/close", response.Headers.Location?.OriginalString);
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/CheckAnswersTests.cs
@@ -46,25 +46,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : DeleteAlertTestBase(ho
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage(bool isOpenAlert)
-    {
-        // Arrange
-        var (person, alert) = isOpenAlert ? await CreatePersonWithOpenAlert() : await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/delete", response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
     [InlineData(true, true, true, DeleteAlertReasonOption.AnotherReason)]
     [InlineData(true, false, false, DeleteAlertReasonOption.AnotherReason)]
     [InlineData(false, true, false, DeleteAlertReasonOption.AddedInError)]
@@ -129,25 +110,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : DeleteAlertTestBase(ho
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task GPost_MissingDataInJourneyState_RedirectsToIndexPage(bool isOpenAlert)
-    {
-        // Arrange
-        var (person, alert) = isOpenAlert ? await CreatePersonWithOpenAlert() : await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/delete", response.Headers.Location?.OriginalString);
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/CheckAnswersTests.cs
@@ -161,6 +161,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : DeleteAlertTestBase(ho
 
         EventObserver.Clear();
 
+        var state = journeyInstance.State;
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -185,13 +187,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : DeleteAlertTestBase(ho
             p.AssertProcessHasEvents<AlertDeletedEvent>();
 
             var changeReason = Assert.IsType<ChangeReasonWithDetailsAndEvidence>(p.ProcessContext.Process.ChangeReason);
-            Assert.Equal(journeyInstance.State.DeleteReason!.GetDisplayName(), changeReason.Reason);
-            Assert.Equal(journeyInstance.State.DeleteReasonDetail, changeReason.Details);
-            Assert.Equal(journeyInstance.State.Evidence.UploadedEvidenceFile?.ToEventModel(), changeReason.EvidenceFile);
+            Assert.Equal(state.DeleteReason!.GetDisplayName(), changeReason.Reason);
+            Assert.Equal(state.DeleteReasonDetail, changeReason.Details);
+            Assert.Equal(state.Evidence.UploadedEvidenceFile?.ToEventModel(), changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -203,7 +204,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : DeleteAlertTestBase(ho
         var (person, alert) = isOpenAlert ? await CreatePersonWithOpenAlert() : await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/delete/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -219,8 +223,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : DeleteAlertTestBase(ho
             Assert.Equal($"/alerts/{alert.AlertId}", response.Headers.Location!.OriginalString);
         }
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/DeleteAlertTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/DeleteAlertTestBase.cs
@@ -1,3 +1,4 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.DeleteAlert;
 
@@ -5,10 +6,10 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.DeleteAlert;
 
 public class DeleteAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected Task<JourneyInstance<DeleteAlertState>> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
+    protected Task<DeleteAlertJourneyCoordinator> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
         CreateJourneyInstanceAsync(alertId, new());
 
-    protected Task<JourneyInstance<DeleteAlertState>> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true, DeleteAlertReasonOption deleteReason = DeleteAlertReasonOption.AnotherReason, bool provideAdditionalInformation = false) =>
+    protected Task<DeleteAlertJourneyCoordinator> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true, DeleteAlertReasonOption deleteReason = DeleteAlertReasonOption.AnotherReason, bool provideAdditionalInformation = false) =>
         CreateJourneyInstanceAsync(alert.AlertId, new DeleteAlertState
         {
             DeleteReason = deleteReason,
@@ -27,7 +28,7 @@ public class DeleteAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture
             AdditionalInformation = provideAdditionalInformation == true ? "Some additional information" : null
         });
 
-    protected Task<JourneyInstance<DeleteAlertState>> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
+    protected Task<DeleteAlertJourneyCoordinator> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
         step switch
         {
             JourneySteps.New =>
@@ -37,11 +38,24 @@ public class DeleteAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture
             _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
         };
 
-    private Task<JourneyInstance<DeleteAlertState>> CreateJourneyInstanceAsync(Guid alertId, DeleteAlertState state) =>
-        CreateJourneyInstance(
+    protected DeleteAlertState? GetJourneyInstanceState(DeleteAlertJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (DeleteAlertState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<DeleteAlertJourneyCoordinator> CreateJourneyInstanceAsync(Guid alertId, DeleteAlertState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<DeleteAlertJourneyCoordinator>(
             JourneyNames.DeleteAlert,
-            state,
-            new KeyValuePair<string, object>("alertId", alertId));
+            new RouteValueDictionary { ["alertId"] = alertId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/alerts/{alertId}/delete",
+                $"/alerts/{alertId}/delete/check-answers",
+            ]);
 
     public static class JourneySteps
     {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/DeleteAlert/IndexTests.cs
@@ -283,7 +283,6 @@ public class IndexTests(HostFixture hostFixture) : DeleteAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(provideAdditionalInformation, journeyInstance.State.ProvideAdditionalInformation);
         Assert.Equal(additionalInformation, journeyInstance.State.AdditionalInformation);
         Assert.Null(journeyInstance.State.DeleteReasonDetail);
@@ -319,7 +318,6 @@ public class IndexTests(HostFixture hostFixture) : DeleteAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.False(journeyInstance.State.ProvideAdditionalInformation);
         Assert.Null(journeyInstance.State.DeleteReasonDetail);
         Assert.Null(journeyInstance.State.AdditionalInformation);
@@ -336,7 +334,10 @@ public class IndexTests(HostFixture hostFixture) : DeleteAlertTestBase(hostFixtu
         var (person, alert) = isOpenAlert ? await CreatePersonWithOpenAlert() : await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/delete/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -352,8 +353,7 @@ public class IndexTests(HostFixture hostFixture) : DeleteAlertTestBase(hostFixtu
             Assert.Equal($"/alerts/{alert.AlertId}", response.Headers.Location!.OriginalString);
         }
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]


### PR DESCRIPTION
Follows #3618 (Add Alert) and #3620 (Close Alert).

## What

1. Migrates the **Delete Alert** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the previous two, and converts its validation to the FluentValidation `ValidateAndThrowAsync` pattern.
2. Removes `IsComplete` and the *check answers* prerequisite guard from **both** Delete Alert and Close Alert — redundant now the journey path model prevents reaching check answers before the preceding steps (same clean-up already done for Add Alert).

## Delete Alert migration

- Add `DeleteAlertJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.DeleteAlert, ["alertId"])]`); drop FormFlow's `IRegisterJourney` from `DeleteAlertState`.
- Rewrite Index and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys, the library's `returnUrl` mechanism for "Change" links, and a form-field `Cancel` submit (so the cancel POST stays on a valid journey step).
- Rewrite `DeleteAlertLinkGenerator` onto the shared `GetJourneyPage` extension; update both person-alerts page entry links.
- **Validation → FluentValidation:** Index moves off the `ValidateAndThrow` + `ModelState` / `PageWithErrors` mix to `ValidateAndThrowAsync`, letting `FluentValidationExceptionFilter` render the errors. Evidence is uploaded *before* validating so the file is retained when the form re-renders with errors.
- Index's back link and the Cancel target keep the existing behaviour of returning to the person's alerts page for an open alert, or the alert detail page for a closed one.

## Guard removal (Delete Alert + Close Alert)

- Drop `DeleteAlertState.IsComplete` / `CloseAlertState.IsComplete` and the `CheckAnswers` guards that used them, plus their missing-data redirect tests.
- Close Alert's **Reason** page guard is deliberately left in place (only the check answers guard was in scope).

## Testing

- `just build` — solution builds with no errors and no new warnings (the only warnings are pre-existing `NU1903` transitive-dependency advisories on `main`).
- DeleteAlert + CloseAlert tests: **114 passed**; all Alerts tests: **558 passed**.
- Route paths (`/alerts/{alertId}/delete` and `/delete/check-answers`) preserved, so the existing end-to-end delete-alert journey test remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)