### PR TITLE
Migrate Edit Alert End Date journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/AlertDetail.cshtml
@@ -48,7 +48,7 @@
         {
             <row-actions>
                 <action href="@LinkGenerator.Alerts.ReopenAlert.Index(Model.Alert.AlertId)" visually-hidden-text="end date">Remove</action>
-                <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Index(Model.Alert.AlertId, journeyInstanceId: null)" visually-hidden-text="end date">Change</action>
+                <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Index(Model.Alert.AlertId)" visually-hidden-text="end date">Change</action>
             </row-actions>
         }
     </row>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/alerts/{alertId}/end-date/check-answers/{handler?}"
+@page "/alerts/{alertId}/end-date/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before editing alert";
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Alerts.EditAlert.EndDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -19,7 +24,7 @@
                     <key>New end date</key>
                     <value data-testid="new-end-date">@Model.NewEndDate!.Value.ToString(WebConstants.DateDisplayFormat)</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="new end date">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="new end date">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -35,7 +40,7 @@
                     <key>Reason</key>
                     <value>@Model.ChangeReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for change">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -44,7 +49,7 @@
                         @Html.ConvertNewlinesToLineBreaks(Model.ChangeReasonDetail)
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -53,14 +58,14 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.EndDate.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and update alert</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.EndDate.CheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/CheckAnswers.cshtml.cs
@@ -8,20 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertEndDate), RequireJourneyInstance]
+[Journey(JourneyNames.EditAlertEndDate)]
 public class CheckAnswersModel(
+    EditAlertEndDateJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     AlertService alertService,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<EditAlertEndDateState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -39,26 +42,27 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.EndDate.Index(AlertId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        NewEndDate = JourneyInstance!.State.EndDate;
+        NewEndDate = journey.State.EndDate;
         PreviousEndDate = alertInfo.Alert.EndDate;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var alert = HttpContext.GetCurrentAlertFeature().Alert;
         var processContext = new ProcessContext(
             ProcessType.AlertUpdating,
@@ -80,16 +84,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Alert changed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateJourneyCoordinator.cs
@@ -1,0 +1,16 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
+
+[JourneyCoordinator(JourneyNames.EditAlertEndDate, routeValueKeys: ["alertId"])]
+public class EditAlertEndDateJourneyCoordinator : JourneyCoordinator<EditAlertEndDateState>
+{
+    public override EditAlertEndDateState GetStartingState()
+    {
+        var alertInfo = HttpContext.GetCurrentAlertFeature();
+
+        return new EditAlertEndDateState
+        {
+            CurrentEndDate = alertInfo.Alert.EndDate,
+            EndDate = alertInfo.Alert.EndDate
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateLinkGenerator.cs
@@ -2,22 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
 public class EditAlertEndDateLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/EndDate/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid alertId) =>
+        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/EndDate/Index", routeValues: new { alertId });
 
-    public string Cancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/EndDate/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/EndDate/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/EndDate/Reason", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/EndDate/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/EndDate/Reason", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/EndDate/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/EndDate/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/EndDate/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/EditAlertEndDateState.cs
@@ -1,19 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
-public class EditAlertEndDateState : IRegisterJourney
+public class EditAlertEndDateState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.EditAlertEndDate,
-        typeof(EditAlertEndDateState),
-        requestDataKeys: ["alertId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public DateOnly? CurrentEndDate { get; set; }
 
     public DateOnly? EndDate { get; set; }
@@ -25,23 +15,4 @@ public class EditAlertEndDateState : IRegisterJourney
     public string? ChangeReasonDetail { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(EndDate), nameof(ChangeReason), nameof(HasAdditionalReasonDetail))]
-    public bool IsComplete => EndDate is not null &&
-        ChangeReason.HasValue &&
-        HasAdditionalReasonDetail is bool hasDetail &&
-        (!hasDetail || ChangeReasonDetail is not null) &&
-        Evidence.IsComplete;
-
-    public void EnsureInitialized(CurrentAlertFeature alertInfo)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        EndDate = CurrentEndDate = alertInfo.Alert.EndDate;
-        Initialized = true;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/end-date/{handler?}"
+@page "/alerts/{alertId}/end-date"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate.IndexModel
 @{
     ViewBag.Title = "Enter a new end date";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.Alerts.EditAlert.EndDate.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.AlertDetail(Model.AlertId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -24,7 +27,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.EndDate.Cancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
    </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Index.cshtml.cs
@@ -5,16 +5,32 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertEndDate), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceController, TimeProvider timeProvider) : PageModel
+[Journey(JourneyNames.EditAlertEndDate), StartsJourney]
+public class IndexModel(
+    EditAlertEndDateJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceController,
+    TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<EditAlertEndDateState>? JourneyInstance { get; set; }
+    private readonly InlineValidator<IndexModel> _validator = new()
+    {
+        v => v.RuleFor(m => m.EndDate)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Enter an end date")
+            .LessThanOrEqualTo(timeProvider.Today).WithMessage("End date cannot be in the future")
+            .GreaterThan(m => m.StartDate).WithMessage("End date must be after the start date")
+            .Must((m, endDate) => endDate != m.PreviousEndDate).WithMessage("Enter a different end date")
+    };
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -29,44 +45,27 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        EndDate = JourneyInstance!.State.EndDate;
+        EndDate = journey.State.EndDate;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (EndDate is null)
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(EndDate), "Enter an end date");
-        }
-        else if (EndDate > timeProvider.Today)
-        {
-            ModelState.AddModelError(nameof(EndDate), "End date cannot be in the future");
-        }
-        else if (EndDate <= StartDate)
-        {
-            ModelState.AddModelError(nameof(EndDate), "End date must be after the start date");
-        }
-        else if (EndDate == PreviousEndDate)
-        {
-            ModelState.AddModelError(nameof(EndDate), "Enter a different end date");
+            return await CancelAsync();
         }
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
+        await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state => state.EndDate = EndDate);
-
-        return Redirect(FromCheckAnswers
-            ? linkGenerator.Alerts.EditAlert.EndDate.CheckAnswers(AlertId, JourneyInstance.InstanceId)
-            : linkGenerator.Alerts.EditAlert.EndDate.Reason(AlertId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.EndDate.Reason(journey.InstanceId),
+            state => state.EndDate = EndDate);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
     }
 
@@ -75,11 +74,11 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        JourneyInstance!.State.EnsureInitialized(alertInfo);
-
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         PreviousEndDate = alertInfo.Alert.EndDate;
         StartDate = alertInfo.Alert.StartDate;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Alerts.AlertDetail(AlertId);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/end-date/reason/{handler?}"
+@page "/alerts/{alertId}/end-date/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate.ReasonModel
 @{
     ViewBag.Title = "Why are you changing the end date?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Alerts.EditAlert.EndDate.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.EditAlert.EndDate.Index(Model.AlertId, Model.JourneyInstance!.InstanceId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -49,7 +52,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.EndDate.ReasonCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/EndDate/Reason.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertEndDate), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditAlertEndDate)]
+public class ReasonModel(
+    EditAlertEndDateJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -25,13 +28,15 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public const int ChangeReasonDetailMaxLength = 4000;
 
-    public JourneyInstance<EditAlertEndDateState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -51,11 +56,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.EndDate is null)
+        if (journey.State.EndDate is null)
         {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.EndDate.Index(AlertId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.Alerts.EditAlert.EndDate.Index(journey.InstanceId));
             return;
         }
+
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -65,37 +72,40 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance.State.HasAdditionalReasonDetail;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        Evidence = JourneyInstance.State.Evidence;
+        ChangeReason = journey.State.ChangeReason;
+        HasAdditionalReasonDetail = journey.State.HasAdditionalReasonDetail;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        Evidence = journey.State.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
-            state.ChangeReasonDetail = ChangeReasonDetail;
-            state.Evidence = Evidence;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Alerts.EditAlert.EndDate.CheckAnswers(AlertId, JourneyInstance!.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.EndDate.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+                state.ChangeReasonDetail = ChangeReasonDetail;
+                state.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Alerts.AlertDetail(AlertId));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/CheckAnswersTests.cs
@@ -59,23 +59,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : EndDateTestBase(hostFi
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/end-date", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -150,24 +133,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : EndDateTestBase(hostFi
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/end-date", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -178,6 +143,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : EndDateTestBase(hostFi
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional);
 
         EventObserver.Clear();
+
+        var state = journeyInstance.State;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -194,7 +161,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : EndDateTestBase(hostFi
         await WithDbContextAsync(async dbContext =>
         {
             var updatedAlert = await dbContext.Alerts.FirstOrDefaultAsync(a => a.AlertId == alert.AlertId);
-            Assert.Equal(journeyInstance.State.EndDate, updatedAlert!.EndDate);
+            Assert.Equal(state.EndDate, updatedAlert!.EndDate);
         });
 
         Events.AssertProcessesCreated(p =>
@@ -203,13 +170,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : EndDateTestBase(hostFi
             p.AssertProcessHasEvents<AlertUpdatedEvent>();
 
             var changeReason = Assert.IsType<ChangeReasonWithDetailsAndEvidence>(p.ProcessContext.Process.ChangeReason);
-            Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), changeReason.Reason);
-            Assert.Equal(populateOptional ? journeyInstance.State.ChangeReasonDetail : null, changeReason.Details);
-            Assert.Equal(populateOptional ? journeyInstance.State.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
+            Assert.Equal(state.ChangeReason!.GetDisplayName(), changeReason.Reason);
+            Assert.Equal(populateOptional ? state.ChangeReasonDetail : null, changeReason.Details);
+            Assert.Equal(populateOptional ? state.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -219,7 +185,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : EndDateTestBase(hostFi
         var (person, alert) = await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, true);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -228,8 +197,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : EndDateTestBase(hostFi
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/EndDateTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/EndDateTestBase.cs
@@ -1,3 +1,4 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.EndDate;
 
@@ -5,13 +6,12 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.EndDat
 
 public abstract class EndDateTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected Task<JourneyInstance<EditAlertEndDateState>> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
+    protected Task<EditAlertEndDateJourneyCoordinator> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
         CreateJourneyInstanceAsync(alertId, new());
 
-    protected Task<JourneyInstance<EditAlertEndDateState>> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
+    protected Task<EditAlertEndDateJourneyCoordinator> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
         CreateJourneyInstanceAsync(alert.AlertId, new EditAlertEndDateState
         {
-            Initialized = true,
             CurrentEndDate = alert.EndDate,
             EndDate = alert.EndDate!.Value.AddDays(-5),
             ChangeReason = AlertChangeEndDateReasonOption.AnotherReason,
@@ -29,19 +29,17 @@ public abstract class EndDateTestBase(HostFixture hostFixture) : TestBase(hostFi
             }
         });
 
-    protected Task<JourneyInstance<EditAlertEndDateState>> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
+    protected Task<EditAlertEndDateJourneyCoordinator> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert) =>
         step switch
         {
             JourneySteps.New =>
                 CreateJourneyInstanceAsync(alert.AlertId, new EditAlertEndDateState
                 {
-                    Initialized = true,
                     CurrentEndDate = alert.EndDate
                 }),
             JourneySteps.Index =>
                 CreateJourneyInstanceAsync(alert.AlertId, new EditAlertEndDateState
                 {
-                    Initialized = true,
                     CurrentEndDate = alert.EndDate,
                     EndDate = alert.EndDate!.Value.AddDays(-5)
                 }),
@@ -50,11 +48,25 @@ public abstract class EndDateTestBase(HostFixture hostFixture) : TestBase(hostFi
             _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
         };
 
-    private Task<JourneyInstance<EditAlertEndDateState>> CreateJourneyInstanceAsync(Guid alertId, EditAlertEndDateState state) =>
-        CreateJourneyInstance(
+    protected EditAlertEndDateState? GetJourneyInstanceState(EditAlertEndDateJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (EditAlertEndDateState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<EditAlertEndDateJourneyCoordinator> CreateJourneyInstanceAsync(Guid alertId, EditAlertEndDateState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<EditAlertEndDateJourneyCoordinator>(
             JourneyNames.EditAlertEndDate,
-            state,
-            new KeyValuePair<string, object>("alertId", alertId));
+            new RouteValueDictionary { ["alertId"] = alertId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/alerts/{alertId}/end-date",
+                $"/alerts/{alertId}/end-date/reason",
+                $"/alerts/{alertId}/end-date/check-answers",
+            ]);
 
     public static class JourneySteps
     {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/IndexTests.cs
@@ -60,16 +60,16 @@ public class IndexTests(HostFixture hostFixture) : EndDateTestBase(hostFixture),
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    public async Task Get_NewJourneyInstance_PopulatesModelFromDatabase()
     {
         // Arrange
         var (person, alert) = await CreatePersonWithClosedAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/end-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/end-date");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Starts the journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
@@ -232,7 +232,7 @@ public class IndexTests(HostFixture hostFixture) : EndDateTestBase(hostFixture),
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
         var newEndDate = alert.EndDate!.Value.AddDays(-5);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = CreatePostContent(newEndDate)
         };
@@ -252,7 +252,10 @@ public class IndexTests(HostFixture hostFixture) : EndDateTestBase(hostFixture),
         var (person, alert) = await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -261,8 +264,7 @@ public class IndexTests(HostFixture hostFixture) : EndDateTestBase(hostFixture),
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -279,7 +281,7 @@ public class IndexTests(HostFixture hostFixture) : EndDateTestBase(hostFixture),
         });
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/end-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/end-date?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/EndDate/ReasonTests.cs
@@ -301,7 +301,6 @@ public class ReasonTests(HostFixture hostFixture) : EndDateTestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.True(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Equal(reasonDetail, journeyInstance.State.ChangeReasonDetail);
@@ -335,7 +334,6 @@ public class ReasonTests(HostFixture hostFixture) : EndDateTestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/end-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.False(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Null(journeyInstance.State.ChangeReasonDetail);
@@ -350,7 +348,10 @@ public class ReasonTests(HostFixture hostFixture) : EndDateTestBase(hostFixture)
         var (person, alert) = await CreatePersonWithClosedAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/end-date/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -359,8 +360,7 @@ public class ReasonTests(HostFixture hostFixture) : EndDateTestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -377,7 +377,7 @@ public class ReasonTests(HostFixture hostFixture) : EndDateTestBase(hostFixture)
         });
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/end-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/alerts/{alert.AlertId}/end-date?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);


### PR DESCRIPTION
Follows #3618, #3620, #3621, #3622, #3623 and #3624. One alert journey left after this: Edit Alert Link.

## What

Migrates the **Edit Alert End Date** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the other alert journeys, and converts its validation to the FluentValidation `ValidateAndThrowAsync` pattern.

## Changes

- Add `EditAlertEndDateJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.EditAlertEndDate, ["alertId"])]`); drop FormFlow's `IRegisterJourney` from `EditAlertEndDateState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys, the library's `returnUrl` mechanism for "Change" links, and a form-field `Cancel` submit.
- Rewrite `EditAlertEndDateLinkGenerator` onto the shared `GetJourneyPage` extension; update the alert-detail page entry link.
- **Validation → FluentValidation:** Index's four end-date rules (required / not in the future / after the start date / different from the current end date) move from `ModelState` into an `InlineValidator` with `Cascade(CascadeMode.Stop)`, preserving the message order. Reason moves off the `ValidateAndThrow` + `PageWithErrors` mix, and uploads evidence *before* validating so the file is retained when the form re-renders with errors.
- Seed the starting state from the alert in the coordinator's `GetStartingState` (possible since `CheckAlertExistsFilter` runs at order -200), so `Initialized` / `EnsureInitialized` are deleted.
- `IsComplete` and the check answers guard are dropped, consistent with the other journeys; their two redirect tests go with them. The Reason page's own guard (and its tests) are kept.

## Notes

- All three pages' Cancel and the Index back link keep their existing target of the **alert detail** page.
- Dropped some spurious `?personId=` query params from test request URLs — these pages don't read them, and under the path model they'd form part of the journey step id. Also pointed the Reason page's cancel test at the Reason page; it was posting to the *index* page's cancel URL.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- EditAlert/EndDate tests: **65 passed**; all Alerts tests: **551 passed**. The count drops by exactly the 2 removed check answers guard tests (`CheckAnswersTests` 12 → 10 methods, Index/Reason unchanged).
- Route paths (`/alerts/{alertId}/end-date`, `/end-date/reason`, `/end-date/check-answers`) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)