### PR TITLE
Migrate Resolve TRN request journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml
@@ -1,20 +1,19 @@
-@page "/support-tasks/trn-requests/{supportTaskReference}/resolve/check-answers/{handler?}"
+@page "/support-tasks/trn-requests/{supportTaskReference}/resolve/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.CheckAnswers
 @{
     ViewBag.Title = Model.CreatingNewRecord ? "Check details before creating a new record" : "Check details before updating record";
 
-    var backLink = Model.CreatingNewRecord
-        ? LinkGenerator.SupportTasks.TrnRequests.Resolve.Matches(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)
-        : LinkGenerator.SupportTasks.TrnRequests.Resolve.Merge(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId);
+    var returnUrl = Request.GetEncodedPathAndQuery();
     var changeLink = Model.CreatingNewRecord
-        ? LinkGenerator.SupportTasks.TrnRequests.Resolve.Matches(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)
-        : LinkGenerator.SupportTasks.TrnRequests.Resolve.Merge(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true);
+        ? LinkGenerator.SupportTasks.TrnRequests.Resolve.Matches(Model.InstanceId, returnUrl: returnUrl)
+        : LinkGenerator.SupportTasks.TrnRequests.Resolve.Merge(Model.InstanceId, returnUrl: returnUrl);
 
     var confirmButtonLabel = Model.CreatingNewRecord ? "Confirm and create record" : "Confirm and update existing record";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@backLink" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 
@@ -121,7 +120,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">@confirmButtonLabel</govuk-button>
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswersCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/CheckAnswers.cshtml.cs
@@ -9,17 +9,20 @@ using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resol
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTrnRequest), RequireJourneyInstance]
+[Journey(JourneyNames.ResolveTrnRequest)]
 public class CheckAnswers(
+    ResolveTrnRequestJourneyCoordinator journey,
     TrsDbContext dbContext,
     TrnRequestService trnRequestService,
     SupportUiLinkGenerator linkGenerator,
     TimeProvider timeProvider,
     PersonChangeableAttributesService changedService) :
