### PR TITLE
Add support tasks to the homepage

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
@@ -53,7 +53,51 @@
             </govuk-tabs-item>
         </govuk-tabs>
     </div>
+    @if ((await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.SupportTasksEdit)).Succeeded)
+    {
+        <div class="govuk-grid-column-full">
+            <div class="trs-task-tile-section">
+                <div class="trs-task-tile-layout">
+                    <div class="trs-task-panel">
+                        <h3 class="govuk-heading-m">My tasks</h3>
+                        <div class="trs-task-tile">
+                            <div class="trs-task-tile__header">
+                                <span class="trs-task-tile__count" data-testid="my-tasks-count">@Model.MyTasksCount</span>
+                            </div>
+                            <a class="govuk-link" href="@LinkGenerator.SupportTasks.Active(type: null, assignedToUserId: User.GetUserId(), statuses: new[] { SupportTaskStatus.Open, SupportTaskStatus.InProgress }, sortBy: null, sortDirection: null)">Tasks assigned to me</a>
+                        </div>
+                    </div>
+                    <div class="trs-task-panel">
+                        <h3 class="govuk-heading-m">Tasks overview</h3>
+                        <div class="trs-task-tile-row">
+                            <div class="trs-task-tile">
+                                <div class="trs-task-tile__header">
+                                    <span class="trs-task-tile__count" data-testid="unassigned-task-count">@Model.UnassignedCount</span>
 
+                                    <tag color="TagColor.Yellow">Unassigned</tag>
+                                </div>
+                                <a class="govuk-link" href="@LinkGenerator.SupportTasks.Active(type: null, assignedToUserId: null, statuses: new[] { SupportTaskStatus.Open, SupportTaskStatus.InProgress }, sortBy: null, sortDirection: null)">Manage unassigned tasks</a>
+                            </div>
+                            <div class="trs-task-tile">
+                                <div class="trs-task-tile__header">
+                                    <span class="trs-task-tile__count" data-testid="in-progress-tasks-count">@Model.InProgressCount</span>
+
+                                    <tag color="TagColor.LightBlue">In progress</tag>
+                                </div>
+                                <a class="govuk-link" href="@LinkGenerator.SupportTasks.Active(type: null, assignedToUserId: null, statuses: new[] { SupportTaskStatus.InProgress }, sortBy: null, sortDirection: null)">Manage tasks in progress</a>
+                            </div>
+                            <div class="trs-task-tile">
+                                <div class="trs-task-tile__header">
+                                    <span class="govuk-heading-s">Completed tasks</span>
+                                </div>
+                                <a class="govuk-link" href="@LinkGenerator.SupportTasks.Completed()">View completed tasks</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
     <div class="govuk-grid-column-full">
         <div class="trs-tiles govuk-!-margin-top-5">
             @if ((await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.SupportTasksEdit)).Succeeded)

--- a/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml
@@ -53,7 +53,7 @@
             </govuk-tabs-item>
         </govuk-tabs>
     </div>
