### PR TITLE
Migrate DisconnectPerson and DisconnectOneLogin journeys to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswers.cshtml
@@ -1,4 +1,5 @@
 @page "/one-logins/{oneLoginUserSubject}/disconnect-person/{personId}/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPerson.CheckAnswers
 @{
     Layout = "_Layout";
@@ -6,10 +7,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link data-testid="back-link"
-                     href="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Verified(Model.OneLoginUserSubject, Model.PersonId, Model!.JourneyInstance!.InstanceId)">
-        Back
-    </govuk-back-link>
+    <govuk-back-link data-testid="back-link" href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">
@@ -36,7 +34,7 @@
                     </value>
                     <row-actions>
                         <action
-                            href="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Index(Model.OneLoginUserSubject, Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                            href="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Index(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery())"
                             visually-hidden-text="disconnect reason">Change
                         </action>
                     </row-actions>
@@ -48,7 +46,7 @@
                     </value>
                     <row-actions>
                         <action
-                            href="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Verified(Model.OneLoginUserSubject, Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                            href="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Verified(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery())"
                             visually-hidden-text="stay verified">Change
                         </action>
                     </row-actions>
@@ -58,10 +56,8 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Confirm and disconnect</govuk-button>
-                <govuk-button data-testid="cancel-button"
-                              formaction="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.CheckAnswersCancel(Model.OneLoginUserSubject!, Model.PersonId, Model.JourneyInstance!.InstanceId)"
-                              class="govuk-button--secondary" type="submit">Cancel
-                </govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true"
+                              class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswers.cshtml.cs
@@ -8,9 +8,10 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPerson;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DisconnectPerson), RequireJourneyInstance]
+[Journey(JourneyNames.DisconnectPerson)]
 [TypeFilter(typeof(CheckOneLoginUserExistsFilterFactory))]
 public class CheckAnswers(
+    DisconnectPersonJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     TimeProvider timeProvider,
     OneLoginService oneLoginService,
@@ -21,7 +22,13 @@ public class CheckAnswers(
 
     [FromRoute] public required Guid PersonId { get; set; }
 
-    public JourneyInstance<DisconnectPersonState>? JourneyInstance { get; set; }
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
@@ -35,25 +42,31 @@ public class CheckAnswers(
     {
         var person = await dbContext.Persons.SingleAsync(x => x.PersonId == PersonId);
         PersonName = $"{person.FirstName} {person.LastName}";
-        Reason = JourneyInstance!.State.DisconnectReason;
-        Detail = JourneyInstance!.State.DisconnectReason == DisconnectPersonReason.AnotherReason ? JourneyInstance.State.Detail : null;
-        StayVerified = JourneyInstance!.State.StayVerified;
+        Reason = journey.State.DisconnectReason;
+        Detail = journey.State.DisconnectReason == DisconnectPersonReason.AnotherReason ? journey.State.Detail : null;
+        StayVerified = journey.State.StayVerified;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        }
+
         var changeReason = new ChangeReasonWithDetailsAndEvidence()
         {
             Reason = Reason?.GetDisplayName(),
-            Details = JourneyInstance!.State.DisconnectReason == DisconnectPersonReason.AnotherReason
-                ? JourneyInstance.State.Detail
+            Details = journey.State.DisconnectReason == DisconnectPersonReason.AnotherReason
+                ? journey.State.Detail
                 : null,
             EvidenceFile = null,
             AdditionalInformation = null
         };
         var processContext = new ProcessContext(ProcessType.OneLoginUserPersonDisconnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);
         var person = await dbContext.Persons.SingleAsync(x => x.PersonId == PersonId);
-        if (JourneyInstance!.State.StayVerified == DisconnectPersonStayVerified.Yes)
+        if (journey.State.StayVerified == DisconnectPersonStayVerified.Yes)
         {
             await oneLoginService.SetUserUnmatchedAsync(OneLoginUserSubject, processContext);
         }
@@ -65,21 +78,13 @@ public class CheckAnswers(
 
         var personName = $"{person.FirstName} {person.LastName}";
         TempData.SetFlashNotificationBanner($"{personName}\u2019s record disconnected from GOV.UK One Login");
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
-    }
 
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
+        journey.DeleteInstance();
         return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.DisconnectReason.HasValue || !JourneyInstance.State.StayVerified.HasValue)
-        {
-            context.Result = Redirect(linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Index(OneLoginUserSubject, PersonId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonJourneyCoordinator.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPerson;
+
+// Both route values scope the journey: a disconnect is about a specific One Login *and* person pair,
+// and scoping by both is what lets the library carry them through every generated URL.
+[JourneyCoordinator(JourneyNames.DisconnectPerson, routeValueKeys: ["oneLoginUserSubject", "personId"])]
+public class DisconnectPersonJourneyCoordinator : JourneyCoordinator<DisconnectPersonState>
+{
+    public override DisconnectPersonState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonLinkGenerator.cs
@@ -2,28 +2,16 @@ namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.Disconne
 
 public class DisconnectPersonLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(string oneLoginUserSubject, Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId,
-        bool? fromCheckAnswers = null) =>
+    public string Index(string oneLoginUserSubject, Guid personId) =>
         linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/DisconnectPerson/Index",
-            routeValues: new { oneLoginUserSubject, personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+            routeValues: new { oneLoginUserSubject, personId });
 
-    public string Cancel(string oneLoginUserSubject, Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/DisconnectPerson/Index", "cancel",
-            routeValues: new { oneLoginUserSubject, personId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/OneLogins/OneLoginDetail/DisconnectPerson/Index", journeyInstanceId, returnUrl);
 
-    public string Verified(string oneLoginUserSubject, Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/DisconnectPerson/Verified",
-            routeValues: new { oneLoginUserSubject, personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Verified(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/OneLogins/OneLoginDetail/DisconnectPerson/Verified", journeyInstanceId, returnUrl);
 
-    public string VerifiedCancel(string oneLoginUserSubject, Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/DisconnectPerson/Verified", "cancel",
-            routeValues: new { oneLoginUserSubject, personId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(string oneLoginUserSubject, Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswers",
-            routeValues: new { oneLoginUserSubject, personId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(string oneLoginUserSubject, Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswers", "cancel",
-            routeValues: new { oneLoginUserSubject, personId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonState.cs
@@ -2,14 +2,8 @@ using TeachingRecordSystem.Core.Services.OneLogin;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPerson;
 
-public class DisconnectPersonState : IRegisterJourney
+public class DisconnectPersonState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.DisconnectPerson,
-        typeof(DisconnectPersonState),
-        requestDataKeys: ["oneLoginUserSubject"],
-        appendUniqueKey: true);
-
     public DisconnectPersonReason? DisconnectReason { get; set; }
 
     public DisconnectPersonStayVerified? StayVerified { get; set; }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Index.cshtml
@@ -44,10 +44,8 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button"
-                              formaction="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Cancel(Model.OneLoginUserSubject!, Model.PersonId, Model.JourneyInstance!.InstanceId)"
-                              class="govuk-button--secondary" type="submit">Cancel
-                </govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true"
+                              class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Index.cshtml.cs
@@ -6,9 +6,9 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPerson;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DisconnectPerson), ActivatesJourney, RequireJourneyInstance]
+[Journey(JourneyNames.DisconnectPerson), StartsJourney]
 [TypeFilter(typeof(CheckOneLoginUserExistsFilterFactory))]
-public class Index(SupportUiLinkGenerator linkGenerator, TrsDbContext dbContext) : PageModel
+public class Index(DisconnectPersonJourneyCoordinator journey, SupportUiLinkGenerator linkGenerator, TrsDbContext dbContext) : PageModel
 {
     private readonly InlineValidator<Index> _validator = new()
     {
@@ -36,50 +36,42 @@ public class Index(SupportUiLinkGenerator linkGenerator, TrsDbContext dbContext)
 
     [FromRoute] public required Guid PersonId { get; set; }
 
-    public JourneyInstance<DisconnectPersonState>? JourneyInstance { get; set; }
 
-    [FromQuery] public bool? FromCheckAnswers { get; set; }
 
-    public string BackLink => FromCheckAnswers == true
-        ? linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.CheckAnswers(OneLoginUserSubject, PersonId,
-            JourneyInstance!.InstanceId)
-        : linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject);
+    public string? BackLink { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public async Task OnGetAsync()
     {
         var person = await dbContext.Persons.SingleAsync(p => p.PersonId == PersonId);
-        ReasonDetail = JourneyInstance!.State.Detail;
-        Reason = JourneyInstance.State.DisconnectReason;
+        ReasonDetail = journey.State.Detail;
+        Reason = journey.State.DisconnectReason;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
-
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.DisconnectReason = Reason;
-            state.Detail = Reason == DisconnectPersonReason.AnotherReason ? ReasonDetail : null;
-        });
-
-        if (FromCheckAnswers == true)
-        {
-            return Redirect(linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.CheckAnswers(OneLoginUserSubject, PersonId,
-                JourneyInstance.InstanceId));
-        }
-
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Verified(OneLoginUserSubject, PersonId,
-            JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Verified(journey.InstanceId),
+            state =>
+            {
+                state.DisconnectReason = Reason;
+                state.Detail = Reason == DisconnectPersonReason.AnotherReason ? ReasonDetail : null;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    public override void OnPageHandlerExecuting(Microsoft.AspNetCore.Mvc.Filters.PageHandlerExecutingContext context)
     {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        BackLink = journey.GetBackLink() ?? linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject);
     }
+
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Verified.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Verified.cshtml
@@ -36,10 +36,8 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button"
-                              formaction="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.VerifiedCancel(Model.OneLoginUserSubject, Model.PersonId, Model.JourneyInstance!.InstanceId)"
-                              class="govuk-button--secondary" type="submit">Cancel
-                </govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true"
+                              class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Verified.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/DisconnectPerson/Verified.cshtml.cs
@@ -6,9 +6,11 @@ using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPerson;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DisconnectPerson), RequireJourneyInstance]
+[Journey(JourneyNames.DisconnectPerson)]
 [TypeFilter(typeof(CheckOneLoginUserExistsFilterFactory))]
-public class Verified(SupportUiLinkGenerator linkGenerator) : PageModel
+public class Verified(
+    DisconnectPersonJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private readonly InlineValidator<Verified> _validator = new()
     {
@@ -23,52 +25,33 @@ public class Verified(SupportUiLinkGenerator linkGenerator) : PageModel
 
     [BindProperty] public DisconnectPersonStayVerified? StayVerified { get; set; }
 
-    public JourneyInstance<DisconnectPersonState>? JourneyInstance { get; set; }
+    public string? BackLink { get; set; }
 
-    [FromQuery] public bool? FromCheckAnswers { get; set; }
-
-    public string BackLink => FromCheckAnswers == true
-        ? linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.CheckAnswers(OneLoginUserSubject, PersonId,
-            JourneyInstance!.InstanceId)
-        : linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Index(OneLoginUserSubject,
-            PersonId, JourneyInstance!.InstanceId);
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public void OnGet()
     {
-        StayVerified = JourneyInstance?.State.StayVerified;
+        StayVerified = journey.State.StayVerified;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.StayVerified = StayVerified;
-        });
-
-        return Redirect(
-            linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.CheckAnswers(
-                OneLoginUserSubject,
-                PersonId,
-                JourneyInstance.InstanceId));
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.OneLogins.OneLoginDetail.Index(OneLoginUserSubject));
+        return journey.AdvanceTo(
+            linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.CheckAnswers(journey.InstanceId),
+            state => state.StayVerified = StayVerified);
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.DisconnectReason.HasValue)
-        {
-            context.Result = Redirect(
-                linkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Index(
-                    OneLoginUserSubject,
-                    PersonId,
-                    JourneyInstance.InstanceId));
-        }
+        BackLink = journey.GetBackLink();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml
@@ -1,4 +1,5 @@
 @page "/persons/{PersonId}/disconnect-one-login/{oneLoginSubject}/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLogin.CheckAnswers
 @{
     Layout = "_Layout";
@@ -6,10 +7,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link data-testid="back-link"
-                     href="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Verified(Model.PersonId, Model.OneLoginSubject, Model!.JourneyInstance!.InstanceId)">
-        Back
-    </govuk-back-link>
+    <govuk-back-link data-testid="back-link" href="@Model.BackLink">Back</govuk-back-link>
 }
 
 <div class="govuk-grid-row">
@@ -36,7 +34,7 @@
                     </value>
                     <row-actions>
                         <action
-                            href="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Index(Model.PersonId, Model.OneLoginSubject, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                            href="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Index(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery())"
                             visually-hidden-text="disconnect reason">Change
                         </action>
                     </row-actions>
@@ -48,7 +46,7 @@
                     </value>
                     <row-actions>
                         <action
-                            href="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Verified(Model.PersonId, Model.OneLoginSubject, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
+                            href="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Verified(Model.InstanceId, returnUrl: Request.GetEncodedPathAndQuery())"
                             visually-hidden-text="stay verified">Change
                         </action>
                     </row-actions>
@@ -58,10 +56,8 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Confirm and disconnect</govuk-button>
-                <govuk-button data-testid="cancel-button"
-                              formaction="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.CheckAnswersCancel(Model.PersonId!, Model.OneLoginSubject, Model.JourneyInstance!.InstanceId)"
-                              class="govuk-button--secondary" type="submit">Cancel
-                </govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true"
+                              class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers.cshtml.cs
@@ -8,8 +8,9 @@ using TeachingRecordSystem.Core.Services.Persons;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLogin;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DisconnectOneLogin), RequireJourneyInstance]
+[Journey(JourneyNames.DisconnectOneLogin)]
 public class CheckAnswers(
+    DisconnectOneLoginJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     TimeProvider timeProvider,
     OneLoginService oneLoginService,
@@ -20,7 +21,13 @@ public class CheckAnswers(
 
     [FromRoute] public required string OneLoginSubject { get; set; }
 
-    public JourneyInstance<DisconnectOneLoginState>? JourneyInstance { get; set; }
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? EmailAddress { get; set; }
 
@@ -34,25 +41,31 @@ public class CheckAnswers(
     {
         var oneLogin = await dbContext.OneLoginUsers.SingleAsync(x => x.Subject == OneLoginSubject);
         EmailAddress = oneLogin.EmailAddress;
-        Reason = JourneyInstance!.State.DisconnectReason;
-        Detail = JourneyInstance!.State.DisconnectReason == DisconnectOneLoginReason.AnotherReason ? JourneyInstance.State.Detail : null;
-        StayVerified = JourneyInstance!.State.StayVerified;
+        Reason = journey.State.DisconnectReason;
+        Detail = journey.State.DisconnectReason == DisconnectOneLoginReason.AnotherReason ? journey.State.Detail : null;
+        StayVerified = journey.State.StayVerified;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        }
+
         var changeReason = new ChangeReasonWithDetailsAndEvidence()
         {
             Reason = Reason?.GetDisplayName(),
-            Details = JourneyInstance!.State.DisconnectReason == DisconnectOneLoginReason.AnotherReason
-                ? JourneyInstance.State.Detail
+            Details = journey.State.DisconnectReason == DisconnectOneLoginReason.AnotherReason
+                ? journey.State.Detail
                 : null,
             EvidenceFile = null,
             AdditionalInformation = null
         };
         var processContext = new ProcessContext(ProcessType.PersonOneLoginUserDisconnecting, timeProvider.UtcNow, User.GetUserId(), changeReason: changeReason);
         var person = await dbContext.Persons.SingleAsync(x => x.PersonId == PersonId);
-        if (JourneyInstance!.State.StayVerified == DisconnectOneLoginStayVerified.Yes)
+        if (journey.State.StayVerified == DisconnectOneLoginStayVerified.Yes)
         {
             await oneLoginService.SetUserUnmatchedAsync(OneLoginSubject, processContext);
         }
@@ -64,21 +77,13 @@ public class CheckAnswers(
 
         var personName = $"{person.FirstName} {person.LastName}";
         TempData.SetFlashNotificationBanner($"GOV.UK One Login disconnected from {personName}’s record");
-        return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
-    }
 
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.DisconnectReason.HasValue || !JourneyInstance.State.StayVerified.HasValue)
-        {
-            context.Result = Redirect(linkGenerator.Persons.PersonDetail.DisconnectOneLogin.Index(PersonId, OneLoginSubject, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginJourneyCoordinator.cs
@@ -1,0 +1,9 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLogin;
+
+// Both route values scope the journey: a disconnect is about a specific person *and* One Login pair,
+// and scoping by both is what lets the library carry them through every generated URL.
+[JourneyCoordinator(JourneyNames.DisconnectOneLogin, routeValueKeys: ["personId", "oneLoginSubject"])]
+public class DisconnectOneLoginJourneyCoordinator : JourneyCoordinator<DisconnectOneLoginState>
+{
+    public override DisconnectOneLoginState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginLinkGenerator.cs
@@ -2,28 +2,16 @@ namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOn
 
 public class DisconnectOneLoginLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid personId, string oneLoginSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId,
-        bool? fromCheckAnswers = null) =>
+    public string Index(Guid personId, string oneLoginSubject) =>
         linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/DisconnectOneLogin/Index",
-            routeValues: new { personId, oneLoginSubject, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+            routeValues: new { personId, oneLoginSubject });
 
-    public string Cancel(Guid personId, string oneLoginSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/DisconnectOneLogin/Index", "cancel",
-            routeValues: new { personId, oneLoginSubject }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Persons/PersonDetail/DisconnectOneLogin/Index", journeyInstanceId, returnUrl);
 
-    public string Verified(Guid personId, string oneLoginSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/DisconnectOneLogin/Verified",
-            routeValues: new { personId, oneLoginSubject, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Verified(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Persons/PersonDetail/DisconnectOneLogin/Verified", journeyInstanceId, returnUrl);
 
-    public string VerifiedCancel(Guid personId, string oneLoginSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/DisconnectOneLogin/Verified", "cancel",
-            routeValues: new { personId, oneLoginSubject }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid personId, string oneLoginSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers",
-            routeValues: new { personId, oneLoginSubject }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid personId, string oneLoginSubject, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers", "cancel",
-            routeValues: new { personId, oneLoginSubject }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Persons/PersonDetail/DisconnectOneLogin/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginState.cs
@@ -2,18 +2,11 @@ using TeachingRecordSystem.Core.Services.Persons;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLogin;
 
-public class DisconnectOneLoginState : IRegisterJourney
+public class DisconnectOneLoginState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.DisconnectOneLogin,
-        typeof(DisconnectOneLoginState),
-        requestDataKeys: ["personId"],
-        appendUniqueKey: true);
-
     public DisconnectOneLoginReason? DisconnectReason { get; set; }
 
     public DisconnectOneLoginStayVerified? StayVerified { get; set; }
 
     public string? Detail { get; set; }
-
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Index.cshtml
@@ -44,10 +44,8 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button"
-                              formaction="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Cancel(Model.PersonId, Model.OneLoginSubject!, Model.JourneyInstance!.InstanceId)"
-                              class="govuk-button--secondary" type="submit">Cancel
-                </govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true"
+                              class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
 
         </form>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Index.cshtml.cs
@@ -5,8 +5,8 @@ using TeachingRecordSystem.Core.Services.Persons;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLogin;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DisconnectOneLogin), ActivatesJourney, RequireJourneyInstance]
-public class Index(SupportUiLinkGenerator linkGenerator, TrsDbContext dbContext) : PageModel
+[Journey(JourneyNames.DisconnectOneLogin), StartsJourney]
+public class Index(DisconnectOneLoginJourneyCoordinator journey, SupportUiLinkGenerator linkGenerator, TrsDbContext dbContext) : PageModel
 {
     private readonly InlineValidator<Index> _validator = new()
     {
@@ -34,53 +34,45 @@ public class Index(SupportUiLinkGenerator linkGenerator, TrsDbContext dbContext)
 
     [FromRoute] public required string OneLoginSubject { get; set; }
 
-    public JourneyInstance<DisconnectOneLoginState>? JourneyInstance { get; set; }
 
-    [FromQuery] public bool? FromCheckAnswers { get; set; }
 
     public string? EmailAddress { get; set; }
 
-    public string BackLink => FromCheckAnswers == true
-        ? linkGenerator.Persons.PersonDetail.DisconnectOneLogin.CheckAnswers(PersonId, OneLoginSubject!,
-            JourneyInstance!.InstanceId)
-        : linkGenerator.Persons.PersonDetail.Index(PersonId);
+    public string? BackLink { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public async Task OnGetAsync()
     {
         var oneLogin = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == OneLoginSubject);
-        ReasonDetail = JourneyInstance!.State.Detail;
-        Reason = JourneyInstance.State.DisconnectReason;
+        ReasonDetail = journey.State.Detail;
+        Reason = journey.State.DisconnectReason;
         EmailAddress = oneLogin.EmailAddress;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
-
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.DisconnectReason = Reason;
-            state.Detail = Reason == DisconnectOneLoginReason.AnotherReason ? ReasonDetail : null;
-        });
-
-        if (FromCheckAnswers == true)
-        {
-            return Redirect(linkGenerator.Persons.PersonDetail.DisconnectOneLogin.CheckAnswers(PersonId, OneLoginSubject,
-                JourneyInstance.InstanceId));
-        }
-
-        return Redirect(linkGenerator.Persons.PersonDetail.DisconnectOneLogin.Verified(PersonId, OneLoginSubject,
-            JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Persons.PersonDetail.DisconnectOneLogin.Verified(journey.InstanceId),
+            state =>
+            {
+                state.DisconnectReason = Reason;
+                state.Detail = Reason == DisconnectOneLoginReason.AnotherReason ? ReasonDetail : null;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    public override void OnPageHandlerExecuting(Microsoft.AspNetCore.Mvc.Filters.PageHandlerExecutingContext context)
     {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Index(PersonId);
     }
+
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Verified.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Verified.cshtml
@@ -35,10 +35,8 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button"
-                              formaction="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.VerifiedCancel(Model.PersonId, Model.OneLoginSubject, Model.JourneyInstance!.InstanceId)"
-                              class="govuk-button--secondary" type="submit">Cancel
-                </govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true"
+                              class="govuk-button--secondary" type="submit">Cancel</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Verified.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/DisconnectOneLogin/Verified.cshtml.cs
@@ -5,8 +5,8 @@ using TeachingRecordSystem.Core.Services.Persons;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLogin;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DisconnectOneLogin), RequireJourneyInstance]
-public class Verified(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.DisconnectOneLogin)]
+public class Verified(DisconnectOneLoginJourneyCoordinator journey, SupportUiLinkGenerator linkGenerator) : PageModel
 {
     private readonly InlineValidator<Verified> _validator = new()
     {
@@ -21,52 +21,36 @@ public class Verified(SupportUiLinkGenerator linkGenerator) : PageModel
 
     [BindProperty] public DisconnectOneLoginStayVerified? StayVerified { get; set; }
 
-    public JourneyInstance<DisconnectOneLoginState>? JourneyInstance { get; set; }
 
-    [FromQuery] public bool? FromCheckAnswers { get; set; }
 
-    public string BackLink => FromCheckAnswers == true
-        ? linkGenerator.Persons.PersonDetail.DisconnectOneLogin.CheckAnswers(PersonId, OneLoginSubject!,
-            JourneyInstance!.InstanceId)
-        : linkGenerator.Persons.PersonDetail.DisconnectOneLogin.Index(PersonId,
-            OneLoginSubject!, JourneyInstance!.InstanceId);
+    public string? BackLink { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public void OnGet()
     {
-        StayVerified = JourneyInstance?.State.StayVerified;
+        StayVerified = journey.State.StayVerified;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            journey.DeleteInstance();
+            return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        }
+
         await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.StayVerified = StayVerified;
-        });
-
-        return Redirect(
-            linkGenerator.Persons.PersonDetail.DisconnectOneLogin.CheckAnswers(
-                PersonId,
-                OneLoginSubject,
-                JourneyInstance.InstanceId));
-    }
-
-    public async Task<IActionResult> OnPostCancelAsync()
-    {
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
+        return journey.AdvanceTo(
+            linkGenerator.Persons.PersonDetail.DisconnectOneLogin.CheckAnswers(journey.InstanceId),
+            state => state.StayVerified = StayVerified);
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.DisconnectReason.HasValue)
-        {
-            context.Result = Redirect(
-                linkGenerator.Persons.PersonDetail.DisconnectOneLogin.Index(
-                    PersonId,
-                    OneLoginSubject,
-                    JourneyInstance.InstanceId));
-        }
+        BackLink = journey.GetBackLink();
     }
+
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Index.cshtml
@@ -33,7 +33,7 @@
                     {
                         <row-actions>
                             <action
-                                href="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Index(Model.PersonId, user.Subject, journeyInstanceId: null)"
+                                href="@LinkGenerator.Persons.PersonDetail.DisconnectOneLogin.Index(Model.PersonId, user.Subject)"
                                 visually-hidden-text="@user.EmailAddress">
                                 Disconnect
                             </action>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/CheckAnswersTests.cs
@@ -3,34 +3,8 @@ using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPe
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.DisconnectPerson;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : DisconnectPersonTestBase(hostFixture)
 {
-    [Theory]
-    [InlineData(null, null)]
-    [InlineData(DisconnectPersonStayVerified.Yes, null)]
-    [InlineData(null, DisconnectPersonReason.NewInformation)]
-    public async Task Get_WithMissingOptions_ReturnsToIndex(DisconnectPersonStayVerified? stayVerified,
-        DisconnectPersonReason? reason)
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            oneLogin.Subject,
-            new DisconnectPersonState() { DisconnectReason = reason, StayVerified = stayVerified });
-
-        var request = new HttpRequestMessage(HttpMethod.Get,
-            $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Fact]
     public async Task Post_RemovingVerification_RemovesPersonAndVerification()
     {
@@ -39,6 +13,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState() { DisconnectReason = DisconnectPersonReason.NewInformation, StayVerified = DisconnectPersonStayVerified.No });
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -77,6 +52,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState() { DisconnectReason = DisconnectPersonReason.NewInformation, StayVerified = DisconnectPersonStayVerified.Yes });
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -111,6 +87,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState() { DisconnectReason = DisconnectPersonReason.NewInformation, StayVerified = DisconnectPersonStayVerified.Yes });
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -139,6 +116,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState() { DisconnectReason = reason, StayVerified = stayVerified, Detail = details });
 
         var request = new HttpRequestMessage(HttpMethod.Get,
@@ -163,6 +141,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState() { DisconnectReason = reason, StayVerified = stayVerified, Detail = details });
 
         var request = new HttpRequestMessage(HttpMethod.Get,
@@ -176,9 +155,30 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         doc.GetElementByTestId("disconnect-reason-detail");
     }
 
-    private Task<JourneyInstance<DisconnectPersonState>> CreateJourneyInstanceAsync(string oneLoginUserSubject, DisconnectPersonState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DisconnectPerson,
-            state ?? new DisconnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUserSubject));
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToOneLoginDetail()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLogin.Subject,
+            person.PersonId,
+            new DisconnectPersonState
+            {
+                DisconnectReason = DisconnectPersonReason.NewInformation,
+                StayVerified = DisconnectPersonStayVerified.Yes
+            });
+
+        var pageUrl = $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}";
+
+        // Act
+        var response = await PostCancelAsync(pageUrl);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/one-logins/{oneLogin.Subject}", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/DisconnectPersonTestBase.cs
@@ -1,0 +1,51 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPerson;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.DisconnectPerson;
+
+public abstract class DisconnectPersonTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<DisconnectPersonJourneyCoordinator> CreateJourneyInstanceAsync(
+        string oneLoginUserSubject,
+        Guid personId,
+        DisconnectPersonState? state = null)
+    {
+        var basePath = $"/one-logins/{oneLoginUserSubject}/disconnect-person/{personId}";
+
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        return JourneyHelper.CreateInstanceAsync<DisconnectPersonJourneyCoordinator>(
+            JourneyNames.DisconnectPerson,
+            new RouteValueDictionary
+            {
+                ["oneLoginUserSubject"] = oneLoginUserSubject,
+                ["personId"] = personId
+            },
+            _ => Task.FromResult<object>(state ?? new DisconnectPersonState()),
+            pathUrls: [basePath, $"{basePath}/verified", $"{basePath}/check-answers"]);
+    }
+
+    protected DisconnectPersonState? GetJourneyInstanceState(DisconnectPersonJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (DisconnectPersonState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    /// <summary>
+    /// Submits the page's Cancel button exactly as the rendered page defines it, rather than a URL of
+    /// our own choosing.
+    /// </summary>
+    protected async Task<HttpResponseMessage> PostCancelAsync(string pageUrl)
+    {
+        var doc = await AssertEx.HtmlResponseAsync(await HttpClient.GetAsync(pageUrl));
+        var cancelButton = doc.GetElementByTestId("cancel-button")!;
+        Assert.Null(cancelButton.GetAttribute("formaction"));
+
+        return await HttpClient.PostAsync(
+            pageUrl,
+            new FormUrlEncodedContentBuilder
+            {
+                { cancelButton.GetAttribute("name")!, cancelButton.GetAttribute("value")! }
+            });
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/IndexTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPe
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.DisconnectPerson;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : DisconnectPersonTestBase(hostFixture)
 {
     [Fact]
     public async Task Post_WithoutReason_ReturnsError()
@@ -13,6 +13,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -38,6 +39,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -64,6 +66,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -93,6 +96,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -112,9 +116,30 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Contains($"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/verified", response.Headers.Location?.OriginalString);
     }
 
-    private Task<JourneyInstance<DisconnectPersonState>> CreateJourneyInstanceAsync(string oneLoginUserSubject, DisconnectPersonState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DisconnectPerson,
-            state ?? new DisconnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUserSubject));
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToOneLoginDetail()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLogin.Subject,
+            person.PersonId,
+            new DisconnectPersonState
+            {
+                DisconnectReason = DisconnectPersonReason.NewInformation,
+                StayVerified = DisconnectPersonStayVerified.Yes
+            });
+
+        var pageUrl = $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}?{journeyInstance.GetUniqueIdQueryParameter()}";
+
+        // Act
+        var response = await PostCancelAsync(pageUrl);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/one-logins/{oneLogin.Subject}", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/VerifiedTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/DisconnectPerson/VerifiedTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.OneLogins.OneLoginDetail.DisconnectPe
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.OneLogins.OneLoginDetail.DisconnectPerson;
 
-public class VerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class VerifiedTests(HostFixture hostFixture) : DisconnectPersonTestBase(hostFixture)
 {
     [Fact]
     public async Task Post_WithoutOption_ReturnsError()
@@ -13,6 +13,7 @@ public class VerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState()
             {
                 DisconnectReason = DisconnectPersonReason.NewInformation
@@ -43,6 +44,7 @@ public class VerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             oneLogin.Subject,
+            person.PersonId,
             new DisconnectPersonState() { DisconnectReason = DisconnectPersonReason.NewInformation, StayVerified = DisconnectPersonStayVerified.No });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/verified?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -61,9 +63,30 @@ public class VerifiedTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Contains($"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/check-answers", response.Headers.Location?.OriginalString);
     }
 
-    private Task<JourneyInstance<DisconnectPersonState>> CreateJourneyInstanceAsync(string oneLoginUserSubject, DisconnectPersonState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DisconnectPerson,
-            state ?? new DisconnectPersonState(),
-            new KeyValuePair<string, object>("oneLoginUserSubject", oneLoginUserSubject));
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToOneLoginDetail()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            oneLogin.Subject,
+            person.PersonId,
+            new DisconnectPersonState
+            {
+                DisconnectReason = DisconnectPersonReason.NewInformation,
+                StayVerified = DisconnectPersonStayVerified.Yes
+            });
+
+        var pageUrl = $"/one-logins/{oneLogin.Subject}/disconnect-person/{person.PersonId}/verified?{journeyInstance.GetUniqueIdQueryParameter()}";
+
+        // Act
+        var response = await PostCancelAsync(pageUrl);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/one-logins/{oneLogin.Subject}", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/CheckAnswersTests.cs
@@ -3,34 +3,8 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLog
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.DisconnectOneLogin;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : DisconnectOneLoginTestBase(hostFixture)
 {
-    [Theory]
-    [InlineData(null, null)]
-    [InlineData(DisconnectOneLoginStayVerified.Yes, null)]
-    [InlineData(null, DisconnectOneLoginReason.NewInformation)]
-    public async Task Get_WithMissingOptions_ReturnsToIndex(DisconnectOneLoginStayVerified? stayVerified,
-        DisconnectOneLoginReason? reason)
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            person.PersonId,
-            new DisconnectOneLoginState() { DisconnectReason = reason, StayVerified = stayVerified });
-
-        var request = new HttpRequestMessage(HttpMethod.Get,
-            $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}",
-            response.Headers.Location?.OriginalString);
-    }
-
     [Fact]
     public async Task Post_RemovingVerification_RemovesPersonAndVerification()
     {
@@ -39,6 +13,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState() { DisconnectReason = DisconnectOneLoginReason.NewInformation, StayVerified = DisconnectOneLoginStayVerified.No });
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -77,6 +52,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState() { DisconnectReason = DisconnectOneLoginReason.NewInformation, StayVerified = DisconnectOneLoginStayVerified.Yes });
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -113,6 +89,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState() { DisconnectReason = reason, StayVerified = stayVerified, Detail = details });
 
         var request = new HttpRequestMessage(HttpMethod.Get,
@@ -138,6 +115,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState() { DisconnectReason = reason, StayVerified = stayVerified, Detail = details });
 
         var request = new HttpRequestMessage(HttpMethod.Get,
@@ -156,12 +134,30 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(details, otherReasonDetails!.TextContent!.Trim());
     }
 
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToPersonDetail()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            oneLogin.Subject,
+            new DisconnectOneLoginState
+            {
+                DisconnectReason = DisconnectOneLoginReason.NewInformation,
+                StayVerified = DisconnectOneLoginStayVerified.Yes
+            });
 
+        var pageUrl = $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}";
 
-    private Task<JourneyInstance<DisconnectOneLoginState>> CreateJourneyInstanceAsync(Guid personId,
-        DisconnectOneLoginState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DisconnectOneLogin,
-            state ?? new DisconnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", personId));
+        // Act
+        var response = await PostCancelAsync(pageUrl);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/DisconnectOneLoginTestBase.cs
@@ -1,0 +1,51 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLogin;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.DisconnectOneLogin;
+
+public abstract class DisconnectOneLoginTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<DisconnectOneLoginJourneyCoordinator> CreateJourneyInstanceAsync(
+        Guid personId,
+        string oneLoginSubject,
+        DisconnectOneLoginState? state = null)
+    {
+        var basePath = $"/persons/{personId}/disconnect-one-login/{oneLoginSubject}";
+
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        return JourneyHelper.CreateInstanceAsync<DisconnectOneLoginJourneyCoordinator>(
+            JourneyNames.DisconnectOneLogin,
+            new RouteValueDictionary
+            {
+                ["personId"] = personId,
+                ["oneLoginSubject"] = oneLoginSubject
+            },
+            _ => Task.FromResult<object>(state ?? new DisconnectOneLoginState()),
+            pathUrls: [basePath, $"{basePath}/verified", $"{basePath}/check-answers"]);
+    }
+
+    protected DisconnectOneLoginState? GetJourneyInstanceState(DisconnectOneLoginJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (DisconnectOneLoginState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+
+    /// <summary>
+    /// Submits the page's Cancel button exactly as the rendered page defines it, rather than a URL of
+    /// our own choosing.
+    /// </summary>
+    protected async Task<HttpResponseMessage> PostCancelAsync(string pageUrl)
+    {
+        var doc = await AssertEx.HtmlResponseAsync(await HttpClient.GetAsync(pageUrl));
+        var cancelButton = doc.GetElementByTestId("cancel-button")!;
+        Assert.Null(cancelButton.GetAttribute("formaction"));
+
+        return await HttpClient.PostAsync(
+            pageUrl,
+            new FormUrlEncodedContentBuilder
+            {
+                { cancelButton.GetAttribute("name")!, cancelButton.GetAttribute("value")! }
+            });
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/IndexTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLog
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.DisconnectOneLogin;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : DisconnectOneLoginTestBase(hostFixture)
 {
     [Fact]
     public async Task Post_WithoutReason_ReturnsError()
@@ -13,6 +13,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -38,6 +39,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -64,6 +66,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -93,6 +96,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState());
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -112,9 +116,30 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Contains($"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/verified", response.Headers.Location?.OriginalString);
     }
 
-    private Task<JourneyInstance<DisconnectOneLoginState>> CreateJourneyInstanceAsync(Guid personId, DisconnectOneLoginState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DisconnectOneLogin,
-            state ?? new DisconnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", personId));
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToPersonDetail()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            oneLogin.Subject,
+            new DisconnectOneLoginState
+            {
+                DisconnectReason = DisconnectOneLoginReason.NewInformation,
+                StayVerified = DisconnectOneLoginStayVerified.Yes
+            });
+
+        var pageUrl = $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}?{journeyInstance.GetUniqueIdQueryParameter()}";
+
+        // Act
+        var response = await PostCancelAsync(pageUrl);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/VerifyTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/DisconnectOneLogin/VerifyTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.DisconnectOneLog
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Persons.PersonDetail.DisconnectOneLogin;
 
-public class VerifyTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class VerifyTests(HostFixture hostFixture) : DisconnectOneLoginTestBase(hostFixture)
 {
     [Fact]
     public async Task Post_WithoutOption_ReturnsError()
@@ -13,6 +13,7 @@ public class VerifyTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState()
             {
                 DisconnectReason = DisconnectOneLoginReason.NewInformation
@@ -43,6 +44,7 @@ public class VerifyTests(HostFixture hostFixture) : TestBase(hostFixture)
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         var journeyInstance = await CreateJourneyInstanceAsync(
             person.PersonId,
+            oneLogin.Subject,
             new DisconnectOneLoginState() { DisconnectReason = DisconnectOneLoginReason.NewInformation, StayVerified = DisconnectOneLoginStayVerified.No });
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/verified?{journeyInstance.GetUniqueIdQueryParameter()}")
@@ -61,9 +63,30 @@ public class VerifyTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Contains($"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/check-answers", response.Headers.Location?.OriginalString);
     }
 
-    private Task<JourneyInstance<DisconnectOneLoginState>> CreateJourneyInstanceAsync(Guid personId, DisconnectOneLoginState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DisconnectOneLogin,
-            state ?? new DisconnectOneLoginState(),
-            new KeyValuePair<string, object>("personId", personId));
+    [Fact]
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToPersonDetail()
+    {
+        // Arrange
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        var journeyInstance = await CreateJourneyInstanceAsync(
+            person.PersonId,
+            oneLogin.Subject,
+            new DisconnectOneLoginState
+            {
+                DisconnectReason = DisconnectOneLoginReason.NewInformation,
+                StayVerified = DisconnectOneLoginStayVerified.Yes
+            });
+
+        var pageUrl = $"/persons/{person.PersonId}/disconnect-one-login/{oneLogin.Subject}/verified?{journeyInstance.GetUniqueIdQueryParameter()}";
+
+        // Act
+        var response = await PostCancelAsync(pageUrl);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}", response.Headers.Location?.OriginalString);
+
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+    }
 }


### PR DESCRIPTION
### Context

Continues moving SupportUi journeys off `FormFlow` and onto `GovUk.Questions.AspNetCore` (DFE issue #369). Follows #3634, which did the two *connect* journeys; this is the matching pair of *disconnect* journeys:

- `OneLogins/OneLoginDetail/DisconnectPerson` — start from the One Login.
- `Persons/PersonDetail/DisconnectOneLogin` — start from the person.

Same three-step shape either way (Index → Verified → Check answers), and every change is the same change made twice, so they're in one PR.

Branched from `main`, independent of the other open migration PRs.

### Changes proposed in this pull request

- **Coordinators.** Add `DisconnectPersonJourneyCoordinator` and `DisconnectOneLoginJourneyCoordinator`, and drop `IRegisterJourney` from both states. Neither needs anything beyond a default starting state.
- **Both route values are now journey scoping keys.** This is the one structurally interesting bit. Every page in these journeys carries *two* route values (`{oneLoginUserSubject}` + `{personId}`, and `{personId}` + `{oneLoginSubject}`), but FormFlow scoped each instance by only one of them and passed the other explicitly to every link-generator call. The library builds URLs from `InstanceId.RouteValues`, so the second value has to be a scoping key for links to generate at all. It's also more accurate: a disconnect is about a specific One Login/person *pair*.
- **Index is the first question, not a redirect**, so `[StartsJourney]` goes straight on it (as in #3634).
- **Cancel** moves from `OnPostCancel` handlers to a `Cancel` form field on the same URL.
- **Change links** use `returnUrl` instead of `fromCheckAnswers`.
- **Guards dropped** on Verified (`DisconnectReason` null → Index) and CheckAnswers (either answer null → Index). Each guarded step can only enter the path via an `AdvanceTo` that sets the state it was checking.

### A leak fixed

Neither CheckAnswers deleted the journey instance after a successful disconnect — the answers outlived the journey. Both now call `DeleteInstance()`, matching every other migrated journey. Not user-visible (each entry mints a fresh key), but it left state in the session indefinitely.

### Guidance to review

- **Route paths are unchanged** for all six pages.
- **The scoping change is worth a look.** It changes what identifies an instance. For a fresh journey it makes no difference, and the E2E tests below exercise it for real; but if you'd rather keep single-key scoping, the alternative is teaching the shared `GetJourneyPage` extension to take extra route values.
- `Persons/PersonDetail/Index.cshtml` needed a one-line change — its "Disconnect" link passed `journeyInstanceId: null`, which no longer exists as a parameter.
- Two of these `.cshtml` files contain a Windows-1252 byte (0x92) rather than UTF-8. I've preserved them byte-for-byte rather than silently re-encoding, but they're worth fixing separately.

### Testing

- `just build` — no errors, no warnings (only the pre-existing `NU1903` transitive advisories).
- Disconnect page tests: **33 passed** (33 before: −6 dropped guard cases, +6 new cancel tests). `just test-changed`: SupportUi.Tests **3961 passed**, SupportUi E2E **139 passed**. Only the two known-ignored `AuthorizeAccess` `OidcTests` fail.
- **Both journeys already have Playwright E2E coverage** (`DisconnectPersonTests`, `DisconnectOneLoginTests` — 5 tests) and both still pass. Since those drive the real journeys through a browser with every URL coming from the link generator, they're the direct evidence that the two-key scoping works end to end.
- **New coverage**: cancel had no test at all in either journey — not at page level, not in E2E — and this PR changes how it's submitted. There's now a test per page (6 total) that reads the Cancel button out of the rendered HTML, asserts it has no `formaction`, and submits it as a browser would. I checked the assertion isn't vacuous by removing one `DeleteInstance()` and confirming the test fails.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
