### PR TITLE
Migrate ConnectPerson and ConnectOneLogin journeys to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers.cshtml
@@ -1,11 +1,12 @@
 @page "/one-logins/{OneLoginUserSubject}/connect-person/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before connecting this GOV.UK One Login to a record";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Reason(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <form method="post">
@@ -32,7 +33,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Reason(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" data-testid="change-reason-link" visually-hidden-text="reason">Change</action>
+                        <action href="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Reason(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery())" data-testid="change-reason-link" visually-hidden-text="reason">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
@@ -48,7 +49,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="confirm-button">Confirm and connect</govuk-button>
-                <govuk-button formaction="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.CheckAnswersCancel(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers.cshtml.cs
@@ -8,9 +8,10 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectPerson), RequireJourneyInstance]
+[Journey(JourneyNames.ConnectPerson)]
 [TypeFilter(typeof(CheckOneLoginUserExistsFilterFactory))]
 public class CheckAnswersModel(
+    ConnectPersonJourneyCoordinator journey,
     TrsDbContext dbContext,
     OneLoginService oneLoginService,
     TimeProvider timeProvider,
@@ -24,10 +25,15 @@ public class CheckAnswersModel(
             .When(m => !m.IsOneLoginUserVerified)
     };
 
-    public JourneyInstance<ConnectPersonState>? JourneyInstance { get; set; }
-
     [FromRoute]
     public string OneLoginUserSubject { get; set; } = null!;
+
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     public string? OneLoginEmailAddress { get; set; }
 
@@ -44,38 +50,39 @@ public class CheckAnswersModel(
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (!JourneyInstance!.State.ConnectReason.HasValue)
-        {
-            context.Result = Redirect(linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Reason(OneLoginUserSubject, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var oneLoginUserFeature = context.HttpContext.GetCurrentOneLoginUserFeature();
 
         IsOneLoginUserVerified = oneLoginUserFeature.VerifiedOn is not null;
         OneLoginEmailAddress = oneLoginUserFeature.EmailAddress;
-        PersonTrn = JourneyInstance.State.PersonTrn;
-        ConnectReason = JourneyInstance.State.ConnectReason;
-        ReasonDetail = JourneyInstance.State.ReasonDetail;
+        PersonTrn = journey.State.PersonTrn;
+        ConnectReason = journey.State.ConnectReason;
+        ReasonDetail = journey.State.ReasonDetail;
 
         await next();
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return CancelJourney();
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
         var oneLoginUserFeature = HttpContext.GetCurrentOneLoginUserFeature();
 
         var person = await dbContext.Persons
-            .Where(p => p.PersonId == JourneyInstance!.State.PersonId)
+            .Where(p => p.PersonId == journey.State.PersonId)
             .SingleAsync();
 
         var changeReason = new ChangeReasonWithDetailsAndEvidence()
         {
-            Reason = JourneyInstance!.State.ConnectReason?.GetDisplayName(),
-            Details = JourneyInstance.State.ConnectReason == ConnectPersonReason.AnotherReason
-                ? JourneyInstance.State.ReasonDetail
+            Reason = journey.State.ConnectReason?.GetDisplayName(),
+            Details = journey.State.ConnectReason == ConnectPersonReason.AnotherReason
+                ? journey.State.ReasonDetail
                 : null,
             EvidenceFile = null,
             AdditionalInformation = null
@@ -119,13 +126,14 @@ public class CheckAnswersModel(
         var personName = string.JoinNonEmpty(' ', person.FirstName, person.MiddleName, person.LastName);
         TempData.SetFlashNotificationBanner($"Record connected to {personName}’s GOV.UK One Login");
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
+
         return Redirect(linkGenerator.Persons.PersonDetail.Index(person.PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private IActionResult CancelJourney()
     {
-        await JourneyInstance!.DeleteAsync();
+        journey.DeleteInstance();
         return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonJourneyCoordinator.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson;
+
+[JourneyCoordinator(JourneyNames.ConnectPerson, routeValueKeys: ["oneLoginUserSubject"])]
+public class ConnectPersonJourneyCoordinator : JourneyCoordinator<ConnectPersonState>
+{
+    public override ConnectPersonState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonLinkGenerator.cs
@@ -2,27 +2,18 @@ namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectP
 
 public class ConnectPersonLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/Index", routeValues: new { oneLoginUserSubject }, journeyInstanceId: journeyInstanceId);
+    public string Index(string oneLoginUserSubject) =>
+        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/Index", routeValues: new { oneLoginUserSubject });
 
-    public string IndexCancel(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/Index", handler: "Cancel", routeValues: new { oneLoginUserSubject }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/OneLogins/OneLoginDetail/ConnectPerson/Index", journeyInstanceId);
 
-    public string Match(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/Match", routeValues: new { oneLoginUserSubject }, journeyInstanceId: journeyInstanceId);
+    public string Match(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/OneLogins/OneLoginDetail/ConnectPerson/Match", journeyInstanceId);
 
-    public string MatchCancel(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/Match", handler: "Cancel", routeValues: new { oneLoginUserSubject }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/OneLogins/OneLoginDetail/ConnectPerson/Reason", journeyInstanceId, returnUrl);
 
-    public string Reason(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool fromCheckAnswers = false) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/Reason", routeValues: new { oneLoginUserSubject, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-
-    public string ReasonCancel(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/Reason", handler: "Cancel", routeValues: new { oneLoginUserSubject }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers", routeValues: new { oneLoginUserSubject }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(string oneLoginUserSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers", handler: "Cancel", routeValues: new { oneLoginUserSubject }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonState.cs
@@ -1,17 +1,9 @@
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson;
 
-public class ConnectPersonState : IRegisterJourney
+public class ConnectPersonState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.ConnectPerson,
-        typeof(ConnectPersonState),
-        requestDataKeys: ["oneLoginUserSubject"],
-        appendUniqueKey: true);
-
     public Guid? PersonId { get; set; }
     public string? PersonTrn { get; set; }
     public ConnectPersonReason? ConnectReason { get; set; }
     public string? ReasonDetail { get; set; }
-
-    public bool IsComplete => PersonId.HasValue && ConnectReason.HasValue;
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.OneLogins.OneLoginDetail.Index(Model.OneLoginUserSubject)">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">
@@ -24,7 +24,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.IndexCancel(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Index.cshtml.cs
@@ -6,10 +6,10 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectPerson)]
-[ActivatesJourney, RequireJourneyInstance]
+[Journey(JourneyNames.ConnectPerson), StartsJourney]
 [TypeFilter(typeof(CheckOneLoginUserExistsFilterFactory))]
 public class IndexModel(
+    ConnectPersonJourneyCoordinator journey,
     TrsDbContext dbContext,
     SupportUiLinkGenerator linkGenerator) : PageModel
 {
@@ -25,21 +25,29 @@ public class IndexModel(
             .When(m => !string.IsNullOrEmpty(m.Trn))
     };
 
-    public JourneyInstance<ConnectPersonState>? JourneyInstance { get; set; }
-
     [FromRoute]
     public string OneLoginUserSubject { get; set; } = null!;
 
     [BindProperty]
     public string? Trn { get; set; }
 
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
+
     public void OnGet()
     {
-        Trn = JourneyInstance?.State.PersonTrn;
+        Trn = journey.State.PersonTrn;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return CancelJourney();
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
         var person = await dbContext.Persons
@@ -60,18 +68,23 @@ public class IndexModel(
             return this.PageWithErrors();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.PersonId = person.PersonId;
-            state.PersonTrn = person.Trn;
-        });
-
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Match(OneLoginUserSubject, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Match(journey.InstanceId),
+            state =>
+            {
+                state.PersonId = person.PersonId;
+                state.PersonTrn = person.Trn;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private IActionResult CancelJourney()
     {
-        await JourneyInstance!.DeleteAsync();
+        journey.DeleteInstance();
         return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+    }
+
+    public override void OnPageHandlerExecuting(Microsoft.AspNetCore.Mvc.Filters.PageHandlerExecutingContext context)
+    {
+        BackLink = journey.GetBackLink() ?? linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Match.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Match.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Index(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <form method="post">
@@ -69,7 +69,7 @@
             <govuk-summary-card data-testid="record">
                 <title>Record details</title>
                 <card-actions>
-                    <action href="@LinkGenerator.Persons.PersonDetail.Index(Model.JourneyInstance!.State.PersonId!.Value)" visually-hidden-text="view record">View record (opens in a new tab)</action>
+                    <action href="@LinkGenerator.Persons.PersonDetail.Index(Model.PersonId)" visually-hidden-text="view record">View record (opens in a new tab)</action>
                 </card-actions>
                 <govuk-summary-list>
                     @if (Model.PersonConnectedOneLoginEmailAddresses is not null && Model.PersonConnectedOneLoginEmailAddresses.Length > 0)
@@ -143,7 +143,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Connect record to GOV.UK One Login</govuk-button>
-                <govuk-button formaction="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.MatchCancel(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Match.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Match.cshtml.cs
@@ -6,14 +6,17 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectPerson)]
-[RequireJourneyInstance]
+[Journey(JourneyNames.ConnectPerson)]
 [TypeFilter(typeof(CheckOneLoginUserExistsFilterFactory))]
 public class MatchModel(
+    ConnectPersonJourneyCoordinator journey,
     TrsDbContext dbContext,
     SupportUiLinkGenerator linkGenerator) : PageModel
 {
-    public JourneyInstance<ConnectPersonState>? JourneyInstance { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public string OneLoginUserSubject { get; set; } = null!;
@@ -22,6 +25,7 @@ public class MatchModel(
     public string[][]? OneLoginUserVerifiedNames { get; set; }
     public DateOnly[]? OneLoginUserVerifiedDatesOfBirth { get; set; }
 
+    public Guid PersonId { get; set; }
     public string? PersonFirstName { get; set; }
     public string? PersonMiddleName { get; set; }
     public string? PersonLastName { get; set; }
@@ -33,22 +37,18 @@ public class MatchModel(
 
     public IActionResult OnPost()
     {
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Reason(OneLoginUserSubject, JourneyInstance!.InstanceId));
-    }
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        }
 
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        return journey.AdvanceTo(linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Reason(journey.InstanceId));
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (!JourneyInstance!.State.PersonId.HasValue)
-        {
-            context.Result = NotFound();
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var oneLoginUserFeature = context.HttpContext.GetCurrentOneLoginUserFeature();
         OneLoginUserEmailAddress = oneLoginUserFeature.EmailAddress;
@@ -57,9 +57,10 @@ public class MatchModel(
 
         var person = await dbContext.Persons
             .AsNoTracking()
-            .Where(p => p.PersonId == JourneyInstance.State.PersonId)
+            .Where(p => p.PersonId == journey.State.PersonId)
             .SingleAsync();
 
+        PersonId = person.PersonId;
         PersonFirstName = person.FirstName;
         PersonMiddleName = person.MiddleName;
         PersonLastName = person.LastName;

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Reason.cshtml
@@ -6,11 +6,8 @@
 
 @section BeforeContent {
     @{
-        var backLink = Model.FromCheckAnswers
-            ? LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.CheckAnswers(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId)
-            : LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Match(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId);
     }
-    <govuk-back-link href="@backLink">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">
@@ -47,7 +44,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.OneLogins.OneLoginDetail.ConnectPerson.ReasonCancel(Model.OneLoginUserSubject, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/ConnectPerson/Reason.cshtml.cs
@@ -5,9 +5,11 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectPerson), RequireJourneyInstance]
+[Journey(JourneyNames.ConnectPerson)]
 [TypeFilter(typeof(CheckOneLoginUserExistsFilterFactory))]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator) : PageModel
+public class ReasonModel(
+    ConnectPersonJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -19,13 +21,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator) : PageModel
             .When(m => m.ConnectReason == ConnectPersonReason.AnotherReason)
     };
 
-    public JourneyInstance<ConnectPersonState>? JourneyInstance { get; set; }
-
     [FromRoute]
     public string OneLoginUserSubject { get; set; } = null!;
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
 
     public string? PersonTrn { get; set; }
 
@@ -37,37 +39,33 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator) : PageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.PersonId.HasValue)
-        {
-            context.Result = Redirect(linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.Index(OneLoginUserSubject, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
-        PersonTrn = JourneyInstance.State.PersonTrn;
+        PersonTrn = journey.State.PersonTrn;
     }
 
     public void OnGet()
     {
-        ConnectReason = JourneyInstance!.State.ConnectReason;
-        ReasonDetail = JourneyInstance.State.ReasonDetail;
+        ConnectReason = journey.State.ConnectReason;
+        ReasonDetail = journey.State.ReasonDetail;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ConnectReason = ConnectReason;
-            state.ReasonDetail = ReasonDetail;
-        });
-
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.CheckAnswers(OneLoginUserSubject, JourneyInstance.InstanceId));
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        return journey.AdvanceTo(
+            linkGenerator.OneLogins.OneLoginDetail.ConnectPerson.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ConnectReason = ConnectReason;
+                state.ReasonDetail = ReasonDetail;
+            });
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml
@@ -1,11 +1,12 @@
 @page "/persons/{PersonId}/connect-one-login/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before connecting this record to a GOV.UK One Login";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <form method="post">
@@ -28,7 +29,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" data-testid="change-reason-link" visually-hidden-text="reason">Change</action>
+                        <action href="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.Reason(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery())" data-testid="change-reason-link" visually-hidden-text="reason">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
@@ -44,7 +45,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="confirm-button">Confirm and connect</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.CheckAnswersCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/CheckAnswers.cshtml.cs
@@ -7,8 +7,9 @@ using TeachingRecordSystem.Core.Services.OneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectOneLogin), RequireJourneyInstance]
+[Journey(JourneyNames.ConnectOneLogin)]
 public class CheckAnswersModel(
+    ConnectOneLoginJourneyCoordinator journey,
     TrsDbContext dbContext,
     OneLoginService oneLoginService,
     TimeProvider timeProvider,
@@ -22,10 +23,15 @@ public class CheckAnswersModel(
             .When(m => !m.IsOneLoginUserVerified)
     };
 
-    public JourneyInstance<ConnectOneLoginState>? JourneyInstance { get; set; }
-
     [FromRoute]
     public Guid PersonId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     public string? OneLoginEmailAddress { get; set; }
 
@@ -40,31 +46,32 @@ public class CheckAnswersModel(
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (!JourneyInstance!.State.ConnectReason.HasValue)
-        {
-            context.Result = Redirect(linkGenerator.Persons.PersonDetail.ConnectOneLogin.Reason(PersonId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var oneLoginUser = await dbContext.OneLoginUsers
-            .Where(u => u.Subject == JourneyInstance.State.Subject)
+            .Where(u => u.Subject == journey.State.Subject)
             .Select(u => new { u.VerifiedOn, u.VerifiedNames, u.VerifiedDatesOfBirth })
             .SingleAsync();
 
         IsOneLoginUserVerified = oneLoginUser.VerifiedOn is not null;
-        OneLoginEmailAddress = JourneyInstance.State.OneLoginEmailAddress;
-        ConnectReason = JourneyInstance.State.ConnectReason;
-        ReasonDetail = JourneyInstance.State.ReasonDetail;
+        OneLoginEmailAddress = journey.State.OneLoginEmailAddress;
+        ConnectReason = journey.State.ConnectReason;
+        ReasonDetail = journey.State.ReasonDetail;
 
         await next();
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return CancelJourney();
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
         var oneLoginUser = await dbContext.OneLoginUsers
-            .Where(u => u.Subject == JourneyInstance!.State.Subject)
+            .Where(u => u.Subject == journey.State.Subject)
             .SingleAsync();
 
         var person = await dbContext.Persons
@@ -73,9 +80,9 @@ public class CheckAnswersModel(
 
         var changeReason = new ChangeReasonWithDetailsAndEvidence()
         {
-            Reason = JourneyInstance!.State.ConnectReason?.GetDisplayName(),
-            Details = JourneyInstance.State.ConnectReason == ConnectOneLoginReason.AnotherReason
-                ? JourneyInstance.State.ReasonDetail
+            Reason = journey.State.ConnectReason?.GetDisplayName(),
+            Details = journey.State.ConnectReason == ConnectOneLoginReason.AnotherReason
+                ? journey.State.ReasonDetail
                 : null,
             EvidenceFile = null,
             AdditionalInformation = null
@@ -83,7 +90,7 @@ public class CheckAnswersModel(
 
         var processContext = new ProcessContext(ProcessType.PersonOneLoginUserConnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);
 
-        var matchedAttributes = JourneyInstance!.State.MatchedAttributes!;
+        var matchedAttributes = journey.State.MatchedAttributes!;
 
         if (oneLoginUser.VerifiedOn is null)
         {
@@ -94,7 +101,7 @@ public class CheckAnswersModel(
             await oneLoginService.SetUserVerifiedAndMatchedAsync(
                 new SetUserVerifiedAndMatchedOptions
                 {
-                    OneLoginUserSubject = JourneyInstance.State.Subject!,
+                    OneLoginUserSubject = journey.State.Subject!,
                     VerificationRoute = OneLoginUserVerificationRoute.Support,
                     VerifiedNames = [verifiedNames],
                     VerifiedDatesOfBirth = person.DateOfBirth.HasValue ? [person.DateOfBirth.Value] : [],
@@ -110,7 +117,7 @@ public class CheckAnswersModel(
             await oneLoginService.SetUserMatchedAsync(
                 new SetUserMatchedOptions
                 {
-                    OneLoginUserSubject = JourneyInstance.State.Subject!,
+                    OneLoginUserSubject = journey.State.Subject!,
                     MatchedPersonId = PersonId,
                     MatchRoute = OneLoginUserMatchRoute.SupportUi,
                     MatchedAttributes = matchedAttributes
@@ -121,13 +128,14 @@ public class CheckAnswersModel(
         var personName = string.JoinNonEmpty(' ', person.FirstName, person.MiddleName, person.LastName);
         TempData.SetFlashNotificationBanner($"Record connected to {personName}’s GOV.UK One Login");
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
+
         return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private IActionResult CancelJourney()
     {
-        await JourneyInstance!.DeleteAsync();
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginJourneyCoordinator.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
+
+[JourneyCoordinator(JourneyNames.ConnectOneLogin, routeValueKeys: ["personId"])]
+public class ConnectOneLoginJourneyCoordinator : JourneyCoordinator<ConnectOneLoginState>
+{
+    public override ConnectOneLoginState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginLinkGenerator.cs
@@ -2,32 +2,18 @@ namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLo
 
 public class ConnectOneLoginLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/Index", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid personId) =>
+        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/Index", routeValues: new { personId });
 
-    public string IndexCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/Index", handler: "Cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Persons/PersonDetail/ConnectOneLogin/Index", journeyInstanceId);
 
-    public string Match(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/Match", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+    public string Match(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Persons/PersonDetail/ConnectOneLogin/Match", journeyInstanceId);
 
-    public string MatchCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/Match", handler: "Cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Persons/PersonDetail/ConnectOneLogin/Reason", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/Reason", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-
-    public string ReasonCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/Reason", handler: "Cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/CheckAnswers", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/ConnectOneLogin/CheckAnswers", handler: "Cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Persons/PersonDetail/ConnectOneLogin/CheckAnswers", journeyInstanceId);
 }
-
-
-
-
-

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginState.cs
@@ -1,19 +1,10 @@
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
-public class ConnectOneLoginState : IRegisterJourney
+public class ConnectOneLoginState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.ConnectOneLogin,
-        typeof(ConnectOneLoginState),
-        requestDataKeys: ["personId"],
-        appendUniqueKey: true);
-
     public string? Subject { get; set; }
     public string? OneLoginEmailAddress { get; set; }
     public IReadOnlyCollection<KeyValuePair<PersonMatchedAttribute, string>>? MatchedAttributes { get; set; }
     public ConnectOneLoginReason? ConnectReason { get; set; }
     public string? ReasonDetail { get; set; }
-
-    public bool IsComplete => !string.IsNullOrEmpty(Subject) && ConnectReason.HasValue;
 }
-

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Index.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons.PersonDetail.Index(Model.PersonId)">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">
@@ -24,7 +24,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.IndexCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Index.cshtml.cs
@@ -6,9 +6,9 @@ using TeachingRecordSystem.Core.Services.OneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectOneLogin)]
-[ActivatesJourney, RequireJourneyInstance]
+[Journey(JourneyNames.ConnectOneLogin), StartsJourney]
 public class IndexModel(
+    ConnectOneLoginJourneyCoordinator journey,
     TrsDbContext dbContext,
     OneLoginService oneLoginService,
     SupportUiLinkGenerator linkGenerator) : PageModel
@@ -21,23 +21,32 @@ public class IndexModel(
             .EmailAddress()
     };
 
-    public JourneyInstance<ConnectOneLoginState>? JourneyInstance { get; set; }
-
     [FromRoute]
     public Guid PersonId { get; set; }
 
     [BindProperty]
     public string? EmailAddress { get; set; }
 
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
+
     public string? Trn { get; set; }
 
     public void OnGet()
     {
-        EmailAddress = JourneyInstance?.State.OneLoginEmailAddress;
+        EmailAddress = journey.State.OneLoginEmailAddress;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
         var oneLoginUser = await dbContext.OneLoginUsers
@@ -69,25 +78,21 @@ public class IndexModel(
                 EmailAddress = oneLoginUser.EmailAddress
             });
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.Subject = oneLoginUser.Subject;
-            state.OneLoginEmailAddress = oneLoginUser.EmailAddress;
-            state.MatchedAttributes = matchedAttributes;
-        });
-
-        return Redirect(linkGenerator.Persons.PersonDetail.ConnectOneLogin.Match(PersonId, JourneyInstance.InstanceId));
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        return journey.AdvanceTo(
+            linkGenerator.Persons.PersonDetail.ConnectOneLogin.Match(journey.InstanceId),
+            state =>
+            {
+                state.Subject = oneLoginUser.Subject;
+                state.OneLoginEmailAddress = oneLoginUser.EmailAddress;
+                state.MatchedAttributes = matchedAttributes;
+            });
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
         Trn = context.HttpContext.GetCurrentPersonFeature().Trn;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Index(PersonId);
 
         await next();
     }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Match.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Match.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.Index(Model.PersonId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <form method="post">
@@ -104,7 +104,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Connect record to GOV.UK One Login</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.MatchCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </div>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Match.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Match.cshtml.cs
@@ -5,13 +5,16 @@ using TeachingRecordSystem.Core.DataStore.Postgres;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectOneLogin)]
-[RequireJourneyInstance]
+[Journey(JourneyNames.ConnectOneLogin)]
 public class MatchModel(
+    ConnectOneLoginJourneyCoordinator journey,
     TrsDbContext dbContext,
     SupportUiLinkGenerator linkGenerator) : PageModel
 {
-    public JourneyInstance<ConnectOneLoginState>? JourneyInstance { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid PersonId { get; set; }
@@ -30,24 +33,20 @@ public class MatchModel(
 
     public IReadOnlyCollection<PersonMatchedAttribute>? MatchedAttributeTypes { get; set; }
 
-    public async Task<IActionResult> OnPostAsync()
+    public IActionResult OnPost()
     {
-        return Redirect(linkGenerator.Persons.PersonDetail.ConnectOneLogin.Reason(PersonId, JourneyInstance!.InstanceId));
-    }
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        }
 
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        return journey.AdvanceTo(linkGenerator.Persons.PersonDetail.ConnectOneLogin.Reason(journey.InstanceId));
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        if (JourneyInstance!.State.MatchedAttributes is null)
-        {
-            context.Result = NotFound();
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personFeature = context.HttpContext.GetCurrentPersonFeature();
 
@@ -61,14 +60,15 @@ public class MatchModel(
 
         var oneLoginUser = await dbContext.OneLoginUsers
             .AsNoTracking()
-            .Where(u => u.Subject == JourneyInstance!.State.Subject)
+            .Where(u => u.Subject == journey.State.Subject)
             .SingleAsync();
 
         OneLoginUserEmailAddress = oneLoginUser.EmailAddress;
         OneLoginUserVerifiedNames = oneLoginUser.VerifiedNames;
         OneLoginUserVerifiedDatesOfBirth = oneLoginUser.VerifiedDatesOfBirth;
 
-        MatchedAttributeTypes = JourneyInstance.State.MatchedAttributes
+        // Set by the Index page, which is the only step this one can be reached from
+        MatchedAttributeTypes = journey.State.MatchedAttributes!
             .Select(a => a.Key)
             .ToArray();
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Reason.cshtml
@@ -6,11 +6,8 @@
 
 @section BeforeContent {
     @{
-        var backLink = Model.FromCheckAnswers
-            ? LinkGenerator.Persons.PersonDetail.ConnectOneLogin.CheckAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId)
-            : LinkGenerator.Persons.PersonDetail.ConnectOneLogin.Match(Model.PersonId, Model.JourneyInstance!.InstanceId);
     }
-    <govuk-back-link href="@backLink">Back</govuk-back-link>
+    <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">
@@ -47,7 +44,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Persons.PersonDetail.ConnectOneLogin.ReasonCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/ConnectOneLogin/Reason.cshtml.cs
@@ -4,8 +4,10 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.ConnectOneLogin), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.ConnectOneLogin)]
+public class ReasonModel(
+    ConnectOneLoginJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -17,13 +19,13 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator) : PageModel
             .When(m => m.ConnectReason == ConnectOneLoginReason.AnotherReason)
     };
 
-    public JourneyInstance<ConnectOneLoginState>? JourneyInstance { get; set; }
-
     [FromRoute]
     public Guid PersonId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public string? BackLink { get; set; }
 
     public string? OneLoginEmailAddress { get; set; }
 
@@ -35,32 +37,34 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator) : PageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        OneLoginEmailAddress = JourneyInstance!.State.OneLoginEmailAddress;
+        BackLink = journey.GetBackLink();
+
+        OneLoginEmailAddress = journey.State.OneLoginEmailAddress;
     }
 
     public void OnGet()
     {
-        ConnectReason = JourneyInstance!.State.ConnectReason;
-        ReasonDetail = JourneyInstance.State.ReasonDetail;
+        ConnectReason = journey.State.ConnectReason;
+        ReasonDetail = journey.State.ReasonDetail;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ConnectReason = ConnectReason;
-            state.ReasonDetail = ReasonDetail;
-        });
-
-        return Redirect(linkGenerator.Persons.PersonDetail.ConnectOneLogin.CheckAnswers(PersonId, JourneyInstance.InstanceId));
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        return journey.AdvanceTo(
+            linkGenerator.Persons.PersonDetail.ConnectOneLogin.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ConnectReason = ConnectReason;
+                state.ReasonDetail = ReasonDetail;
+            });
     }
 }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswersTests.cs
@@ -6,10 +6,10 @@ using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerso
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.ConnectPerson;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : ConnectPersonTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsNotFound()
+    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
@@ -19,36 +19,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_WithoutReason_RedirectsToReasonPage()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(
-            personId: null,
-            email: Option.Some<string?>("test@example.com"),
-            verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
-
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState
-            {
-                PersonId = person.PersonId,
-                PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/one-logins/{oneLoginUser.Subject}/connect-person/reason", response.Headers.Location?.OriginalString);
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Theory]
@@ -68,15 +39,14 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 email: Option.Some<string?>("test@example.com"),
                 verifiedInfo: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.DataLossOrIncompleteInformation
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -92,7 +62,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(person.Trn, summaryList.GetSummaryListValueByKey("TRN"));
         Assert.Equal("Data loss or incomplete information", summaryList.GetSummaryListValueByKey("Reason"));
 
-        var expectedChangeLink = $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var checkAnswersUrl = $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?returnUrl={Uri.EscapeDataString(checkAnswersUrl)}&{journeyInstance.GetUniqueIdQueryParameter()}";
         Assert.Equal(expectedChangeLink, doc.GetElementByTestId("change-reason-link")?.GetAttribute("href"));
 
         var checkbox = doc.QuerySelector<IHtmlInputElement>("input[name='IdentityConfirmed'][type='checkbox']");
@@ -116,16 +87,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.AnotherReason,
                 ReasonDetail = "Custom connection reason"
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -150,15 +120,14 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.DataLossOrIncompleteInformation
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -185,15 +154,14 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.DataLossOrIncompleteInformation
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -243,9 +211,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var expectedFlashMessage = $"Record connected to {string.JoinNonEmpty(' ', person.FirstName, person.MiddleName, person.LastName)}’s GOV.UK One Login";
         AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, expectedFlashMessage);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.NotNull(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -258,15 +224,14 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.DataLossOrIncompleteInformation
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -304,9 +269,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var expectedFlashMessage = $"Record connected to {string.JoinNonEmpty(' ', person.FirstName, person.MiddleName, person.LastName)}’s GOV.UK One Login";
         AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, expectedFlashMessage);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.NotNull(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -319,16 +282,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.AnotherReason,
                 ReasonDetail = "Custom connection reason details"
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -351,8 +313,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal("Custom connection reason details", changeReason.Details);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.NotNull(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/CheckAnswersTests.cs
@@ -8,20 +8,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetai
 
 public class CheckAnswersTests(HostFixture hostFixture) : ConnectPersonTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/ConnectPersonTestBase.cs
@@ -1,0 +1,34 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerson;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.ConnectPerson;
+
+public abstract class ConnectPersonTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<ConnectPersonJourneyCoordinator> CreateJourneyInstanceAsync(
+        string oneLoginUserSubject,
+        ConnectPersonState state)
+    {
+        var basePath = $"/one-logins/{oneLoginUserSubject}/connect-person";
+
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        return JourneyHelper.CreateInstanceAsync<ConnectPersonJourneyCoordinator>(
+            JourneyNames.ConnectPerson,
+            new RouteValueDictionary { ["oneLoginUserSubject"] = oneLoginUserSubject },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                basePath,
+                $"{basePath}/match",
+                $"{basePath}/reason",
+                $"{basePath}/check-answers"
+            ]);
+    }
+
+    protected ConnectPersonState? GetJourneyInstanceState(ConnectPersonJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (ConnectPersonState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/IndexTests.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerso
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.ConnectPerson;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : ConnectPersonTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithValidOneLoginUserSubject_RedirectsWithJourneyInstanceId()
@@ -16,7 +16,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/one-logins/{oneLoginUser.Subject}/connect-person?{Constants.UniqueKeyQueryParameterName}", response.Headers.Location?.OriginalString);
+        Assert.StartsWith($"/one-logins/{oneLoginUser.Subject}/connect-person?_jid", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -25,10 +25,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -47,10 +46,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var oneLoginUserSubject = "invalid-subject";
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUserSubject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUserSubject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUserSubject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -67,10 +65,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -93,10 +90,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -119,10 +115,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -146,10 +141,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
         var trn = "1234567";
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -173,10 +167,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(person);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -200,10 +193,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -220,9 +212,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(person.PersonId, journeyInstance.State.PersonId);
-        Assert.Equal(person.Trn, journeyInstance.State.PersonTrn);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(person.PersonId, journeyState!.PersonId);
+        Assert.Equal(person.Trn, journeyState!.PersonTrn);
     }
 
     [Fact]
@@ -233,10 +225,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var otherPerson = await TestData.CreatePersonAsync();
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(otherPerson);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -253,9 +244,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(person.PersonId, journeyInstance.State.PersonId);
-        Assert.Equal(person.Trn, journeyInstance.State.PersonTrn);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(person.PersonId, journeyState!.PersonId);
+        Assert.Equal(person.Trn, journeyState!.PersonTrn);
     }
 
     [Fact]
@@ -264,14 +255,13 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
+            new ConnectPersonState());
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?handler=Cancel&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
         };
 
         // Act
@@ -281,7 +271,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/one-logins/{oneLoginUser.Subject}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/MatchTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/MatchTests.cs
@@ -7,21 +7,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetai
 public class MatchTests(HostFixture hostFixture) : ConnectPersonTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-    }
-
-    [Fact]
     public async Task Get_WithInvalidOneLoginUserSubject_ReturnsNotFound()
     {
         // Arrange

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/MatchTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/MatchTests.cs
@@ -4,30 +4,10 @@ using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerso
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.ConnectPerson;
 
-public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class MatchTests(HostFixture hostFixture) : ConnectPersonTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutMatchedPerson_ReturnsNotFound()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
-
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsNotFound()
+    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
@@ -38,7 +18,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -47,10 +27,9 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var oneLoginUserSubject = "invalid-subject";
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
-            new ConnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUserSubject));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUserSubject,
+            new ConnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUserSubject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -78,14 +57,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -138,14 +116,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         ["Johnny", "Smith"]
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -189,14 +166,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         new DateOnly(1992, 12, 25)
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -228,14 +204,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: null);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -268,14 +243,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -306,14 +280,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -342,14 +315,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -378,14 +350,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("onelogin@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -426,14 +397,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         ["Johnny", "Bloggs"]
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -472,14 +442,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         ["Jim", "Brown"]
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -517,14 +486,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         new DateOnly(1992, 12, 25)
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -562,14 +530,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         new DateOnly(1992, 12, 25)
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -597,14 +564,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("new@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -629,14 +595,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -660,16 +625,18 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?handler=Cancel&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/match?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -678,8 +645,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/one-logins/{oneLoginUser.Subject}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     private void AssertPersonRowIsHighlighted(IElement recordCard, string summaryListKey)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/ReasonTests.cs
@@ -8,20 +8,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetai
 public class ReasonTests(HostFixture hostFixture) : ConnectPersonTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
-    {
-        // Arrange
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-    }
-
-    [Fact]
     public async Task Get_WithValidJourney_RendersExpectedContent()
     {
         // Arrange

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/ConnectPerson/ReasonTests.cs
@@ -5,10 +5,10 @@ using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.ConnectPerso
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.ConnectPerson;
 
-public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ReasonTests(HostFixture hostFixture) : ConnectPersonTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsNotFound()
+    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
     {
         // Arrange
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: null);
@@ -18,7 +18,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -31,14 +31,13 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -67,16 +66,15 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.AnotherReason,
                 ReasonDetail = "Test reason detail"
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -106,14 +104,13 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -137,14 +134,13 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -171,14 +167,13 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -195,8 +190,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(ConnectPersonReason.DataLossOrIncompleteInformation, journeyInstance.State.ConnectReason);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(ConnectPersonReason.DataLossOrIncompleteInformation, journeyState!.ConnectReason);
     }
 
     [Fact]
@@ -209,14 +204,13 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -234,9 +228,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/one-logins/{oneLoginUser.Subject}/connect-person/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(ConnectPersonReason.AnotherReason, journeyInstance.State.ConnectReason);
-        Assert.Equal("Custom connection reason", journeyInstance.State.ReasonDetail);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(ConnectPersonReason.AnotherReason, journeyState!.ConnectReason);
+        Assert.Equal("Custom connection reason", journeyState!.ReasonDetail);
     }
 
     [Fact]
@@ -249,15 +243,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectPerson,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLoginUser.Subject,
             new ConnectPersonState
             {
                 PersonId = person.PersonId,
                 PersonTrn = person.Trn,
                 ConnectReason = ConnectPersonReason.DataLossOrIncompleteInformation
-            },
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUser.Subject));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLoginUser.Subject}/connect-person/reason?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}")
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
@@ -8,20 +8,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.Co
 
 public class CheckAnswersTests(HostFixture hostFixture) : ConnectOneLoginTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/check-answers");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/CheckAnswersTests.cs
@@ -6,10 +6,10 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : ConnectOneLoginTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsNotFound()
+    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
     {
         // Arrange
         var person = await TestData.CreatePersonAsync();
@@ -19,37 +19,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_WithoutReason_RedirectsToReasonPage()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(
-            personId: null,
-            email: Option.Some<string?>("test@example.com"),
-            verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
-
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState
-            {
-                Subject = oneLoginUser.Subject,
-                OneLoginEmailAddress = oneLoginUser.EmailAddress,
-                MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/persons/{person.PersonId}/connect-one-login/reason", response.Headers.Location?.OriginalString);
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Theory]
@@ -68,16 +38,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 email: Option.Some<string?>("test@example.com"),
                 verified: false);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -92,7 +61,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal("test@example.com", summaryList.GetSummaryListValueByKey("GOV.UK One Login email address"));
         Assert.Equal("The system could not find a match automatically", summaryList.GetSummaryListValueByKey("Reason"));
 
-        var expectedChangeLink = $"/persons/{person.PersonId}/connect-one-login/reason?fromCheckAnswers=True&{journeyInstance.GetUniqueIdQueryParameter()}";
+        var checkAnswersUrl = $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}";
+        var expectedChangeLink = $"/persons/{person.PersonId}/connect-one-login/reason?returnUrl={Uri.EscapeDataString(checkAnswersUrl)}&{journeyInstance.GetUniqueIdQueryParameter()}";
         Assert.Equal(expectedChangeLink, doc.GetElementByTestId("change-reason-link")?.GetAttribute("href"));
 
         var checkbox = doc.QuerySelector<IHtmlInputElement>("input[name='IdentityConfirmed'][type='checkbox']");
@@ -116,8 +86,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -125,8 +95,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.AnotherReason,
                 ReasonDetail = "Custom connection reason"
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -150,16 +119,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verified: false);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -185,16 +153,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verified: false);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -244,9 +211,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var expectedFlashMessage = $"Record connected to {string.JoinNonEmpty(' ', person.FirstName, person.MiddleName, person.LastName)}’s GOV.UK One Login";
         AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, expectedFlashMessage);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.NotNull(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -259,16 +224,15 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -306,9 +270,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var expectedFlashMessage = $"Record connected to {string.JoinNonEmpty(' ', person.FirstName, person.MiddleName, person.LastName)}’s GOV.UK One Login";
         AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, expectedFlashMessage);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.NotNull(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -321,20 +283,19 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.SystemCouldNotMatch
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/check-answers?handler=Cancel&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>())
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
         };
 
         // Act
@@ -344,8 +305,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -358,8 +318,8 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -367,8 +327,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.AnotherReason,
                 ReasonDetail = "Custom connection reason details"
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -391,8 +350,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal("Custom connection reason details", changeReason.Details);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.NotNull(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ConnectOneLoginTestBase.cs
@@ -1,0 +1,34 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
+
+public abstract class ConnectOneLoginTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<ConnectOneLoginJourneyCoordinator> CreateJourneyInstanceAsync(
+        Guid personId,
+        ConnectOneLoginState state)
+    {
+        var basePath = $"/persons/{personId}/connect-one-login";
+
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        return JourneyHelper.CreateInstanceAsync<ConnectOneLoginJourneyCoordinator>(
+            JourneyNames.ConnectOneLogin,
+            new RouteValueDictionary { ["personId"] = personId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                basePath,
+                $"{basePath}/match",
+                $"{basePath}/reason",
+                $"{basePath}/check-answers"
+            ]);
+    }
+
+    protected ConnectOneLoginState? GetJourneyInstanceState(ConnectOneLoginJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (ConnectOneLoginState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/IndexTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : ConnectOneLoginTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithValidPersonId_RedirectsWithJourneyInstanceId()
@@ -17,7 +17,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith($"/persons/{person.PersonId}/connect-one-login?{Constants.UniqueKeyQueryParameterName}", response.Headers.Location?.OriginalString);
+        Assert.StartsWith($"/persons/{person.PersonId}/connect-one-login?_jid", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -26,10 +26,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -63,10 +62,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -89,10 +87,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -116,10 +113,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var emailAddress = Faker.Internet.Email();
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -144,10 +140,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var emailAddress = Faker.Internet.Email();
         await TestData.CreateOneLoginUserAsync(person, email: Option.Some<string?>(emailAddress));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -173,10 +168,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var emailAddress = Faker.Internet.Email();
         await TestData.CreateOneLoginUserAsync(otherPerson, email: Option.Some<string?>(emailAddress));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -204,10 +198,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>(emailAddress),
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -231,14 +224,13 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var person = await TestData.CreatePersonAsync();
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            new ConnectOneLoginState());
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?handler=Cancel&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>())
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
         };
 
         // Act
@@ -248,7 +240,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/MatchTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/MatchTests.cs
@@ -7,21 +7,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.Co
 public class MatchTests(HostFixture hostFixture) : ConnectOneLoginTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-    }
-
-    [Fact]
     public async Task Get_WithInvalidPersonId_ReturnsNotFound()
     {
         // Arrange

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/MatchTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/MatchTests.cs
@@ -4,30 +4,10 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
 
-public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class MatchTests(HostFixture hostFixture) : ConnectOneLoginTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutMatchedOneLogin_ReturnsNotFound()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", person.PersonId));
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsNotFound()
+    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
     {
         // Arrange
         var person = await TestData.CreatePersonAsync();
@@ -38,7 +18,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -47,10 +27,9 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var personId = Guid.NewGuid();
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
-            new ConnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", personId));
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            personId,
+            new ConnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{personId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -77,8 +56,8 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -87,8 +66,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                     KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
                     KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
                 ]
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -137,8 +115,8 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         ["Johnny", "Smith"]
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -146,8 +124,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                     KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
                     KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName)
                 ]
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -192,16 +169,15 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         new DateOnly(1992, 12, 25)
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 MatchedAttributes = [
                     KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
                 ]
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -231,14 +207,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verified: false);
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -269,8 +244,8 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -280,8 +255,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                     KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd")),
                     KeyValuePair.Create(PersonMatchedAttribute.EmailAddress, person.EmailAddress!)
                 ]
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -310,14 +284,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["Jane", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -343,14 +316,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1985, 5, 20)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -389,8 +361,8 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         ["Johnny", "Bloggs"]
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -398,8 +370,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                     KeyValuePair.Create(PersonMatchedAttribute.FirstName, person.FirstName),
                     KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName)
                 ]  // Name matches (one of the multiple names)
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -438,14 +409,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         ["Jim", "Brown"]
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 MatchedAttributes = []  // No matched attributes - none of the names match
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -483,16 +453,15 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         new DateOnly(1992, 12, 25)
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 MatchedAttributes = [
                     KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
                 ]  // DOB matches (one of the multiple DOBs)
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -530,14 +499,13 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                         new DateOnly(1992, 12, 25)
                     ])));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -562,8 +530,8 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -572,8 +540,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                     KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
                     KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
                 ]
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -598,8 +565,8 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -608,10 +575,12 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
                     KeyValuePair.Create(PersonMatchedAttribute.LastName, person.LastName),
                     KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, person.DateOfBirth.ToString("yyyy-MM-dd"))
                 ]
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/match?handler=Cancel&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/match?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -620,8 +589,7 @@ public class MatchTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     private void AssertOneLoginRowIsHighlighted(IElement oneLoginCard, string summaryListKey)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ReasonTests.cs
@@ -8,20 +8,6 @@ namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.Co
 public class ReasonTests(HostFixture hostFixture) : ConnectOneLoginTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/reason");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-    }
