### PR TITLE
Migrate Resolve Teacher Pensions duplicate journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml
@@ -1,13 +1,14 @@
-@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/check-answers/{handler?}"
+@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before merging records";
-    var changeLink = LinkGenerator.SupportTasks.TeacherPensions.Resolve.Matches(Model.SupportTaskReference, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true);
+    var changeLink = LinkGenerator.SupportTasks.TeacherPensions.Resolve.Matches(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery());
     var confirmButtonLabel = "Confirm and merge records";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.Merge(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">
@@ -84,7 +85,7 @@
             </govuk-summary-list>
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="submit">@confirmButtonLabel</govuk-button>
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswersCancel(Model.SupportTaskReference, Model.JourneyInstance!.InstanceId, false)" class="govuk-button--secondary">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/CheckAnswers.cshtml.cs
@@ -7,19 +7,22 @@ using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.SupportTasks.TeacherPensions;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 using TeachingRecordSystem.SupportUi.Services;
-using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.ResolveTeacherPensionsPotentialDuplicateState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTpsPotentialDuplicate), RequireJourneyInstance]
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate)]
 public class CheckAnswersModel(
+    ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator journey,
     TrsDbContext dbContext,
     SupportUiLinkGenerator linkGenerator,
     TeacherPensionsSupportTaskService teacherPensionsSupportTaskService,
     EvidenceUploadManager evidenceController,
     TimeProvider timeProvider,
-    PersonChangeableAttributesService changedService) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
+    PersonChangeableAttributesService changedService) : ResolveTeacherPensionsPotentialDuplicatePageModel(journey, dbContext)
 {
+    [BindProperty]
+    public bool Cancel { get; set; }
+
     public string? SourceApplicationUserName { get; set; }
 
     public bool MergingRecord { get; set; }
@@ -64,19 +67,10 @@ public class CheckAnswersModel(
     {
         var supportTask = GetSupportTask();
         var requestData = supportTask.TrnRequestMetadata!;
-        var state = JourneyInstance!.State;
+        var state = Journey.State;
 
-        if (state.PersonId is not Guid personId)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TeacherPensions.Resolve.Matches(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
+        BackLink = Journey.GetBackLink();
 
-        if (personId != CreateNewRecordPersonIdSentinel && !state.PersonAttributeSourcesSet)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TeacherPensions.Resolve.Merge(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
         Debug.Assert(state.PersonId is not null);
 
         var selectedPerson = await DbContext.Persons
@@ -105,7 +99,7 @@ public class CheckAnswersModel(
 
         MergeComments = state.MergeComments;
         PotentialDuplicate = requestData.PotentialDuplicate;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        EvidenceFile = Journey.State.Evidence.UploadedEvidenceFile;
 
         ResolvableAttributes = changedService.GetResolvableAttributes(
         [
@@ -126,9 +120,17 @@ public class CheckAnswersModel(
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            await evidenceController.DeleteUploadedFileAsync(Journey.State.Evidence.UploadedEvidenceFile);
+            Journey.DeleteInstance();
+
+            return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
+        }
+
         var processContext = new ProcessContext(ProcessType.TeacherPensionsDuplicateSupportTaskResolvingWithMerge, timeProvider.UtcNow, User.GetUserId());
 
-        var existingPersonId = JourneyInstance!.State.PersonId!.Value;
+        var existingPersonId = Journey.State.PersonId!.Value;
 
         await teacherPensionsSupportTaskService.ResolveWithMergeAsync(
             new()
@@ -154,14 +156,7 @@ public class CheckAnswersModel(
                 b.AppendHtml(span);
             });
 
-        await JourneyInstance!.CompleteAsync();
-        return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        Journey.DeleteInstance();
 
         return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
     }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason.cshtml
@@ -1,4 +1,5 @@
-@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/confirm-keep-record-separate/{handler?}"
+@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/confirm-keep-record-separate"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.ConfirmKeepRecordSeparateReasonModel
 @{
     ViewBag.Title = "Check details";
@@ -18,7 +19,7 @@
                     <key>Reason</key>
                     <value>@Model.GetReason()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.KeepRecordSeparate(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)"
+                        <action href="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.KeepRecordSeparate(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery())"
                             visually-hidden-text="reason">Change</action>
                     </row-actions>
                 </row>
@@ -32,7 +33,7 @@
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.ConfirmKeepRecordSeparateReasonCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason.cshtml.cs
@@ -6,36 +6,46 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTpsPotentialDuplicate), RequireJourneyInstance]
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate)]
 public class ConfirmKeepRecordSeparateReasonModel(
+    ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator journey,
     TrsDbContext dbContext,
     TeacherPensionsSupportTaskService teacherPensionsSupportTaskService,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
-    TimeProvider timeProvider) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
+    TimeProvider timeProvider) : ResolveTeacherPensionsPotentialDuplicatePageModel(journey, dbContext)
 {
+    [BindProperty]
+    public bool Cancel { get; set; }
+
     public string? Reason { get; set; }
 
     public KeepingRecordSeparateReason? KeepSeparateReason { get; set; }
 
     public void OnGet()
     {
-        Reason = JourneyInstance!.State.Reason;
-        KeepSeparateReason = JourneyInstance!.State.KeepSeparateReason;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            await evidenceController.DeleteUploadedFileAsync(Journey.State.Evidence.UploadedEvidenceFile);
+            Journey.DeleteInstance();
+
+            return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
+        }
+
         // Conditionally override the value in Reason.
         // if KeepSeparateReason is AnotherReason - the event will contain the reason provided from the user
         // if RecordDoesNotMatch, override reason using the display name from the enum
-        if (JourneyInstance!.State.KeepSeparateReason == KeepingRecordSeparateReason.RecordDoesNotMatch)
+        if (Journey.State.KeepSeparateReason == KeepingRecordSeparateReason.RecordDoesNotMatch)
         {
-            Reason = JourneyInstance!.State.KeepSeparateReason.GetDisplayName()!;
+            Reason = Journey.State.KeepSeparateReason.GetDisplayName()!;
         }
-        else if (JourneyInstance!.State.KeepSeparateReason == KeepingRecordSeparateReason.AnotherReason)
+        else if (Journey.State.KeepSeparateReason == KeepingRecordSeparateReason.AnotherReason)
         {
-            Reason = JourneyInstance!.State.Reason;
+            Reason = Journey.State.Reason;
         }
 
         var processContext = new ProcessContext(ProcessType.TeacherPensionsDuplicateSupportTaskResolvingWithoutMerge, timeProvider.UtcNow, User.GetUserId());
@@ -52,7 +62,8 @@ public class ConfirmKeepRecordSeparateReasonModel(
             "Teachers’ Pensions duplicate task completed",
             "The records were not merged.");
 
-        await JourneyInstance!.CompleteAsync();
+        Journey.DeleteInstance();
+
         return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
     }
 
@@ -69,22 +80,11 @@ public class ConfirmKeepRecordSeparateReasonModel(
         return string.Empty;
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        BackLink = Journey.GetBackLink();
 
-        return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
-    }
-
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
-    {
-        if (JourneyInstance!.State.KeepSeparateReason is null ||
-            JourneyInstance!.State.KeepSeparateReason == KeepingRecordSeparateReason.AnotherReason && string.IsNullOrEmpty(JourneyInstance!.State.Reason))
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
-            return;
-        }
-        await base.OnPageHandlerExecutionAsync(context, next);
+        Reason = Journey.State.Reason;
+        KeepSeparateReason = Journey.State.KeepSeparateReason;
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Index.cshtml.cs
@@ -3,13 +3,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTpsPotentialDuplicate), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate), StartsJourney]
+public class IndexModel(
+    ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
-    public JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>? JourneyInstance { get; set; }
-
-    [FromRoute]
-    public required string SupportTaskReference { get; init; }
-
-    public IActionResult OnGet() => Redirect(linkGenerator.SupportTasks.TeacherPensions.Resolve.Matches(SupportTaskReference, JourneyInstance!.InstanceId));
+    public IActionResult OnGet() =>
+        journey.AdvanceTo(
+            linkGenerator.SupportTasks.TeacherPensions.Resolve.Matches(journey.InstanceId),
+            new PushStepOptions { SetAsFirstStep = true });
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparate.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparate.cshtml
@@ -1,12 +1,11 @@
-@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/keep-record-separate/{handler?}"
+@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/keep-record-separate"
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.KeepRecordSeparateModel
 @{
     ViewBag.Title = "Why are you keeping the records separate?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswers(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId) :
-        LinkGenerator.SupportTasks.TeacherPensions.Index())" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <div class="govuk-grid-row">
@@ -31,7 +30,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswers(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId, true)" class="govuk-button--secondary">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparate.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparate.cshtml.cs
@@ -4,24 +4,38 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTpsPotentialDuplicate), RequireJourneyInstance]
-public class KeepRecordSeparateModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceController) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate)]
+public class KeepRecordSeparateModel(
+    ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator journey,
+    TrsDbContext dbContext,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceController) : ResolveTeacherPensionsPotentialDuplicatePageModel(journey, dbContext)
 {
     [BindProperty]
     public string? Reason { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     [BindProperty]
     public KeepingRecordSeparateReason? KeepSeparateReason { get; set; }
 
     public void OnGet()
     {
-        KeepSeparateReason = JourneyInstance!.State.KeepSeparateReason;
+        KeepSeparateReason = Journey.State.KeepSeparateReason;
+        Reason = Journey.State.Reason;
     }
-
-    public bool? FromCheckDetails { get; set; }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            await evidenceController.DeleteUploadedFileAsync(Journey.State.Evidence.UploadedEvidenceFile);
+            Journey.DeleteInstance();
+
+            return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
+        }
+
         if (KeepSeparateReason == KeepingRecordSeparateReason.AnotherReason && string.IsNullOrEmpty(Reason))
         {
             ModelState.AddModelError($"{nameof(Reason)}.{Reason}", "Enter Reason");
@@ -32,20 +46,17 @@ public class KeepRecordSeparateModel(TrsDbContext dbContext, SupportUiLinkGenera
             return this.PageWithErrors();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.Reason = Reason;
-            state.KeepSeparateReason = KeepSeparateReason;
-        });
-
-        return Redirect(linkGenerator.SupportTasks.TeacherPensions.Resolve.ConfirmKeepRecordSeparateReason(SupportTaskReference!, JourneyInstance!.InstanceId));
+        return Journey.AdvanceTo(
+            linkGenerator.SupportTasks.TeacherPensions.Resolve.ConfirmKeepRecordSeparateReason(Journey.InstanceId),
+            state =>
+            {
+                state.Reason = Reason;
+                state.KeepSeparateReason = KeepSeparateReason;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    public override void OnPageHandlerExecuting(Microsoft.AspNetCore.Mvc.Filters.PageHandlerExecutingContext context)
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
-
-        return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
+        BackLink = Journey.GetBackLink() ?? linkGenerator.SupportTasks.TeacherPensions.Index();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/matches/{handler?}"
+@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/matches"
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 @model MatchesModel
 @{
@@ -7,7 +7,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswers(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId) : LinkGenerator.SupportTasks.TeacherPensions.Index())"/>
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <form method="post">
@@ -159,7 +159,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.MatchesCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Matches.cshtml.cs
@@ -6,9 +6,16 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTpsPotentialDuplicate), RequireJourneyInstance]
-public class MatchesModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceController) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate)]
+public class MatchesModel(
+    ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator journey,
+    TrsDbContext dbContext,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceController) : ResolveTeacherPensionsPotentialDuplicatePageModel(journey, dbContext)
 {
+    [BindProperty]
+    public bool Cancel { get; set; }
+
     private readonly InlineValidator<MatchesModel> _validator = new()
     {
         v => v.RuleFor(m => m.PersonId)
@@ -34,13 +41,18 @@ public class MatchesModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGen
 
     public void OnGet()
     {
-        PersonId = JourneyInstance!.State.PersonId;
+        PersonId = Journey.State.PersonId;
         OneLoginEmails = DbContext.OneLoginUsers.Where(x => x.PersonId == SupportTask!.PersonId).Select(x => x.EmailAddress!)
             .ToArray();
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         // Verify the submitted ID is legit
         if (PersonId is Guid personId && PersonId != Guid.Empty &&
             (!PotentialDuplicates!.Any(d => d.PersonId == personId)))
@@ -50,7 +62,11 @@ public class MatchesModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGen
 
         _validator.ValidateAndThrow(this);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
+        var nextStepUrl = PersonId == ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel ?
+            linkGenerator.SupportTasks.TeacherPensions.Resolve.KeepRecordSeparate(Journey.InstanceId) :
+            linkGenerator.SupportTasks.TeacherPensions.Resolve.Merge(Journey.InstanceId);
+
+        return Journey.AdvanceTo(nextStepUrl, state =>
         {
             var oldPersonId = state.PersonId;
             state.PersonId = PersonId;
@@ -67,17 +83,12 @@ public class MatchesModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGen
                 state.TeachersPensionPersonId = SupportTask!.PersonId!;
             }
         });
-
-        return Redirect(
-            PersonId == Guid.Empty ?
-                linkGenerator.SupportTasks.TeacherPensions.Resolve.KeepRecordSeparate(SupportTaskReference!, JourneyInstance!.InstanceId) :
-                linkGenerator.SupportTasks.TeacherPensions.Resolve.Merge(SupportTaskReference!, JourneyInstance!.InstanceId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(Journey.State.Evidence.UploadedEvidenceFile);
+        Journey.DeleteInstance();
 
         return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
     }
@@ -87,16 +98,18 @@ public class MatchesModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGen
         SupportTask = GetSupportTask();
         RequestData = SupportTask!.TrnRequestMetadata!;
 
+        BackLink = Journey.GetBackLink() ?? linkGenerator.SupportTasks.TeacherPensions.Index();
+
         var person = await DbContext.Persons.Include(x => x.OneLoginUsers).SingleOrDefaultAsync(x => x.PersonId == SupportTask!.PersonId);
         if (person != null)
         {
             Trn = person.Trn;
         }
 
-        var matchedAttributesLookup = JourneyInstance!.State.MatchedPersons.ToDictionary(
+        var matchedAttributesLookup = Journey.State.MatchedPersons.ToDictionary(
                 mp => mp.PersonId,
                 mp => mp.MatchedAttributes);
-        var matchedPersonIds = JourneyInstance!.State.MatchedPersons.Select(p => p.PersonId).ToArray();
+        var matchedPersonIds = Journey.State.MatchedPersons.Select(p => p.PersonId).ToArray();
 
         PotentialDuplicates = (await DbContext.Persons.Include(x => x.OneLoginUsers)
             .Where(p => matchedPersonIds.Contains(p.PersonId))

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml
@@ -1,4 +1,4 @@
-@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/merge/{handler?}"
+@page "/support-tasks/teacher-pensions/{supportTaskReference}/resolve/merge"
 @using TeachingRecordSystem.SupportUi.Pages.Shared
 @using TeachingRecordSystem.Core.Models.SupportTasks
 @using TeachingRecordSystem.SupportUi.Services
@@ -9,7 +9,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers? LinkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswers(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId) : LinkGenerator.SupportTasks.TeacherPensions.Resolve.Matches(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId))" />
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 @functions {
@@ -131,7 +131,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button type="submit" formaction="@LinkGenerator.SupportTasks.TeacherPensions.Resolve.MergeCancel(Model.SupportTaskReference!, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" data-testid="cancel-button">Cancel</govuk-button>
+                <govuk-button type="submit" name="Cancel" value="true" class="govuk-button--secondary" data-testid="cancel-button">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/Merge.cshtml.cs
@@ -3,17 +3,23 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
-using static TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve.ResolveTeacherPensionsPotentialDuplicateState;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ResolveTpsPotentialDuplicate), RequireJourneyInstance]
-public class MergeModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : ResolveTeacherPensionsPotentialDuplicatePageModel(dbContext)
+[Journey(JourneyNames.ResolveTpsPotentialDuplicate)]
+public class MergeModel(
+    ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator journey,
+    TrsDbContext dbContext,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : ResolveTeacherPensionsPotentialDuplicatePageModel(journey, dbContext)
 {
     private readonly InlineValidator<MergeModel> _validator = new()
     {
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
@@ -60,22 +66,14 @@ public class MergeModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
     {
         var supportTask = GetSupportTask();
         var requestData = supportTask.TrnRequestMetadata!;
-        var state = JourneyInstance!.State;
+        var state = Journey.State;
         var person = DbContext!.Persons.Single(x => x.PersonId == supportTask.PersonId);
+        var personId = state.PersonId!.Value;
 
-        if (state.PersonId is not Guid personId)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TeacherPensions.Resolve.Matches(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
+        BackLink = Journey.GetBackLink();
 
-        if (state.PersonId == CreateNewRecordPersonIdSentinel)
-        {
-            context.Result = Redirect(linkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswers(SupportTaskReference!, JourneyInstance!.InstanceId));
-            return;
-        }
         var personAttributes = await GetPersonAttributesAsync(personId);
-        var attributeMatches = JourneyInstance!.State.MatchedPersons
+        var attributeMatches = state.MatchedPersons
             .Single(m => m.PersonId == personId)
             .MatchedAttributes;
 
@@ -122,18 +120,23 @@ public class MergeModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
 
     public void OnGet()
     {
-        DateOfBirthSource = JourneyInstance!.State.DateOfBirthSource;
-        NationalInsuranceNumberSource = JourneyInstance!.State.NationalInsuranceNumberSource;
-        GenderSource = JourneyInstance!.State.GenderSource;
-        MergeComments = JourneyInstance!.State.MergeComments;
-        FirstNameSource = JourneyInstance!.State.FirstNameSource;
-        LastNameSource = JourneyInstance!.State.LastNameSource;
-        TRNSource = JourneyInstance!.State.TRNSource;
-        Evidence = JourneyInstance!.State.Evidence;
+        DateOfBirthSource = Journey.State.DateOfBirthSource;
+        NationalInsuranceNumberSource = Journey.State.NationalInsuranceNumberSource;
+        GenderSource = Journey.State.GenderSource;
+        MergeComments = Journey.State.MergeComments;
+        FirstNameSource = Journey.State.FirstNameSource;
+        LastNameSource = Journey.State.LastNameSource;
+        TRNSource = Journey.State.TRNSource;
+        Evidence = Journey.State.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         await evidenceUploadManager.ValidateAndUploadAsync<MergeModel>(m => m.Evidence, ViewData);
 
         if (DateOfBirth!.Different && DateOfBirthSource is null)
@@ -168,25 +171,26 @@ public class MergeModel(TrsDbContext dbContext, SupportUiLinkGenerator linkGener
             return this.PageWithErrors();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.DateOfBirthSource = DateOfBirthSource;
-            state.NationalInsuranceNumberSource = NationalInsuranceNumberSource;
-            state.GenderSource = GenderSource;
-            state.PersonAttributeSourcesSet = true;
-            state.MergeComments = MergeComments;
-            state.FirstNameSource = FirstNameSource;
-            state.LastNameSource = LastNameSource;
-            state.Evidence = Evidence;
-        });
-
-        return Redirect(linkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswers(SupportTaskReference!, JourneyInstance!.InstanceId));
+        return Journey.AdvanceTo(
+            linkGenerator.SupportTasks.TeacherPensions.Resolve.CheckAnswers(Journey.InstanceId),
+            state =>
+            {
+                state.DateOfBirthSource = DateOfBirthSource;
+                state.NationalInsuranceNumberSource = NationalInsuranceNumberSource;
+                state.GenderSource = GenderSource;
+                state.PersonAttributeSourcesSet = true;
+                state.MergeComments = MergeComments;
+                state.FirstNameSource = FirstNameSource;
+                state.LastNameSource = LastNameSource;
+                state.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(Journey.State.Evidence.UploadedEvidenceFile);
+        Journey.DeleteInstance();
+
         return Redirect(linkGenerator.SupportTasks.TeacherPensions.Index());
     }
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.TrnRequests;
+
+namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
+
+[JourneyCoordinator(JourneyNames.ResolveTpsPotentialDuplicate, routeValueKeys: ["supportTaskReference"])]
+public class ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator(TrnRequestService trnRequestService) :
+    JourneyCoordinator<ResolveTeacherPensionsPotentialDuplicateState>
+{
+    public override Task<ResolveTeacherPensionsPotentialDuplicateState> GetStartingStateAsync()
+    {
+        var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
+        return CreateStateAsync(trnRequestService, supportTask);
+    }
+
+    public static async Task<ResolveTeacherPensionsPotentialDuplicateState> CreateStateAsync(
+        TrnRequestService trnRequestService,
+        SupportTask supportTask)
+    {
+        Debug.Assert(supportTask.SupportTaskType is SupportTaskType.TeacherPensionsPotentialDuplicate);
+        var requestData = supportTask.TrnRequestMetadata!;
+
+        var matchResult = await trnRequestService.MatchPersonsAsync(requestData, excludePersonIds: supportTask.PersonId!.Value);
+
+        return new ResolveTeacherPensionsPotentialDuplicateState
+        {
+            MatchedPersons = matchResult.Outcome switch
+            {
+                MatchPersonsResultOutcome.DefiniteMatch => [new MatchPersonsResultPerson(matchResult.PersonId, matchResult.MatchedAttributes)],
+                MatchPersonsResultOutcome.PotentialMatches => matchResult.Matches.ToArray(),
+                _ => []
+            }
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateLinkGenerator.cs
@@ -5,33 +5,18 @@ public class ResolveTeacherPensionsPotentialDuplicateLinkGenerator(LinkGenerator
     public string Index(string supportTaskReference) =>
         linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/Index", routeValues: new { supportTaskReference });
 
-    public string Matches(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/Matches", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Matches(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TeacherPensions/Resolve/Matches", journeyInstanceId, returnUrl);
 
-    public string MatchesCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/Matches", handler: "Cancel", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+    public string Merge(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TeacherPensions/Resolve/Merge", journeyInstanceId, returnUrl);
 
-    public string Merge(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/Merge", routeValues: new { supportTaskReference, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string KeepRecordSeparate(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparate", journeyInstanceId, returnUrl);
 
-    public string MergeCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/Merge", handler: "Cancel", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
+    public string ConfirmKeepRecordSeparateReason(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason", journeyInstanceId);
 
-    public string KeepRecordSeparate(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparate", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
-
-    public string KeepRecordSeparateCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparate", handler: "Cancel", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
-
-    public string ConfirmKeepRecordSeparateReason(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
-
-    public string ConfirmKeepRecordSeparateReasonCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReason", handler: "Cancel", routeValues: new { supportTaskReference }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool keepRecordSeparate = false) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/CheckAnswers", routeValues: new { supportTaskReference, keepRecordSeparate }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(string supportTaskReference, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool keepRecordSeparate = false) =>
-        linkGenerator.GetRequiredPathByPage("/SupportTasks/TeacherPensions/Resolve/CheckAnswers", handler: "Cancel", routeValues: new { supportTaskReference, keepRecordSeparate }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/SupportTasks/TeacherPensions/Resolve/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicatePageModel.cs
@@ -6,15 +6,18 @@ using TeachingRecordSystem.Core.Models.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(TrsDbContext dbContext) : PageModel
+public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(
+    ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator journey,
+    TrsDbContext dbContext) : PageModel
 {
     [FromRoute]
     public required string SupportTaskReference { get; init; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    public string? BackLink { get; set; }
 
-    public JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    protected ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator Journey => journey;
 
     protected TrsDbContext DbContext => dbContext!;
 
@@ -28,7 +31,7 @@ public abstract class ResolveTeacherPensionsPotentialDuplicatePageModel(TrsDbCon
     /// middle name is kept.
     protected PersonAttributeSources GetPersonAttributeSources()
     {
-        var state = JourneyInstance!.State;
+        var state = journey.State;
 
         if (!state.PersonAttributeSourcesSet)
         {

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateState.cs
@@ -1,20 +1,15 @@
-using System.Diagnostics;
-using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Models.SupportTasks;
 using TeachingRecordSystem.Core.Services.TrnRequests;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
-public class ResolveTeacherPensionsPotentialDuplicateState : IRegisterJourney
+public class ResolveTeacherPensionsPotentialDuplicateState
 {
-    public static Guid CreateNewRecordPersonIdSentinel => Guid.Empty;
-
-    public static JourneyDescriptor Journey { get; } = new(
-        JourneyNames.ResolveTpsPotentialDuplicate,
-        typeof(ResolveTeacherPensionsPotentialDuplicateState),
-        ["supportTaskReference"],
-        appendUniqueKey: true);
+    /// <summary>
+    /// The value the Matches page submits for "keep the records separate" rather than picking a record.
+    /// </summary>
+    public static Guid KeepRecordSeparatePersonIdSentinel => Guid.Empty;
 
     public required IReadOnlyCollection<MatchPersonsResultPerson> MatchedPersons { get; init; }
     public Guid? PersonId { get; set; }
@@ -31,33 +26,4 @@ public class ResolveTeacherPensionsPotentialDuplicateState : IRegisterJourney
     public KeepingRecordSeparateReason? KeepSeparateReason { get; set; }
     public Guid? TeachersPensionPersonId { get; set; }
     public EvidenceUploadModel Evidence { get; set; } = new();
-}
-
-public class ResolveTeacherPensionsPotentialDuplicateStateFactory(TrnRequestService trnRequestService) : IJourneyStateFactory<ResolveTeacherPensionsPotentialDuplicateState>
-{
-    public Task<ResolveTeacherPensionsPotentialDuplicateState> CreateAsync(CreateJourneyStateContext context)
-    {
-        var supportTask = context.HttpContext.GetCurrentSupportTaskFeature().SupportTask;
-        return CreateAsync(supportTask);
-    }
-
-    public async Task<ResolveTeacherPensionsPotentialDuplicateState> CreateAsync(SupportTask supportTask)
-    {
-        Debug.Assert(supportTask.SupportTaskType is SupportTaskType.TeacherPensionsPotentialDuplicate);
-        var requestData = supportTask.TrnRequestMetadata!;
-
-        var matchResult = await trnRequestService.MatchPersonsAsync(requestData, excludePersonIds: supportTask.PersonId!.Value);
-
-        var state = new ResolveTeacherPensionsPotentialDuplicateState
-        {
-            MatchedPersons = matchResult.Outcome switch
-            {
-                MatchPersonsResultOutcome.DefiniteMatch => [new MatchPersonsResultPerson(matchResult.PersonId, matchResult.MatchedAttributes)],
-                MatchPersonsResultOutcome.PotentialMatches => matchResult.Matches.ToArray(),
-                _ => []
-            }
-        };
-
-        return state;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/SupportUiLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/SupportUiLinkGenerator.cs
@@ -35,7 +35,7 @@ public class SupportUiLinkGenerator(LinkGenerator linkGenerator)
             SupportTaskType.TrnRequestManualChecksNeeded => SupportTasks.TrnRequestManualChecksNeeded.Resolve.Index(supportTaskReference),
             SupportTaskType.ChangeDateOfBirthRequest => SupportTasks.ChangeRequests.EditChangeRequest.Index(supportTaskReference),
             SupportTaskType.ChangeNameRequest => SupportTasks.ChangeRequests.EditChangeRequest.Index(supportTaskReference),
-            SupportTaskType.TeacherPensionsPotentialDuplicate => SupportTasks.TeacherPensions.Resolve.Matches(supportTaskReference),
+            SupportTaskType.TeacherPensionsPotentialDuplicate => SupportTasks.TeacherPensions.Resolve.Index(supportTaskReference),
             SupportTaskType.OneLoginUserIdVerification => SupportTasks.OneLoginUserMatching.Resolve.Index(supportTaskReference),
             _ => throw new ArgumentException($"Unknown {nameof(SupportTaskType)}: '{supportTaskType}'.", nameof(supportTaskType))
         };

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/CheckAnswersTests.cs
@@ -8,7 +8,7 @@ using SupportTaskUpdatedEvent = TeachingRecordSystem.Core.Events.SupportTaskUpda
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
 
-public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswers(HostFixture hostFixture) : ResolveTeacherPensionsPotentialDuplicateTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_PotentialDuplicateTaskDoesNotExist_ReturnsNotFound()
@@ -19,7 +19,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
         {
             MatchedPersons = []
         };
-        var journeyInstance = await CreateJourneyInstance(taskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(taskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{taskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -82,8 +82,8 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             MergeComments = mergeComments
         };
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -153,8 +153,11 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             PersonAttributeSourcesSet = true
         };
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -162,8 +165,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/support-tasks/teacher-pensions", response.Headers.Location?.OriginalString);
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -217,7 +219,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             MergeComments = mergeComments
         };
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         EventObserver.Clear();
         var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -256,8 +258,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -313,7 +314,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             MergeComments = mergeComments
         };
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         EventObserver.Clear();
         var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -355,8 +356,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(TimeProvider.UtcNow, updatedSupportTask.UpdatedOn);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -405,7 +405,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             MergeComments = mergeComments
         };
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         EventObserver.Clear();
         var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -468,8 +468,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.NotNull(viewRecordLink);
         Assert.Contains(duplicatePerson1.PersonId.ToString(), viewRecordLink.GetAttribute("href"));
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     // This journey's merge page offers no middle name choice, so MiddleNameSource is always unset. An unset
@@ -518,7 +517,7 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
             Evidence = new() { UploadEvidence = false }
         };
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         var request = new HttpRequestMessage(
             HttpMethod.Post,
             $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -545,11 +544,4 @@ public class CheckAnswers(HostFixture hostFixture) : TestBase(hostFixture)
         });
     }
 
-    private Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(
-        string supportTaskReference,
-        ResolveTeacherPensionsPotentialDuplicateState state) =>
-        CreateJourneyInstance(
-            JourneyNames.ResolveTpsPotentialDuplicate,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ConfirmKeepRecordSeparateReasonTests.cs
@@ -7,15 +7,15 @@ using SupportTaskUpdatedEvent = TeachingRecordSystem.Core.Events.SupportTaskUpda
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
 
-public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : ResolveTeacherPensionsPotentialDuplicateTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_PotentialDuplicateTaskDoesNotExist_ReturnsNotFound()
     {
         // Arrange
         var taskReference = "1234567";
-        var state = new ResolveTeacherPensionsPotentialDuplicateState { MatchedPersons = [] };
-        var journeyInstance = await CreateJourneyInstance(taskReference, state);
+        var state = new ResolveTeacherPensionsPotentialDuplicateState { MatchedPersons = [], PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel };
+        var journeyInstance = await CreateJourneyInstanceAsync(taskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{taskReference}/resolve/keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -55,10 +55,11 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
         var state = new ResolveTeacherPensionsPotentialDuplicateState
         {
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel,
             Reason = "THIS IS A DIFFERENT RECORD",
             KeepSeparateReason = KeepingRecordSeparateReason.AnotherReason
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/confirm-keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -99,10 +100,11 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
         var state = new ResolveTeacherPensionsPotentialDuplicateState
         {
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel,
             KeepSeparateReason = KeepingRecordSeparateReason.RecordDoesNotMatch,
             Reason = null
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/confirm-keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -143,9 +145,10 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
         var state = new ResolveTeacherPensionsPotentialDuplicateState
         {
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel,
             KeepSeparateReason = KeepingRecordSeparateReason.RecordDoesNotMatch
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         EventObserver.Clear();
 
         // Act
@@ -194,8 +197,7 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
             "Teachers’ Pensions duplicate task completed",
             $"The records were not merged.");
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -229,10 +231,11 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
         var state = new ResolveTeacherPensionsPotentialDuplicateState
         {
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel,
             KeepSeparateReason = KeepingRecordSeparateReason.AnotherReason,
             Reason = keepReason
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         EventObserver.Clear();
 
         // Act
@@ -281,16 +284,8 @@ public class ConfirmKeepRecordSeparateReasonTests(HostFixture hostFixture) : Tes
             "Teachers’ Pensions duplicate task completed",
             $"The records were not merged.");
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
-    private Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(
-        string supportTaskReference,
-        ResolveTeacherPensionsPotentialDuplicateState state) =>
-            CreateJourneyInstance(
-                JourneyNames.ResolveTpsPotentialDuplicate,
-                state,
-                new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
 
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/IndexTests.cs
@@ -1,0 +1,87 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
+
+public class IndexTests(HostFixture hostFixture) : ResolveTeacherPensionsPotentialDuplicateTestBase(hostFixture)
+{
+    [Fact]
+    public async Task Get_PotentialDuplicateTaskDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/teacher-pensions/TRS-000/resolve");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_StartsJourneyAndRedirectsToMatches()
+    {
+        // Arrange
+        var supportTask = await CreateSupportTaskAsync();
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);  // Initializes journey
+        response = await response.FollowRedirectAsync(HttpClient);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith(
+            $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/matches?",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ViaSupportTaskResolveLink_StartsJourney()
+    {
+        // The "View task" link on the support task pages used to point straight at the Matches page,
+        // which has no journey instance to work with.
+        // Arrange
+        var supportTask = await CreateSupportTaskAsync();
+
+        var linkGenerator = HostFixture.Services.GetRequiredService<SupportUiLinkGenerator>();
+        var resolveLink = linkGenerator.SupportTaskResolve(
+            supportTask.SupportTaskReference,
+            SupportTaskType.TeacherPensionsPotentialDuplicate);
+
+        // Act
+        var response = await HttpClient.GetAsync(resolveLink);
+        response = await response.FollowRedirectAsync(HttpClient);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith(
+            $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/matches?",
+            response.Headers.Location?.OriginalString);
+    }
+
+    private async Task<SupportTask> CreateSupportTaskAsync()
+    {
+        var person = await TestData.CreatePersonAsync(x => x.WithNationalInsuranceNumber());
+        var duplicatePerson = await TestData.CreatePersonAsync(x => x
+            .WithFirstName(person.FirstName)
+            .WithLastName(person.LastName)
+            .WithNationalInsuranceNumber(person.NationalInsuranceNumber!));
+        var user = await TestData.CreateUserAsync();
+
+        return await TestData.CreateTeacherPensionsPotentialDuplicateTaskAsync(
+            person.PersonId,
+            user.UserId,
+            s =>
+            {
+                s.WithMatchedPersons(duplicatePerson.PersonId);
+                s.WithFirstName(person.FirstName);
+                s.WithLastName(person.LastName);
+                s.WithNationalInsuranceNumber(person.NationalInsuranceNumber);
+                s.WithDateOfBirth(person.DateOfBirth);
+                s.WithStatus(SupportTaskStatus.Open);
+            });
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparateTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/KeepRecordSeparateTests.cs
@@ -4,16 +4,16 @@ using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
 
-public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class KeepRecordSeparateTests(HostFixture hostFixture) : ResolveTeacherPensionsPotentialDuplicateTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_PotentialDuplicateTaskDoesNotExist_ReturnsNotFound()
     {
         // Arrange
         var taskReference = "1234567";
-        var state = new ResolveTeacherPensionsPotentialDuplicateState { MatchedPersons = [] };
-        var journeyInstance = await CreateJourneyInstance(taskReference, state);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{taskReference}/keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var state = new ResolveTeacherPensionsPotentialDuplicateState { MatchedPersons = [], PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel };
+        var journeyInstance = await CreateJourneyInstanceAsync(taskReference, state);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{taskReference}/resolve/keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -53,9 +53,10 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
 
         var state = new ResolveTeacherPensionsPotentialDuplicateState
         {
-            MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])]
+            MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
 
         // Act
         var request = new HttpRequestMessage(
@@ -71,9 +72,9 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(reason, journeyInstance.State.KeepSeparateReason);
-        Assert.Equal(additionalComments, journeyInstance.State.Reason);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(reason, journeyState!.KeepSeparateReason);
+        Assert.Equal(additionalComments, journeyState!.Reason);
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/confirm-keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
@@ -107,9 +108,10 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
 
         var state = new ResolveTeacherPensionsPotentialDuplicateState
         {
-            MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])]
+            MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
 
         // Act
         var request = new HttpRequestMessage(
@@ -125,9 +127,9 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance.State.KeepSeparateReason);
-        Assert.Null(journeyInstance.State.Reason);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Null(journeyState!.KeepSeparateReason);
+        Assert.Null(journeyState!.Reason);
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
         await AssertEx.HtmlResponseHasErrorAsync(response, "Reason", "Enter Reason");
     }
@@ -161,28 +163,35 @@ public class KeepRecordSeparateTests(HostFixture hostFixture) : TestBase(hostFix
 
         var state = new ResolveTeacherPensionsPotentialDuplicateState
         {
-            MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])]
+            MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
+            PersonId = ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/keep-record-separate/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
+        var pageUrl = $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}";
+
+        // Submit the Cancel button exactly as the rendered page defines it, rather than a URL of our
+        // own choosing — this button used to post to the check answers page, which threw.
+        var doc = await AssertEx.HtmlResponseAsync(await HttpClient.GetAsync(pageUrl));
+        var cancelButton = doc.GetElementsByTagName("button").Single(b => b.TextContent.Trim() == "Cancel");
+        Assert.Null(cancelButton.GetAttribute("formaction"));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, pageUrl)
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { cancelButton.GetAttribute("name")!, cancelButton.GetAttribute("value")! }
+            }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/support-tasks/teacher-pensions", response.Headers.Location?.OriginalString);
+        Assert.Equal("/support-tasks/teacher-pensions", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
-    private Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(
-        string supportTaskReference,
-        ResolveTeacherPensionsPotentialDuplicateState state) =>
-        CreateJourneyInstance(
-            JourneyNames.ResolveTpsPotentialDuplicate,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
 
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MatchesTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MatchesTests.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
 
-public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class MatchesTests(HostFixture hostFixture) : ResolveTeacherPensionsPotentialDuplicateTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_PotentialDuplicateTaskDoesNotExist_ReturnsNotFound()
@@ -539,8 +539,8 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
             $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(duplicatePerson1.PersonId, journeyInstance.State.PersonId);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(duplicatePerson1.PersonId, journeyState!.PersonId);
     }
 
     [Fact]
@@ -593,8 +593,8 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
             $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/keep-record-separate?{journeyInstance.GetUniqueIdQueryParameter()}",
             response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(Guid.Empty, journeyInstance.State.PersonId);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(Guid.Empty, journeyState!.PersonId);
     }
 
     private void AssertMatchRowHasExpectedHighlight(IElement matchDetails, string summaryListKey, bool expectHighlight)
@@ -613,26 +613,19 @@ public class MatchesTests(HostFixture hostFixture) : TestBase(hostFixture)
         }
     }
 
-    private async Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(
+    private async Task<ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator> CreateJourneyInstance(
         SupportTask supportTask,
         MatchPersonsResultPerson[] matchedPersons,
         bool useFactory = true)
     {
         var state = useFactory
-            ? await CreateJourneyStateWithFactory<ResolveTeacherPensionsPotentialDuplicateStateFactory, ResolveTeacherPensionsPotentialDuplicateState>(factory => factory.CreateAsync(supportTask))
+            ? await CreateStateAsync(supportTask)
             : new ResolveTeacherPensionsPotentialDuplicateState
             {
                 MatchedPersons = matchedPersons
             };
 
-        return await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        return await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
     }
 
-    private Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(
-            string supportTaskReference,
-            ResolveTeacherPensionsPotentialDuplicateState state) =>
-        CreateJourneyInstance(
-            JourneyNames.ResolveTpsPotentialDuplicate,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MergeTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/MergeTests.cs
@@ -7,7 +7,7 @@ using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
 
-public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class MergeTests(HostFixture hostFixture) : ResolveTeacherPensionsPotentialDuplicateTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_PotentialDuplicateTaskDoesNotExist_ReturnsNotFound()
@@ -34,7 +34,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
                 s.WithStatus(SupportTaskStatus.Open);
             });
         var journeyInstance = await CreateJourneyInstance(supportTask, null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{taskReference}/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{taskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -75,7 +75,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
             PersonId = duplicatePerson1.PersonId
         };
 
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -169,8 +169,11 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
             PersonId = duplicatePerson1.PersonId
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge/cancel?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -179,8 +182,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/support-tasks/teacher-pensions", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -214,7 +216,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
             PersonId = duplicatePerson1.PersonId
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new MultipartFormDataContentBuilder
@@ -262,7 +264,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
             PersonId = duplicatePerson1.PersonId
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -309,7 +311,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
             PersonId = duplicatePerson1.PersonId
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = new FormUrlEncodedContentBuilder
@@ -331,14 +333,14 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyInstance.State.FirstNameSource);
-        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyInstance.State.LastNameSource);
-        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyInstance.State.DateOfBirthSource);
-        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyInstance.State.NationalInsuranceNumberSource);
-        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyInstance.State.GenderSource);
-        Assert.Equal(mergeComments, journeyInstance.State.MergeComments);
-        Assert.Equal(false, journeyInstance.State.Evidence.UploadEvidence);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyState!.FirstNameSource);
+        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyState!.LastNameSource);
+        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyState!.DateOfBirthSource);
+        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyState!.NationalInsuranceNumberSource);
+        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyState!.GenderSource);
+        Assert.Equal(mergeComments, journeyState!.MergeComments);
+        Assert.Equal(false, journeyState!.Evidence.UploadEvidence);
     }
 
     [Fact]
@@ -374,7 +376,7 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
             MatchedPersons = [new MatchPersonsResultPerson(duplicatePerson1.PersonId, [])],
             PersonId = duplicatePerson1.PersonId
         };
-        var journeyInstance = await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        var journeyInstance = await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/merge?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
             Content = CreatePostContent(
@@ -396,15 +398,15 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/support-tasks/teacher-pensions/{supportTask.SupportTaskReference}/resolve/check-answers", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(PersonAttributeSource.TrnRequest, journeyInstance.State.FirstNameSource);
-        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyInstance.State.LastNameSource);
-        Assert.Equal(PersonAttributeSource.TrnRequest, journeyInstance.State.DateOfBirthSource);
-        Assert.Equal(PersonAttributeSource.TrnRequest, journeyInstance.State.NationalInsuranceNumberSource);
-        Assert.Equal(PersonAttributeSource.TrnRequest, journeyInstance.State.GenderSource);
-        Assert.Equal(mergeComments, journeyInstance.State.MergeComments);
-        Assert.Equal(true, journeyInstance.State.Evidence.UploadEvidence);
-        Assert.Equal(evidenceFile, journeyInstance.State.Evidence.UploadedEvidenceFile!.FileName);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(PersonAttributeSource.TrnRequest, journeyState!.FirstNameSource);
+        Assert.Equal(PersonAttributeSource.ExistingRecord, journeyState!.LastNameSource);
+        Assert.Equal(PersonAttributeSource.TrnRequest, journeyState!.DateOfBirthSource);
+        Assert.Equal(PersonAttributeSource.TrnRequest, journeyState!.NationalInsuranceNumberSource);
+        Assert.Equal(PersonAttributeSource.TrnRequest, journeyState!.GenderSource);
+        Assert.Equal(mergeComments, journeyState!.MergeComments);
+        Assert.Equal(true, journeyState!.Evidence.UploadEvidence);
+        Assert.Equal(evidenceFile, journeyState!.Evidence.UploadedEvidenceFile!.FileName);
     }
 
     private static MultipartFormDataContentBuilder CreatePostContent(
@@ -430,21 +432,13 @@ public class MergeTests(HostFixture hostFixture) : TestBase(hostFixture)
         };
     }
 
-    private async Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(SupportTask supportTask, Guid? personId)
+    private async Task<ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator> CreateJourneyInstance(SupportTask supportTask, Guid? personId)
     {
-        var state = await CreateJourneyStateWithFactory<ResolveTeacherPensionsPotentialDuplicateStateFactory, ResolveTeacherPensionsPotentialDuplicateState>(
-            factory => factory.CreateAsync(supportTask));
+        var state = await CreateStateAsync(supportTask);
         state.PersonId = personId;
 
-        return await CreateJourneyInstance(supportTask.SupportTaskReference, state);
+        return await CreateJourneyInstanceAsync(supportTask.SupportTaskReference, state);
     }
 
-    private Task<JourneyInstance<ResolveTeacherPensionsPotentialDuplicateState>> CreateJourneyInstance(
-            string supportTaskReference,
-            ResolveTeacherPensionsPotentialDuplicateState state) =>
-        CreateJourneyInstance(
-            JourneyNames.ResolveTpsPotentialDuplicate,
-            state,
-            new KeyValuePair<string, object>("supportTaskReference", supportTaskReference));
 
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateTestBase.cs
@@ -1,0 +1,49 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.Core.Services.TrnRequests;
+using TeachingRecordSystem.SupportUi.Pages.SupportTasks.TeacherPensions.Resolve;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.TeacherPensions.Resolve;
+
+public abstract class ResolveTeacherPensionsPotentialDuplicateTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected async Task<ResolveTeacherPensionsPotentialDuplicateState> CreateStateAsync(SupportTask supportTask)
+    {
+        // Resolve TrnRequestService from its own scope so that it doesn't share a DbContext with the
+        // test's other operations.
+        await using var scope = HostFixture.Services.CreateAsyncScope();
+        var trnRequestService = scope.ServiceProvider.GetRequiredService<TrnRequestService>();
+
+        return await ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator.CreateStateAsync(trnRequestService, supportTask);
+    }
+
+    protected Task<ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator> CreateJourneyInstanceAsync(
+        string supportTaskReference,
+        ResolveTeacherPensionsPotentialDuplicateState state)
+    {
+        var basePath = $"/support-tasks/teacher-pensions/{supportTaskReference}/resolve";
+
+        // Seed the path the real journey would have built up by this point, so that every page is
+        // reachable and back links match production. The journey forks at Matches: keeping the records
+        // separate never visits Merge or CheckAnswers, and merging never visits the keep-separate pages.
+        string[] pathUrls = state.PersonId == ResolveTeacherPensionsPotentialDuplicateState.KeepRecordSeparatePersonIdSentinel
+            ? [$"{basePath}/matches", $"{basePath}/keep-record-separate", $"{basePath}/confirm-keep-record-separate"]
+            : [$"{basePath}/matches", $"{basePath}/merge", $"{basePath}/check-answers"];
+
+        return JourneyHelper.CreateInstanceAsync<ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator>(
+            JourneyNames.ResolveTpsPotentialDuplicate,
+            new RouteValueDictionary { ["supportTaskReference"] = supportTaskReference },
+            _ => Task.FromResult<object>(state),
+            pathUrls: pathUrls,
+            // JourneyHelper activates coordinators with Activator.CreateInstance, which can't supply
+            // this one's constructor dependencies.
+            coordinatorFactory: () => ActivatorUtilities.CreateInstance<ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator>(HostFixture.Services));
+    }
+
+    protected ResolveTeacherPensionsPotentialDuplicateState? GetJourneyInstanceState(
+        ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (ResolveTeacherPensionsPotentialDuplicateState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}


### PR DESCRIPTION
### Context

Continues moving SupportUi journeys off `FormFlow` and onto `GovUk.Questions.AspNetCore` (DFE issue #369), after the alert journeys, OneLoginUserMatching and TRN requests. This covers `SupportTasks/TeacherPensions/Resolve` — five pages that fork into a "merge the records" branch and a "keep the records separate" branch.

Branched from `main`, independent of the other open migration PRs.

### Changes proposed in this pull request

- **Coordinator.** Add `ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.ResolveTpsPotentialDuplicate, ["supportTaskReference"])]`) and drop `IRegisterJourney` from the state. `ResolveTeacherPensionsPotentialDuplicateStateFactory` becomes `GetStartingStateAsync`, which can read the support task from `CurrentSupportTaskFeature` because `CheckSupportTaskExistsFilter` runs at order -200, ahead of the library's filter at -100. Exposed as a static `CreateStateAsync` so tests can build realistic state.
- **Shared base** holds the coordinator instead of a `JourneyInstance`, and gains the `BackLink` the pages share.
- **Pages** use `AdvanceTo` / `GetBackLink` / `DeleteInstance` with `_jid` URLs via the shared `GetJourneyPage` extension. Index is `[StartsJourney]`.
- **Cancel** moves from `OnPostCancel` handlers to a `Cancel` form field on the same URL — the library validates the request URL against the journey path, so `?handler=Cancel` would be an invalid step. This lets the `{handler?}` segment come off all five routes.
- **Change links** use `returnUrl` instead of `fromCheckAnswers`.
- **Guards dropped** on Merge, CheckAnswers and ConfirmKeepRecordSeparateReason. Each guarded step can only enter the path via an `AdvanceTo` that sets the state it was checking, so path validation enforces the same thing.
- Renamed the state's `CreateNewRecordPersonIdSentinel` to `KeepRecordSeparatePersonIdSentinel` — this journey has no "create a new record" option; the name was copied from the TRN request journey and the pages were comparing against a bare `Guid.Empty` instead.
- Dropped the dead `keepRecordSeparate` route value from the CheckAnswers links (nothing bound it, and under the new model it would have become part of the step id).

### Two pre-existing bugs fixed

Both were surfaced by the migration rather than sought out, and I verified each against `main` before changing anything.

1. **Cancel on the "Keep record separate" page returned a 500.** Its `formaction` pointed at `.../resolve/check-answers?keepRecordSeparate=True` — the *confirm and merge* handler — rather than at a cancel handler. On that branch no person is selected, so check answers ran `Persons.Where(p => p.PersonId == Guid.Empty).SingleAsync()` and threw `Sequence contains no elements`. I confirmed this by reading the button out of the rendered page on `main` and posting to it. The existing `Post_Cancel_DeletesJourneyAndRedirects` test passed throughout, because it posted to `/keep-record-separate/cancel` — a URL the page never renders. That test now reads the Cancel button from the rendered HTML and submits it as a browser would, so it actually guards the behaviour.
2. **The "View task" link 404'd for these tasks.** `SupportTaskResolve` pointed `TeacherPensionsPotentialDuplicate` straight at the Matches page, which requires a journey instance the link doesn't create; FormFlow's `MissingInstanceHandler` returns 404. Every other support task type points at its `Resolve.Index`. Now this one does too, covered by a new `Get_ViaSupportTaskResolveLink_StartsJourney` test.

### Guidance to review

- **Route paths are preserved** for all five pages; only the `{handler?}` segment is gone.
- **The test base seeds a path that depends on the state**, as in the TRN request PR: the journey forks at Matches, so keeping records separate seeds `[matches, keep-record-separate, confirm-keep-record-separate]` and merging seeds `[matches, merge, check-answers]`. Several keep-separate tests were building state with no `PersonId` at all — a state the real journey can't produce — so they now set the sentinel.
- **Two test URLs were wrong and passing for the wrong reason**, fixed here: a GET to `.../check-answers/cancel` that only rendered because `{handler?}` swallowed the segment, and two "task does not exist" URLs missing the `/resolve/` segment (they 404'd because the route didn't exist, not because the task didn't).
- The `CreateJourneyInstance(reference, state)` → `TestBase.CreateJourneyInstance(journeyName, state, params keys)` shadowing I flagged on #3632 bit again here: removing the per-file helper left call sites silently binding to the base overload, passing the support task reference as the journey name. It compiles and fails at runtime with "Journey not found". Worth a shared helper name that can't collide.

### Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive advisories).
- TeacherPensions tests: **61 passed** (58 before, plus 3 new index/deep-link tests). `just test-changed`: SupportUi.Tests **3964 passed**, SupportUi E2E **139 passed**. Only the two known-ignored `AuthorizeAccess` `OidcTests` fail.
- I also wrote a throwaway test walking both branches over HTTP (entry → matches → keep-separate → confirm, and entry → matches → merge → check-answers), checking back links, the returnUrl change link, and that each branch's pages are rejected as invalid steps on the other branch. Both passed; removed.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
