### PR TITLE
Migrate Delete MQ journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/delete/check-answers/{handler?}"
+@page "/mqs/{qualificationId}/delete/check-answers"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before deleting mandatory qualification";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.DeleteMq.Index(Model.QualificationId, Model.JourneyInstance!.InstanceId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -64,7 +67,7 @@
             <h2 class="govuk-heading-m">Are you sure you want to delete this mandatory qualification?</h2>
             <div class="govuk-button-group">
                 <govuk-button class="govuk-button--warning" type="submit">Confirm and delete qualification</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.DeleteMq.CheckAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/CheckAnswers.cshtml.cs
@@ -7,17 +7,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DeleteMq), RequireJourneyInstance]
+[Journey(JourneyNames.DeleteMq)]
 public class CheckAnswersModel(
+    DeleteMqJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     TimeProvider timeProvider,
     MandatoryQualificationService mandatoryQualificationService) : PageModel
 {
-    public JourneyInstance<DeleteMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -43,11 +49,7 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.DeleteMq.Index(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var qualificationInfo = context.HttpContext.GetCurrentMandatoryQualificationFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
@@ -59,14 +61,19 @@ public class CheckAnswersModel(
         Status = qualificationInfo.MandatoryQualification.Status;
         StartDate = qualificationInfo.MandatoryQualification.StartDate;
         EndDate = qualificationInfo.MandatoryQualification.EndDate;
-        DeletionReason = JourneyInstance.State.DeletionReason;
-        DeletionReasonDetail = JourneyInstance.State.DeletionReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
+        DeletionReason = journey.State.DeletionReason;
+        DeletionReasonDetail = journey.State.DeletionReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = journey.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var qualification = HttpContext.GetCurrentMandatoryQualificationFeature().MandatoryQualification;
 
         var processContext = new ProcessContext(
@@ -88,16 +95,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Mandatory qualification deleted");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqJourneyCoordinator.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+[JourneyCoordinator(JourneyNames.DeleteMq, routeValueKeys: ["qualificationId"])]
+public class DeleteMqJourneyCoordinator : JourneyCoordinator<DeleteMqState>
+{
+    public override DeleteMqState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqLinkGenerator.cs
@@ -2,15 +2,12 @@ namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 public class DeleteMqLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/DeleteMq/Index", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid qualificationId) =>
+        linkGenerator.GetRequiredPathByPage("/Mqs/DeleteMq/Index", routeValues: new { qualificationId });
 
-    public string Cancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/DeleteMq/Index", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/DeleteMq/Index", journeyInstanceId, returnUrl);
 
-    public string CheckAnswers(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/DeleteMq/CheckAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/DeleteMq/CheckAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Mqs/DeleteMq/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/DeleteMqState.cs
@@ -1,19 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
-public class DeleteMqState : IRegisterJourney
+public class DeleteMqState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.DeleteMq,
-        typeof(DeleteMqState),
-        requestDataKeys: ["qualificationId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public MqDeletionReasonOption? DeletionReason { get; set; }
 
     public string? DeletionReasonDetail { get; set; }
@@ -23,12 +13,4 @@ public class DeleteMqState : IRegisterJourney
     public bool? ProvideAdditionalInformation { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(DeletionReason))]
-
-    public bool IsComplete => DeletionReason.HasValue &&
-        (DeletionReason == MqDeletionReasonOption.AnotherReason && !string.IsNullOrEmpty(DeletionReasonDetail) || DeletionReason != MqDeletionReasonOption.AnotherReason && string.IsNullOrEmpty(DeletionReasonDetail)) &&
-        (ProvideAdditionalInformation == true && !string.IsNullOrEmpty(AdditionalInformation) || ProvideAdditionalInformation == false && string.IsNullOrEmpty(AdditionalInformation)) &&
-        Evidence.IsComplete;
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/delete/{handler?}"
+@page "/mqs/{qualificationId}/delete"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq.IndexModel
 @{
     ViewBag.Title = Html.DisplayNameFor(m => m.DeletionReason);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons.PersonDetail.Qualifications(Model.PersonId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -54,7 +57,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.DeleteMq.Cancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/DeleteMq/Index.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DeleteMq), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.DeleteMq), StartsJourney]
+public class IndexModel(
+    DeleteMqJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<IndexModel> _validator = new()
     {
@@ -26,10 +29,15 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<DeleteMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -60,43 +68,48 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         Specialism = qualificationInfo.MandatoryQualification.Specialism;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Qualifications(PersonId);
     }
 
     public void OnGet()
     {
-        DeletionReason = JourneyInstance!.State.DeletionReason;
-        DeletionReasonDetail = DeletionReason == MqDeletionReasonOption.AnotherReason ? JourneyInstance.State.DeletionReasonDetail : null;
-        Evidence = JourneyInstance.State.Evidence;
-        AdditionalInformation = ProvideAdditionalInformation == true ? JourneyInstance.State.AdditionalInformation : null;
-        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
+        DeletionReason = journey.State.DeletionReason;
+        DeletionReasonDetail = DeletionReason == MqDeletionReasonOption.AnotherReason ? journey.State.DeletionReasonDetail : null;
+        Evidence = journey.State.Evidence;
+        AdditionalInformation = ProvideAdditionalInformation == true ? journey.State.AdditionalInformation : null;
+        ProvideAdditionalInformation = journey.State.ProvideAdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<IndexModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.DeletionReason = DeletionReason;
-            state.DeletionReasonDetail = DeletionReasonDetail;
-            state.Evidence = Evidence;
-            state.AdditionalInformation = AdditionalInformation;
-            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Mqs.DeleteMq.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.DeleteMq.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.DeletionReason = DeletionReason;
+                state.DeletionReasonDetail = DeletionReasonDetail;
+                state.Evidence = Evidence;
+                state.AdditionalInformation = AdditionalInformation;
+                state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -175,7 +175,7 @@ else
             <card-actions>
                 @if (Model.CanEdit)
                 {
-                    <action href="@LinkGenerator.Mqs.DeleteMq.Index(mq.QualificationId, null)" data-testid="delete-link-@mq.QualificationId">Delete qualification</action>
+                    <action href="@LinkGenerator.Mqs.DeleteMq.Index(mq.QualificationId)" data-testid="delete-link-@mq.QualificationId">Delete qualification</action>
                 }
             </card-actions>
             <govuk-summary-list>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/CheckAnswersTests.cs
@@ -4,31 +4,8 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.DeleteMq;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : DeleteMqTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new DeleteMqState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData("University of Leeds", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Passed, "2021-11-05", MqDeletionReasonOption.AnotherReason, "Some details about the deletion reason", true, "additional info", true)]
     [InlineData("University of Leeds", MandatoryQualificationSpecialism.Hearing, "2021-10-05", MandatoryQualificationStatus.Deferred, null, MqDeletionReasonOption.ProviderRequest, null, false, "additional info", true)]
@@ -61,7 +38,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualification.QualificationId,
             new DeleteMqState
             {
-                Initialized = true,
                 DeletionReason = deletionReason,
                 DeletionReasonDetail = deletionReasonDetail,
                 Evidence = new()
@@ -110,32 +86,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new DeleteMqState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Post_Confirm_DeletesMqCreatesEventCompletesJourneyAndRedirectsWithFlashMessage()
     {
         // Arrange
@@ -164,7 +114,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new DeleteMqState
             {
-                Initialized = true,
                 DeletionReason = deletionReason,
                 DeletionReasonDetail = deletionReasonDetail,
                 Evidence = new()
@@ -218,8 +167,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             Assert.Equal(new EventModels.File { FileId = evidenceFileId, Name = evidenceFileName }, changeReason.EvidenceFile);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
@@ -232,7 +180,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new DeleteMqState
             {
-                Initialized = true,
                 DeletionReason = MqDeletionReasonOption.AnotherReason,
                 DeletionReasonDetail = "Some details about the deletion reason",
                 Evidence = new()
@@ -243,9 +190,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 AdditionalInformation = null
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -254,8 +201,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -290,7 +236,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new DeleteMqState
             {
-                Initialized = true,
                 DeletionReason = deletionReason,
                 DeletionReasonDetail = null,
                 Evidence = new()
@@ -316,9 +261,4 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<DeleteMqState>> CreateJourneyInstanceAsync(Guid qualificationId, DeleteMqState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.DeleteMq,
-            state ?? new DeleteMqState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/DeleteMqTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/DeleteMqTestBase.cs
@@ -1,0 +1,26 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.DeleteMq;
+
+public abstract class DeleteMqTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<DeleteMqJourneyCoordinator> CreateJourneyInstanceAsync(Guid qualificationId, DeleteMqState? state = null) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<DeleteMqJourneyCoordinator>(
+            JourneyNames.DeleteMq,
+            new RouteValueDictionary { ["qualificationId"] = qualificationId },
+            _ => Task.FromResult<object>(state ?? new DeleteMqState()),
+            pathUrls:
+            [
+                $"/mqs/{qualificationId}/delete",
+                $"/mqs/{qualificationId}/delete/check-answers",
+            ]);
+
+    protected DeleteMqState? GetJourneyInstanceState(DeleteMqJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (DeleteMqState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/DeleteMq/IndexTests.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.DeleteMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.DeleteMq;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : DeleteMqTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
@@ -228,9 +228,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualification = person.MandatoryQualifications.Single();
         var journeyInstance = await CreateJourneyInstanceAsync(qualification.QualificationId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualification.QualificationId}/delete/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualification.QualificationId}/delete?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -239,8 +239,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -266,12 +265,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
-
-    private async Task<JourneyInstance<DeleteMqState>> CreateJourneyInstanceAsync(Guid qualificationId, DeleteMqState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.DeleteMq,
-            state ?? new DeleteMqState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 
     private MultipartFormDataContent CreateFormFileUpload(string fileExtension)
     {


### PR DESCRIPTION
Follows the alert journey migrations (#3618, #3620–#3624, #3629, #3630). First of the MQ journeys.

## What

Migrates the **Delete MQ** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the alert journeys.

## Changes

- Add `DeleteMqJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.DeleteMq, ["qualificationId"])]`); drop FormFlow's `IRegisterJourney` from `DeleteMqState`.
- Rewrite Index and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys and a form-field `Cancel` submit in place of the `/cancel` handler URLs.
- Rewrite `DeleteMqLinkGenerator` onto the shared `GetJourneyPage` extension; update the person qualifications page entry link.
- Index moves off the `ValidateAndThrow` + `PageWithErrors` mix onto `ValidateAndThrowAsync`, and uploads evidence *before* validating (the `Evidence()` validator already carries the "Select a file" rule that `ValidateAndUploadAsync` was adding by hand).
- `IsComplete`, the never-read `Initialized` flag and the check answers guard are dropped — the library's path validation already stops users reaching a step they haven't advanced to. The guard's two redirect tests go with it.
- Test journey seeding moves into a shared `DeleteMqTestBase`.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- DeleteMq page tests: **20 passed** (22 before, minus the 2 removed guard tests). All `PageTests.Mqs` + person qualifications tests: **256 passed**.
- Route paths (`/mqs/{qualificationId}/delete`, `/delete/check-answers`) preserved, so the E2E `DeleteMq` journey test needs no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)