### PR TITLE
Migrate Edit Alert Start Date journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/alerts/{alertId}/start-date/check-answers/{handler?}"
+@page "/alerts/{alertId}/start-date/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before editing alert";
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Alerts.EditAlert.StartDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -19,7 +24,7 @@
                     <key>New start date</key>
                     <value>@Model.NewStartDate.ToString(WebConstants.DateDisplayFormat)</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="new start date">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="new start date">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -35,7 +40,7 @@
                     <key>Reason</key>
                     <value>@Model.ChangeReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for change">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -44,7 +49,7 @@
                         @Html.ConvertNewlinesToLineBreaks(Model.ChangeReasonDetail)
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -53,14 +58,14 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and update alert</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.StartDate.CheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/CheckAnswers.cshtml.cs
@@ -8,20 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertStartDate), RequireJourneyInstance]
+[Journey(JourneyNames.EditAlertStartDate)]
 public class CheckAnswersModel(
+    EditAlertStartDateJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager,
     AlertService alertService,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<EditAlertStartDateState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -39,26 +42,27 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.StartDate.Index(AlertId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        NewStartDate = JourneyInstance.State.StartDate!.Value;
+        NewStartDate = journey.State.StartDate!.Value;
         PreviousStartDate = alertInfo.Alert.StartDate!.Value;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var alert = HttpContext.GetCurrentAlertFeature().Alert;
         var processContext = new ProcessContext(
             ProcessType.AlertUpdating,
@@ -80,16 +84,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Alert changed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateJourneyCoordinator.cs
@@ -1,0 +1,16 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
+
+[JourneyCoordinator(JourneyNames.EditAlertStartDate, routeValueKeys: ["alertId"])]
+public class EditAlertStartDateJourneyCoordinator : JourneyCoordinator<EditAlertStartDateState>
+{
+    public override EditAlertStartDateState GetStartingState()
+    {
+        var alertInfo = HttpContext.GetCurrentAlertFeature();
+
+        return new EditAlertStartDateState
+        {
+            CurrentStartDate = alertInfo.Alert.StartDate,
+            StartDate = alertInfo.Alert.StartDate
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateLinkGenerator.cs
@@ -2,22 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
 
 public class EditAlertStartDateLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid alertId) =>
+        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Index", routeValues: new { alertId });
 
-    public string Cancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/StartDate/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Reason", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/StartDate/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/StartDate/Reason", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/StartDate/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/StartDate/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/StartDate/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/EditAlertStartDateState.cs
@@ -1,19 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
 
-public class EditAlertStartDateState : IRegisterJourney
+public class EditAlertStartDateState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.EditAlertStartDate,
-        typeof(EditAlertStartDateState),
-        requestDataKeys: ["alertId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public DateOnly? CurrentStartDate { get; set; }
 
     public DateOnly? StartDate { get; set; }
@@ -25,22 +15,4 @@ public class EditAlertStartDateState : IRegisterJourney
     public string? ChangeReasonDetail { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(StartDate), nameof(ChangeReason), nameof(HasAdditionalReasonDetail))]
-    public bool IsComplete => StartDate is not null && StartDate != CurrentStartDate &&
-        ChangeReason.HasValue &&
-        HasAdditionalReasonDetail.HasValue &&
-        Evidence.IsComplete;
-
-    public void EnsureInitialized(CurrentAlertFeature alertInfo)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        StartDate = CurrentStartDate = alertInfo.Alert.StartDate;
-        Initialized = true;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/start-date/{handler?}"
+@page "/alerts/{alertId}/start-date"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate.IndexModel
 @{
     ViewBag.Title = "Change start date";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.Alerts.EditAlert.StartDate.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Persons.PersonDetail.Alerts(Model.PersonId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -24,7 +27,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.StartDate.Cancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Index.cshtml.cs
@@ -5,19 +5,31 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertStartDate), ActivatesJourney, RequireJourneyInstance]
+[Journey(JourneyNames.EditAlertStartDate), StartsJourney]
 public class IndexModel(
+    EditAlertStartDateJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<EditAlertStartDateState>? JourneyInstance { get; set; }
+    private readonly InlineValidator<IndexModel> _validator = new()
+    {
+        v => v.RuleFor(m => m.StartDate)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Enter a start date")
+            .LessThanOrEqualTo(timeProvider.Today).WithMessage("Start date cannot be in the future")
+            .Must((m, startDate) => startDate != m.PreviousStartDate).WithMessage("Enter a different start date")
+    };
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -30,40 +42,27 @@ public class IndexModel(
 
     public void OnGet()
     {
-        StartDate = JourneyInstance!.State.StartDate;
+        StartDate = journey.State.StartDate;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (StartDate is null)
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(StartDate), "Enter a start date");
-        }
-        else if (StartDate > timeProvider.Today)
-        {
-            ModelState.AddModelError(nameof(StartDate), "Start date cannot be in the future");
-        }
-        else if (StartDate == PreviousStartDate)
-        {
-            ModelState.AddModelError(nameof(StartDate), "Enter a different start date");
+            return await CancelAsync();
         }
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
+        await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state => state.StartDate = StartDate);
-
-        return Redirect(FromCheckAnswers
-            ? linkGenerator.Alerts.EditAlert.StartDate.CheckAnswers(AlertId, JourneyInstance.InstanceId)
-            : linkGenerator.Alerts.EditAlert.StartDate.Reason(AlertId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.StartDate.Reason(journey.InstanceId),
+            state => state.StartDate = StartDate);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
@@ -72,10 +71,10 @@ public class IndexModel(
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        JourneyInstance!.State.EnsureInitialized(alertInfo);
-
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         PreviousStartDate = alertInfo.Alert.StartDate;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Alerts(PersonId);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/start-date/reason/{handler?}"
+@page "/alerts/{alertId}/start-date/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate.ReasonModel
 @{
     ViewBag.Title = "Why are you changing the start date?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Alerts.EditAlert.StartDate.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.EditAlert.StartDate.Index(Model.AlertId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -49,7 +52,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.StartDate.ReasonCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/StartDate/Reason.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertStartDate), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditAlertStartDate)]
+public class ReasonModel(
+    EditAlertStartDateJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -23,13 +26,15 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<EditAlertStartDateState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -49,12 +54,14 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.StartDate is null ||
-            JourneyInstance.State.StartDate == JourneyInstance.State.CurrentStartDate)
+        if (journey.State.StartDate is null ||
+            journey.State.StartDate == journey.State.CurrentStartDate)
         {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.StartDate.Index(AlertId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.Alerts.EditAlert.StartDate.Index(journey.InstanceId));
             return;
         }
+
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -64,37 +71,40 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance.State.HasAdditionalReasonDetail;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        Evidence = JourneyInstance.State.Evidence;
+        ChangeReason = journey.State.ChangeReason;
+        HasAdditionalReasonDetail = journey.State.HasAdditionalReasonDetail;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        Evidence = journey.State.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
-            state.ChangeReasonDetail = ChangeReasonDetail;
-            state.Evidence = Evidence;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Alerts.EditAlert.StartDate.CheckAnswers(AlertId, JourneyInstance!.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.StartDate.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+                state.ChangeReasonDetail = ChangeReasonDetail;
+                state.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -88,7 +88,7 @@
                         @if (canWrite)
                         {
                             <row-actions>
-                                <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Index(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="start date">Change</action>
+                                <action href="@LinkGenerator.Alerts.EditAlert.StartDate.Index(alert.AlertId)" visually-hidden-text="start date">Change</action>
                             </row-actions>
                         }
                     </row>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/CheckAnswersTests.cs
@@ -59,23 +59,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : StartDateTestBase(host
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_ReasonHasNotBeenSet_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/start-date", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -157,23 +140,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : StartDateTestBase(host
     }
 
     [Fact]
-    public async Task Post_ReasonHasNotBeenSet_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/start-date", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Post_Confirm_UpdatesAlertCreatesEventCompletesJourneyAndRedirectsWithFlashMessage()
     {
         // Arrange
@@ -181,6 +147,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : StartDateTestBase(host
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional: true);
 
         EventObserver.Clear();
+
+        var state = journeyInstance.State;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -197,7 +165,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : StartDateTestBase(host
         await WithDbContextAsync(async dbContext =>
         {
             var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alert.AlertId);
-            Assert.Equal(journeyInstance.State.StartDate, updatedAlert!.StartDate);
+            Assert.Equal(state.StartDate, updatedAlert!.StartDate);
         });
 
         Events.AssertProcessesCreated(p =>
@@ -206,13 +174,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : StartDateTestBase(host
             p.AssertProcessHasEvents<AlertUpdatedEvent>();
 
             var changeReason = Assert.IsType<ChangeReasonWithDetailsAndEvidence>(p.ProcessContext.Process.ChangeReason);
-            Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), changeReason.Reason);
-            Assert.Equal(journeyInstance.State.ChangeReasonDetail, changeReason.Details);
-            Assert.Equal(journeyInstance.State.Evidence.UploadedEvidenceFile?.ToEventModel(), changeReason.EvidenceFile);
+            Assert.Equal(state.ChangeReason!.GetDisplayName(), changeReason.Reason);
+            Assert.Equal(state.ChangeReasonDetail, changeReason.Details);
+            Assert.Equal(state.Evidence.UploadedEvidenceFile?.ToEventModel(), changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -222,7 +189,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : StartDateTestBase(host
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional: true);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -231,8 +201,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : StartDateTestBase(host
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/IndexTests.cs
@@ -61,16 +61,16 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    public async Task Get_NewJourneyInstance_PopulatesModelFromDatabase()
     {
         // Arrange
         var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/start-date");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Starts the journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
@@ -109,7 +109,7 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
         var newStartDate = alert.StartDate!.Value.AddDays(-18);
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = CreatePostContent(newStartDate)
         };
@@ -224,7 +224,7 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
         var newStartDate = alert.StartDate!.Value.AddDays(1);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = CreatePostContent(newStartDate: newStartDate)
         };
@@ -236,7 +236,6 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/start-date/reason", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(newStartDate, journeyInstance.State.StartDate);
     }
 
@@ -247,7 +246,10 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -256,8 +258,7 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -274,7 +275,7 @@ public class IndexTests(HostFixture hostFixture) : StartDateTestBase(hostFixture
         });
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/ReasonTests.cs
@@ -342,7 +342,6 @@ public class ReasonTests(HostFixture hostFixture) : StartDateTestBase(hostFixtur
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.Equal(hasAdditionalReasonDetail, journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Equal(reasonDetail, journeyInstance.State.ChangeReasonDetail);
@@ -376,7 +375,6 @@ public class ReasonTests(HostFixture hostFixture) : StartDateTestBase(hostFixtur
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.False(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Null(journeyInstance.State.ChangeReasonDetail);
@@ -391,7 +389,10 @@ public class ReasonTests(HostFixture hostFixture) : StartDateTestBase(hostFixtur
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/start-date/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -400,8 +401,7 @@ public class ReasonTests(HostFixture hostFixture) : StartDateTestBase(hostFixtur
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -418,7 +418,7 @@ public class ReasonTests(HostFixture hostFixture) : StartDateTestBase(hostFixtur
         });
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/StartDateTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/StartDate/StartDateTestBase.cs
@@ -1,3 +1,4 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.StartDate;
 
@@ -5,13 +6,12 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.StartD
 
 public abstract class StartDateTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected Task<JourneyInstance<EditAlertStartDateState>> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
+    protected Task<EditAlertStartDateJourneyCoordinator> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
         CreateJourneyInstanceAsync(alertId, new());
 
-    protected Task<JourneyInstance<EditAlertStartDateState>> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
+    protected Task<EditAlertStartDateJourneyCoordinator> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
         CreateJourneyInstanceAsync(alert.AlertId, new EditAlertStartDateState
         {
-            Initialized = true,
             CurrentStartDate = alert.StartDate,
             StartDate = alert.StartDate!.Value.AddDays(1),
             ChangeReason = AlertChangeStartDateReasonOption.AnotherReason,
@@ -29,19 +29,17 @@ public abstract class StartDateTestBase(HostFixture hostFixture) : TestBase(host
             }
         });
 
-    protected Task<JourneyInstance<EditAlertStartDateState>> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
+    protected Task<EditAlertStartDateJourneyCoordinator> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
         step switch
         {
             JourneySteps.New =>
                 CreateJourneyInstanceAsync(alert.AlertId, new EditAlertStartDateState
                 {
-                    Initialized = true,
                     CurrentStartDate = alert.StartDate
                 }),
             JourneySteps.Index =>
                 CreateJourneyInstanceAsync(alert.AlertId, new EditAlertStartDateState
                 {
-                    Initialized = true,
                     CurrentStartDate = alert.StartDate,
                     StartDate = alert.StartDate!.Value.AddDays(1)
                 }),
@@ -50,11 +48,25 @@ public abstract class StartDateTestBase(HostFixture hostFixture) : TestBase(host
             _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
         };
 
-    private Task<JourneyInstance<EditAlertStartDateState>> CreateJourneyInstanceAsync(Guid alertId, EditAlertStartDateState state) =>
-        CreateJourneyInstance(
+    protected EditAlertStartDateState? GetJourneyInstanceState(EditAlertStartDateJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (EditAlertStartDateState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<EditAlertStartDateJourneyCoordinator> CreateJourneyInstanceAsync(Guid alertId, EditAlertStartDateState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<EditAlertStartDateJourneyCoordinator>(
             JourneyNames.EditAlertStartDate,
-            state,
-            new KeyValuePair<string, object>("alertId", alertId));
+            new RouteValueDictionary { ["alertId"] = alertId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/alerts/{alertId}/start-date",
+                $"/alerts/{alertId}/start-date/reason",
+                $"/alerts/{alertId}/start-date/check-answers",
+            ]);
 
     public static class JourneySteps
     {


### PR DESCRIPTION
Follows #3618, #3620, #3621, #3622 and #3623. Two alert journeys left after this: Edit Alert End Date and Edit Alert Link.

## What

Migrates the **Edit Alert Start Date** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the other alert journeys, and converts its validation to the FluentValidation `ValidateAndThrowAsync` pattern.

## Changes

- Add `EditAlertStartDateJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.EditAlertStartDate, ["alertId"])]`); drop FormFlow's `IRegisterJourney` from `EditAlertStartDateState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys, the library's `returnUrl` mechanism for "Change" links, and a form-field `Cancel` submit.
- Rewrite `EditAlertStartDateLinkGenerator` onto the shared `GetJourneyPage` extension; update the person-alerts page entry link.
- **Validation → FluentValidation:** Index's start-date rules (required / not in the future / different from the current date) move from `ModelState` into an `InlineValidator` with `Cascade(CascadeMode.Stop)`, preserving the message order. Reason moves off the `ValidateAndThrow` + `PageWithErrors` mix, and uploads evidence *before* validating so the file is retained when the form re-renders with errors.
- Seed the starting state from the alert in the coordinator's `GetStartingState` (possible since `CheckAlertExistsFilter` runs at order -200, added in #3623), so `Initialized` / `EnsureInitialized` are deleted.
- `IsComplete` and the check answers guard are dropped, consistent with the other journeys; their two redirect tests go with them.

## Notes

- Index's back link keeps its existing fallback to the **person's alerts page** (unlike Edit Alert Details, which falls back to the alert detail page).
- Dropped some spurious `?personId=` query params from test request URLs — these pages don't read them, and under the path model they'd form part of the journey step id. Also pointed the Reason page's cancel test at the Reason page; it was posting to the *index* page's cancel URL.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- EditAlert/StartDate tests: **65 passed**; all Alerts tests: **553 passed**. The count drops by exactly the 2 removed check answers guard tests.
- Route paths (`/alerts/{alertId}/start-date`, `/start-date/reason`, `/start-date/check-answers`) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)