-    ResolveTrnRequestPageModel(dbContext)
+    ResolveTrnRequestPageModel(journey, dbContext)
 {
-    [FromRoute]
-    public string? SupportTaskReference { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public JourneyInstanceId InstanceId => Journey.InstanceId;
 
     public string? SourceApplicationUserName { get; set; }
 
@@ -65,9 +68,16 @@ public class CheckAnswers(
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            Journey.DeleteInstance();
+
+            return Redirect(linkGenerator.SupportTasks.TrnRequests.Index());
+        }
+
         var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
         var trnRequest = supportTask.TrnRequestMetadata!;
-        var state = JourneyInstance!.State;
+        var state = Journey.State;
 
         var processContext = new ProcessContext(ProcessType.TrnRequestResolving, timeProvider.UtcNow, User.GetUserId());
 
@@ -100,12 +110,7 @@ public class CheckAnswers(
             $"{(CreatingNewRecord ? "Record created" : "Records merged")} for {string.JoinNonEmpty(' ', FirstName, MiddleName, LastName)}",
             buildMessageHtml: LinkTagBuilder.BuildViewRecordLink(linkGenerator.Persons.PersonDetail.Index(resolvedPersonId)));
 
-        return Redirect(linkGenerator.SupportTasks.TrnRequests.Index());
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
+        Journey.DeleteInstance();
 
         return Redirect(linkGenerator.SupportTasks.TrnRequests.Index());
     }
@@ -113,19 +118,9 @@ public class CheckAnswers(
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         var requestData = GetRequestData();
-        var state = JourneyInstance!.State;
+        var state = Journey.State;
 
-        if (state.PersonId is not Guid personId)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TrnRequests.Resolve.Matches(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
-
-        if (personId != CreateNewRecordPersonIdSentinel && !state.PersonAttributeSourcesSet)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TrnRequests.Resolve.Merge(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
+        BackLink = Journey.GetBackLink();
 
         if (state.PersonId == CreateNewRecordPersonIdSentinel)
         {

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Index.cshtml.cs
@@ -3,13 +3,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTrnRequest), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ResolveTrnRequest), StartsJourney]
+public class IndexModel(
+    ResolveTrnRequestJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
-    public JourneyInstance<ResolveTrnRequestState>? JourneyInstance { get; set; }
-
-    [FromRoute]
-    public required string SupportTaskReference { get; init; }
-
-    public IActionResult OnGet() => Redirect(linkGenerator.SupportTasks.TrnRequests.Resolve.Matches(SupportTaskReference, JourneyInstance!.InstanceId));
+    public IActionResult OnGet() =>
+        journey.AdvanceTo(
+            linkGenerator.SupportTasks.TrnRequests.Resolve.Matches(journey.InstanceId),
+            new PushStepOptions { SetAsFirstStep = true });
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Matches.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Matches.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/trn-requests/{supportTaskReference}/resolve/matches/{handler?}"
+@page "/support-tasks/trn-requests/{supportTaskReference}/resolve/matches"
 @using TeachingRecordSystem.Core.Services.TrnRequests
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.Matches
 @{
@@ -7,9 +7,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ?
-        LinkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswers(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId) :
-        LinkGenerator.SupportTasks.TrnRequests.Index())"/>
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">
@@ -225,7 +223,7 @@
                 {
                     <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
                 }
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TrnRequests.Resolve.MatchesCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Matches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Matches.cshtml.cs
@@ -6,8 +6,11 @@ using TeachingRecordSystem.Core.Services.TrnRequests;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTrnRequest), RequireJourneyInstance]
-public class Matches(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerator) : ResolveTrnRequestPageModel(dbContext)
+[Journey(JourneyNames.ResolveTrnRequest)]
+public class Matches(
+    ResolveTrnRequestJourneyCoordinator journey,
+    TrsDbContext dbContext,
+    SupportUiLinkGenerator linkGenerator) : ResolveTrnRequestPageModel(journey, dbContext)
 {
     private readonly InlineValidator<Matches> _validator = new()
     {
@@ -15,11 +18,8 @@ public class Matches(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerato
             .NotNull().WithMessage("Select a record")
     };
 
-    [FromRoute]
-    public string? SupportTaskReference { get; set; }
-
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public TrnRequestMetadata? RequestData { get; set; }
 
@@ -38,11 +38,18 @@ public class Matches(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerato
 
     public void OnGet()
     {
-        PersonId = JourneyInstance!.State.PersonId;
+        PersonId = Journey.State.PersonId;
     }
 
-    public async Task<IActionResult> OnPostAsync()
+    public IActionResult OnPost()
     {
+        if (Cancel)
+        {
+            Journey.DeleteInstance();
+
+            return Redirect(linkGenerator.SupportTasks.TrnRequests.Index());
+        }
+
         // Verify the submitted ID is legit
         if (PersonId is Guid personId &&
             (!PotentialDuplicates!.Any(d => d.PersonId == personId) && personId != ResolveTrnRequestState.CreateNewRecordPersonIdSentinel))
@@ -52,7 +59,11 @@ public class Matches(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerato
 
         _validator.ValidateAndThrow(this);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
+        var nextStepUrl = PersonId == ResolveTrnRequestState.CreateNewRecordPersonIdSentinel ?
+            linkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswers(Journey.InstanceId) :
+            linkGenerator.SupportTasks.TrnRequests.Resolve.Merge(Journey.InstanceId);
+
+        return Journey.AdvanceTo(nextStepUrl, state =>
         {
             var oldPersonId = state.PersonId;
             state.PersonId = PersonId;
@@ -69,29 +80,19 @@ public class Matches(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerato
                 state.PersonAttributeSourcesSet = false;
             }
         });
-
-        return Redirect(
-            PersonId == ResolveTrnRequestState.CreateNewRecordPersonIdSentinel ?
-                linkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswers(SupportTaskReference!, JourneyInstance!.InstanceId) :
-                linkGenerator.SupportTasks.TrnRequests.Resolve.Merge(SupportTaskReference!, JourneyInstance!.InstanceId));
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-
-        return Redirect(linkGenerator.SupportTasks.TrnRequests.Index());
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         RequestData = GetRequestData();
 
-        var matchedAttributesLookup = JourneyInstance!.State.MatchedPersons.ToDictionary(
+        BackLink = Journey.GetBackLink() ?? linkGenerator.SupportTasks.TrnRequests.Index();
+
+        var matchedAttributesLookup = Journey.State.MatchedPersons.ToDictionary(
                 mp => mp.PersonId,
                 mp => mp.MatchedAttributes);
-        var matchedPersonIds = JourneyInstance!.State.MatchedPersons.Select(p => p.PersonId).ToArray();
-        MatchOutcome = JourneyInstance.State.MatchOutcome;
+        var matchedPersonIds = Journey.State.MatchedPersons.Select(p => p.PersonId).ToArray();
+        MatchOutcome = Journey.State.MatchOutcome;
 
         PotentialDuplicates = (await DbContext.Persons
             .Where(p => matchedPersonIds.Contains(p.PersonId))

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/trn-requests/{supportTaskReference}/resolve/merge/{handler?}"
+@page "/support-tasks/trn-requests/{supportTaskReference}/resolve/merge"
 @using TeachingRecordSystem.SupportUi.Pages.Shared
 @using TeachingRecordSystem.Core.Models.SupportTasks
 @using TeachingRecordSystem.SupportUi.Services
@@ -9,9 +9,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ?
-                         LinkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswers(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId) :
-                         LinkGenerator.SupportTasks.TrnRequests.Resolve.Matches(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId))" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 @functions {
@@ -142,7 +140,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TrnRequests.Resolve.MergeCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/Merge.cshtml.cs
@@ -2,18 +2,17 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Models.SupportTasks;
-using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.ResolveTrnRequestState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTrnRequest), RequireJourneyInstance]
-public class Merge(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerator) : ResolveTrnRequestPageModel(dbContext)
+[Journey(JourneyNames.ResolveTrnRequest)]
+public class Merge(
+    ResolveTrnRequestJourneyCoordinator journey,
+    TrsDbContext dbContext,
+    SupportUiLinkGenerator linkGenerator) : ResolveTrnRequestPageModel(journey, dbContext)
 {
-    [FromRoute]
-    public string? SupportTaskReference { get; set; }
-
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? SourceApplicationUserName { get; set; }
 
@@ -57,18 +56,25 @@ public class Merge(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerator)
 
     public void OnGet()
     {
-        FirstNameSource = JourneyInstance!.State.FirstNameSource;
-        MiddleNameSource = JourneyInstance!.State.MiddleNameSource;
-        LastNameSource = JourneyInstance!.State.LastNameSource;
-        DateOfBirthSource = JourneyInstance!.State.DateOfBirthSource;
-        EmailAddressSource = JourneyInstance!.State.EmailAddressSource;
-        NationalInsuranceNumberSource = JourneyInstance!.State.NationalInsuranceNumberSource;
-        GenderSource = JourneyInstance!.State.GenderSource;
-        Comments = JourneyInstance!.State.Comments;
+        FirstNameSource = Journey.State.FirstNameSource;
+        MiddleNameSource = Journey.State.MiddleNameSource;
+        LastNameSource = Journey.State.LastNameSource;
+        DateOfBirthSource = Journey.State.DateOfBirthSource;
+        EmailAddressSource = Journey.State.EmailAddressSource;
+        NationalInsuranceNumberSource = Journey.State.NationalInsuranceNumberSource;
+        GenderSource = Journey.State.GenderSource;
+        Comments = Journey.State.Comments;
     }
 
-    public async Task<IActionResult> OnPostAsync()
+    public IActionResult OnPost()
     {
+        if (Cancel)
+        {
+            Journey.DeleteInstance();
+
+            return Redirect(linkGenerator.SupportTasks.TrnRequests.Index());
+        }
+
         if (FirstName!.Different && FirstNameSource is null)
         {
             ModelState.AddModelError(nameof(FirstNameSource), "Select a first name");
@@ -109,48 +115,32 @@ public class Merge(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerator)
             return this.PageWithErrors();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.FirstNameSource = FirstNameSource;
-            state.MiddleNameSource = MiddleNameSource;
-            state.LastNameSource = LastNameSource;
-            state.DateOfBirthSource = DateOfBirthSource;
-            state.EmailAddressSource = EmailAddressSource;
-            state.NationalInsuranceNumberSource = NationalInsuranceNumberSource;
-            state.GenderSource = GenderSource;
-            state.PersonAttributeSourcesSet = true;
-            state.Comments = Comments;
-        });
-
-        return Redirect(linkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswers(SupportTaskReference!, JourneyInstance!.InstanceId));
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-
-        return Redirect(linkGenerator.SupportTasks.TrnRequests.Index());
+        return Journey.AdvanceTo(
+            linkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswers(Journey.InstanceId),
+            state =>
+            {
+                state.FirstNameSource = FirstNameSource;
+                state.MiddleNameSource = MiddleNameSource;
+                state.LastNameSource = LastNameSource;
+                state.DateOfBirthSource = DateOfBirthSource;
+                state.EmailAddressSource = EmailAddressSource;
+                state.NationalInsuranceNumberSource = NationalInsuranceNumberSource;
+                state.GenderSource = GenderSource;
+                state.PersonAttributeSourcesSet = true;
+                state.Comments = Comments;
+            });
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         var requestData = GetRequestData();
-        var state = JourneyInstance!.State;
+        var state = Journey.State;
+        var personId = state.PersonId!.Value;
 
-        if (state.PersonId is not Guid personId)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TrnRequests.Resolve.Matches(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
-
-        if (state.PersonId == CreateNewRecordPersonIdSentinel)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TrnRequests.Resolve.CheckAnswers(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
+        BackLink = Journey.GetBackLink();
 
         var personAttributes = await GetPersonAttributesAsync(personId);
-        var attributeMatches = JourneyInstance!.State.MatchedPersons
+        var attributeMatches = state.MatchedPersons
             .Single(m => m.PersonId == personId)
             .MatchedAttributes;
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestJourneyCoordinator.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.TrnRequests;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
+
+[JourneyCoordinator(JourneyNames.ResolveTrnRequest, routeValueKeys: ["supportTaskReference"])]
+public class ResolveTrnRequestJourneyCoordinator(TrnRequestService trnRequestService) :
+    JourneyCoordinator<ResolveTrnRequestState>
+{
+    public override Task<ResolveTrnRequestState> GetStartingStateAsync()
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        return CreateStateAsync(trnRequestService, supportTask);
+    }
+
+    public static async Task<ResolveTrnRequestState> CreateStateAsync(
+        TrnRequestService trnRequestService,
+        SupportTask supportTask)
+    {
+        Debug.Assert(supportTask.SupportTaskType is SupportTaskType.TrnRequest);
+        var requestData = supportTask.TrnRequestMetadata!;
+
+        var matchResult = await trnRequestService.MatchPersonsAsync(requestData);
+
+        return new ResolveTrnRequestState
+        {
+            MatchOutcome = matchResult.Outcome,
+            MatchedPersons = matchResult.Outcome switch
+            {
+                MatchPersonsResultOutcome.DefiniteMatch => [new MatchPersonsResultPerson(matchResult.PersonId, matchResult.MatchedAttributes)],
+                MatchPersonsResultOutcome.PotentialMatches => matchResult.Matches.ToArray(),
+                _ => []
+            }
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestLinkGenerator.cs
@@ -5,21 +5,12 @@ public class ResolveTrnRequestLinkGenerator(LinkGenerator linkGenerator)
     public string Index(string supportTaskReference) =>
         linkGenerator.GetRequiredPathByPage("/SupportTasks/TrnRequests/Resolve/Index", routeValues: new { supportTaskReference });
 
-    public string Matches(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TrnRequests/Resolve/Matches", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Matches(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TrnRequests/Resolve/Matches", journeyInstanceId, returnUrl);
 
-    public string MatchesCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TrnRequests/Resolve/Matches", handler: "Cancel", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+    public string Merge(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TrnRequests/Resolve/Merge", journeyInstanceId, returnUrl);
 
-    public string Merge(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TrnRequests/Resolve/Merge", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-
-    public string MergeCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TrnRequests/Resolve/Merge", handler: "Cancel", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TrnRequests/Resolve/CheckAnswers", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TrnRequests/Resolve/CheckAnswers", handler: "Cancel", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TrnRequests/Resolve/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestPageModel.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestPageModel.cs
@@ -5,9 +5,13 @@ using TeachingRecordSystem.Core.Models.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
-public abstract class ResolveTrnRequestPageModel(TrsDbContext dbContext) : PageModel
+public abstract class ResolveTrnRequestPageModel(
+    ResolveTrnRequestJourneyCoordinator journey,
+    TrsDbContext dbContext) : PageModel
 {
-    public JourneyInstance<ResolveTrnRequestState>? JourneyInstance { get; set; }
+    public string? BackLink { get; set; }
+
+    protected ResolveTrnRequestJourneyCoordinator Journey => journey;
 
     protected TrsDbContext DbContext => dbContext;
 
@@ -19,7 +23,7 @@ public abstract class ResolveTrnRequestPageModel(TrsDbContext dbContext) : PageM
 
     protected PersonAttributeSources GetPersonAttributeSources()
     {
-        var state = JourneyInstance!.State;
+        var state = journey.State;
 
         if (!state.PersonAttributeSourcesSet)
         {

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TrnRequests/Resolve/ResolveTrnRequestState.cs
@@ -1,19 +1,11 @@
-using System.Diagnostics;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
-public class ResolveTrnRequestState : IRegisterJourney
+public class ResolveTrnRequestState
 {
     public static Guid CreateNewRecordPersonIdSentinel => Guid.Empty;
-
-    public static JourneyDescriptor Journey { get; } = new(
-        JourneyNames.ResolveTrnRequest,
-        typeof(ResolveTrnRequestState),
-        ["supportTaskReference"],
-        appendUniqueKey: true);
 
     public required IReadOnlyCollection<MatchPersonsResultPerson> MatchedPersons { get; init; } = [];
     public MatchPersonsResultOutcome MatchOutcome { get; set; }
@@ -27,34 +19,4 @@ public class ResolveTrnRequestState : IRegisterJourney
     public PersonAttributeSource? NationalInsuranceNumberSource { get; set; }
     public PersonAttributeSource? GenderSource { get; set; }
     public string? Comments { get; set; }
-}
-
-public class ResolveApiTrnRequestStateFactory(TrnRequestService trnRequestService) : IJourneyStateFactory<ResolveTrnRequestState>
-{
-    public Task<ResolveTrnRequestState> CreateAsync(CreateJourneyStateContext context)
-    {
-        var supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-        return CreateAsync(supportTask);
-    }
-
-    public async Task<ResolveTrnRequestState> CreateAsync(SupportTask supportTask)
-    {
-        Debug.Assert(supportTask.SupportTaskType is SupportTaskType.TrnRequest);
-        var requestData = supportTask.TrnRequestMetadata!;
-
-        var matchResult = await trnRequestService.MatchPersonsAsync(requestData);
-
-        var state = new ResolveTrnRequestState
-        {
-            MatchOutcome = matchResult.Outcome,
-            MatchedPersons = matchResult.Outcome switch
-            {
-                MatchPersonsResultOutcome.DefiniteMatch => [new MatchPersonsResultPerson(matchResult.PersonId, matchResult.MatchedAttributes)],
-                MatchPersonsResultOutcome.PotentialMatches => matchResult.Matches.ToArray(),
-                _ => []
-            }
-        };
-
-        return state;
-    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/CheckAnswersTests.cs
@@ -13,89 +13,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TrnRequest
 
 public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_NoPersonIdSelected_RedirectsToMatches()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(
-            supportTask.SupportTaskReference,
-            new ResolveTrnRequestState
-            {
-                MatchedPersons = matchedPersonIds.Select(
-                    p => new MatchPersonsResultPerson(
-                        p,
-                        [
-                            PersonMatchedAttribute.FirstName,
-                            PersonMatchedAttribute.MiddleName,
-                            PersonMatchedAttribute.LastName,
-                            PersonMatchedAttribute.DateOfBirth,
-                            PersonMatchedAttribute.EmailAddress,
-                            PersonMatchedAttribute.Gender
-                        ]
-                    )).ToArray(),
-                PersonId = null
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
-    public async Task Get_NoAttributesSourcesSet_RedirectsToMerge()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(
-            supportTask.SupportTaskReference,
-            new ResolveTrnRequestState
-            {
-                MatchedPersons = matchedPersonIds.Select(
-                    p => new MatchPersonsResultPerson(
-                        p,
-                        [
-                            PersonMatchedAttribute.FirstName,
-                            PersonMatchedAttribute.MiddleName,
-                            PersonMatchedAttribute.LastName,
-                            PersonMatchedAttribute.DateOfBirth,
-                            PersonMatchedAttribute.EmailAddress,
-                            PersonMatchedAttribute.Gender
-                        ]
-                    )).ToArray(),
-                PersonId = matchedPersonIds[0],
-                PersonAttributeSourcesSet = false
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [MemberData(nameof(GetPersonAttributeInfosData))]
     public async Task Get_AttributeSourceIsTrnRequest_RendersChosenAttributeValues(PersonAttributeInfo sourcedFromRequestDataAttribute)
@@ -130,7 +47,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         };
         SetPersonAttributeSourceToTrnRequest(state, sourcedFromRequestDataAttribute.Attribute);
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,
@@ -185,7 +102,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -224,7 +141,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -263,7 +180,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -303,7 +220,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -345,7 +262,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var comments = Faker.Lorem.Paragraph();
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -386,7 +303,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -405,12 +322,11 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
                 PersonId = CreateNewRecordPersonIdSentinel
             });
 
+        var checkAnswersUrl = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}";
         var expectedBackLink = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}";
-        var expectedChangeLink = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?returnUrl={Uri.EscapeDataString(checkAnswersUrl)}&{journeyInstance.GetUniqueIdQueryParameter()}";
 
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, checkAnswersUrl);
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -432,7 +348,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
 
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -456,12 +372,11 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
                 GenderSource = PersonAttributeSource.TrnRequest
             });
 
+        var checkAnswersUrl = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}";
         var expectedBackLink = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}";
-        var expectedChangeLink = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?returnUrl={Uri.EscapeDataString(checkAnswersUrl)}&{journeyInstance.GetUniqueIdQueryParameter()}";
 
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, checkAnswersUrl);
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -473,89 +388,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         Assert.Equal(expectedChangeLink, doc.GetElementByTestId("ni-change-link")?.GetAttribute("href"));
         Assert.Equal(expectedChangeLink, doc.GetElementByTestId("dob-change-link")?.GetAttribute("href"));
         Assert.Equal(expectedChangeLink, doc.GetElementByTestId("gender-change-link")?.GetAttribute("href"));
-    }
-
-    [Fact]
-    public async Task Post_NoPersonIdSelected_RedirectsToMatches()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(
-            supportTask.SupportTaskReference,
-            new ResolveTrnRequestState
-            {
-                MatchedPersons = matchedPersonIds.Select(
-                    p => new MatchPersonsResultPerson(
-                        p,
-                        [
-                            PersonMatchedAttribute.FirstName,
-                            PersonMatchedAttribute.MiddleName,
-                            PersonMatchedAttribute.LastName,
-                            PersonMatchedAttribute.DateOfBirth,
-                            PersonMatchedAttribute.EmailAddress,
-                            PersonMatchedAttribute.Gender
-                        ]
-                    )).ToArray(),
-                PersonId = null
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
-    public async Task Post_NoAttributesSourcesSet_RedirectsToMerge()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(
-            supportTask.SupportTaskReference,
-            new ResolveTrnRequestState
-            {
-                MatchedPersons = matchedPersonIds.Select(
-                    p => new MatchPersonsResultPerson(
-                        p,
-                        [
-                            PersonMatchedAttribute.FirstName,
-                            PersonMatchedAttribute.MiddleName,
-                            PersonMatchedAttribute.LastName,
-                            PersonMatchedAttribute.DateOfBirth,
-                            PersonMatchedAttribute.EmailAddress,
-                            PersonMatchedAttribute.Gender
-                        ]
-                    )).ToArray(),
-                PersonId = matchedPersonIds[0],
-                PersonAttributeSourcesSet = false
-            });
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -572,7 +404,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -658,7 +490,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -741,7 +573,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -795,7 +627,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         TimeProvider.Advance(TimeSpan.FromDays(1));
 
         var comments = Faker.Lorem.Paragraph();
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -833,13 +665,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         Assert.NotEmpty(furtherChecksRequiredTasks);
     }
 
-    private Task<JourneyInstance<ResolveTrnRequestState>> CreateJourneyInstance(
-        string supportTaskReference,
-        ResolveTrnRequestState state) =>
-        CreateJourneyInstance(
-            JourneyNames.ResolveTrnRequest,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
 
     private static void SetPersonAttributeSourceToTrnRequest(ResolveTrnRequestState state, PersonMatchedAttribute attribute)
     {
@@ -872,7 +697,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
             applicationUser.UserId,
             PersonMatchedAttribute.MiddleName);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -1013,4 +838,37 @@ public class CheckAnswersTests(HostFixture hostFixture) : ResolveApiTrnRequestTe
         Func<TrnRequestMetadata, object?> GetValueFromRequestData,
         Func<TestData.CreatePersonResult, object?> GetValueFromPerson,
         Func<object?, object?>? MapValueToSummaryListRowValue = null);
+
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToListPage()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var (supportTask, matchedPerson) = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            supportTask.SupportTaskReference,
+            new ResolveTrnRequestState
+            {
+                MatchedPersons = [new MatchPersonsResultPerson(matchedPerson.PersonId, [])],
+                PersonId = matchedPerson.PersonId,
+                PersonAttributeSourcesSet = true
+            });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal("/support-tasks/trn-requests", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/IndexTests.cs
@@ -1,0 +1,39 @@
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TrnRequests.Resolve;
+
+public class IndexTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_TaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/trn-requests/TRS-000/resolve");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_StartsJourneyAndRedirectsToMatches()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var (supportTask, _, _) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);  // Initializes journey
+        response = await response.FollowRedirectAsync(HttpClient);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith(
+            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?",
+            response.Headers.Location?.OriginalString);
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MatchesTests.cs
@@ -317,7 +317,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var firstMatchId = matchedPersonIds[0];
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -359,7 +359,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         var applicationUser = await TestData.CreateApplicationUserAsync();
         var (supportTask, _, matchedPersonIds) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -949,8 +949,8 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
             $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(personId, journeyInstance.State.PersonId);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(personId, journeyState!.PersonId);
     }
 
     [Fact]
@@ -993,8 +993,8 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
             $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(personId, journeyInstance.State.PersonId);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(personId, journeyState!.PersonId);
     }
 
     [Fact]
@@ -1006,7 +1006,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var selectedPersonId = ResolveTrnRequestState.CreateNewRecordPersonIdSentinel;
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -1044,15 +1044,15 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance.State.FirstNameSource);
-        Assert.Null(journeyInstance.State.MiddleNameSource);
-        Assert.Null(journeyInstance.State.LastNameSource);
-        Assert.Null(journeyInstance.State.DateOfBirthSource);
-        Assert.Null(journeyInstance.State.EmailAddressSource);
-        Assert.Null(journeyInstance.State.NationalInsuranceNumberSource);
-        Assert.Null(journeyInstance.State.GenderSource);
-        Assert.False(journeyInstance.State.PersonAttributeSourcesSet);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Null(journeyState!.FirstNameSource);
+        Assert.Null(journeyState!.MiddleNameSource);
+        Assert.Null(journeyState!.LastNameSource);
+        Assert.Null(journeyState!.DateOfBirthSource);
+        Assert.Null(journeyState!.EmailAddressSource);
+        Assert.Null(journeyState!.NationalInsuranceNumberSource);
+        Assert.Null(journeyState!.GenderSource);
+        Assert.False(journeyState!.PersonAttributeSourcesSet);
     }
 
     [Fact]
@@ -1064,7 +1064,7 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
 
         var selectedPersonId = ResolveTrnRequestState.CreateNewRecordPersonIdSentinel;
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -1102,15 +1102,15 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.NotNull(journeyInstance.State.FirstNameSource);
-        Assert.NotNull(journeyInstance.State.MiddleNameSource);
-        Assert.NotNull(journeyInstance.State.LastNameSource);
-        Assert.NotNull(journeyInstance.State.DateOfBirthSource);
-        Assert.NotNull(journeyInstance.State.EmailAddressSource);
-        Assert.NotNull(journeyInstance.State.NationalInsuranceNumberSource);
-        Assert.NotNull(journeyInstance.State.GenderSource);
-        Assert.True(journeyInstance.State.PersonAttributeSourcesSet);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.NotNull(journeyState!.FirstNameSource);
+        Assert.NotNull(journeyState!.MiddleNameSource);
+        Assert.NotNull(journeyState!.LastNameSource);
+        Assert.NotNull(journeyState!.DateOfBirthSource);
+        Assert.NotNull(journeyState!.EmailAddressSource);
+        Assert.NotNull(journeyState!.NationalInsuranceNumberSource);
+        Assert.NotNull(journeyState!.GenderSource);
+        Assert.True(journeyState!.PersonAttributeSourcesSet);
     }
 
     private void AssertMatchRowHasExpectedHighlight(IElement matchDetails, string summaryListKey, bool expectHighlight)
@@ -1129,26 +1129,51 @@ public class MatchesTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBas
         }
     }
 
-    private async Task<JourneyInstance<ResolveTrnRequestState>> CreateJourneyInstance(
+    private async Task<ResolveTrnRequestJourneyCoordinator> CreateJourneyInstance(
         SupportTask supportTask,
         MatchPersonsResultPerson[] matchedPersons,
         bool useFactory = true)
     {
         var state = useFactory
-            ? await CreateJourneyStateWithFactory<ResolveApiTrnRequestStateFactory, ResolveTrnRequestState>(factory => factory.CreateAsync(supportTask))
+            ? await CreateStateAsync(supportTask)
             : new ResolveTrnRequestState
             {
                 MatchedPersons = matchedPersons
             };
 
-        return await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        return await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
     }
 
-    private Task<JourneyInstance<ResolveTrnRequestState>> CreateJourneyInstance(
-            string supportTaskReference,
-            ResolveTrnRequestState state) =>
-        CreateJourneyInstance(
-            JourneyNames.ResolveTrnRequest,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToListPage()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var (supportTask, matchedPerson) = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            supportTask.SupportTaskReference,
+            new ResolveTrnRequestState
+            {
+                MatchedPersons = [new MatchPersonsResultPerson(matchedPerson.PersonId, [])],
+                PersonId = matchedPerson.PersonId,
+                PersonAttributeSourcesSet = true
+            });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal("/support-tasks/trn-requests", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MergeTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/MergeTests.cs
@@ -4,64 +4,11 @@ using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
-using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve.ResolveTrnRequestState;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TrnRequests.Resolve;
 
 public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_NoPersonIdSelected_RedirectsToMatches()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, _) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(
-            supportTask,
-            personId: null);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
-    public async Task Get_CreateNewRecordSelected_RedirectsToCheckAnswers()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, _) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(
-            supportTask,
-            personId: CreateNewRecordPersonIdSentinel);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Get,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [MemberData(nameof(GetAttributesAndFieldsData))]
     public async Task Get_AttributeIsNotDifferent_RendersDisabledAndUnselectedRadioButtons(
@@ -144,7 +91,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var (supportTask, matchedPerson) = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -184,7 +131,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var (supportTask, matchedPerson) = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -223,7 +170,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
 
         var comments = "Some comments";
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -253,60 +200,6 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         // Assert
         var doc = await response.GetDocumentAsync();
         Assert.Equal(comments, doc.GetElementsByName("Comments").Single().TrimmedText());
-    }
-
-    [Fact]
-    public async Task Post_NoPersonIdSelected_RedirectsToMatches()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, _) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(supportTask, personId: null);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
-    public async Task Post_CreateNewRecordSelected_RedirectsToCheckAnswers()
-    {
-        // Arrange
-        var applicationUser = await TestData.CreateApplicationUserAsync();
-
-        var (supportTask, _, _) = await TestData.CreateTrnRequestSupportTaskAsync(applicationUser.UserId);
-
-        var journeyInstance = await CreateJourneyInstance(supportTask, personId: CreateNewRecordPersonIdSentinel);
-
-        var request = new HttpRequestMessage(
-            HttpMethod.Post,
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(
-            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
-            response.Headers.Location?.OriginalString);
     }
 
     [Theory]
@@ -378,7 +271,7 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         // Deliberately create a support task with all differences to test setting all fields (even though it would not actually be a match!)
         var (supportTask, matchedPerson) = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
 
-        var journeyInstance = await CreateJourneyInstance(
+        var journeyInstance = await CreateJourneyInstanceAsync(
             supportTask.SupportTaskReference,
             new ResolveTrnRequestState
             {
@@ -419,14 +312,14 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
             $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(firstNameSelection, journeyInstance.State.FirstNameSource);
-        Assert.Equal(middleNameSelection, journeyInstance.State.MiddleNameSource);
-        Assert.Equal(lastNameSelection, journeyInstance.State.LastNameSource);
-        Assert.Equal(dateOfBirthSelection, journeyInstance.State.DateOfBirthSource);
-        Assert.Equal(emailAddressSelection, journeyInstance.State.EmailAddressSource);
-        Assert.Equal(nationalInsuranceNumberSelection, journeyInstance.State.NationalInsuranceNumberSource);
-        Assert.Equal(genderSelection, journeyInstance.State.GenderSource);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(firstNameSelection, journeyState!.FirstNameSource);
+        Assert.Equal(middleNameSelection, journeyState!.MiddleNameSource);
+        Assert.Equal(lastNameSelection, journeyState!.LastNameSource);
+        Assert.Equal(dateOfBirthSelection, journeyState!.DateOfBirthSource);
+        Assert.Equal(emailAddressSelection, journeyState!.EmailAddressSource);
+        Assert.Equal(nationalInsuranceNumberSelection, journeyState!.NationalInsuranceNumberSource);
+        Assert.Equal(genderSelection, journeyState!.GenderSource);
     }
 
     public static (PersonMatchedAttribute Attribute, string SourceFieldName)[] GetAttributesAndFieldsData() =>
@@ -440,22 +333,46 @@ public class MergeTests(HostFixture hostFixture) : ResolveApiTrnRequestTestBase(
         (PersonMatchedAttribute.Gender, "GenderSource")
     ];
 
-    private async Task<JourneyInstance<ResolveTrnRequestState>> CreateJourneyInstance(
+    private async Task<ResolveTrnRequestJourneyCoordinator> CreateJourneyInstance(
         SupportTask supportTask,
         Guid? personId)
     {
-        var state = await CreateJourneyStateWithFactory<ResolveApiTrnRequestStateFactory, ResolveTrnRequestState>(
-            factory => factory.CreateAsync(supportTask));
+        var state = await CreateStateAsync(supportTask);
         state.PersonId = personId;
 
-        return await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        return await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
     }
 
-    private Task<JourneyInstance<ResolveTrnRequestState>> CreateJourneyInstance(
-            string supportTaskReference,
-            ResolveTrnRequestState state) =>
-        CreateJourneyInstance(
-            JourneyNames.ResolveTrnRequest,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToListPage()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+        var (supportTask, matchedPerson) = await CreateSupportTaskWithAllDifferences(applicationUser.UserId);
+
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            supportTask.SupportTaskReference,
+            new ResolveTrnRequestState
+            {
+                MatchedPersons = [new MatchPersonsResultPerson(matchedPerson.PersonId, [])],
+                PersonId = matchedPerson.PersonId,
+                PersonAttributeSourcesSet = true
+            });
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/trn-requests/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal("/support-tasks/trn-requests", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
@@ -1,9 +1,51 @@
+using GovUk.Questions.AspNetCore.State;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.TrnRequests;
+using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TrnRequests.Resolve;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TrnRequests.Resolve;
 
 public abstract class ResolveApiTrnRequestTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
+    protected async Task<ResolveTrnRequestState> CreateStateAsync(SupportTask supportTask)
+    {
+        // Resolve TrnRequestService from its own scope so that it doesn't share a DbContext with the
+        // test's other operations.
+        await using var scope = HostFixture.Services.CreateAsyncScope();
+        var trnRequestService = scope.ServiceProvider.GetRequiredService<TrnRequestService>();
+
+        return await ResolveTrnRequestJourneyCoordinator.CreateStateAsync(trnRequestService, supportTask);
+    }
+
+    protected Task<ResolveTrnRequestJourneyCoordinator> CreateJourneyInstanceAsync(
+        string supportTaskReference,
+        ResolveTrnRequestState state)
+    {
+        var basePath = $"/support-tasks/trn-requests/{supportTaskReference}/resolve";
+
+        // Seed the path the real journey would have built up by this point, so that every page is
+        // reachable and back links match production. Creating a new record skips the Merge step —
+        // there are no attribute sources to choose — so it must not appear in the path.
+        string[] pathUrls = state.PersonId == ResolveTrnRequestState.CreateNewRecordPersonIdSentinel
+            ? [$"{basePath}/matches", $"{basePath}/check-answers"]
+            : [$"{basePath}/matches", $"{basePath}/merge", $"{basePath}/check-answers"];
+
+        return JourneyHelper.CreateInstanceAsync<ResolveTrnRequestJourneyCoordinator>(
+            JourneyNames.ResolveTrnRequest,
+            new RouteValueDictionary { ["supportTaskReference"] = supportTaskReference },
+            _ => Task.FromResult<object>(state),
+            pathUrls: pathUrls,
+            // JourneyHelper activates coordinators with Activator.CreateInstance, which can't supply
+            // this one's constructor dependencies.
+            coordinatorFactory: () => ActivatorUtilities.CreateInstance<ResolveTrnRequestJourneyCoordinator>(HostFixture.Services));
+    }
+
+    protected ResolveTrnRequestState? GetJourneyInstanceState(ResolveTrnRequestJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (ResolveTrnRequestState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
     protected async Task<(SupportTask SupportTask, TestData.CreatePersonResult MatchedPerson)> CreateSupportTaskWithAllDifferences(Guid applicationUserId)
     {
         var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber());


### PR DESCRIPTION
### Context

Continues the move of SupportUi journeys off `FormFlow` and onto `GovUk.Questions.AspNetCore` (DFE issue #369), after the alert journeys (#3618, #3620–#3624, #3629, #3630) and OneLoginUserMatching. This covers `SupportTasks/TrnRequests/Resolve` — the journey support users work through to merge a TRN request into an existing record or create a new one.

Branched from `main`, independent of the OneLoginUserMatching PR.

### Changes proposed in this pull request

- **Coordinator.** Add `ResolveTrnRequestJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.ResolveTrnRequest, ["supportTaskReference"])]`) and drop `IRegisterJourney` from `ResolveTrnRequestState`. `ResolveApiTrnRequestStateFactory` becomes `GetStartingStateAsync`, which can read the support task from `CurrentSupportTaskFeature` because `CheckSupportTaskExistsFilter` runs at order -200, ahead of the library's `ValidateJourneyFilter` at -100. The logic is exposed as a static `CreateStateAsync(trnRequestService, supportTask)` so tests can build realistic state.
- **Shared base.** `ResolveTrnRequestPageModel` holds the coordinator instead of a `JourneyInstance`, and gains the `BackLink` property the three pages share.
- **Pages.** Index is `[StartsJourney]` and `AdvanceTo`s to Matches with `SetAsFirstStep`. Matches, Merge and CheckAnswers use `AdvanceTo` / `GetBackLink` / `DeleteInstance` with `_jid` URLs via the shared `GetJourneyPage` extension.
- **Cancel.** Moves from a separate `OnPostCancelAsync` handler to a `Cancel` form field posted to the same URL. The library validates the request URL against the journey path, so a `?handler=Cancel` URL is an invalid step and would bounce. This also lets the `{handler?}` segment come off all three routes.
- **Change links** use the library's `returnUrl` query param instead of `fromCheckAnswers`.
- **Guards dropped.** The state-based redirects on Merge (`PersonId is not Guid` → Matches, `PersonId == sentinel` → CheckAnswers) and CheckAnswers (`PersonId is not Guid` → Matches, `!PersonAttributeSourcesSet` → Merge) are removed. I checked each: every guarded step can only enter the path via an `AdvanceTo` that sets the state it was checking, so path validation enforces the same thing. Their 8 redirect tests go with them.

### Guidance to review

- **Route paths are preserved** for all four pages; only the `{handler?}` segment is gone, which was solely for the cancel handlers.
- **The test base seeds a path that depends on the state.** Creating a new record skips the Merge step, so seeding a fixed `[matches, merge, check-answers]` path gave CheckAnswers the wrong back link. The base now derives the path from `state.PersonId`, mirroring what the journey actually walks. This is what the two updated back/change-link assertions in `CheckAnswersTests` reflect.
- **The dropped guards are the main thing to sanity-check**, same as the OneLogin PR. If you'd rather keep any, they'd need a redirect target that's a valid step.
- Two library quirks the test base has to work around, both commented in place: `JourneyHelper` activates coordinators with `Activator.CreateInstance` so one with constructor deps needs an explicit `coordinatorFactory:`; and building starting state with `TrnRequestService` needs its own DI scope or EF complains about concurrent `DbContext` use.
- One thing worth knowing: the old per-file `CreateJourneyInstance(supportTaskReference, state)` helpers, once removed, silently bound to `TestBase.CreateJourneyInstance(journeyName, state, params keys)` — it compiles, passing the support task reference as the journey name. Caught at the next compile error rather than at runtime, but worth a look if you see a similar pattern elsewhere.

### Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive advisories on `main`).
- TrnRequests Resolve tests: **92 passed** (was 87 before, +8 guard tests removed, +5 new cancel/index tests). `just test-changed`: SupportUi.Tests **3958 passed**.
- **New coverage**: the journey had no cancel tests and no index tests at all. Added `Post_Cancel_DeletesJourneyAndRedirectsToListPage` to all three pages — cancel's mechanism changed in this PR, so it needed covering — plus `IndexTests` for the entry redirect.
- I also wrote a throwaway test driving both flows over HTTP (merge: entry → matches → merge → check-answers → change link → confirm; create-new: entry → matches → check-answers, asserting Merge is rejected as an invalid step). Both passed; I removed it. Happy to add a permanent version.
- `MergePersonTests` E2E failures under `test-changed` are the known-flaky *Persons* merge journey, untouched here — all 17 pass in isolation.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