-    @if ((await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.SupportTasksEdit)).Succeeded)
+    @if (FeatureProvider.IsEnabled("SupportTaskDashboard") && (await AuthorizationService.AuthorizeAsync(User, AuthorizationPolicies.SupportTasksEdit)).Succeeded)
     {
         <div class="govuk-grid-column-full">
             <div class="trs-task-tile-section">

--- a/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Index.cshtml.cs
@@ -1,11 +1,18 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages;
 
-public class IndexModel(TrsDbContext dbContext) : PageModel
+public class IndexModel(TrsDbContext dbContext, IAuthorizationService authorizationService) : PageModel
 {
     public IReadOnlyDictionary<SupportTaskType, int>? SupportTaskCounts { get; set; }
+
+    // Task dashboard counts
+    public int MyTasksCount { get; set; }
+    public int UnassignedCount { get; set; }
+    public int InProgressCount { get; set; }
 
     public async Task OnGetAsync()
     {
@@ -15,5 +22,24 @@ public class IndexModel(TrsDbContext dbContext) : PageModel
                 .Select(g => new { Status = g.Key, Count = g.Count() })
                 .ToArrayAsync())
             .ToDictionary(t => t.Status, t => t.Count);
+
+        var canViewSupportTasks = (await authorizationService.AuthorizeAsync(User, AuthorizationPolicies.SupportTasksEdit)).Succeeded;
+
+        if (canViewSupportTasks)
+        {
+            var userId = User.GetUserId();
+
+            MyTasksCount = await dbContext.SupportTasks
+                .Where(t => t.AssignedToUserId == userId && t.IsOutstanding)
+                .CountAsync();
+
+            UnassignedCount = await dbContext.SupportTasks
+                .Where(t => t.AssignedToUserId == null && t.IsOutstanding)
+                .CountAsync();
+
+            InProgressCount = await dbContext.SupportTasks
+                .Where(t => t.Status == SupportTaskStatus.InProgress)
+                .CountAsync();
+        }
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Styles/app.scss
+++ b/src/TeachingRecordSystem.SupportUi/Styles/app.scss
@@ -382,6 +382,31 @@
   }
 }
 
+.trs-task-tile-layout {
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+  column-gap: 30px;
+}
+
+.trs-task-tile-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  column-gap: 15px;
+}
+
+.trs-task-tile__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 52px;
+  padding-bottom: 16px;
+}
+
+.trs-task-tile__count {
+  @include govuk-font($size: 36, $weight: bold);
+  line-height: 1;
+}
+
 .trs-potential-duplicates.trs-potential-duplicates--side-by-side {
   @include govuk-media-query($from: desktop) {
     display: flex;

--- a/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
+++ b/src/TeachingRecordSystem.SupportUi/appsettings.Development.json
@@ -1,4 +1,4 @@
 {
   "DetailedErrors": true,
-  "EnabledFeatures": [ "SwitchRoles" ]
+  "EnabledFeatures": [ "SwitchRoles","SupportTaskDashboard" ]
 }

--- a/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
+++ b/src/TeachingRecordSystem.SupportUi/appsettings.EndToEndTests.json
@@ -7,5 +7,5 @@
       }
     }
   },
-  "EnabledFeatures": [ "NewUserRoles" ]
+  "EnabledFeatures": [ "SwitchRoles","SupportTaskDashboard" ],
 }

--- a/src/TeachingRecordSystem.SupportUi/appsettings.Tests.json
+++ b/src/TeachingRecordSystem.SupportUi/appsettings.Tests.json
@@ -8,5 +8,5 @@
     }
   },
   "ConcurrentNameChangeWindowSeconds": 1,
-  "EnabledFeatures": [ ]
+  "EnabledFeatures": [ "SupportTaskDashboard" ]
 }

--- a/src/TeachingRecordSystem.SupportUi/appsettings.aks_dev.json
+++ b/src/TeachingRecordSystem.SupportUi/appsettings.aks_dev.json
@@ -1,4 +1,4 @@
 {
   "CrmUrl": "https://ent-dqt-build.crm4.dynamics.com",
-  "EnabledFeatures": [ "NewUserRoles" ]
+  "EnabledFeatures": [ "NewUserRoles","SupportTaskDashboard" ]
 }

