### PR TITLE
Migrate Edit Alert Details journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
+++ b/src/TeachingRecordSystem.SupportUi/Infrastructure/Filters/CheckAlertExistsFilter.cs
@@ -79,8 +79,12 @@ public class CheckAlertExistsFilter(Permissions.Alerts requiredPermissionType, T
 }
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-public class CheckAlertExistsFilterFactory(Permissions.Alerts requiredPermission) : Attribute, IFilterFactory
+public class CheckAlertExistsFilterFactory(Permissions.Alerts requiredPermission) : Attribute, IFilterFactory, IOrderedFilter
 {
+    // Run before the filter that creates journey instances so that the CurrentAlertFeature is available
+    // to a journey's starting state.
+    public int Order => -200;
+
     public bool IsReusable => false;
 
     public IFilterMetadata CreateInstance(IServiceProvider serviceProvider) =>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/alerts/{alertId}/details/check-answers/{handler?}"
+@page "/alerts/{alertId}/details/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before editing alert";
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -19,7 +24,7 @@
                     <key>New details</key>
                     <value>@Html.ConvertNewlinesToLineBreaks(Model.NewDetails)</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="new start date">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="new start date">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -37,7 +42,7 @@
                     <key>Reason</key>
                     <value>@Model.ChangeReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for change">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -46,7 +51,7 @@
                         @Html.ConvertNewlinesToLineBreaks(Model.ChangeReasonDetail)
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -55,7 +60,7 @@
                         @Html.ConvertNewlinesToLineBreaks(Model.AdditionalInformation)
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="additional details">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="additional details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -64,14 +69,14 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Details.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and update alert</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.Details.CheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/CheckAnswers.cshtml.cs
@@ -8,20 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertDetails), RequireJourneyInstance]
+[Journey(JourneyNames.EditAlertDetails)]
 public class CheckAnswersModel(
+    EditAlertDetailsJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     AlertService alertService,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<EditAlertDetailsState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -34,33 +37,35 @@ public class CheckAnswersModel(
     public AlertChangeDetailsReasonOption ChangeReason { get; set; }
 
     public string? ChangeReasonDetail { get; set; }
+
     public string? AdditionalInformation { get; set; }
 
     public UploadedEvidenceFile? EvidenceFile { get; set; }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.Details.Index(AlertId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        NewDetails = JourneyInstance!.State.Details;
+        NewDetails = journey.State.Details;
         PreviousDetails = alertInfo.Alert.Details;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = journey.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var alert = HttpContext.GetCurrentAlertFeature().Alert;
         var processContext = new ProcessContext(
             ProcessType.AlertUpdating,
@@ -82,16 +87,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Alert changed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/EditAlertDetailsJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/EditAlertDetailsJourneyCoordinator.cs
@@ -1,0 +1,16 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
+
+[JourneyCoordinator(JourneyNames.EditAlertDetails, routeValueKeys: ["alertId"])]
+public class EditAlertDetailsJourneyCoordinator : JourneyCoordinator<EditAlertDetailsState>
+{
+    public override EditAlertDetailsState GetStartingState()
+    {
+        var alertInfo = HttpContext.GetCurrentAlertFeature();
+
+        return new EditAlertDetailsState
+        {
+            CurrentDetails = alertInfo.Alert.Details,
+            Details = alertInfo.Alert.Details
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/EditAlertDetailsLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/EditAlertDetailsLinkGenerator.cs
@@ -2,22 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 
 public class EditAlertDetailsLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Details/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid alertId) =>
+        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Details/Index", routeValues: new { alertId });
 
-    public string Cancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Details/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/Details/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Details/Reason", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/Details/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Details/Reason", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Details/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Details/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/Details/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/EditAlertDetailsState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/EditAlertDetailsState.cs
@@ -2,16 +2,8 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 
-public class EditAlertDetailsState : IRegisterJourney
+public class EditAlertDetailsState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.EditAlertDetails,
-        typeof(EditAlertDetailsState),
-        requestDataKeys: ["alertId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public string? CurrentDetails { get; set; }
 
     public string? Details { get; set; }
@@ -25,24 +17,4 @@ public class EditAlertDetailsState : IRegisterJourney
     public string? AdditionalInformation { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    public bool IsComplete =>
-        !string.IsNullOrWhiteSpace(Details) &&
-        ChangeReason.HasValue &&
-        (ChangeReason.HasValue && ChangeReason == AlertChangeDetailsReasonOption.AnotherReason && !string.IsNullOrEmpty(ChangeReasonDetail) ||
-         ChangeReason != AlertChangeDetailsReasonOption.AnotherReason && string.IsNullOrEmpty(ChangeReasonDetail)) &&
-        (ProvideAdditionalInformation == true && !string.IsNullOrEmpty(AdditionalInformation) ||
-         ProvideAdditionalInformation == false && string.IsNullOrEmpty(AdditionalInformation)) &&
-        Evidence.IsComplete;
-
-    public void EnsureInitialized(CurrentAlertFeature alertInfo)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        Details = CurrentDetails = alertInfo.Alert.Details;
-        Initialized = true;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/details/{handler?}"
+@page "/alerts/{alertId}/details"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details.IndexModel
 @{
     ViewBag.Title = "Change details";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.Alerts.EditAlert.Details.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.AlertDetail(Model.AlertId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -24,7 +27,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.Details.Cancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Index.cshtml.cs
@@ -5,25 +5,32 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertDetails), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceController) : PageModel
+[Journey(JourneyNames.EditAlertDetails), StartsJourney]
+public class IndexModel(
+    EditAlertDetailsJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceController) : PageModel
 {
     public const int DetailsMaxLength = 4000;
 
     private readonly InlineValidator<IndexModel> _validator = new()
     {
         v => v.RuleFor(m => m.Details)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty().WithMessage("Enter details")
             .MaximumLength(DetailsMaxLength).WithMessage("Details must be 4000 characters or less")
+            .Must((m, details) => details != m.CurrentDetails).WithMessage("Enter changed details")
     };
 
-    public JourneyInstance<EditAlertDetailsState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -36,37 +43,27 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        Details = JourneyInstance!.State.Details;
+        Details = journey.State.Details;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (Details == CurrentDetails)
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(Details), "Enter changed details");
+            return await CancelAsync();
         }
 
-        _validator.ValidateAndThrow(this);
+        await _validator.ValidateAndThrowAsync(this);
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
-
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.Details = Details;
-        });
-
-        return Redirect(FromCheckAnswers
-            ? linkGenerator.Alerts.EditAlert.Details.CheckAnswers(AlertId, JourneyInstance.InstanceId)
-            : linkGenerator.Alerts.EditAlert.Details.Reason(AlertId, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.Details.Reason(journey.InstanceId),
+            state => state.Details = Details);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
@@ -75,10 +72,10 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        JourneyInstance!.State.EnsureInitialized(alertInfo);
-
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         CurrentDetails = alertInfo.Alert.Details;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Alerts.AlertDetail(AlertId);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/details/reason/{handler?}"
+@page "/alerts/{alertId}/details/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details.ReasonModel
 @{
     ViewBag.Title = "Why are you changing the alert details?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Alerts.EditAlert.Details.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.EditAlert.Details.Index(Model.AlertId, Model.JourneyInstance!.InstanceId))" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -54,7 +57,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.Details.ReasonCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Details/Reason.cshtml.cs
@@ -6,8 +6,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertDetails), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditAlertDetails)]
+public class ReasonModel(
+    EditAlertDetailsJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -25,16 +28,17 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         v => v.RuleFor(m => m.ChangeReasonDetail)
             .NotEmpty().WithMessage("Enter a reason")
             .When(m => m.ChangeReason == AlertChangeDetailsReasonOption.AnotherReason),
-
     };
 
-    public JourneyInstance<EditAlertDetailsState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -58,11 +62,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.Details is null)
+        if (journey.State.Details is null)
         {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.Details.Index(AlertId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.Alerts.EditAlert.Details.Index(journey.InstanceId));
             return;
         }
+
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -72,39 +78,42 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        Evidence = JourneyInstance.State.Evidence;
+        ChangeReason = journey.State.ChangeReason;
+        ProvideAdditionalInformation = journey.State.ProvideAdditionalInformation;
+        AdditionalInformation = journey.State.AdditionalInformation;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        Evidence = journey.State.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
-            state.ChangeReasonDetail = ChangeReason == AlertChangeDetailsReasonOption.AnotherReason ? ChangeReasonDetail : null;
-            state.AdditionalInformation = ProvideAdditionalInformation!.Value ? AdditionalInformation : null;
-            state.Evidence = Evidence;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Alerts.EditAlert.Details.CheckAnswers(AlertId, JourneyInstance.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.Details.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+                state.ChangeReasonDetail = ChangeReason == AlertChangeDetailsReasonOption.AnotherReason ? ChangeReasonDetail : null;
+                state.AdditionalInformation = ProvideAdditionalInformation!.Value ? AdditionalInformation : null;
+                state.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml.cs
@@ -67,7 +67,7 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
     {
         await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
         await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Alerts.EditAlert.Details.Index(AlertId, JourneyInstance!.InstanceId));
+        return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -59,7 +59,7 @@
                         @if (canWrite)
                         {
                             <row-actions>
-                                <action href="@LinkGenerator.Alerts.EditAlert.Details.Index(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="details">Change</action>
+                                <action href="@LinkGenerator.Alerts.EditAlert.Details.Index(alert.AlertId)" visually-hidden-text="details">Change</action>
                             </row-actions>
                         }
                     </row>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/CheckAnswersTests.cs
@@ -60,23 +60,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : DetailsTestBase(hostFi
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/details?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true, true, AlertChangeDetailsReasonOption.AnotherReason)]
     [InlineData(false, false, AlertChangeDetailsReasonOption.IncorrectDetails)]
@@ -152,23 +135,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : DetailsTestBase(hostFi
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/details?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true, false, AlertChangeDetailsReasonOption.AnotherReason)]
     [InlineData(false, true, AlertChangeDetailsReasonOption.IncorrectDetails)]
@@ -179,6 +145,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : DetailsTestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional, provideAdditionalInformation, changeReasonOption);
 
         EventObserver.Clear();
+
+        var state = journeyInstance.State;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -198,14 +166,13 @@ public class CheckAnswersTests(HostFixture hostFixture) : DetailsTestBase(hostFi
             p.AssertProcessHasEvents<AlertUpdatedEvent>();
 
             var changeReason = Assert.IsType<ChangeReasonWithDetailsAndEvidence>(p.ProcessContext.Process.ChangeReason);
-            Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), changeReason.Reason);
-            Assert.Equal(changeReasonOption == AlertChangeDetailsReasonOption.AnotherReason ? journeyInstance.State.ChangeReasonDetail : null, changeReason.Details);
-            Assert.Equal(provideAdditionalInformation ? journeyInstance.State.AdditionalInformation : null, changeReason.AdditionalInformation);
-            Assert.Equal(populateOptional ? journeyInstance.State.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
+            Assert.Equal(state.ChangeReason!.GetDisplayName(), changeReason.Reason);
+            Assert.Equal(changeReasonOption == AlertChangeDetailsReasonOption.AnotherReason ? state.ChangeReasonDetail : null, changeReason.Details);
+            Assert.Equal(provideAdditionalInformation ? state.AdditionalInformation : null, changeReason.AdditionalInformation);
+            Assert.Equal(populateOptional ? state.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -215,7 +182,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : DetailsTestBase(hostFi
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional: true);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -224,8 +194,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : DetailsTestBase(hostFi
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/DetailsTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/DetailsTestBase.cs
@@ -1,3 +1,4 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Details;
 
@@ -5,13 +6,12 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.Detail
 
 public abstract class DetailsTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected Task<JourneyInstance<EditAlertDetailsState>> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
+    protected Task<EditAlertDetailsJourneyCoordinator> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
         CreateJourneyInstanceAsync(alertId, new());
 
-    protected Task<JourneyInstance<EditAlertDetailsState>> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true, bool provideAdditionalInformation = false, AlertChangeDetailsReasonOption changeReasonOption = AlertChangeDetailsReasonOption.AnotherReason) =>
+    protected Task<EditAlertDetailsJourneyCoordinator> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true, bool provideAdditionalInformation = false, AlertChangeDetailsReasonOption changeReasonOption = AlertChangeDetailsReasonOption.AnotherReason) =>
         CreateJourneyInstanceAsync(alert.AlertId, new EditAlertDetailsState
         {
-            Initialized = true,
             CurrentDetails = alert.Details,
             Details = "New details",
             ChangeReason = changeReasonOption,
@@ -30,7 +30,7 @@ public abstract class DetailsTestBase(HostFixture hostFixture) : TestBase(hostFi
             }
         });
 
-    protected Task<JourneyInstance<EditAlertDetailsState>> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
+    protected Task<EditAlertDetailsJourneyCoordinator> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
         step switch
         {
             JourneySteps.New =>
@@ -38,7 +38,6 @@ public abstract class DetailsTestBase(HostFixture hostFixture) : TestBase(hostFi
             JourneySteps.Index =>
                 CreateJourneyInstanceAsync(alert.AlertId, new EditAlertDetailsState
                 {
-                    Initialized = true,
                     CurrentDetails = alert.Details,
                     Details = "New details"
                 }),
@@ -47,11 +46,25 @@ public abstract class DetailsTestBase(HostFixture hostFixture) : TestBase(hostFi
             _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
         };
 
-    private Task<JourneyInstance<EditAlertDetailsState>> CreateJourneyInstanceAsync(Guid alertId, EditAlertDetailsState state) =>
-        CreateJourneyInstance(
+    protected EditAlertDetailsState? GetJourneyInstanceState(EditAlertDetailsJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (EditAlertDetailsState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<EditAlertDetailsJourneyCoordinator> CreateJourneyInstanceAsync(Guid alertId, EditAlertDetailsState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<EditAlertDetailsJourneyCoordinator>(
             JourneyNames.EditAlertDetails,
-            state,
-            new KeyValuePair<string, object>("alertId", alertId));
+            new RouteValueDictionary { ["alertId"] = alertId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/alerts/{alertId}/details",
+                $"/alerts/{alertId}/details/reason",
+                $"/alerts/{alertId}/details/check-answers",
+            ]);
 
     public static class JourneySteps
     {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/IndexTests.cs
@@ -60,16 +60,16 @@ public class IndexTests(HostFixture hostFixture) : DetailsTestBase(hostFixture),
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    public async Task Get_NewJourneyInstance_PopulatesModelFromDatabase()
     {
         // Arrange
         var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/details?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/details");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Starts the journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
@@ -208,7 +208,6 @@ public class IndexTests(HostFixture hostFixture) : DetailsTestBase(hostFixture),
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/details/reason", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(newDetails, journeyInstance.State.Details);
     }
 
@@ -219,7 +218,10 @@ public class IndexTests(HostFixture hostFixture) : DetailsTestBase(hostFixture),
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -228,8 +230,7 @@ public class IndexTests(HostFixture hostFixture) : DetailsTestBase(hostFixture),
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Details/ReasonTests.cs
@@ -341,7 +341,6 @@ public class ReasonTests(HostFixture hostFixture) : DetailsTestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.True(journeyInstance.State.ProvideAdditionalInformation);
         Assert.Equal(additionalInformation, journeyInstance.State.AdditionalInformation);
@@ -379,7 +378,6 @@ public class ReasonTests(HostFixture hostFixture) : DetailsTestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/details/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.False(journeyInstance.State.ProvideAdditionalInformation);
         Assert.Equal(changeReasonDetail, journeyInstance.State.ChangeReasonDetail);
@@ -395,7 +393,10 @@ public class ReasonTests(HostFixture hostFixture) : DetailsTestBase(hostFixture)
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details/reason/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/details/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -404,8 +405,7 @@ public class ReasonTests(HostFixture hostFixture) : DetailsTestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]


### PR DESCRIPTION
Follows #3618 (Add Alert), #3620 (Close Alert), #3621 (Delete Alert) and #3622 (Reopen Alert).

## What

Migrates the **Edit Alert Details** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the other alert journeys, and converts its validation to the FluentValidation `ValidateAndThrowAsync` pattern.

## Changes

- Add `EditAlertDetailsJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.EditAlertDetails, ["alertId"])]`); drop FormFlow's `IRegisterJourney` from `EditAlertDetailsState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys, the library's `returnUrl` mechanism for "Change" links, and a form-field `Cancel` submit.
- Rewrite `EditAlertDetailsLinkGenerator` onto the shared `GetJourneyPage` extension; update the person-alerts page entry link.
- **Validation → FluentValidation:** Index and Reason move off the `ValidateAndThrow` + `ModelState` / `PageWithErrors` mix to `ValidateAndThrowAsync`. Index's "Enter changed details" check becomes a rule on the same `Details` chain. Reason uploads evidence *before* validating so the file is retained when the form re-renders with errors.
- `IsComplete` and the check answers guard are dropped up front, consistent with the other journeys.

## Starting state / filter ordering

The journey previously seeded `Details` from the alert lazily, via `EnsureInitialized` on every page load. That doesn't work with this library (`State` returns a fresh copy and mutations aren't persisted), so the seeding moves to the coordinator's `GetStartingState`, which runs once when the instance is created.

For the alert to be available at that point, **`CheckAlertExistsFilterFactory` now specifies `Order = -200`** so it runs ahead of the library's `ValidateJourneyFilter` (order -100), which is what creates journey instances. The state's `Initialized` flag and `EnsureInitialized` are deleted as a result.

This filter ordering change is global to alert pages, so the whole SupportUi suite was run to check it (below).

## Bug fix

The **Edit Alert End Date** index page's Cancel redirected into the *edit-details journey*, passing its own journey's instance id — its sibling pages (Reason, CheckAnswers) both return to the alert detail page. Fixed to match. (Its existing test asserts `StartsWith("/alerts/{alertId}")`, which holds either way.)

## Testing

- `just build` — solution builds with no errors and no new warnings (the only warnings are pre-existing `NU1903` transitive-dependency advisories on `main`).
- EditAlert/Details tests: **65 passed**; all Alerts tests: **562 passed**; **full SupportUi suite: 3973 passed, 0 failed** (to cover the filter ordering change).
- Route paths (`/alerts/{alertId}/details`, `/details/reason`, `/details/check-answers`) preserved, so the existing end-to-end journey test remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)