-
-    [Fact]
     public async Task Get_WithValidJourney_RendersExpectedContent()
     {
         // Arrange

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/ConnectOneLogin/ReasonTests.cs
@@ -5,10 +5,10 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.ConnectOneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.ConnectOneLogin;
 
-public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ReasonTests(HostFixture hostFixture) : ConnectOneLoginTestBase(hostFixture)
 {
     [Fact]
-    public async Task Get_WithoutJourneyInstance_ReturnsNotFound()
+    public async Task Get_WithoutJourneyInstance_ReturnsBadRequest()
     {
         // Arrange
         var person = await TestData.CreatePersonAsync();
@@ -18,7 +18,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -31,15 +31,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -64,8 +63,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
@@ -73,8 +72,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 MatchedAttributes = [],
                 ConnectReason = ConnectOneLoginReason.AnotherReason,
                 ReasonDetail = "Test reason detail"
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -104,15 +102,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -136,15 +133,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -171,15 +167,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -207,15 +202,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -232,9 +226,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/connect-one-login/check-answers", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
         Assert.Equal(ConnectOneLoginReason.SystemCouldNotMatch, journeyInstance!.State.ConnectReason);
-        Assert.Null(journeyInstance.State.ReasonDetail);
+        Assert.Null(journeyState!.ReasonDetail);
     }
 
     [Fact]
@@ -247,15 +241,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -272,9 +265,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/connect-one-login/check-answers", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
         Assert.Equal(ConnectOneLoginReason.ConnectedToWrongOneLogin, journeyInstance!.State.ConnectReason);
-        Assert.Null(journeyInstance.State.ReasonDetail);
+        Assert.Null(journeyState!.ReasonDetail);
     }
 
     [Fact]
@@ -287,15 +280,14 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -313,9 +305,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith($"/persons/{person.PersonId}/connect-one-login/check-answers", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
+        var journeyState = GetJourneyInstanceState(journeyInstance);
         Assert.Equal(ConnectOneLoginReason.AnotherReason, journeyInstance!.State.ConnectReason);
-        Assert.Equal("Custom reason for connection", journeyInstance.State.ReasonDetail);
+        Assert.Equal("Custom reason for connection", journeyState!.ReasonDetail);
     }
 
     [Fact]
@@ -328,19 +320,18 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             email: Option.Some<string?>("test@example.com"),
             verifiedInfo: (["John", "Doe"], new DateOnly(1990, 1, 15)));
 
-        var journeyInstance = await CreateJourneyInstance(
-            JourneyNames.ConnectOneLogin,
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
             new ConnectOneLoginState
             {
                 Subject = oneLoginUser.Subject,
                 OneLoginEmailAddress = oneLoginUser.EmailAddress,
                 MatchedAttributes = []
-            },
-            new KeyValuePair<string, object>("personId", person.PersonId));
+            });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?handler=Cancel&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/connect-one-login/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContent(new Dictionary<string, string>())
+            Content = new FormUrlEncodedContentBuilder { { "Cancel", "True" } }
         };
 
         // Act
@@ -350,7 +341,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 }


### PR DESCRIPTION
### Context

Continues moving SupportUi journeys off `FormFlow` and onto `GovUk.Questions.AspNetCore` (DFE issue #369), after the alert journeys, OneLoginUserMatching, TRN requests and Teacher Pensions duplicates.

This covers **both** "connect a GOV.UK One Login to a record" journeys, which are mirror images of each other and share the same four-step shape (Index → Match → Reason → Check answers):

- `OneLogins/OneLoginDetail/ConnectPerson` — start from the One Login, find a person by TRN.
- `Persons/PersonDetail/ConnectOneLogin` — start from the person, find a One Login by email.

They're in one PR because every change is the same change made twice; splitting them would just double the review.

Branched from `main`, independent of the other open migration PRs.

### Changes proposed in this pull request

- **Coordinators.** Add `ConnectPersonJourneyCoordinator` (`["oneLoginUserSubject"]`) and `ConnectOneLoginJourneyCoordinator` (`["personId"]`), and drop `IRegisterJourney` from both states. Neither journey derives its starting state from anything, so both coordinators are one-liners — no `GetStartingStateAsync`, no service dependencies, no test-side scoping needed.
- **Index is the first question, not a redirect.** Unlike the journeys migrated so far, these entry pages already ask something (a TRN / an email address). So `[StartsJourney]` goes straight on Index and there's no `AdvanceTo(..., SetAsFirstStep)` hop: the library creates the instance on the first GET and redirects to the same page with the key. Its back link falls back to the One Login / person detail page.
- **Cancel** moves from `OnPostCancel` handlers to a `Cancel` form field on the same URL — the library validates the request URL against the journey path, so `?handler=Cancel` is an invalid step.
- **Change links** use `returnUrl` instead of `fromCheckAnswers`.
- **Guards dropped** on Match (`PersonId` / `MatchedAttributes` null → `NotFound`), Reason (`PersonId` null → Index) and CheckAnswers (`ConnectReason` null → Reason). Each guarded step can only enter the path via an `AdvanceTo` that sets the state it was checking, so path validation enforces the same thing. Their 4 tests go with them.
- Removed `IsComplete` from both states — dead in both.

### Guidance to review

- **Route paths are unchanged** for all eight pages. These journeys had no `{handler?}` segments to remove; the cancel handlers were reached via `?handler=Cancel`.
- **One behaviour change worth knowing:** requesting a journey page with no instance now returns **400** rather than FormFlow's 404. This is the library's default for a non-`[StartsJourney]` endpoint with no instance; nothing in the app links to those URLs without a key. The six `Get_WithoutJourneyInstance_ReturnsNotFound` tests are **deleted** rather than re-pointed — they were asserting a GovUk.Questions guarantee rather than anything this codebase decides.
- **The dropped guards are the main thing to sanity-check**, as with the previous migrations.
- Dropping Match's null guard surfaced a nullable warning on `MatchedAttributes`; it's now `!` with a comment, matching how the other migrated pages read state that the path guarantees.
- The test bases deliberately use `CreateJourneyInstanceAsync`, which cannot collide with `TestBase.CreateJourneyInstance` — see the note on #3632/#3633 about call sites silently binding to the base overload.

### Testing

- `just build` — no errors, no warnings (only the pre-existing `NU1903` transitive advisories).
- ConnectPerson + ConnectOneLogin page tests: **117 passed** (127 before, minus 4 dropped guard tests and 6 dropped no-journey-instance tests). `just test-changed`: SupportUi.Tests **3957 passed**, SupportUi E2E **139 passed**. Only the two known-ignored `AuthorizeAccess` `OidcTests` fail.
- **The existing Playwright E2E tests for ConnectOneLogin still pass** (5 tests, including `ConnectOneLogin_NavigateBack`) — real browser coverage of the mirror journey's back links through the whole flow.
- For ConnectPerson, which has no E2E coverage, I wrote a throwaway test walking the journey over HTTP: entry → key redirect → index → match → reason → check answers, asserting the back link at each step, following the `returnUrl` change link and confirming it returns to check answers, then completing. It passed; removed.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