--- a/src/TeachingRecordSystem.SupportUi/appsettings.aks_pre-production.json
+++ b/src/TeachingRecordSystem.SupportUi/appsettings.aks_pre-production.json
@@ -1,4 +1,4 @@
 {
   "CrmUrl": "https://ent-dqt-preprod.crm4.dynamics.com",
-  "EnabledFeatures": [ "SwitchRoles", "NewUserRoles" ]
+  "EnabledFeatures": [ "SwitchRoles", "NewUserRoles","SupportTaskDashboard" ]
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/IndexTests.cs
@@ -1,0 +1,133 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests;
+
+[ClearDbBeforeTest, Collection(nameof(DisableParallelization))]
+public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    [Fact]
+    public async Task? Get_UserWithoutRole_DoesNotRenderSupportTaskPanel()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(name: "Reviewer One");
+        SetCurrentUser(user);
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var supportTasks = doc.GetElementByTestId($"support-tasks-panel");
+        Assert.Null(supportTasks);
+    }
+
+    [Fact]
+    public async Task Get_NoTasks_RendersCorrectCounts()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(name: "Reviewer One", role: UserRoles.RecordManager);
+        SetCurrentUser(user);
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var myTasks = doc.GetElementByTestId($"my-tasks-count");
+        var unassignedTasks = doc.GetElementByTestId($"unassigned-task-count");
+        var inProgressTasks = doc.GetElementByTestId($"in-progress-tasks-count");
+        Assert.NotNull(myTasks);
+        Assert.NotNull(unassignedTasks);
+        Assert.NotNull(inProgressTasks);
+        Assert.Equal("0", myTasks.TextContent);
+        Assert.Equal("0", unassignedTasks.TextContent);
+        Assert.Equal("0", inProgressTasks.TextContent);
+    }
+
+    [Fact]
+    public async Task Get_TasksAssignedToMe_RendersCorrectCount()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(name: "Reviewer One", role: UserRoles.RecordManager);
+        SetCurrentUser(user);
+        var supportTask1 = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            configure: r => r
+                .WithCreatedOn(new DateTime(2025, 1, 20))
+                .WithStatus(SupportTaskStatus.InProgress),
+            configurePerson: p => p
+                .WithFirstName("Alice")
+                .WithMiddleName("The")
+                .WithLastName("Apple"));
+        var supportTask2 = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            configure: r => r
+                .WithCreatedOn(new DateTime(2023, 1, 20))
+                .WithStatus(SupportTaskStatus.Open),
+            configurePerson: p => p
+                .WithFirstName("bob")
+                .WithLastName("smith"));
+        await AssignToUserAsync(supportTask1, user.UserId);
+        await AssignToUserAsync(supportTask2, user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var myTasks = doc.GetElementByTestId($"my-tasks-count");
+        var inProgressTasks = doc.GetElementByTestId($"in-progress-tasks-count");
+        Assert.NotNull(myTasks);
+        Assert.Equal("2", myTasks.TextContent);
+        Assert.NotNull(inProgressTasks);
+        Assert.Equal("1", inProgressTasks.TextContent);
+    }
+
+    [Fact]
+    public async Task Get_Tasks_RendersCorrectCount()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(name: "Reviewer One", role: UserRoles.RecordManager);
+        SetCurrentUser(user);
+        var supportTask1 = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            configure: r => r
+                .WithCreatedOn(new DateTime(2025, 1, 20))
+                .WithStatus(SupportTaskStatus.Open),
+            configurePerson: p => p
+                .WithFirstName("Alice")
+                .WithMiddleName("The")
+                .WithLastName("Apple"));
+        var supportTask2 = await TestData.CreateChangeNameRequestSupportTaskAsync(
+            configure: r => r
+                .WithCreatedOn(new DateTime(2023, 1, 20))
+                .WithStatus(SupportTaskStatus.Open),
+            configurePerson: p => p
+                .WithFirstName("bob")
+                .WithLastName("smith"));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var unassignedTasks = doc.GetElementByTestId($"unassigned-task-count");
+        Assert.NotNull(unassignedTasks);
+        Assert.Equal("2", unassignedTasks.TextContent);
+    }
+
+    private Task AssignToUserAsync(SupportTask task, Guid userId) =>
+        WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.FindAsync(task.SupportTaskReference);
+            dbTask!.AssignedToUserId = userId;
+            await dbContext.SaveChangesAsync();
+        });
+}


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/teaching-record-team-project-board/issues/324

Add support tasks to home page to show tasks.

### Changes proposed in this pull request
Added support tasks to home page to task information.

- Assigned to Me
- Unassigned
- In Progress
- Completed

Added an indexTests

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally