### PR TITLE
Migrate Edit Alert Link journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/alerts/{alertId}/link/check-answers/{handler?}"
+@page "/alerts/{alertId}/link/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before editing alert";
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Alerts.EditAlert.Link.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -28,7 +33,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Index(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="new link">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Index(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="new link">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -53,7 +58,7 @@
                     <key>Reason</key>
                     <value>@Model.ChangeReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for change">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for change">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -69,7 +74,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -78,14 +83,14 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Reason(Model.AlertId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Alerts.EditAlert.Link.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and update alert</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.Link.CheckAnswersCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/CheckAnswers.cshtml.cs
@@ -8,20 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertLink), RequireJourneyInstance]
+[Journey(JourneyNames.EditAlertLink)]
 public class CheckAnswersModel(
+    EditAlertLinkJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     AlertService alertService,
     TimeProvider timeProvider) : PageModel
 {
-    public JourneyInstance<EditAlertLinkState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -43,28 +46,29 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.Link.Index(AlertId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        NewLink = JourneyInstance!.State.Link;
+        NewLink = journey.State.Link;
         NewLinkUri = TrsUriHelper.TryCreateWebsiteUri(NewLink, out var newLinkUri) ? newLinkUri : null;
         PreviousLink = alertInfo.Alert.ExternalLink;
         PreviousLinkUri = TrsUriHelper.TryCreateWebsiteUri(PreviousLink, out var currentLinkUri) ? currentLinkUri : null;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var alert = HttpContext.GetCurrentAlertFeature().Alert;
         var processContext = new ProcessContext(
             ProcessType.AlertUpdating,
@@ -86,16 +90,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Alert changed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/EditAlertLinkJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/EditAlertLinkJourneyCoordinator.cs
@@ -1,0 +1,16 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
+
+[JourneyCoordinator(JourneyNames.EditAlertLink, routeValueKeys: ["alertId"])]
+public class EditAlertLinkJourneyCoordinator : JourneyCoordinator<EditAlertLinkState>
+{
+    public override EditAlertLinkState GetStartingState()
+    {
+        var alertInfo = HttpContext.GetCurrentAlertFeature();
+
+        return new EditAlertLinkState
+        {
+            CurrentLink = alertInfo.Alert.ExternalLink,
+            Link = alertInfo.Alert.ExternalLink
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/EditAlertLinkLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/EditAlertLinkLinkGenerator.cs
@@ -2,22 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 
 public class EditAlertLinkLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Link/Index", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid alertId) =>
+        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Link/Index", routeValues: new { alertId });
 
-    public string Cancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Link/Index", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/Link/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Link/Reason", routeValues: new { alertId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/Link/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Link/Reason", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Link/CheckAnswers", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid alertId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Alerts/EditAlert/Link/CheckAnswers", "cancel", routeValues: new { alertId }, journeyInstanceId: journeyInstanceId);
-
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Alerts/EditAlert/Link/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/EditAlertLinkState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/EditAlertLinkState.cs
@@ -2,16 +2,8 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 
-public class EditAlertLinkState : IRegisterJourney
+public class EditAlertLinkState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.EditAlertLink,
-        typeof(EditAlertLinkState),
-        requestDataKeys: ["alertId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public string? CurrentLink { get; set; }
 
     public bool? AddLink { get; set; }
@@ -25,23 +17,4 @@ public class EditAlertLinkState : IRegisterJourney
     public string? ChangeReasonDetail { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    public bool IsComplete =>
-        AddLink is bool addLink &&
-        (!addLink || Link is not null) &&
-        ChangeReason.HasValue &&
-        HasAdditionalReasonDetail is bool hasDetail &&
-        (!hasDetail || ChangeReasonDetail is not null) &&
-        Evidence.IsComplete;
-
-    public void EnsureInitialized(CurrentAlertFeature alertInfo)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        Link = CurrentLink = alertInfo.Alert.ExternalLink;
-        Initialized = true;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Index.cshtml
@@ -1,8 +1,11 @@
-@page "/alerts/{alertId}/link/{handler?}"
+@page "/alerts/{alertId}/link"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link.IndexModel
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers == true ? LinkGenerator.Alerts.EditAlert.Link.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Persons.PersonDetail.Alerts(Model.PersonId))" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -37,7 +40,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.Link.Cancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Index.cshtml.cs
@@ -5,16 +5,35 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertLink), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceController) : PageModel
+[Journey(JourneyNames.EditAlertLink), StartsJourney]
+public class IndexModel(
+    EditAlertLinkJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceController) : PageModel
 {
-    public JourneyInstance<EditAlertLinkState>? JourneyInstance { get; set; }
+    private readonly InlineValidator<IndexModel> _validator = new()
+    {
+        v => v.RuleFor(m => m.AddLink)
+            .NotNull()
+            .WithMessage(m => string.IsNullOrEmpty(m.PreviousLink)
+                ? "Select yes if you want to add a link to a panel outcome"
+                : "Select change link if you want to change the link to the panel outcome"),
+        v => v.RuleFor(m => m.Link)
+            .Cascade(CascadeMode.Stop)
+            .Must(link => TrsUriHelper.TryCreateWebsiteUri(link, out _)).WithMessage("Enter a valid URL")
+            .Must((m, link) => link != m.PreviousLink).WithMessage("Enter a different link")
+            .When(m => m.AddLink == true)
+    };
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -30,60 +49,39 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        AddLink = JourneyInstance!.State.AddLink;
-        Link = JourneyInstance!.State.Link;
+        AddLink = journey.State.AddLink;
+        Link = journey.State.Link;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (AddLink is null)
+        if (Cancel)
         {
-            if (string.IsNullOrEmpty(PreviousLink))
-            {
-                ModelState.AddModelError(nameof(AddLink), "Select yes if you want to add a link to a panel outcome");
-            }
-            else
-            {
-                ModelState.AddModelError(nameof(AddLink), "Select change link if you want to change the link to the panel outcome");
-            }
-        }
-        else if (AddLink == true)
-        {
-            if (!TrsUriHelper.TryCreateWebsiteUri(Link, out _))
-            {
-                ModelState.AddModelError(nameof(Link), "Enter a valid URL");
-            }
-            else if (Link == PreviousLink)
-            {
-                ModelState.AddModelError(nameof(Link), "Enter a different link");
-            }
+            return await CancelAsync();
         }
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
+        await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.AddLink = AddLink;
-            state.Link = AddLink == true ? Link : null;
-        });
-
+        // There was no link to begin with and the user doesn't want to add one, so there's nothing to
+        // change; abandon the journey and return to the record.
         if (string.IsNullOrEmpty(PreviousLink) && AddLink == false)
         {
-            return await OnPostCancelAsync();
+            return await CancelAsync();
         }
 
-        return Redirect(FromCheckAnswers
-            ? linkGenerator.Alerts.EditAlert.Link.CheckAnswers(AlertId, JourneyInstance.InstanceId)
-            : linkGenerator.Alerts.EditAlert.Link.Reason(AlertId, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.Link.Reason(journey.InstanceId),
+            state =>
+            {
+                state.AddLink = AddLink;
+                state.Link = AddLink == true ? Link : null;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 
@@ -92,10 +90,10 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         var alertInfo = context.HttpContext.GetCurrentAlertFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        JourneyInstance!.State.EnsureInitialized(alertInfo);
-
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         PreviousLink = alertInfo.Alert.ExternalLink;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Alerts(PersonId);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/alerts/{alertId}/link/reason/{handler?}"
+@page "/alerts/{alertId}/link/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link.ReasonModel
 @{
     ViewBag.Title = "Why are you changing the panel outcome link?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Alerts.EditAlert.Link.CheckAnswers(Model.AlertId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Alerts.EditAlert.Link.Index(Model.AlertId, Model.JourneyInstance!.InstanceId))" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -49,7 +52,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Alerts.EditAlert.Link.ReasonCancel(Model.AlertId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Alerts/EditAlert/Link/Reason.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditAlertLink), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditAlertLink)]
+public class ReasonModel(
+    EditAlertLinkJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     public const int MaxFileSizeMb = 50;
     public const int ChangeReasonDetailMaxLength = 4000;
@@ -26,13 +29,15 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<EditAlertLinkState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid AlertId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -52,11 +57,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.AddLink is null)
+        if (journey.State.AddLink is null)
         {
-            context.Result = Redirect(linkGenerator.Alerts.EditAlert.Link.Index(AlertId, JourneyInstance.InstanceId));
+            context.Result = Redirect(linkGenerator.Alerts.EditAlert.Link.Index(journey.InstanceId));
             return;
         }
+
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -66,37 +73,40 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        HasAdditionalReasonDetail = JourneyInstance.State.HasAdditionalReasonDetail;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        Evidence = JourneyInstance.State.Evidence;
+        ChangeReason = journey.State.ChangeReason;
+        HasAdditionalReasonDetail = journey.State.HasAdditionalReasonDetail;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        Evidence = journey.State.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
-            state.ChangeReasonDetail = HasAdditionalReasonDetail!.Value ? ChangeReasonDetail : null;
-            state.Evidence = Evidence;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Alerts.EditAlert.Link.CheckAnswers(AlertId, JourneyInstance.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Alerts.EditAlert.Link.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.HasAdditionalReasonDetail = HasAdditionalReasonDetail;
+                state.ChangeReasonDetail = HasAdditionalReasonDetail!.Value ? ChangeReasonDetail : null;
+                state.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Alerts(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Alerts.cshtml
@@ -78,7 +78,7 @@
                         @if (canWrite)
                         {
                             <row-actions>
-                                <action href="@LinkGenerator.Alerts.EditAlert.Link.Index(alert.AlertId, journeyInstanceId: null)" visually-hidden-text="link">Change</action>
+                                <action href="@LinkGenerator.Alerts.EditAlert.Link.Index(alert.AlertId)" visually-hidden-text="link">Change</action>
                             </row-actions>
                         }
                     </row>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/CheckAnswersTests.cs
@@ -59,23 +59,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : LinkTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/link/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/link?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -150,23 +133,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : LinkTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Post_MissingDataInJourneyState_RedirectsToIndexPage()
-    {
-        // Arrange
-        var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(JourneySteps.Index, alert);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/alerts/{alert.AlertId}/link?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -177,6 +143,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : LinkTestBase(hostFixtu
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional);
 
         EventObserver.Clear();
+
+        var state = journeyInstance.State;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -196,13 +164,12 @@ public class CheckAnswersTests(HostFixture hostFixture) : LinkTestBase(hostFixtu
             p.AssertProcessHasEvents<AlertUpdatedEvent>();
 
             var changeReason = Assert.IsType<ChangeReasonWithDetailsAndEvidence>(p.ProcessContext.Process.ChangeReason);
-            Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), changeReason.Reason);
-            Assert.Equal(populateOptional ? journeyInstance.State.ChangeReasonDetail : null, changeReason.Details);
-            Assert.Equal(populateOptional ? journeyInstance.State.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
+            Assert.Equal(state.ChangeReason!.GetDisplayName(), changeReason.Reason);
+            Assert.Equal(populateOptional ? state.ChangeReasonDetail : null, changeReason.Details);
+            Assert.Equal(populateOptional ? state.Evidence.UploadedEvidenceFile?.ToEventModel() : null, changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -212,7 +179,10 @@ public class CheckAnswersTests(HostFixture hostFixture) : LinkTestBase(hostFixtu
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForAllStepsCompletedAsync(alert, populateOptional: true);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -221,8 +191,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : LinkTestBase(hostFixtu
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/IndexTests.cs
@@ -61,16 +61,16 @@ public class IndexTests(HostFixture hostFixture) : LinkTestBase(hostFixture), IA
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    public async Task Get_NewJourneyInstance_PopulatesModelFromDatabase()
     {
         // Arrange
         var (person, alert) = await CreatePersonWithOpenAlert();
-        var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/link?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/alerts/{alert.AlertId}/link");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Starts the journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
@@ -240,8 +240,7 @@ public class IndexTests(HostFixture hostFixture) : LinkTestBase(hostFixture), IA
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -264,7 +263,6 @@ public class IndexTests(HostFixture hostFixture) : LinkTestBase(hostFixture), IA
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/link/reason", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.True(journeyInstance.State.AddLink);
         Assert.Equal(newLink, journeyInstance.State.Link);
     }
@@ -288,7 +286,6 @@ public class IndexTests(HostFixture hostFixture) : LinkTestBase(hostFixture), IA
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/link/reason", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.False(journeyInstance.State.AddLink);
         Assert.Null(journeyInstance.State.Link);
     }
@@ -300,7 +297,10 @@ public class IndexTests(HostFixture hostFixture) : LinkTestBase(hostFixture), IA
         var (person, alert) = await CreatePersonWithOpenAlert(populateOptional: true);
         var journeyInstance = await CreateEmptyJourneyInstanceAsync(alert.AlertId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -309,8 +309,7 @@ public class IndexTests(HostFixture hostFixture) : LinkTestBase(hostFixture), IA
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/LinkTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/LinkTestBase.cs
@@ -1,3 +1,4 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.SupportUi.Pages.Alerts.EditAlert.Link;
 
@@ -5,13 +6,12 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Alerts.EditAlert.Link;
 
 public abstract class LinkTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected Task<JourneyInstance<EditAlertLinkState>> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
+    protected Task<EditAlertLinkJourneyCoordinator> CreateEmptyJourneyInstanceAsync(Guid alertId) =>
         CreateJourneyInstanceAsync(alertId, new());
 
-    protected Task<JourneyInstance<EditAlertLinkState>> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
+    protected Task<EditAlertLinkJourneyCoordinator> CreateJourneyInstanceForAllStepsCompletedAsync(Alert alert, bool populateOptional = true) =>
         CreateJourneyInstanceAsync(alert.AlertId, new EditAlertLinkState
         {
-            Initialized = true,
             CurrentLink = populateOptional ? null : alert.ExternalLink,
             AddLink = populateOptional,
             Link = populateOptional ? "https://www.example.com" : null,
@@ -30,7 +30,7 @@ public abstract class LinkTestBase(HostFixture hostFixture) : TestBase(hostFixtu
             }
         });
 
-    protected Task<JourneyInstance<EditAlertLinkState>> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert, bool populateOptional = true) =>
+    protected Task<EditAlertLinkJourneyCoordinator> CreateJourneyInstanceForCompletedStepAsync(string step, Alert alert, bool populateOptional = true) =>
         step switch
         {
             JourneySteps.New =>
@@ -38,7 +38,6 @@ public abstract class LinkTestBase(HostFixture hostFixture) : TestBase(hostFixtu
             JourneySteps.Index =>
                 CreateJourneyInstanceAsync(alert.AlertId, new EditAlertLinkState
                 {
-                    Initialized = true,
                     CurrentLink = populateOptional ? null : alert.ExternalLink,
                     AddLink = populateOptional,
                     Link = populateOptional ? "https://www.example.com" : null
@@ -48,11 +47,25 @@ public abstract class LinkTestBase(HostFixture hostFixture) : TestBase(hostFixtu
             _ => throw new ArgumentException($"Unknown {nameof(step)}: '{step}'.", nameof(step))
         };
 
-    private Task<JourneyInstance<EditAlertLinkState>> CreateJourneyInstanceAsync(Guid alertId, EditAlertLinkState state) =>
-        CreateJourneyInstance(
+    protected EditAlertLinkState? GetJourneyInstanceState(EditAlertLinkJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (EditAlertLinkState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<EditAlertLinkJourneyCoordinator> CreateJourneyInstanceAsync(Guid alertId, EditAlertLinkState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<EditAlertLinkJourneyCoordinator>(
             JourneyNames.EditAlertLink,
-            state,
-            new KeyValuePair<string, object>("alertId", alertId));
+            new RouteValueDictionary { ["alertId"] = alertId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/alerts/{alertId}/link",
+                $"/alerts/{alertId}/link/reason",
+                $"/alerts/{alertId}/link/check-answers",
+            ]);
 
     public static class JourneySteps
     {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Alerts/EditAlert/Link/ReasonTests.cs
@@ -342,7 +342,6 @@ public class ReasonTests(HostFixture hostFixture) : LinkTestBase(hostFixture), I
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/link/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.True(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Equal(reasonDetail, journeyInstance.State.ChangeReasonDetail);
@@ -376,7 +375,6 @@ public class ReasonTests(HostFixture hostFixture) : LinkTestBase(hostFixture), I
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/alerts/{alert.AlertId}/link/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(reason, journeyInstance.State.ChangeReason);
         Assert.False(journeyInstance.State.HasAdditionalReasonDetail);
         Assert.Null(journeyInstance.State.ChangeReasonDetail);
@@ -391,7 +389,10 @@ public class ReasonTests(HostFixture hostFixture) : LinkTestBase(hostFixture), I
         var (person, alert) = await CreatePersonWithOpenAlert();
         var journeyInstance = await CreateJourneyInstanceForCompletedStepAsync(PreviousStep, alert);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link/reason/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/alerts/{alert.AlertId}/link/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new MultipartFormDataContentBuilder { { "Cancel", bool.TrueString } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -400,8 +401,7 @@ public class ReasonTests(HostFixture hostFixture) : LinkTestBase(hostFixture), I
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/alerts", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]


### PR DESCRIPTION
Follows #3618, #3620, #3621, #3622, #3623, #3624 and #3629. Together with #3629 (End Date) this is the last of the alert journeys.

## What

Migrates the **Edit Alert Link** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the other alert journeys, and converts its validation to the FluentValidation `ValidateAndThrowAsync` pattern.

## Changes

- Add `EditAlertLinkJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.EditAlertLink, ["alertId"])]`); drop FormFlow's `IRegisterJourney` from `EditAlertLinkState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys, the library's `returnUrl` mechanism for "Change" links, and a form-field `Cancel` submit.
- Rewrite `EditAlertLinkLinkGenerator` onto the shared `GetJourneyPage` extension; update the person-alerts page entry link.
- **Validation → FluentValidation:** Index's rules move from `ModelState` into an `InlineValidator`. The "not answered" message still varies with whether the alert already has a link (via `WithMessage(m => ...)`), and the link rules (valid URL, then must differ) are a `Cascade(CascadeMode.Stop)` chain gated on `.When(m => m.AddLink == true)` — preserving the original if/else-if behaviour. Reason moves off the `ValidateAndThrow` + `PageWithErrors` mix and uploads evidence *before* validating.
- Seed the starting state from the alert in the coordinator's `GetStartingState`, so `Initialized` / `EnsureInitialized` are deleted.
- `IsComplete` and the check answers guard are dropped; their two redirect tests go with them. The Reason page's own guard (and its tests) are kept.

## Notes

- The index page's "there was no link to begin with and the user doesn't want to add one" shortcut previously called `OnPostCancelAsync()` directly from `OnPostAsync`. It now shares the same private `CancelAsync` helper as the Cancel button, so the behaviour (discard the journey, return to the record) is unchanged.

## FormFlow clean-up check

The task noted it would be worth removing the alert `JourneyNames` entries and any orphaned FormFlow plumbing once the alerts were done. Having checked, **neither applies**:

- The alert `JourneyNames` constants are all still referenced (4–9 uses each) — they now name the *GovUk.Questions* journeys via `[JourneyCoordinator]` / `[Journey]`.
- FormFlow is still used by 13 other page areas (Mqs, Persons, OneLogins, RoutesToProfessionalStatus, SupportTasks), so none of its plumbing can go yet.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- EditAlert/Link tests: **70 passed**; all Alerts tests: **551 passed**. The count drops by exactly the 2 removed check answers guard tests (`CheckAnswersTests` 12 → 10 methods, Index/Reason unchanged).
- Route paths (`/alerts/{alertId}/link`, `/link/reason`, `/link/check-answers`) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)