### PR TITLE
Migrate Reopen Alert journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
@@ -47,7 +47,7 @@
         @if (Model.CanEdit)
         {
             <row-actions>
-                <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.Alert.AlertId, journeyInstanceId: null)" visually-hidden-text="end date">Remove</action>
+                <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.Alert.AlertId)" visually-hidden-text="end date">Remove</action>
                 <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Index(Model.Alert.AlertId, journeyInstanceId: null)" visually-hidden-text="end date">Change</action>
             </row-actions>
         }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/alerts/{alertId}/reopen/check-answers/{handler?}"
+@page "/alerts/{alertId}/reopen/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before reopening alert";
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -49,7 +54,7 @@
                     <key>Reason for change</key>
                     <value>@Model.ChangeReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</action>
+                        <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for change">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -65,7 +70,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -74,7 +79,7 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
@@ -82,7 +87,7 @@
             <h2 class="govuk-heading-m">Are you sure you want to reopen this alert?</h2>
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and reopen alert</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.ReopenAlert.CheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/CheckAnswers.cshtml.cs
@@ -8,20 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ReopenAlert), RequireJourneyInstance]
+[Journey(JourneyNames.ReopenAlert)]
 public class CheckAnswersModel(
+    ReopenAlertJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager,
     AlertService alertService,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<ReopenAlertState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -45,11 +48,7 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Alerts.ReopenAlert.Index(AlertId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
@@ -61,13 +60,18 @@ public class CheckAnswersModel(
         Link = alertInfo.Alert.ExternalLink;
         LinkUri = TrsUriHelper.TryCreateWebsiteUri(Link, out var linkUri) ? linkUri : null;
         StartDate = alertInfo.Alert.StartDate;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var alert = HttpContext.GetCurrentAlertFeature().Alert;
         var processContext = new ProcessContext(
             ProcessType.AlertUpdating,
@@ -89,16 +93,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Alert re-opened");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/reopen/{handler?}"
+@page "/alerts/{alertId}/reopen"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert.IndexModel
 @{
     ViewBag.Title = "Why are you removing the end date?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Alerts.ReopenAlert.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.AlertDetail(Model.AlertId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -46,7 +49,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.ReopenAlert.Cancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ReopenAlert), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.ReopenAlert), StartsJourney]
+public class IndexModel(
+    ReopenAlertJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<IndexModel> _validator = new()
     {
@@ -23,13 +26,15 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<ReopenAlertState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -49,37 +54,35 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance.State.HasAdditionalReasonDetail;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        Evidence = JourneyInstance.State.Evidence;
+        ChangeReason = journey.State.ChangeReason;
+        HasAdditionalReasonDetail = journey.State.HasAdditionalReasonDetail;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        Evidence = journey.State.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<IndexModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
-            state.ChangeReasonDetail = ChangeReasonDetail;
-            state.Evidence = Evidence;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Alerts.ReopenAlert.CheckAnswers(AlertId, JourneyInstance!.InstanceId));
-    }
+        await _validator.ValidateAndThrowAsync(this);
 
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.ReopenAlert.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+                state.ChangeReasonDetail = ChangeReasonDetail;
+                state.Evidence = Evidence;
+            });
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -88,5 +91,7 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Alerts.AlertDetail(AlertId);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/Index.cshtml.cs
@@ -64,8 +64,7 @@ public class IndexModel(
     {
         if (Cancel)
         {
-            journey.DeleteInstance();
-            return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
+            return await CancelAsync();
         }
 
         // Upload the evidence file before validating so that it's retained if the form is re-rendered
@@ -83,6 +82,13 @@ public class IndexModel(
                 state.ChangeReasonDetail = ChangeReasonDetail;
                 state.Evidence = Evidence;
             });
+    }
+
+    private async Task<IActionResult> CancelAsync()
+    {
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
+        return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertJourneyCoordinator.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
+
+[JourneyCoordinator(JourneyNames.ReopenAlert, routeValueKeys: ["alertId"])]
+public class ReopenAlertJourneyCoordinator : JourneyCoordinator<ReopenAlertState>
+{
+    public override ReopenAlertState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertLinkGenerator.cs
@@ -2,15 +2,12 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
 
 public class ReopenAlertLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/ReopenAlert/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid alertId) =>
+        linkGenerator.GetRequiredPathByPage("/Alerts/ReopenAlert/Index", routeValues: new { alertId });
 
-    public string Cancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/ReopenAlert/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/ReopenAlert/Index", journeyInstanceId, returnUrl);
 
-    public string CheckAnswers(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/ReopenAlert/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/ReopenAlert/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Alerts/ReopenAlert/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/ReopenAlert/ReopenAlertState.cs
@@ -1,17 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
 
-public class ReopenAlertState : IRegisterJourney
+public class ReopenAlertState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.ReopenAlert,
-        typeof(ReopenAlertState),
-        requestDataKeys: ["alertId"],
-        appendUniqueKey: true);
-
     public ReopenAlertReasonOption? ChangeReason { get; set; }
 
     public bool? HasAdditionalReasonDetail { get; set; }
@@ -19,12 +11,4 @@ public class ReopenAlertState : IRegisterJourney
     public string? ChangeReasonDetail { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(ChangeReason), nameof(HasAdditionalReasonDetail))]
-    public bool IsComplete =>
-        ChangeReason.HasValue &&
-        HasAdditionalReasonDetail is bool hasDetail &&
-        (!hasDetail || ChangeReasonDetail is not null) &&
-        Evidence.IsComplete;
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/CheckAnswersTests.cs
@@ -61,23 +61,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : ReopenAlertTestBase(ho
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/reopen", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -155,23 +138,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : ReopenAlertTestBase(ho
     }
 
     [Fact]
-    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/reopen", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Post_Confirm_UpdatesAlertCreatesEventCompletesJourneyAndRedirectsWithFlashMessage()
     {
         // Arrange
@@ -179,6 +145,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : ReopenAlertTestBase(ho
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert);
 
         EventObserver.Clear();
+
+        var state = journeyInstance.State;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -204,13 +172,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : ReopenAlertTestBase(ho
             p.AssertProcessHasEvents<AlertUpdatedEvent>();
 
             var changeReason = Assert.IsType<ChangeReasonWithDetailsAndEvidence>(p.ProcessContext.Process.ChangeReason);
-            Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), changeReason.Reason);
-            Assert.Equal(journeyInstance.State.ChangeReasonDetail, changeReason.Details);
-            Assert.Equal(journeyInstance.State.Evidence.UploadedEvidenceFile?.ToEventModel(), changeReason.EvidenceFile);
+            Assert.Equal(state.ChangeReason!.GetDisplayName(), changeReason.Reason);
+            Assert.Equal(state.ChangeReasonDetail, changeReason.Details);
+            Assert.Equal(state.Evidence.UploadedEvidenceFile?.ToEventModel(), changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -220,7 +187,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : ReopenAlertTestBase(ho
         var (person, alert) = await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/reopen/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -229,8 +199,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ReopenAlertTestBase(ho
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
@@ -367,6 +367,28 @@ public class IndexTests(HostFixture hostFixture) : ReopenAlertTestBase(hostFixtu
         Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
+    [Fact]
+    public async Task Post_Cancel_WithUploadedEvidenceFile_DeletesTheUploadedFile()
+    {
+        // Arrange
+        var (person, alert) = await CreatePersonWithClosedAlert();
+        var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional: true);
+        var evidenceFileId = journeyInstance.State.Evidence.UploadedEvidenceFile!.FileId;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+        FileServiceMock.Verify(s => s.DeleteFileAsync(evidenceFileId), Times.Once());
+    }
+
     [Theory]
     [HttpMethods(TestHttpMethods.GetAndPost)]
     public async Task PersonIsDeactivated_ReturnsBadRequest(HttpMethod httpMethod)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/IndexTests.cs
@@ -305,7 +305,6 @@ public class IndexTests(HostFixture hostFixture) : ReopenAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.Equal(hasAdditionalReasonDetail, journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Equal(reasonDetail, journeyInstance.State.ChangeReasonDetail);
@@ -339,7 +338,6 @@ public class IndexTests(HostFixture hostFixture) : ReopenAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/reopen/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.False(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Null(journeyInstance.State.ChangeReasonDetail);
@@ -354,7 +352,10 @@ public class IndexTests(HostFixture hostFixture) : ReopenAlertTestBase(hostFixtu
         var (person, alert) = await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/reopen/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/reopen?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -363,8 +364,7 @@ public class IndexTests(HostFixture hostFixture) : ReopenAlertTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/alerts/{alert.AlertId}", response.Headers.Location!.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/ReopenAlertTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/ReopenAlert/ReopenAlertTestBase.cs
@@ -1,3 +1,4 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.ReopenAlert;
 
@@ -5,10 +6,10 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.ReopenAlert;
 
 public abstract class ReopenAlertTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected Task<JourneyInstance<ReopenAlertState>> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
+    protected Task<ReopenAlertJourneyCoordinator> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
         CreateJourneyInstanceAsync(alertId, new());
 
-    protected Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
+    protected Task<ReopenAlertJourneyCoordinator> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
         CreateJourneyInstanceAsync(alert.AlertId, new ReopenAlertState
         {
             ChangeReason = ReopenAlertReasonOption.ClosedInError,
@@ -26,7 +27,7 @@ public abstract class ReopenAlertTestBase(HostFixture hostFixture) : TestBase(ho
             }
         });
 
-    protected Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
+    protected Task<ReopenAlertJourneyCoordinator> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
         step switch
         {
             JourneySteps.New =>
@@ -36,11 +37,24 @@ public abstract class ReopenAlertTestBase(HostFixture hostFixture) : TestBase(ho
             _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
         };
 
-    private Task<JourneyInstance<ReopenAlertState>> CreateJourneyInstanceAsync(Guid alertId, ReopenAlertState state) =>
-        CreateJourneyInstance(
+    protected ReopenAlertState? GetJourneyInstanceState(ReopenAlertJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (ReopenAlertState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<ReopenAlertJourneyCoordinator> CreateJourneyInstanceAsync(Guid alertId, ReopenAlertState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<ReopenAlertJourneyCoordinator>(
             JourneyNames.ReopenAlert,
-            state,
-            new KeyValuePair<string, object>("alertId", alertId));
+            new RouteValueDictionary { ["alertId"] = alertId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/alerts/{alertId}/reopen",
+                $"/alerts/{alertId}/reopen/check-answers",
+            ]);
 
     public static class JourneySteps
     {


### PR DESCRIPTION
Follows #3618 (Add Alert), #3620 (Close Alert) and #3621 (Delete Alert).

## What

Migrates the **Reopen Alert** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the other alert journeys, and converts its validation to the FluentValidation `ValidateAndThrowAsync` pattern.

## Changes

- Add `ReopenAlertJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.ReopenAlert, ["alertId"])]`); drop FormFlow's `IRegisterJourney` from `ReopenAlertState`.
- Rewrite Index and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys, the library's `returnUrl` mechanism for "Change" links, and a form-field `Cancel` submit (so the cancel POST stays on a valid journey step).
- Rewrite `ReopenAlertLinkGenerator` onto the shared `GetJourneyPage` extension; update the alert-detail page entry link.
- **Validation → FluentValidation:** Index moves off the `ValidateAndThrow` + `ModelState` / `PageWithErrors` mix to `ValidateAndThrowAsync`, letting `FluentValidationExceptionFilter` render the errors. Evidence is uploaded *before* validating so the file is retained when the form re-renders with errors.
- `ReopenAlertState.IsComplete` and the check answers guard are dropped up front (rather than added then removed), matching where the other journeys have landed — the journey path model already prevents reaching check answers early. Their missing-data redirect tests are removed accordingly.

## Bug fix

Cancelling from the **index** page discarded the journey without deleting any evidence file the user had already uploaded, leaking it in blob storage — the check answers page and the other alert journeys all delete it. Fixed, with a regression test (verified it fails without the fix).

## Testing

- `just build` — solution builds with no errors and no new warnings (the only warnings are pre-existing `NU1903` transitive-dependency advisories on `main`).
- ReopenAlert tests: **43 passed**; all Alerts tests pass.
- Route paths (`/alerts/{alertId}/reopen` and `/reopen/check-answers`) preserved, so the existing end-to-end reopen-alert journey test remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)