### PR TITLE
Migrate Edit MQ Provider journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/provider/check-answers/{handler?}"
+@page "/mqs/{qualificationId}/provider/check-answers"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before editing mandatory qualification";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.EditMq.Provider.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -50,7 +53,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and update qualification</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.Provider.CheckAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/CheckAnswers.cshtml.cs
@@ -9,17 +9,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqProvider), RequireJourneyInstance]
+[Journey(JourneyNames.EditMqProvider)]
 public class CheckAnswersModel(
+    EditMqProviderJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     TimeProvider timeProvider,
     MandatoryQualificationService mandatoryQualificationService) : PageModel
 {
-    public JourneyInstance<EditMqProviderState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -43,11 +49,7 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.EditMq.Provider.Index(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var qualificationInfo = context.HttpContext.GetCurrentMandatoryQualificationFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
@@ -55,16 +57,21 @@ public class CheckAnswersModel(
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         CurrentProviderName = qualificationInfo.MandatoryQualification.Provider?.Name;
-        ProviderId = JourneyInstance.State.ProviderId!.Value;
+        ProviderId = journey.State.ProviderId!.Value;
         ProviderName = MandatoryQualificationProvider.GetById(ProviderId).Name;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = journey.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var qualification = HttpContext.GetCurrentMandatoryQualificationFeature().MandatoryQualification;
 
         var processContext = new ProcessContext(
@@ -87,16 +94,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Mandatory qualification changed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderJourneyCoordinator.cs
@@ -1,0 +1,16 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
+
+[JourneyCoordinator(JourneyNames.EditMqProvider, routeValueKeys: ["qualificationId"])]
+public class EditMqProviderJourneyCoordinator : JourneyCoordinator<EditMqProviderState>
+{
+    public override EditMqProviderState GetStartingState()
+    {
+        var qualificationInfo = HttpContext.GetCurrentMandatoryQualificationFeature();
+
+        return new EditMqProviderState
+        {
+            CurrentProviderId = qualificationInfo.MandatoryQualification.ProviderId,
+            ProviderId = qualificationInfo.MandatoryQualification.ProviderId
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderLinkGenerator.cs
@@ -2,21 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
 public class EditMqProviderLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Provider/Index", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid qualificationId) =>
+        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Provider/Index", routeValues: new { qualificationId });
 
-    public string Cancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Provider/Index", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/Provider/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Provider/Reason", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/Provider/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Provider/Reason", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Provider/CheckAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Provider/CheckAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/Provider/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/EditMqProviderState.cs
@@ -1,19 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
-public class EditMqProviderState : IRegisterJourney
+public class EditMqProviderState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.EditMqProvider,
-        typeof(EditMqProviderState),
-        requestDataKeys: ["qualificationId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public Guid? CurrentProviderId { get; set; }
 
     public Guid? ProviderId { get; set; }
@@ -27,24 +17,4 @@ public class EditMqProviderState : IRegisterJourney
     public string? AdditionalInformation { get; set; }
 
     public bool? ProvideAdditionalInformation { get; set; }
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(ProviderId), nameof(ChangeReason))]
-    public bool IsComplete =>
-        ProviderId.HasValue &&
-        ChangeReason.HasValue &&
-        (ChangeReason == MqChangeProviderReasonOption.AnotherReason && !string.IsNullOrEmpty(ChangeReasonDetail) || (ChangeReason != MqChangeProviderReasonOption.AnotherReason && string.IsNullOrEmpty(ChangeReasonDetail))) &&
-        (ProvideAdditionalInformation == true && !string.IsNullOrEmpty(AdditionalInformation) || (ProvideAdditionalInformation != true && string.IsNullOrEmpty(AdditionalInformation))) &&
-        Evidence.IsComplete;
-
-    public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        ProviderId = CurrentProviderId = qualificationInfo.MandatoryQualification.ProviderId;
-        Initialized = true;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml
@@ -1,4 +1,4 @@
-@page "/mqs/{qualificationId}/provider/{handler?}"
+@page "/mqs/{qualificationId}/provider"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider.IndexModel
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 @{
@@ -17,7 +17,10 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons.PersonDetail.Qualifications(Model.PersonId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -36,7 +39,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.Provider.Cancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Index.cshtml.cs
@@ -6,8 +6,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqProvider), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceController) : PageModel
+[Journey(JourneyNames.EditMqProvider), StartsJourney]
+public class IndexModel(
+    EditMqProviderJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceController) : PageModel
 {
     private readonly InlineValidator<IndexModel> _validator = new()
     {
@@ -15,10 +18,15 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
             .NotNull().WithMessage("Select a training provider")
     };
 
-    public JourneyInstance<EditMqProviderState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -31,35 +39,39 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        ProviderId = JourneyInstance!.State.ProviderId;
+        ProviderId = journey.State.ProviderId;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        _validator.ValidateAndThrow(this);
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
 
-        await JourneyInstance!.UpdateStateAsync(state => state.ProviderId = ProviderId);
+        await _validator.ValidateAndThrowAsync(this);
 
-        return Redirect(linkGenerator.Mqs.EditMq.Provider.Reason(QualificationId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.EditMq.Provider.Reason(journey.InstanceId),
+            state => state.ProviderId = ProviderId);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        var qualificationInfo = context.HttpContext.GetCurrentMandatoryQualificationFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
-
-        JourneyInstance!.State.EnsureInitialized(qualificationInfo);
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         Providers = MandatoryQualificationProvider.All.Select(p => new ProviderInfo(p.MandatoryQualificationProviderId, p.Name)).ToArray();
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Qualifications(PersonId);
     }
 
     public record ProviderInfo(Guid MandatoryQualificationProviderId, string Name);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/provider/reason/{handler?}"
+@page "/mqs/{qualificationId}/provider/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider.ReasonModel
 @{
     ViewBag.Title = Html.DisplayNameFor(m => m.ChangeReason);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.EditMq.Provider.Index(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -54,7 +57,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.Provider.ReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Provider/Reason.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqProvider), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditMqProvider)]
+public class ReasonModel(
+    EditMqProviderJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -26,10 +29,15 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<EditMqProviderState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -52,11 +60,7 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.ProviderId.HasValue)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.EditMq.Provider.Index(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -66,39 +70,42 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        ChangeReasonDetail = ChangeReason == MqChangeProviderReasonOption.AnotherReason ? JourneyInstance.State.ChangeReasonDetail : null;
-        Evidence = JourneyInstance.State.Evidence;
-        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
-        AdditionalInformation = ProvideAdditionalInformation == true ? JourneyInstance.State.AdditionalInformation : null;
+        ChangeReason = journey.State.ChangeReason;
+        ChangeReasonDetail = ChangeReason == MqChangeProviderReasonOption.AnotherReason ? journey.State.ChangeReasonDetail : null;
+        Evidence = journey.State.Evidence;
+        ProvideAdditionalInformation = journey.State.ProvideAdditionalInformation;
+        AdditionalInformation = ProvideAdditionalInformation == true ? journey.State.AdditionalInformation : null;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail = ChangeReason == MqChangeProviderReasonOption.AnotherReason ? ChangeReasonDetail : null;
-            state.Evidence = Evidence;
-            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
-            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Mqs.EditMq.Provider.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.EditMq.Provider.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.ChangeReasonDetail = ChangeReason == MqChangeProviderReasonOption.AnotherReason ? ChangeReasonDetail : null;
+                state.Evidence = Evidence;
+                state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+                state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -185,7 +185,7 @@ else
                     <row-actions>
                         @if (Model.CanEdit)
                         {
-                            <action href="@LinkGenerator.Mqs.EditMq.Provider.Index(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="training provider" data-testid="provider-change-link-@mq.QualificationId">Change</action>
+                            <action href="@LinkGenerator.Mqs.EditMq.Provider.Index(mq.QualificationId)" class="govuk-link" visually-hidden-text="training provider" data-testid="provider-change-link-@mq.QualificationId">Change</action>
                         }
                     </row-actions>
                 </row>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/CheckAnswersTests.cs
@@ -4,31 +4,8 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Provider;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : EditMqProviderTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqProviderState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/provider/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/provider?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(MqChangeProviderReasonOption.ChangeOfTrainingProvider, null, false, true, "Additional info")]
     [InlineData(MqChangeProviderReasonOption.AnotherReason, "Some reason", true, false, null)]
@@ -48,7 +25,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = newProvider.MandatoryQualificationProviderId,
                 CurrentProviderId = oldProvider.MandatoryQualificationProviderId,
                 ChangeReason = changeReason,
@@ -96,32 +72,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqProviderState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/provider?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Post_Confirm_UpdatesMqCreatesEventAndCompletesJourneyRedirectsWithFlashMessage()
     {
         // Arrange
@@ -137,7 +87,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = newProvider.MandatoryQualificationProviderId,
                 CurrentProviderId = oldProvider.MandatoryQualificationProviderId,
                 ChangeReason = MqChangeProviderReasonOption.AnotherReason,
@@ -165,8 +114,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var redirectDoc = await redirectResponse.GetDocumentAsync();
         AssertEx.HtmlDocumentHasFlashNotificationBanner(redirectDoc, "Mandatory qualification changed");
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -207,7 +155,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = newProvider.MandatoryQualificationProviderId,
                 CurrentProviderId = oldProvider.MandatoryQualificationProviderId,
                 ChangeReason = MqChangeProviderReasonOption.ChangeOfTrainingProvider,
@@ -220,9 +167,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 AdditionalInformation = null,
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -231,8 +178,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -260,7 +206,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = newProvider.MandatoryQualificationProviderId,
                 CurrentProviderId = oldProvider.MandatoryQualificationProviderId,
                 ChangeReason = MqChangeProviderReasonOption.ChangeOfTrainingProvider,
@@ -280,9 +225,4 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<EditMqProviderState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqProviderState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqProvider,
-            state ?? new EditMqProviderState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/EditMqProviderTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/EditMqProviderTestBase.cs
@@ -1,0 +1,27 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Provider;
+
+public abstract class EditMqProviderTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<EditMqProviderJourneyCoordinator> CreateJourneyInstanceAsync(Guid qualificationId, EditMqProviderState? state = null) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<EditMqProviderJourneyCoordinator>(
+            JourneyNames.EditMqProvider,
+            new RouteValueDictionary { ["qualificationId"] = qualificationId },
+            _ => Task.FromResult<object>(state ?? new EditMqProviderState()),
+            pathUrls:
+            [
+                $"/mqs/{qualificationId}/provider",
+                $"/mqs/{qualificationId}/provider/reason",
+                $"/mqs/{qualificationId}/provider/check-answers",
+            ]);
+
+    protected EditMqProviderState? GetJourneyInstanceState(EditMqProviderJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (EditMqProviderState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/IndexTests.cs
@@ -4,7 +4,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Provider;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : EditMqProviderTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
@@ -23,18 +23,18 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    public async Task Get_NewJourneyInstance_PopulatesModelFromDatabase()
     {
         // Arrange
         var databaseProvider = MandatoryQualificationProvider.All.Single(p => p.Name == "University of Birmingham");
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithProvider(databaseProvider.MandatoryQualificationProviderId)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/provider?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/provider");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Starts the journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
@@ -44,7 +44,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithInitializedJourneyState_PopulatesModelFromJourneyState()
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
         var databaseProvider = MandatoryQualificationProvider.All.Single(p => p.Name == "University of Birmingham");
@@ -55,7 +55,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -126,7 +125,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = oldProvider.MandatoryQualificationProviderId
             });
 
@@ -157,12 +155,11 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = provider.MandatoryQualificationProviderId
             });
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -171,8 +168,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -193,7 +189,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = provider.MandatoryQualificationProviderId
             });
         var request = new HttpRequestMessage(httpMethod, $"/mqs/{qualificationId}/provider?{journeyInstance.GetUniqueIdQueryParameter()}");
@@ -205,9 +200,4 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<EditMqProviderState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqProviderState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqProvider,
-            state ?? new EditMqProviderState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Provider/ReasonTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Provider;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Provider;
 
-public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ReasonTests(HostFixture hostFixture) : EditMqProviderTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
@@ -22,29 +22,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqProviderState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/provider/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/provider?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_ReturnsOK()
     {
         // Arrange
@@ -56,7 +33,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -97,7 +73,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -128,7 +103,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -160,7 +134,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -192,7 +165,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -225,7 +197,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -260,13 +231,12 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/reason/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/provider/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -275,8 +245,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -298,7 +267,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqProviderState
             {
-                Initialized = true,
                 ProviderId = journeyProvider.MandatoryQualificationProviderId
             });
 
@@ -324,9 +292,4 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         return multipartContent;
     }
 
-    private async Task<JourneyInstance<EditMqProviderState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqProviderState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqProvider,
-            state ?? new EditMqProviderState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }


### PR DESCRIPTION
Follows #3637. Second of the MQ journeys.

## What

Migrates the **Edit MQ Provider** journey from `FormFlow` to `GovUk.Questions.AspNetCore`, following the same pattern as the alert journeys.

## Changes

- Add `EditMqProviderJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.EditMqProvider, ["qualificationId"])]`); drop FormFlow's `IRegisterJourney` from `EditMqProviderState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys and a form-field `Cancel` submit in place of the `/cancel` handler URLs.
- Rewrite `EditMqProviderLinkGenerator` onto the shared `GetJourneyPage` extension; update the person qualifications page entry link.
- Seed the starting state from the qualification in the coordinator's `GetStartingState`, so `Initialized` / `EnsureInitialized` are deleted.
- Reason moves off the `ValidateAndThrow` + `PageWithErrors` mix onto `ValidateAndThrowAsync`, and uploads evidence *before* validating.
- `IsComplete` and the Reason/CheckAnswers state guards are dropped — the library's path validation already stops users reaching a step they haven't advanced to. Their three redirect tests go with them.
- Test journey seeding moves into a shared `EditMqProviderTestBase`.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- EditMq/Provider tests: **26 passed** (29 before, minus the 3 removed guard tests). All `PageTests.Mqs` + person qualifications tests: **255 passed**.
- Route paths (`/mqs/{qualificationId}/provider`, `/provider/reason`, `/provider/check-answers`) preserved, so the E2E MQ journey tests need no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)