### PR TITLE
Migrate Resolve OneLoginUserMatching journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(Model.SupportTaskReference, Model.JourneyInstance.InstanceId)" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml.cs
@@ -12,8 +12,7 @@ public class ConfirmConnect(
     ResolveOneLoginUserMatchingJourneyCoordinator journey,
     OneLoginUserMatchingSupportTaskService supportTaskService,
     TrsDbContext dbContext,
-    TimeProvider timeProvider,
-    SupportUiLinkGenerator linkGenerator) : PageModel
+    TimeProvider timeProvider) : PageModel
 {
     private SupportTask? _supportTask;
 
@@ -48,7 +47,7 @@ public class ConfirmConnect(
         {
             journey.DeleteInstance();
 
-            return Redirect(GetListPageUrl());
+            return Redirect(journey.GetListPageUrl());
         }
 
         var matchedPerson = journey.State.MatchedPersons
@@ -87,13 +86,8 @@ public class ConfirmConnect(
             $"GOV.UK One Login connected to {MatchedPersonName}’s record",
             $"We’ve sent {MatchedPersonName} an email confirming their GOV.UK One Login has been connected to their teaching record.");
 
-        return Redirect(GetListPageUrl());
+        return Redirect(journey.GetListPageUrl());
     }
-
-    private string GetListPageUrl() =>
-        _supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect.cshtml.cs
@@ -7,8 +7,9 @@ using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
 public class ConfirmConnect(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
     OneLoginUserMatchingSupportTaskService supportTaskService,
     TrsDbContext dbContext,
     TimeProvider timeProvider,
@@ -16,10 +17,10 @@ public class ConfirmConnect(
 {
     private SupportTask? _supportTask;
 
-    [FromRoute]
-    public string SupportTaskReference { get; set; } = null!;
+    [BindProperty]
+    public bool Cancel { get; set; }
 
-    public JourneyInstance<ResolveOneLoginUserMatchingState> JourneyInstance { get; set; } = null!;
+    public string? BackLink { get; set; }
 
     public Guid MatchedPersonId { get; set; }
 
@@ -41,21 +42,16 @@ public class ConfirmConnect(
     {
     }
 
-    public async Task<IActionResult> OnPostAsync(bool cancel)
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (cancel)
+        if (Cancel)
         {
-            await JourneyInstance.DeleteAsync();
+            journey.DeleteInstance();
 
-            if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
-            {
-                return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
-            }
-
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+            return Redirect(GetListPageUrl());
         }
 
-        var matchedPerson = JourneyInstance.State.MatchedPersons
+        var matchedPerson = journey.State.MatchedPersons
             .Single(m => m.PersonId == MatchedPersonId);
 
         if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
@@ -85,38 +81,31 @@ public class ConfirmConnect(
                 processContext);
         }
 
-        await JourneyInstance.DeleteAsync();
+        journey.DeleteInstance();
 
         TempData.SetFlashNotificationBanner(
             $"GOV.UK One Login connected to {MatchedPersonName}’s record",
             $"We’ve sent {MatchedPersonName} an email confirming their GOV.UK One Login has been connected to their teaching record.");
 
-        return Redirect(_supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+        return Redirect(GetListPageUrl());
     }
+
+    private string GetListPageUrl() =>
+        _supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
+            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
+            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (JourneyInstance.State.Verified is not true)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
-        if (JourneyInstance.State.MatchedPersonId is null)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
         _supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+
+        BackLink = journey.GetBackLink();
 
         OneLoginUserEmailAddress = _supportTask.OneLoginUser!.EmailAddress;
 
         var matchedPerson = await dbContext.Persons
             .Include(p => p.PreviousNames)
-            .SingleAsync(p => p.PersonId == JourneyInstance.State.MatchedPersonId);
+            .SingleAsync(p => p.PersonId == journey.State.MatchedPersonId);
 
         MatchedPersonId = matchedPerson.PersonId;
         MatchedPersonName = $"{matchedPerson.FirstName} {matchedPerson.MiddleName} {matchedPerson.LastName}";

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml
@@ -1,14 +1,16 @@
 @page "/support-tasks/one-login-user-matching/{supportTaskReference}/resolve/confirm-not-connecting"
+@using Microsoft.AspNetCore.Http.Extensions
 @using TeachingRecordSystem.Core.Models.SupportTasks
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve.ConfirmNotConnecting
 @{
     ViewBag.Title = "Confirm you’re not connecting the GOV.UK One Login";
 
     var resolveLinkGenerator = LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve;
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NotConnecting(Model.SupportTaskReference, Model.JourneyInstance.InstanceId)" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">
@@ -26,7 +28,7 @@
                     <key>Reason</key>
                     <value>@Model.Reason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@resolveLinkGenerator.NotConnecting(Model.SupportTaskReference, Model.JourneyInstance.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason">Change</action>
+                        <action href="@resolveLinkGenerator.NotConnecting(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason">Change</action>
                     </row-actions>
                 </row>
                 @if (Model.Reason is OneLoginUserNotConnectingReason.AnotherReason)
@@ -35,7 +37,7 @@
                         <key>Additional details</key>
                         <value>@Model.AdditionalDetails</value>
                         <row-actions>
-                            <action href="@resolveLinkGenerator.NotConnecting(Model.SupportTaskReference, Model.JourneyInstance.InstanceId, fromCheckAnswers: true)" visually-hidden-text="additional details">Change</action>
+                            <action href="@resolveLinkGenerator.NotConnecting(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="additional details">Change</action>
                         </row-actions>
                     </row>
                 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml.cs
@@ -7,18 +7,21 @@ using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
 public class ConfirmNotConnecting(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
     OneLoginUserMatchingSupportTaskService supportTaskService,
     TimeProvider timeProvider,
     SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private SupportTask? _supportTask;
 
-    [FromRoute]
-    public string SupportTaskReference { get; set; } = null!;
+    [BindProperty]
+    public bool Cancel { get; set; }
 
-    public JourneyInstance<ResolveOneLoginUserMatchingState> JourneyInstance { get; set; } = null!;
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     public string? EmailAddress { get; set; }
 
@@ -30,18 +33,13 @@ public class ConfirmNotConnecting(
     {
     }
 
-    public async Task<IActionResult> OnPostAsync(bool cancel)
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (cancel)
+        if (Cancel)
         {
-            await JourneyInstance.DeleteAsync();
+            journey.DeleteInstance();
 
-            if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
-            {
-                return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
-            }
-
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+            return Redirect(GetListPageUrl());
         }
 
         bool emailSent = false;
@@ -54,8 +52,8 @@ public class ConfirmNotConnecting(
                 new VerifiedOnlyWithMatchesOutcomeOptions
                 {
                     SupportTask = _supportTask!,
-                    NotConnectingReason = JourneyInstance.State.NotConnectingReason!.Value,
-                    NotConnectingAdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails
+                    NotConnectingReason = journey.State.NotConnectingReason!.Value,
+                    NotConnectingAdditionalDetails = journey.State.NotConnectingAdditionalDetails
                 },
                 processContext);
         }
@@ -67,15 +65,15 @@ public class ConfirmNotConnecting(
                 new NotConnectingOutcomeOptions
                 {
                     SupportTask = _supportTask!,
-                    NotConnectingReason = JourneyInstance.State.NotConnectingReason!.Value,
-                    NotConnectingAdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails
+                    NotConnectingReason = journey.State.NotConnectingReason!.Value,
+                    NotConnectingAdditionalDetails = journey.State.NotConnectingAdditionalDetails
                 },
                 processContext);
 
             emailSent = resolveResult.EmailSent;
         }
 
-        await JourneyInstance.DeleteAsync();
+        journey.DeleteInstance();
 
         var data = _supportTask!.GetData<IOneLoginUserMatchingData>();
         var firstVerifiedOrStatedName = data.VerifiedOrStatedNames!.First();
@@ -92,38 +90,22 @@ public class ConfirmNotConnecting(
             messageText: emailSent ? emailSentMessage : $"Request closed for {personName}.",
             notificationBannerType: NotificationBannerType.Default);
 
-        if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
-        {
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
-        }
-
-        return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+        return Redirect(GetListPageUrl());
     }
+
+    private string GetListPageUrl() =>
+        _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification ?
+            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
+            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance.State.Verified is not true)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
-        if (JourneyInstance.State.MatchedPersonId != ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
-        if (JourneyInstance.State.NotConnectingReason is null)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NotConnecting(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
         _supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
 
+        BackLink = journey.GetBackLink();
+
         EmailAddress = _supportTask.OneLoginUser!.EmailAddress!;
-        Reason = JourneyInstance.State.NotConnectingReason!.Value;
-        AdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails;
+        Reason = journey.State.NotConnectingReason!.Value;
+        AdditionalDetails = journey.State.NotConnectingAdditionalDetails;
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting.cshtml.cs
@@ -11,8 +11,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching
 public class ConfirmNotConnecting(
     ResolveOneLoginUserMatchingJourneyCoordinator journey,
     OneLoginUserMatchingSupportTaskService supportTaskService,
-    TimeProvider timeProvider,
-    SupportUiLinkGenerator linkGenerator) : PageModel
+    TimeProvider timeProvider) : PageModel
 {
     private SupportTask? _supportTask;
 
@@ -39,7 +38,7 @@ public class ConfirmNotConnecting(
         {
             journey.DeleteInstance();
 
-            return Redirect(GetListPageUrl());
+            return Redirect(journey.GetListPageUrl());
         }
 
         bool emailSent = false;
@@ -90,13 +89,8 @@ public class ConfirmNotConnecting(
             messageText: emailSent ? emailSentMessage : $"Request closed for {personName}.",
             notificationBannerType: NotificationBannerType.Default);
 
-        return Redirect(GetListPageUrl());
+        return Redirect(journey.GetListPageUrl());
     }
-
-    private string GetListPageUrl() =>
-        _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml
@@ -1,14 +1,16 @@
 @page "/support-tasks/one-login-user-matching/{supportTaskReference}/resolve/confirm-reject"
+@using Microsoft.AspNetCore.Http.Extensions
 @using TeachingRecordSystem.Core.Models.SupportTasks
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve.ConfirmReject
 @{
     ViewBag.Title = "Check details before rejecting request";
 
     var resolveLinkGenerator = LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve;
+    var returnUrl = Request.GetEncodedPathAndQuery();
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Reject(Model.SupportTaskReference, Model.JourneyInstance.InstanceId)" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">
@@ -30,7 +32,7 @@
                     <key>Reason</key>
                     <value>@Model.Reason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@resolveLinkGenerator.Reject(Model.SupportTaskReference, Model.JourneyInstance.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason">Change</action>
+                        <action href="@resolveLinkGenerator.Reject(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason">Change</action>
                     </row-actions>
                 </row>
                 @if (Model.Reason is OneLoginIdVerificationRejectReason.AnotherReason)
@@ -39,7 +41,7 @@
                         <key>Additional details</key>
                         <value>@Model.AdditionalDetails</value>
                         <row-actions>
-                            <action href="@resolveLinkGenerator.Reject(Model.SupportTaskReference, Model.JourneyInstance.InstanceId, fromCheckAnswers: true)" visually-hidden-text="additional details">Change</action>
+                            <action href="@resolveLinkGenerator.Reject(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="additional details">Change</action>
                         </row-actions>
                     </row>
                 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml.cs
@@ -7,15 +7,21 @@ using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
-public class ConfirmReject(OneLoginUserMatchingSupportTaskService supportTaskService, TimeProvider timeProvider, SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
+public class ConfirmReject(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
+    OneLoginUserMatchingSupportTaskService supportTaskService,
+    TimeProvider timeProvider,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private SupportTask? _supportTask;
 
-    [FromRoute]
-    public string SupportTaskReference { get; set; } = null!;
+    [BindProperty]
+    public bool Cancel { get; set; }
 
-    public JourneyInstance<ResolveOneLoginUserMatchingState> JourneyInstance { get; set; } = null!;
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     public string? EmailAddress { get; set; }
 
@@ -29,11 +35,11 @@ public class ConfirmReject(OneLoginUserMatchingSupportTaskService supportTaskSer
     {
     }
 
-    public async Task<IActionResult> OnPostAsync(bool cancel)
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (cancel)
+        if (Cancel)
         {
-            await JourneyInstance.DeleteAsync();
+            journey.DeleteInstance();
 
             return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
         }
@@ -44,12 +50,12 @@ public class ConfirmReject(OneLoginUserMatchingSupportTaskService supportTaskSer
             new NotVerifiedOutcomeOptions
             {
                 SupportTask = _supportTask!,
-                RejectReason = JourneyInstance.State.RejectReason!.Value,
-                RejectionAdditionalDetails = JourneyInstance.State.RejectionAdditionalDetails
+                RejectReason = journey.State.RejectReason!.Value,
+                RejectionAdditionalDetails = journey.State.RejectionAdditionalDetails
             },
             processContext);
 
-        await JourneyInstance.DeleteAsync();
+        journey.DeleteInstance();
 
         var data = _supportTask!.GetData<OneLoginUserIdVerificationData>();
         TempData.SetFlashNotificationBanner(
@@ -62,24 +68,14 @@ public class ConfirmReject(OneLoginUserMatchingSupportTaskService supportTaskSer
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance.State.Verified is not false)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
-        if (JourneyInstance.State.RejectReason is null)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Reject(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         _supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
         var data = _supportTask.GetData<OneLoginUserIdVerificationData>();
 
         EmailAddress = _supportTask.OneLoginUser!.EmailAddress!;
         Name = $"{data.StatedFirstName} {data.StatedLastName}";
-        Reason = JourneyInstance.State.RejectReason!.Value;
-        AdditionalDetails = JourneyInstance.State.RejectionAdditionalDetails;
+        Reason = journey.State.RejectReason!.Value;
+        AdditionalDetails = journey.State.RejectionAdditionalDetails;
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Evidence.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Evidence.cshtml
@@ -1,0 +1,2 @@
+@page "/support-tasks/one-login-user-matching/{supportTaskReference}/resolve/verify/evidence"
+@model TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve.EvidenceModel

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Evidence.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Evidence.cshtml.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.StaticFiles;
+using TeachingRecordSystem.Core.Models.SupportTasks;
+using TeachingRecordSystem.Core.Services.Files;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
+
+// Serves the proof of identity file that's embedded in the Verify page. It's deliberately outside the
+// journey; a journey's pages must all be steps within it and this is not a step the user navigates to.
+public class EvidenceModel(ISafeFileService safeFileService) : PageModel
+{
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+
+        if (supportTask.SupportTaskType != SupportTaskType.OneLoginUserIdVerification)
+        {
+            return NotFound();
+        }
+
+        var data = supportTask.GetData<OneLoginUserIdVerificationData>();
+
+        var fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
+        if (!fileExtensionContentTypeProvider.TryGetContentType(data.EvidenceFileName, out var mimeType))
+        {
+            mimeType = "application/octet-stream";
+        }
+
+        var stream = await safeFileService.OpenReadStreamAsync(data.EvidenceFileId);
+        return File(stream, mimeType);
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Index.cshtml.cs
@@ -1,33 +1,23 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ResolveOneLoginUserMatching), StartsJourney]
+public class IndexModel(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
-    public JourneyInstance<ResolveOneLoginUserMatchingState>? JourneyInstance { get; set; }
-
-    [FromRoute]
-    public required string? SupportTaskReference { get; set; }
-
-    public void OnGet()
-    {
-    }
-
-    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    public IActionResult OnGet()
     {
         var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-        if (supportTask.SupportTaskType == SupportTaskType.OneLoginUserRecordMatching)
-        {
-            context.Result = Redirect(JourneyInstance!.State.MatchedPersons.Count > 0 ?
-                linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(SupportTaskReference!, JourneyInstance!.InstanceId) :
-                linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NoMatches(SupportTaskReference!, JourneyInstance!.InstanceId));
-        }
-        else
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Verify(SupportTaskReference!, JourneyInstance!.InstanceId));
-        }
+
+        var firstStepUrl = supportTask.SupportTaskType == SupportTaskType.OneLoginUserRecordMatching ?
+            journey.State.MatchedPersons.Count > 0 ?
+                linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(journey.InstanceId) :
+                linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NoMatches(journey.InstanceId) :
+            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Verify(journey.InstanceId);
+
+        return journey.AdvanceTo(firstStepUrl, new PushStepOptions { SetAsFirstStep = true });
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Index.cshtml.cs
@@ -4,20 +4,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
 [Journey(JourneyNames.ResolveOneLoginUserMatching), StartsJourney]
-public class IndexModel(
-    ResolveOneLoginUserMatchingJourneyCoordinator journey,
-    SupportUiLinkGenerator linkGenerator) : PageModel
+public class IndexModel(ResolveOneLoginUserMatchingJourneyCoordinator journey) : PageModel
 {
-    public IActionResult OnGet()
-    {
-        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-
-        var firstStepUrl = supportTask.SupportTaskType == SupportTaskType.OneLoginUserRecordMatching ?
-            journey.State.MatchedPersons.Count > 0 ?
-                linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(journey.InstanceId) :
-                linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NoMatches(journey.InstanceId) :
-            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Verify(journey.InstanceId);
-
-        return journey.AdvanceTo(firstStepUrl, new PushStepOptions { SetAsFirstStep = true });
-    }
+    public IActionResult OnGet() =>
+        journey.AdvanceTo(journey.GetFirstStepUrl(), new PushStepOptions { SetAsFirstStep = true });
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml
@@ -5,9 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.IsRecordMatchingOnly is true ?
-        LinkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching() :
-        LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Verify(Model.SupportTaskReference, Model.JourneyInstance.InstanceId))" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
@@ -103,26 +103,21 @@ public class Matches(
 
         journey.DeleteInstance();
 
-        return Redirect(GetListPageUrl());
+        return Redirect(journey.GetListPageUrl());
     }
 
     private IActionResult HandleCancel()
     {
         journey.DeleteInstance();
 
-        return Redirect(GetListPageUrl());
+        return Redirect(journey.GetListPageUrl());
     }
-
-    private string GetListPageUrl() =>
-        _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         _supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
 
-        BackLink = journey.GetBackLink() ?? GetListPageUrl();
+        BackLink = journey.GetBackLink() ?? journey.GetListPageUrl();
 
         var oneLoginUser = _supportTask.OneLoginUser!;
         var data = _supportTask.GetData<IOneLoginUserMatchingData>();

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
@@ -9,8 +9,9 @@ using TeachingRecordSystem.SupportUi;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
 public class Matches(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
     TrsDbContext dbContext,
     SupportTaskService supportTaskService,
     TimeProvider timeProvider,
@@ -31,13 +32,13 @@ public class Matches(
 
     private SupportTask? _supportTask;
 
-    public JourneyInstance<ResolveOneLoginUserMatchingState> JourneyInstance { get; set; } = null!;
-
     [FromRoute]
     public required string SupportTaskReference { get; init; }
 
     [BindProperty]
     public Guid? MatchedPersonId { get; set; }
+
+    public string? BackLink { get; set; }
 
     public string? Name { get; set; }
     public string? EmailAddress { get; set; }
@@ -45,20 +46,18 @@ public class Matches(
     public string? NationalInsuranceNumber { get; set; }
     public string? Trn { get; set; }
 
-    public bool? IsRecordMatchingOnly { get; set; }
-
     public IReadOnlyCollection<SuggestedMatchViewModel>? SuggestedMatches { get; set; }
 
     public void OnGet()
     {
-        JourneyInstance.State.ApplySavedModelStateValues(nameof(Matches), ModelState);
+        journey.State.ApplySavedModelStateValues(nameof(Matches), ModelState);
     }
 
     public async Task<IActionResult> OnPostAsync(string? action)
     {
         if (action is Actions.Cancel)
         {
-            return await HandleCancelAsync();
+            return HandleCancel();
         }
 
         if (action is Actions.SaveAndComeBackLater)
@@ -68,22 +67,24 @@ public class Matches(
 
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance.UpdateStateAsync(state =>
-        {
-            state.MatchedPersonId = MatchedPersonId;
-            state.ClearSavedModelStateValues(nameof(Matches));
-        });
+        var nextStepUrl = MatchedPersonId != ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel ?
+            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.ConfirmConnect(journey.InstanceId) :
+            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NotConnecting(journey.InstanceId);
 
-        return MatchedPersonId != ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel ?
-            Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.ConfirmConnect(SupportTaskReference, JourneyInstance.InstanceId)) :
-            Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NotConnecting(SupportTaskReference, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            nextStepUrl,
+            state =>
+            {
+                state.MatchedPersonId = MatchedPersonId;
+                state.ClearSavedModelStateValues(nameof(Matches));
+            });
     }
 
     private async Task<IActionResult> HandleSaveAndReturnAsync()
     {
         var savedJourneyState = this.CreateSavedJourneyState(
             nameof(Matches),
-            JourneyInstance.State,
+            journey.State,
             excludeKeys: ["Action", nameof(SupportTaskReference)]);
 
         var processType = _supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
@@ -100,44 +101,29 @@ public class Matches(
             },
             processContext);
 
-        await JourneyInstance.DeleteAsync();
+        journey.DeleteInstance();
 
-        if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
-        {
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
-        }
-
-        return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+        return Redirect(GetListPageUrl());
     }
 
-    private async Task<IActionResult> HandleCancelAsync()
+    private IActionResult HandleCancel()
     {
-        await JourneyInstance.DeleteAsync();
+        journey.DeleteInstance();
 
-        if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
-        {
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
-        }
-
-        return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+        return Redirect(GetListPageUrl());
     }
+
+    private string GetListPageUrl() =>
+        _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification ?
+            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
+            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (JourneyInstance.State.Verified is not true)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
-        if (JourneyInstance.State.MatchedPersons.Count == 0)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NoMatches(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
         _supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-        IsRecordMatchingOnly = _supportTask.SupportTaskType == SupportTaskType.OneLoginUserRecordMatching;
+
+        BackLink = journey.GetBackLink() ?? GetListPageUrl();
+
         var oneLoginUser = _supportTask.OneLoginUser!;
         var data = _supportTask.GetData<IOneLoginUserMatchingData>();
 
@@ -149,7 +135,7 @@ public class Matches(
         Trn = TrnHelper.NormalizeTrn(data.StatedTrn);
         EmailAddress = oneLoginUser.EmailAddress;
 
-        var matchedPersonIds = JourneyInstance.State.MatchedPersons.Select(m => m.PersonId).ToArray();
+        var matchedPersonIds = journey.State.MatchedPersons.Select(m => m.PersonId).ToArray();
         SuggestedMatches = (await dbContext.Persons
             .Include(p => p.PreviousNames)
             .Where(p => matchedPersonIds.Contains(p.PersonId))
@@ -182,7 +168,7 @@ public class Matches(
                     .OrderBy(n => n.CreatedOn)
                     .Select(n => $"{n.FirstName} {n.MiddleName} {n.LastName}")
                     .ToArray(),
-                MatchedAttributeTypes = JourneyInstance.State.MatchedPersons.Single(m => m.PersonId == match.PersonId)
+                MatchedAttributeTypes = journey.State.MatchedPersons.Single(m => m.PersonId == match.PersonId)
                     .MatchedAttributes
                     .Select(kvp => kvp.Key)
                     .ToArray()

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Matches.cshtml.cs
@@ -57,7 +57,9 @@ public class Matches(
     {
         if (action is Actions.Cancel)
         {
-            return HandleCancel();
+            journey.DeleteInstance();
+
+            return Redirect(journey.GetListPageUrl());
         }
 
         if (action is Actions.SaveAndComeBackLater)
@@ -101,13 +103,6 @@ public class Matches(
             },
             processContext);
 
-        journey.DeleteInstance();
-
-        return Redirect(journey.GetListPageUrl());
-    }
-
-    private IActionResult HandleCancel()
-    {
         journey.DeleteInstance();
 
         return Redirect(journey.GetListPageUrl());

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml
@@ -5,9 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.IsRecordMatchingOnly is true ?
-        LinkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching() :
-        LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Verify(Model.SupportTaskReference, Model.JourneyInstance.InstanceId))" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml.cs
@@ -10,7 +10,6 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching
 [Journey(JourneyNames.ResolveOneLoginUserMatching)]
 public class NoMatches(
     ResolveOneLoginUserMatchingJourneyCoordinator journey,
-    SupportUiLinkGenerator linkGenerator,
     OneLoginUserMatchingSupportTaskService supportTaskService,
     TimeProvider timeProvider) : PageModel
 {
@@ -35,7 +34,7 @@ public class NoMatches(
         {
             journey.DeleteInstance();
 
-            return Redirect(GetListPageUrl());
+            return Redirect(journey.GetListPageUrl());
         }
 
         bool emailSent;
@@ -80,19 +79,14 @@ public class NoMatches(
             messageText: emailSent ? emailSentMessage : $"Request closed for {Name}.",
             notificationBannerType: NotificationBannerType.Default);
 
-        return Redirect(GetListPageUrl());
+        return Redirect(journey.GetListPageUrl());
     }
-
-    private string GetListPageUrl() =>
-        _supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         _supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
 
-        BackLink = journey.GetBackLink() ?? GetListPageUrl();
+        BackLink = journey.GetBackLink() ?? journey.GetListPageUrl();
 
         var data = _supportTask.GetData<IOneLoginUserMatchingData>();
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NoMatches.cshtml.cs
@@ -7,22 +7,21 @@ using TeachingRecordSystem.Core.Services.SupportTasks.OneLoginUserMatching;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
 public class NoMatches(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     OneLoginUserMatchingSupportTaskService supportTaskService,
     TimeProvider timeProvider) : PageModel
 {
     private SupportTask? _supportTask;
 
-    [FromRoute]
-    public string SupportTaskReference { get; set; } = null!;
+    [BindProperty]
+    public bool Cancel { get; set; }
 
-    public JourneyInstance<ResolveOneLoginUserMatchingState> JourneyInstance { get; set; } = null!;
+    public string? BackLink { get; set; }
 
     public string? Name { get; set; }
-
-    public bool? IsRecordMatchingOnly { get; set; }
 
     public string? NoMatchesPageContent { get; set; }
 
@@ -30,15 +29,13 @@ public class NoMatches(
     {
     }
 
-    public async Task<IActionResult> OnPostAsync(bool cancel)
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (cancel)
+        if (Cancel)
         {
-            await JourneyInstance.DeleteAsync();
+            journey.DeleteInstance();
 
-            return Redirect(_supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
-                linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-                linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+            return Redirect(GetListPageUrl());
         }
 
         bool emailSent;
@@ -70,7 +67,7 @@ public class NoMatches(
             emailSent = resolveResult.EmailSent;
         }
 
-        await JourneyInstance.DeleteAsync();
+        journey.DeleteInstance();
 
         var appContent = await supportTaskService.GetAppContentAsync(_supportTask);
 
@@ -83,27 +80,20 @@ public class NoMatches(
             messageText: emailSent ? emailSentMessage : $"Request closed for {Name}.",
             notificationBannerType: NotificationBannerType.Default);
 
-        return Redirect(_supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+        return Redirect(GetListPageUrl());
     }
+
+    private string GetListPageUrl() =>
+        _supportTask!.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
+            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
+            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (JourneyInstance.State.Verified is not true)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
-        if (JourneyInstance.State.MatchedPersons.Count > 0)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
         _supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-        IsRecordMatchingOnly = _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserRecordMatching;
+
+        BackLink = journey.GetBackLink() ?? GetListPageUrl();
+
         var data = _supportTask.GetData<IOneLoginUserMatchingData>();
 
         // For the time being only display first verified name and dob if there are multiples (but still match on both)

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting.cshtml
@@ -6,7 +6,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(Model.SupportTaskReference, Model.JourneyInstance.InstanceId)" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting.cshtml.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
@@ -20,8 +19,6 @@ public class NotConnecting(
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount).WithMessage($"Additional detail must be {UiDefaults.ReasonDetailsMaxCharacterCount} characters or less")
             .When(x => x.Reason is OneLoginUserNotConnectingReason.AnotherReason)
     };
-
-    private SupportTask? _supportTask;
 
     [BindProperty]
     public OneLoginUserNotConnectingReason? Reason { get; set; }
@@ -46,7 +43,7 @@ public class NotConnecting(
         {
             journey.DeleteInstance();
 
-            return Redirect(GetListPageUrl());
+            return Redirect(journey.GetListPageUrl());
         }
 
         await _validator.ValidateAndThrowAsync(this);
@@ -60,15 +57,8 @@ public class NotConnecting(
             });
     }
 
-    private string GetListPageUrl() =>
-        _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
-            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
-
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        _supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-
         BackLink = journey.GetBackLink();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting.cshtml.cs
@@ -6,8 +6,10 @@ using TeachingRecordSystem.Core.Models.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
-public class NotConnecting(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
+public class NotConnecting(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private InlineValidator<NotConnecting> _validator = new()
     {
@@ -21,62 +23,52 @@ public class NotConnecting(SupportUiLinkGenerator linkGenerator) : PageModel
 
     private SupportTask? _supportTask;
 
-    [FromRoute]
-    public string SupportTaskReference { get; set; } = null!;
-
-    public JourneyInstance<ResolveOneLoginUserMatchingState> JourneyInstance { get; set; } = null!;
-
     [BindProperty]
     public OneLoginUserNotConnectingReason? Reason { get; set; }
 
     [BindProperty]
     public string? AdditionalDetails { get; set; }
 
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
+
     public void OnGet()
     {
-        Reason = JourneyInstance.State.NotConnectingReason;
-        AdditionalDetails = JourneyInstance.State.NotConnectingAdditionalDetails;
+        Reason = journey.State.NotConnectingReason;
+        AdditionalDetails = journey.State.NotConnectingAdditionalDetails;
     }
 
-    public async Task<IActionResult> OnPostAsync(bool cancel)
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (cancel)
+        if (Cancel)
         {
-            await JourneyInstance.DeleteAsync();
+            journey.DeleteInstance();
 
-            if (_supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification)
-            {
-                return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
-            }
-
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching());
+            return Redirect(GetListPageUrl());
         }
 
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance.UpdateStateAsync(state =>
-        {
-            state.NotConnectingReason = Reason;
-            state.NotConnectingAdditionalDetails = Reason is OneLoginUserNotConnectingReason.AnotherReason ? AdditionalDetails : null;
-        });
-
-        return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.ConfirmNotConnecting(SupportTaskReference, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.ConfirmNotConnecting(journey.InstanceId),
+            state =>
+            {
+                state.NotConnectingReason = Reason;
+                state.NotConnectingAdditionalDetails = Reason is OneLoginUserNotConnectingReason.AnotherReason ? AdditionalDetails : null;
+            });
     }
+
+    private string GetListPageUrl() =>
+        _supportTask!.SupportTaskType == SupportTaskType.OneLoginUserIdVerification ?
+            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
+            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance.State.Verified is not true)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
-        if (JourneyInstance.State.MatchedPersonId != ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(SupportTaskReference, JourneyInstance.InstanceId));
-            return;
-        }
-
         _supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+
+        BackLink = journey.GetBackLink();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Reject.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Reject.cshtml
@@ -6,7 +6,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(Model.SupportTaskReference, Model.JourneyInstance.InstanceId)" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Reject.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Reject.cshtml.cs
@@ -5,8 +5,10 @@ using TeachingRecordSystem.Core.Models.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
-public class Reject(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
+public class Reject(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private readonly InlineValidator<Reject> _validator = new()
     {
@@ -18,51 +20,45 @@ public class Reject(SupportUiLinkGenerator linkGenerator) : PageModel
             .When(m => m.Reason is OneLoginIdVerificationRejectReason.AnotherReason)
     };
 
-    [FromRoute]
-    public string SupportTaskReference { get; set; } = null!;
-
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
-
-    public JourneyInstance<ResolveOneLoginUserMatchingState> JourneyInstance { get; set; } = null!;
-
     [BindProperty]
     public OneLoginIdVerificationRejectReason? Reason { get; set; }
 
     [BindProperty]
     public string? AdditionalDetails { get; set; }
 
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
+
     public void OnGet()
     {
-        Reason = JourneyInstance.State.RejectReason;
-        AdditionalDetails = JourneyInstance.State.RejectionAdditionalDetails;
+        Reason = journey.State.RejectReason;
+        AdditionalDetails = journey.State.RejectionAdditionalDetails;
     }
 
-    public async Task<IActionResult> OnPostAsync(bool cancel)
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (cancel)
+        if (Cancel)
         {
-            await JourneyInstance.DeleteAsync();
+            journey.DeleteInstance();
 
             return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
         }
 
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance.UpdateStateAsync(state =>
-        {
-            state.RejectReason = Reason;
-            state.RejectionAdditionalDetails = Reason is OneLoginIdVerificationRejectReason.AnotherReason ? AdditionalDetails : null;
-        });
-
-        return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.ConfirmReject(SupportTaskReference, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.ConfirmReject(journey.InstanceId),
+            state =>
+            {
+                state.RejectReason = Reason;
+                state.RejectionAdditionalDetails = Reason is OneLoginIdVerificationRejectReason.AnotherReason ? AdditionalDetails : null;
+            });
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance.State.Verified is not false)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference, JourneyInstance.InstanceId));
-        }
+        BackLink = journey.GetBackLink();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
@@ -6,7 +6,9 @@ using TeachingRecordSystem.Core.Services.OneLogin;
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
 [JourneyCoordinator(JourneyNames.ResolveOneLoginUserMatching, routeValueKeys: ["supportTaskReference"])]
-public class ResolveOneLoginUserMatchingJourneyCoordinator(OneLoginService oneLoginService) :
+public class ResolveOneLoginUserMatchingJourneyCoordinator(
+    OneLoginService oneLoginService,
+    SupportUiLinkGenerator linkGenerator) :
     JourneyCoordinator<ResolveOneLoginUserMatchingState>
 {
     public override Task<ResolveOneLoginUserMatchingState> GetStartingStateAsync()
@@ -14,6 +16,14 @@ public class ResolveOneLoginUserMatchingJourneyCoordinator(OneLoginService oneLo
         var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
         return CreateStateAsync(oneLoginService, supportTask);
     }
+
+    /// <summary>
+    /// Gets the URL of the support task list page that this journey was started from.
+    /// </summary>
+    public string GetListPageUrl() =>
+        HttpContext.GetCurrentSupportTaskFeature().SupportTask.SupportTaskType is SupportTaskType.OneLoginUserIdVerification ?
+            linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification() :
+            linkGenerator.SupportTasks.OneLoginUserMatching.RecordMatching();
 
     public static async Task<ResolveOneLoginUserMatchingState> CreateStateAsync(
         OneLoginService oneLoginService,

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Models.SupportTasks;
+using TeachingRecordSystem.Core.Services.OneLogin;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
+
+[JourneyCoordinator(JourneyNames.ResolveOneLoginUserMatching, routeValueKeys: ["supportTaskReference"])]
+public class ResolveOneLoginUserMatchingJourneyCoordinator(OneLoginService oneLoginService) :
+    JourneyCoordinator<ResolveOneLoginUserMatchingState>
+{
+    public override Task<ResolveOneLoginUserMatchingState> GetStartingStateAsync()
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        return CreateStateAsync(oneLoginService, supportTask);
+    }
+
+    public static async Task<ResolveOneLoginUserMatchingState> CreateStateAsync(
+        OneLoginService oneLoginService,
+        SupportTask supportTask)
+    {
+        Debug.Assert(supportTask.SupportTaskType is SupportTaskType.OneLoginUserIdVerification or SupportTaskType.OneLoginUserRecordMatching);
+        var requestData = supportTask.GetData<IOneLoginUserMatchingData>();
+        var emailAddress = supportTask.OneLoginUser!.EmailAddress;
+
+        IReadOnlyCollection<MatchPersonResult> suggestedMatches;
+
+        if (string.IsNullOrWhiteSpace(requestData.StatedTrn))
+        {
+            suggestedMatches = [];
+        }
+        else
+        {
+            suggestedMatches = await oneLoginService.GetSuggestedPersonMatchesAsync(new(
+                Names: requestData.VerifiedOrStatedNames!,
+                DatesOfBirth: requestData.VerifiedOrStatedDatesOfBirth!,
+                NationalInsuranceNumber: requestData.StatedNationalInsuranceNumber,
+                EmailAddress: emailAddress,
+                Trn: requestData.StatedTrn,
+                TrnTokenTrnHint: requestData.TrnTokenTrn));
+
+            var matchResult = oneLoginService.MatchPerson(suggestedMatches);
+            if (matchResult is not null)
+            {
+                suggestedMatches = [matchResult];
+            }
+        }
+
+        return supportTask.ResolveJourneySavedState?.GetState<ResolveOneLoginUserMatchingState>() is { } existingState ?
+            existingState with
+            {
+                MatchedPersons = suggestedMatches,
+                SavedJourneyState = supportTask.ResolveJourneySavedState
+            } :
+            new ResolveOneLoginUserMatchingState
+            {
+                MatchedPersons = suggestedMatches,
+                Verified = supportTask.SupportTaskType is SupportTaskType.OneLoginUserRecordMatching ? true : null
+            };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
@@ -18,6 +18,26 @@ public class ResolveOneLoginUserMatchingJourneyCoordinator(
     }
 
     /// <summary>
+    /// Gets the URL of the journey's first question, which depends on the type of support task being
+    /// resolved and whether any matching records were found.
+    /// </summary>
+    public string GetFirstStepUrl()
+    {
+        var resolveLinkGenerator = linkGenerator.SupportTasks.OneLoginUserMatching.Resolve;
+
+        // Record matching tasks have already had the person's identity verified, so they skip
+        // straight to picking a record.
+        if (HttpContext.GetCurrentSupportTaskFeature().SupportTask.SupportTaskType is not SupportTaskType.OneLoginUserRecordMatching)
+        {
+            return resolveLinkGenerator.Verify(InstanceId);
+        }
+
+        return State.MatchedPersons.Count > 0 ?
+            resolveLinkGenerator.Matches(InstanceId) :
+            resolveLinkGenerator.NoMatches(InstanceId);
+    }
+
+    /// <summary>
     /// Gets the URL of the support task list page that this journey was started from.
     /// </summary>
     public string GetListPageUrl() =>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingLinkGenerator.cs
@@ -2,33 +2,33 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching
 
 public class ResolveOneLoginUserMatchingLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/Index", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+    public string Index(string supportTaskReference) =>
+        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/Index", routeValues: new { supportTaskReference });
 
-    public string Verify(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/Verify", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+    public string Verify(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/Verify", journeyInstanceId, returnUrl);
 
-    public string Evidence(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/Verify", handler: "Evidence", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+    public string Evidence(string supportTaskReference) =>
+        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/Evidence", routeValues: new { supportTaskReference });
 
-    public string ConfirmConnect(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string ConfirmConnect(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnect", journeyInstanceId);
 
-    public string ConfirmReject(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string ConfirmReject(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject", journeyInstanceId);
 
-    public string Matches(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/Matches", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Matches(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/Matches", journeyInstanceId);
 
-    public string NoMatches(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/NoMatches", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string NoMatches(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/NoMatches", journeyInstanceId);
 
-    public string NotConnecting(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string NotConnecting(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/NotConnecting", journeyInstanceId, returnUrl);
 
-    public string ConfirmNotConnecting(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string ConfirmNotConnecting(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnecting", journeyInstanceId);
 
-    public string Reject(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/OneLoginUserMatching/Resolve/Reject", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Reject(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/OneLoginUserMatching/Resolve/Reject", journeyInstanceId, returnUrl);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
@@ -1,19 +1,11 @@
-using System.Diagnostics;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.OneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-public record ResolveOneLoginUserMatchingState : IRegisterJourney, IJourneyWithSavedState
+public record ResolveOneLoginUserMatchingState : IJourneyWithSavedState
 {
     public static Guid NotMatchedPersonIdSentinel => Guid.Empty;
-
-    public static JourneyDescriptor Journey { get; } = new(
-        JourneyNames.ResolveOneLoginUserMatching,
-        typeof(ResolveOneLoginUserMatchingState),
-        ["supportTaskReference"],
-        appendUniqueKey: true);
 
     public SavedJourneyState? SavedJourneyState { get; set; }
 
@@ -30,58 +22,4 @@ public record ResolveOneLoginUserMatchingState : IRegisterJourney, IJourneyWithS
     public OneLoginUserNotConnectingReason? NotConnectingReason { get; set; }
 
     public string? NotConnectingAdditionalDetails { get; set; }
-}
-
-[UsedImplicitly]
-public class ResolveOneLoginUserMatchingStateFactory(
-    OneLoginService oneLoginService) :
-    IJourneyStateFactory<ResolveOneLoginUserMatchingState>
-{
-    public Task<ResolveOneLoginUserMatchingState> CreateAsync(CreateJourneyStateContext context)
-    {
-        var supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-        return CreateAsync(supportTask);
-    }
-
-    public async Task<ResolveOneLoginUserMatchingState> CreateAsync(SupportTask supportTask)
-    {
-        Debug.Assert(supportTask.SupportTaskType is SupportTaskType.OneLoginUserIdVerification or SupportTaskType.OneLoginUserRecordMatching);
-        var requestData = supportTask.GetData<IOneLoginUserMatchingData>();
-        var emailAddress = supportTask.OneLoginUser!.EmailAddress;
-
-        IReadOnlyCollection<MatchPersonResult> suggestedMatches;
-
-        if (string.IsNullOrWhiteSpace(requestData.StatedTrn))
-        {
-            suggestedMatches = [];
-        }
-        else
-        {
-            suggestedMatches = await oneLoginService.GetSuggestedPersonMatchesAsync(new(
-                Names: requestData.VerifiedOrStatedNames!,
-                DatesOfBirth: requestData.VerifiedOrStatedDatesOfBirth!,
-                NationalInsuranceNumber: requestData.StatedNationalInsuranceNumber,
-                EmailAddress: emailAddress,
-                Trn: requestData.StatedTrn,
-                TrnTokenTrnHint: requestData.TrnTokenTrn));
-
-            var matchResult = oneLoginService.MatchPerson(suggestedMatches);
-            if (matchResult is not null)
-            {
-                suggestedMatches = [matchResult];
-            }
-        }
-
-        return supportTask.ResolveJourneySavedState?.GetState<ResolveOneLoginUserMatchingState>() is { } existingState ?
-            existingState with
-            {
-                MatchedPersons = suggestedMatches,
-                SavedJourneyState = supportTask.ResolveJourneySavedState
-            } :
-            new ResolveOneLoginUserMatchingState
-            {
-                MatchedPersons = suggestedMatches,
-                Verified = supportTask.SupportTaskType is SupportTaskType.OneLoginUserRecordMatching ? true : null
-            };
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml
@@ -1,11 +1,11 @@
-@page "/support-tasks/one-login-user-matching/{supportTaskReference}/resolve/verify/{handler?}"
+@page "/support-tasks/one-login-user-matching/{supportTaskReference}/resolve/verify"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve.VerifyModel
 @{
     ViewBag.Title = "GOV.UK One Login - identity verification";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks.OneLoginUserMatching.IdVerification()" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">
@@ -43,12 +43,12 @@
                         <div class="govuk-!-margin-top-2">
                             @if (Model.Evidence!.MimeType == "application/pdf")
                             {
-                                <object data="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Evidence(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" type="application/pdf" class="govuk-!-width-three-quarters govuk-!-margin-top-1" data-testid="pdf-@Model.Evidence!.FileId">
+                                <object data="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Evidence(Model.SupportTaskReference)" type="application/pdf" class="govuk-!-width-three-quarters govuk-!-margin-top-1" data-testid="pdf-@Model.Evidence!.FileId">
                                 </object>
                             }
                             else
                             {
-                                <img src="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Evidence(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" alt="@Model.Evidence.FileName" class="govuk-!-width-three-quarters govuk-!-margin-top-1" data-testid="image-@Model.Evidence!.FileId" />
+                                <img src="@LinkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Evidence(Model.SupportTaskReference)" alt="@Model.Evidence.FileName" class="govuk-!-width-three-quarters govuk-!-margin-top-1" data-testid="image-@Model.Evidence!.FileId" />
                             }
                         </div>
                     </value>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
@@ -7,8 +7,11 @@ using TeachingRecordSystem.Core.Services.Files;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveOneLoginUserMatching), RequireJourneyInstance]
-public class VerifyModel(ISafeFileService safeFileService, SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ResolveOneLoginUserMatching)]
+public class VerifyModel(
+    ResolveOneLoginUserMatchingJourneyCoordinator journey,
+    ISafeFileService safeFileService,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private readonly InlineValidator<VerifyModel> _validator = new()
     {
@@ -16,13 +19,16 @@ public class VerifyModel(ISafeFileService safeFileService, SupportUiLinkGenerato
             .NotNull().WithMessage("Select yes if you can verify this person’s identity")
     };
 
-    public JourneyInstance<ResolveOneLoginUserMatchingState>? JourneyInstance { get; set; }
-
     [FromRoute]
-    public required string? SupportTaskReference { get; set; }
+    public required string SupportTaskReference { get; set; }
 
     [BindProperty]
     public bool? Verified { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
 
     public string? Name { get; set; }
     public string? EmailAddress { get; set; }
@@ -33,47 +39,36 @@ public class VerifyModel(ISafeFileService safeFileService, SupportUiLinkGenerato
 
     public void OnGet()
     {
-        Verified = JourneyInstance?.State.Verified;
+        Verified = journey.State.Verified;
     }
 
-    public async Task<IActionResult> OnPostAsync(bool cancel)
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (cancel)
+        if (Cancel)
         {
-            await JourneyInstance!.DeleteAsync();
+            journey.DeleteInstance();
 
             return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
         }
 
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state => state.Verified = Verified);
+        var resolveLinkGenerator = linkGenerator.SupportTasks.OneLoginUserMatching.Resolve;
 
-        return Redirect(Verified is false ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Reject(SupportTaskReference!, JourneyInstance!.InstanceId) :
-            string.IsNullOrWhiteSpace(Trn) ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NoMatches(SupportTaskReference!, JourneyInstance!.InstanceId) :
-            JourneyInstance.State.MatchedPersons.Count > 0 ?
-            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Matches(SupportTaskReference!, JourneyInstance!.InstanceId) :
-            linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.NoMatches(SupportTaskReference!, JourneyInstance!.InstanceId));
-    }
+        var nextStepUrl = Verified is false ?
+            resolveLinkGenerator.Reject(journey.InstanceId) :
+            string.IsNullOrWhiteSpace(Trn) || journey.State.MatchedPersons.Count == 0 ?
+            resolveLinkGenerator.NoMatches(journey.InstanceId) :
+            resolveLinkGenerator.Matches(journey.InstanceId);
 
-    public async Task<IActionResult> OnGetEvidenceAsync()
-    {
-        var stream = await safeFileService.OpenReadStreamAsync(Evidence!.FileId);
-        return File(stream, Evidence.MimeType);
+        return journey.AdvanceTo(nextStepUrl, state => state.Verified = Verified);
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-        if (supportTask.SupportTaskType == SupportTaskType.OneLoginUserRecordMatching)
-        {
-            // Belt and braces to stop this page being used for the record matching only support task type
-            context.Result = Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.Resolve.Index(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink() ?? linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification();
 
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
         var oneLoginUser = supportTask.OneLoginUser!;
         var data = supportTask.GetData<OneLoginUserIdVerificationData>();
         Name = data.StatedFirstName + " " + data.StatedLastName;

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnectTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmConnectTests.cs
@@ -5,60 +5,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUs
 
 public class ConfirmConnectTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_UserIsNotVerified_RedirectsToIndex()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            state => state.Verified = false);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Get_NoPersonSelected_RedirectsToMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            state => state.Verified = true);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -229,8 +175,7 @@ public class ConfirmConnectTests(HostFixture hostFixture) : ResolveOneLoginUserM
             Assert.Equal("/support-tasks/one-login-user-matching/id-verification", response.Headers.Location?.OriginalString);
         }
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     private async Task<(OneLoginUser User, SupportTask SupportTask, Person MatchedPerson)> CreateUserSupportTaskAndMatchingPerson(bool isRecordMatchingOnlySupportTask)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnectingTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmNotConnectingTests.cs
@@ -8,103 +8,6 @@ public class ConfirmNotConnectingTests(HostFixture hostFixture) : ResolveOneLogi
 {
     [Theory]
     [InlineData(false)]
-    [InlineData(null)]
-    public async Task Get_UserIsNotVerified_RedirectsToIndex(bool? verified)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s => s.Verified = verified);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder { { "Reason", nameof(OneLoginUserNotConnectingReason.NoMatchingRecord) } }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Get_MatchedPersonIsNotSentinel_RedirectsToMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = true;
-                s.MatchedPersonId = Guid.NewGuid();
-                s.NotConnectingReason = OneLoginUserNotConnectingReason.NoMatchingRecord;
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Get_ReasonNotChosen_RedirectsToNotConnectingPage(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = true;
-                s.MatchedPersonId = ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel;
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
     [InlineData(true)]
     public async Task Get_ShowsExpectedData(bool isRecordMatchingOnlySupportTask)
     {
@@ -139,103 +42,6 @@ public class ConfirmNotConnectingTests(HostFixture hostFixture) : ResolveOneLogi
         Assert.Equal(oneLoginUser.EmailAddress, doc.GetSummaryListValueByKey("Email address"));
         Assert.Equal(notConnectingReason.GetDisplayName(), doc.GetSummaryListValueByKey("Reason"));
         Assert.Equal(additionalDetails, doc.GetSummaryListValueByKey("Additional details"));
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(null)]
-    public async Task Post_UserIsNotVerified_RedirectsToIndex(bool? verified)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s => s.Verified = verified);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder { { "Reason", nameof(OneLoginUserNotConnectingReason.NoMatchingRecord) } }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Post_MatchedPersonIsNotSentinel_RedirectsToMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = true;
-                s.MatchedPersonId = Guid.NewGuid();
-                s.NotConnectingReason = OneLoginUserNotConnectingReason.NoMatchingRecord;
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Post_ReasonNotChosen_RedirectsToNotConnectingPage(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = true;
-                s.MatchedPersonId = ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel;
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -429,8 +235,7 @@ public class ConfirmNotConnectingTests(HostFixture hostFixture) : ResolveOneLogi
                 response.Headers.Location?.OriginalString);
         }
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmRejectTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ConfirmRejectTests.cs
@@ -4,62 +4,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUs
 
 public class ConfirmRejectTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTestBase(hostFixture)
 {
-    [Theory]
-    [InlineData(true)]
-    [InlineData(null)]
-    public async Task Get_UserIsNotUnverified_RedirectsToIndex(bool? verified)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s => s.Verified = verified);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-reject?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
-    public async Task Get_ReasonNotChosen_RedirectsToRejectPage()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = false;
-                s.RejectReason = null;
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-reject?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/reject?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Fact]
     public async Task Get_ShowsExpectedData()
     {
@@ -181,7 +125,6 @@ public class ConfirmRejectTests(HostFixture hostFixture) : ResolveOneLoginUserMa
             "/support-tasks/one-login-user-matching/id-verification",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/IndexTests.cs
@@ -47,31 +47,20 @@ public class IndexTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTe
             await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
             await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = true;
-                s.MatchedPersonId = Guid.NewGuid();
-            });
-
         var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}");
+            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Initializes journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        if (isRecordMatchingOnlySupportTask)
-        {
-            Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/no-matches?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-        }
-        else
-        {
-            Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/verify?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-        }
+        var expectedPage = isRecordMatchingOnlySupportTask ? "no-matches" : "verify";
+        Assert.StartsWith(
+            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/{expectedPage}?",
+            response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/MatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/MatchesTests.cs
@@ -8,69 +8,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUs
 
 public class MatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_UserIsNotVerified_RedirectsToIndex()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(supportTask);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Get_NoMatches_RedirectsToNoMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var matchedPerson = await TestData.CreatePersonAsync();
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
-                oneLoginUser.Subject, t => t
-                    .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
-                    .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
-                    .WithStatedTrn(matchedPerson.Trn!)) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
-                oneLoginUser.Subject, t => t
-                    .WithStatedFirstName(matchedPerson.FirstName)
-                    .WithStatedLastName(matchedPerson.LastName)
-                    .WithStatedDateOfBirth(matchedPerson.DateOfBirth)
-                    .WithStatedTrn(matchedPerson.Trn!));
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask.SupportTaskReference,
-            state => state.Verified = true,
-            matchedPersons: []);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/no-matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -472,8 +409,8 @@ public class MatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatching
             $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(matchedPerson.PersonId, journeyInstance.State.MatchedPersonId);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(matchedPerson.PersonId, journeyState!.MatchedPersonId);
     }
 
     [Theory]
@@ -526,8 +463,8 @@ public class MatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatching
             $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel, journeyInstance.State.MatchedPersonId);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel, journeyState!.MatchedPersonId);
     }
 
     [Theory]
@@ -611,8 +548,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatching
             Assert.True(savedState.Verified);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         Events.AssertProcessesCreated(p => Assert.Equal(
             isRecordMatchingOnlySupportTask ?
@@ -676,8 +612,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatching
             Assert.Equal($"/support-tasks/one-login-user-matching/id-verification", response.Headers.Location?.OriginalString);
         }
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     private void AssertMatchRowIsHighlighted(IElement matchDetails, string summaryListKey)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NoMatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NoMatchesTests.cs
@@ -1,81 +1,9 @@
 using TeachingRecordSystem.Core.Models.SupportTasks;
-using TeachingRecordSystem.Core.Services.OneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUserMatching.Resolve;
 
 public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_UserIsNotVerified_RedirectsToIndex()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(supportTask);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/no-matches?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Get_MatchesPresent_RedirectsToMatchesPage(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var matchedPerson = await TestData.CreatePersonAsync();
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(
-                oneLoginUser.Subject, t => t
-                    .WithVerifiedNames([matchedPerson.FirstName, matchedPerson.LastName])
-                    .WithVerifiedDateOfBirth(matchedPerson.DateOfBirth)
-                    .WithStatedTrn(matchedPerson.Trn!)) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
-                oneLoginUser.Subject, t => t
-                    .WithStatedFirstName(matchedPerson.FirstName)
-                    .WithStatedLastName(matchedPerson.LastName)
-                    .WithStatedDateOfBirth(matchedPerson.DateOfBirth)
-                    .WithStatedTrn(matchedPerson.Trn!));
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask.SupportTaskReference,
-            state => state.Verified = true,
-            new MatchPersonResult(
-                matchedPerson.PersonId,
-                matchedPerson.Trn,
-                [
-                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson.FirstName),
-                    KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson.LastName),
-                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson.DateOfBirth.ToString("yyyy-MM-dd")),
-                    KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson.Trn)
-                ]));
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/no-matches?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Fact]
     public async Task Post_IdVerificationSupportTaskEmailsUserMarksUserVerifiedClosesSupportTaskAndRedirectsToListPageWithFlashMessage()
     {
@@ -217,8 +145,7 @@ public class NoMatchesTests(HostFixture hostFixture) : ResolveOneLoginUserMatchi
             Assert.Equal("/support-tasks/one-login-user-matching/id-verification", response.Headers.Location?.OriginalString);
         }
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NotConnectingTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/NotConnectingTests.cs
@@ -7,99 +7,6 @@ public class NotConnectingTests(HostFixture hostFixture) : ResolveOneLoginUserMa
 {
     [Theory]
     [InlineData(false)]
-    [InlineData(null)]
-    public async Task Get_UserIsNotUnverified_RedirectsToIndex(bool? verified)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = verified;
-                s.MatchedPersonId = ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel;
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Get_MatchedPersonIsNotSentinel_RedirectsToMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = true;
-                s.MatchedPersonId = Guid.NewGuid();
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Get_MatchedPersonNotSet_RedirectsToMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s => s.Verified = true);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
     [InlineData(true)]
     public async Task Get_ValidRequest_ReturnsOk(bool isRecordMatchingOnlySupportTask)
     {
@@ -161,117 +68,6 @@ public class NotConnectingTests(HostFixture hostFixture) : ResolveOneLoginUserMa
         var doc = await AssertEx.HtmlResponseAsync(response);
         Assert.True(doc.GetElementsByName("Reason").SingleOrDefault(e => e.GetAttribute("value") == nameof(OneLoginIdVerificationRejectReason.AnotherReason))!.HasAttribute("checked"));
         Assert.Equal(additionalDetails, doc.GetElementsByName("AdditionalDetails").Single().TrimmedText());
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(null)]
-    public async Task Post_UserIsNotVerified_RedirectsToIndex(bool? verified)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = verified;
-                s.MatchedPersonId = ResolveOneLoginUserMatchingState.NotMatchedPersonIdSentinel;
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "Reason", nameof(OneLoginUserNotConnectingReason.NoMatchingRecord) }
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Post_MatchedPersonIsNotSentinel_RedirectsToMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s =>
-            {
-                s.Verified = true;
-                s.MatchedPersonId = Guid.NewGuid();
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "Reason", nameof(OneLoginUserNotConnectingReason.NoMatchingRecord) }
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task Post_MatchedPersonNotSet_RedirectsToMatches(bool isRecordMatchingOnlySupportTask)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = isRecordMatchingOnlySupportTask ?
-            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
-            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s => s.Verified = true);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "Reason", nameof(OneLoginUserNotConnectingReason.NoMatchingRecord) }
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
     }
 
     [Theory]
@@ -381,9 +177,9 @@ public class NotConnectingTests(HostFixture hostFixture) : ResolveOneLoginUserMa
             $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(OneLoginUserNotConnectingReason.NoMatchingRecord, journeyInstance.State.NotConnectingReason);
-        Assert.Null(journeyInstance.State.NotConnectingAdditionalDetails);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(OneLoginUserNotConnectingReason.NoMatchingRecord, journeyState!.NotConnectingReason);
+        Assert.Null(journeyState!.NotConnectingAdditionalDetails);
     }
 
     [Theory]
@@ -426,9 +222,9 @@ public class NotConnectingTests(HostFixture hostFixture) : ResolveOneLoginUserMa
             $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(OneLoginUserNotConnectingReason.AnotherReason, journeyInstance.State.NotConnectingReason);
-        Assert.Equal(additionalDetails, journeyInstance.State.NotConnectingAdditionalDetails);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(OneLoginUserNotConnectingReason.AnotherReason, journeyState!.NotConnectingReason);
+        Assert.Equal(additionalDetails, journeyState!.NotConnectingAdditionalDetails);
     }
 
     [Theory]
@@ -478,7 +274,6 @@ public class NotConnectingTests(HostFixture hostFixture) : ResolveOneLoginUserMa
                 response.Headers.Location?.OriginalString);
         }
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/RejectTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/RejectTests.cs
@@ -4,33 +4,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUs
 
 public class RejectTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTestBase(hostFixture)
 {
-    [Theory]
-    [InlineData(true)]
-    [InlineData(null)]
-    public async Task Get_UserIsNotUnverified_RedirectsToIndex(bool? verified)
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
-        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            supportTask,
-            s => s.Verified = verified);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/reject?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Fact]
     public async Task Get_ValidRequest_ReturnsOk()
     {
@@ -163,8 +136,8 @@ public class RejectTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
             $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-reject?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(OneLoginIdVerificationRejectReason.ProofDoesNotMatchRequest, journeyInstance.State.RejectReason);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(OneLoginIdVerificationRejectReason.ProofDoesNotMatchRequest, journeyState!.RejectReason);
     }
 
     [Fact]
@@ -199,9 +172,9 @@ public class RejectTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
             $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-reject?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(OneLoginIdVerificationRejectReason.AnotherReason, journeyInstance.State.RejectReason);
-        Assert.Equal(additionalDetails, journeyInstance.State.RejectionAdditionalDetails);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(OneLoginIdVerificationRejectReason.AnotherReason, journeyState!.RejectReason);
+        Assert.Equal(additionalDetails, journeyState!.RejectionAdditionalDetails);
     }
 
     [Fact]
@@ -235,7 +208,6 @@ public class RejectTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
             "/support-tasks/one-login-user-matching/id-verification",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingTestBase.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.OneLogin;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching.Resolve;
@@ -7,24 +8,25 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.OneLoginUs
 
 public abstract class ResolveOneLoginUserMatchingTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected async Task<JourneyInstance<ResolveOneLoginUserMatchingState>> CreateJourneyInstanceAsync(
+    protected async Task<ResolveOneLoginUserMatchingJourneyCoordinator> CreateJourneyInstanceAsync(
         SupportTask supportTask,
         Action<ResolveOneLoginUserMatchingState>? configureState = null)
     {
         Debug.Assert(supportTask.SupportTaskType is SupportTaskType.OneLoginUserIdVerification or SupportTaskType.OneLoginUserRecordMatching);
 
-        var state = await CreateJourneyStateWithFactory<ResolveOneLoginUserMatchingStateFactory, ResolveOneLoginUserMatchingState>(
-            f => f.CreateAsync(supportTask));
+        // Resolve OneLoginService from its own scope so that it doesn't share a DbContext with the
+        // test's other operations.
+        await using var scope = HostFixture.Services.CreateAsyncScope();
+        var oneLoginService = scope.ServiceProvider.GetRequiredService<OneLoginService>();
+
+        var state = await ResolveOneLoginUserMatchingJourneyCoordinator.CreateStateAsync(oneLoginService, supportTask);
 
         configureState?.Invoke(state);
 
-        return await CreateJourneyInstance(
-            JourneyNames.ResolveOneLoginUserMatching,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTask.SupportTaskReference));
+        return await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
     }
 
-    protected async Task<JourneyInstance<ResolveOneLoginUserMatchingState>> CreateJourneyInstanceAsync(
+    protected Task<ResolveOneLoginUserMatchingJourneyCoordinator> CreateJourneyInstanceAsync(
         string supportTaskReference,
         Action<ResolveOneLoginUserMatchingState>? configureState = null,
         params MatchPersonResult[] matchedPersons)
@@ -33,9 +35,39 @@ public abstract class ResolveOneLoginUserMatchingTestBase(HostFixture hostFixtur
 
         configureState?.Invoke(state);
 
-        return await CreateJourneyInstance(
+        return CreateJourneyInstanceAsync(supportTaskReference, state);
+    }
+
+    protected ResolveOneLoginUserMatchingState? GetJourneyInstanceState(ResolveOneLoginUserMatchingJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (ResolveOneLoginUserMatchingState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    private Task<ResolveOneLoginUserMatchingJourneyCoordinator> CreateJourneyInstanceAsync(
+        string supportTaskReference,
+        ResolveOneLoginUserMatchingState state)
+    {
+        var basePath = $"/support-tasks/one-login-user-matching/{supportTaskReference}/resolve";
+
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps). The steps are ordered so that every
+        // transition the journey can make moves forwards through this list.
+        return JourneyHelper.CreateInstanceAsync<ResolveOneLoginUserMatchingJourneyCoordinator>(
             JourneyNames.ResolveOneLoginUserMatching,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
+            new RouteValueDictionary { ["supportTaskReference"] = supportTaskReference },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"{basePath}/verify",
+                $"{basePath}/matches",
+                $"{basePath}/no-matches",
+                $"{basePath}/reject",
+                $"{basePath}/confirm-reject",
+                $"{basePath}/not-connecting",
+                $"{basePath}/confirm-not-connecting",
+                $"{basePath}/confirm-connect"
+            ],
+            coordinatorFactory: () => new ResolveOneLoginUserMatchingJourneyCoordinator(OneLoginService));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingTestBase.cs
@@ -68,6 +68,8 @@ public abstract class ResolveOneLoginUserMatchingTestBase(HostFixture hostFixtur
                 $"{basePath}/confirm-not-connecting",
                 $"{basePath}/confirm-connect"
             ],
-            coordinatorFactory: () => new ResolveOneLoginUserMatchingJourneyCoordinator(OneLoginService));
+            // JourneyHelper activates coordinators with Activator.CreateInstance, which can't supply
+            // this one's constructor dependencies.
+            coordinatorFactory: () => ActivatorUtilities.CreateInstance<ResolveOneLoginUserMatchingJourneyCoordinator>(HostFixture.Services));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
@@ -158,8 +158,8 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/reject?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.False(journeyInstance.State.Verified);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.False(journeyState!.Verified);
     }
 
     [Fact]
@@ -186,8 +186,8 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/no-matches?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.State.Verified);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.True(journeyState!.Verified);
     }
 
     [Fact]
@@ -218,9 +218,9 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/no-matches?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.State.Verified);
-        Assert.Empty(journeyInstance.State.MatchedPersons);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.True(journeyState!.Verified);
+        Assert.Empty(journeyState!.MatchedPersons);
     }
 
     [Fact]
@@ -268,8 +268,8 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.State.Verified);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.True(journeyState!.Verified);
     }
 
     [Fact]
@@ -296,7 +296,6 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/support-tasks/one-login-user-matching/id-verification", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }


### PR DESCRIPTION
### Context

Follows #3618, #3620, #3621, #3622, #3623 and #3624 in moving SupportUi journeys off `FormFlow` and onto `GovUk.Questions.AspNetCore` (DFE issue #369). This one covers the eight pages under `SupportTasks/OneLoginUserMatching/Resolve` — the journey support users work through to resolve GOV.UK One Login ID verification and record matching tasks.

### Changes proposed in this pull request

- **Coordinator.** Add `ResolveOneLoginUserMatchingJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.ResolveOneLoginUserMatching, ["supportTaskReference"])]`) and drop `IRegisterJourney` from `ResolveOneLoginUserMatchingState`. FormFlow's `ResolveOneLoginUserMatchingStateFactory` becomes `GetStartingStateAsync`, which can read the support task from `CurrentSupportTaskFeature` because `CheckSupportTaskExistsFilter` runs at order -200, ahead of the library's `ValidateJourneyFilter` at -100. The state-building logic is exposed as a static `CreateStateAsync(oneLoginService, supportTask)` so tests can still build realistic state (including suggested matches).
- **Pages.** All eight inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance` with `_jid` keys. Back links move from hardcoded `LinkGenerator` calls to a `BackLink` model property fed by `GetBackLink()`, with a fallback to the relevant task list page on the first step. `Index` is `[StartsJourney]` and `AdvanceTo`s to the right first question (`Verify` for ID verification, `Matches`/`NoMatches` for record matching) with `SetAsFirstStep`.
- **Change links.** `ConfirmReject` and `ConfirmNotConnecting` use the library's `returnUrl` query param instead of the `fromCheckAnswers` flag.
- **Link generator** rewritten onto the shared `GetJourneyPage` extension.
- **Evidence endpoint moved to its own page.** `Verify`'s `OnGetEvidence` handler (which streams the proof-of-identity file embedded in the page) had to move to a new `Evidence` page at `/resolve/verify/evidence`. Journey metadata is per-*page* for Razor Pages, so `[ExcludeFromJourney]` on a single handler does nothing and the old `{handler?}` URL would be an invalid journey step. The new page has no `[Journey]` attribute but still picks up the folder conventions (auth policy + `CheckSupportTaskExistsFilter`), and returns `NotFound` for record-matching tasks, which have no evidence file.
- **Guards dropped.** The state-based redirects in `OnPageHandlerExecuting` (`Verified is not true → Index`, `RejectReason is null → Reject`, `MatchedPersonId != sentinel → Matches`, etc.) are removed. I checked each one individually: every guarded step can only enter the journey path via an `AdvanceTo` that sets the state it was checking, so the library's path validation now enforces the same thing. Their 21 redirect tests go with them.
- Removed some route-bound properties and `IsRecordMatchingOnly` view-model members that only existed to build the old back links.

### Guidance to review

- **Cancel buttons needed no rework.** These pages already posted a `Cancel` form field to the same URL rather than using a separate handler, which is exactly what the library requires; they just bind it as `[BindProperty] bool Cancel` now.
- **"Save and come back later"** (`SavedJourneyState` / `ApplySavedModelStateValues`) on the Matches page is unchanged — it now reads `journey.State` instead of `JourneyInstance.State`.
- **Route paths are preserved** for every page. The only URL change is the evidence file: `/resolve/verify/Evidence?ffiid=…` → `/resolve/verify/evidence`. It's an embedded `<object>`/`<img>` source, not a page users navigate to or bookmark.
- **The dropped guards are the main thing to sanity-check.** The reasoning is that `/matches` etc. are unreachable until the user has answered the question that populates the state, because the path only grows through `AdvanceTo`. If you'd rather keep any of them as belt-and-braces, they'd need a redirect target that's a valid step (the old `Index` target no longer is).
- Test base now seeds the whole journey path so any page under test is reachable, mirroring `StartDateTestBase`. Two library quirks worth knowing: `JourneyHelper` activates coordinators with `Activator.CreateInstance`, so one with constructor deps needs an explicit `coordinatorFactory:`; and building starting state with `OneLoginService` needs its own DI scope or EF complains about concurrent `DbContext` use.

### Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive advisories on `main`).
- Resolve journey tests: **90 passed**. All `OneLoginUserMatching` tests: **144 passed**. `just test-changed`: SupportUi.Tests **3926 passed**.
- I also wrote a throwaway test that drove the whole ID verification journey over HTTP (entry → verify → matches → not-connecting → confirm, checking back links and a `returnUrl` change link at each step) to exercise real path building, since the seeded-path tests can't. It passed; I removed it. Happy to add a permanent version if that's wanted.
- Known-flaky failures unrelated to this change, all passing in isolation: `MergePerson_PersonsDifferOnAllFields` and the two `AuthorizeAccess` `OidcTests`.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
