### PR TITLE
Migrate Edit MQ Specialism journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/specialism/check-answers/{handler?}"
+@page "/mqs/{qualificationId}/specialism/check-answers"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before editing mandatory qualification";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.EditMq.Specialism.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -48,7 +51,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and update qualification</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.Specialism.CheckAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/CheckAnswers.cshtml.cs
@@ -8,17 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqSpecialism), RequireJourneyInstance]
+[Journey(JourneyNames.EditMqSpecialism)]
 public class CheckAnswersModel(
+    EditMqSpecialismJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     TimeProvider timeProvider,
     MandatoryQualificationService mandatoryQualificationService) : PageModel
 {
-    public JourneyInstance<EditMqSpecialismState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -38,26 +44,27 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.EditMq.Specialism.Index(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        CurrentSpecialism = JourneyInstance.State.CurrentSpecialism;
-        NewSpecialism = JourneyInstance.State.Specialism;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
+        CurrentSpecialism = journey.State.CurrentSpecialism;
+        NewSpecialism = journey.State.Specialism;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        AdditionalInformation = journey.State.AdditionalInformation;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var qualification = HttpContext.GetCurrentMandatoryQualificationFeature().MandatoryQualification;
 
         var processContext = new ProcessContext(
@@ -80,16 +87,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Mandatory qualification changed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismJourneyCoordinator.cs
@@ -1,0 +1,16 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
+
+[JourneyCoordinator(JourneyNames.EditMqSpecialism, routeValueKeys: ["qualificationId"])]
+public class EditMqSpecialismJourneyCoordinator : JourneyCoordinator<EditMqSpecialismState>
+{
+    public override EditMqSpecialismState GetStartingState()
+    {
+        var qualificationInfo = HttpContext.GetCurrentMandatoryQualificationFeature();
+
+        return new EditMqSpecialismState
+        {
+            CurrentSpecialism = qualificationInfo.MandatoryQualification.Specialism,
+            Specialism = qualificationInfo.MandatoryQualification.Specialism
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismLinkGenerator.cs
@@ -2,21 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 public class EditMqSpecialismLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Specialism/Index", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid qualificationId) =>
+        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Specialism/Index", routeValues: new { qualificationId });
 
-    public string Cancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Specialism/Index", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/Specialism/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Specialism/Reason", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/Specialism/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Specialism/Reason", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Specialism/CheckAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/Specialism/CheckAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/Specialism/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/EditMqSpecialismState.cs
@@ -1,19 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
-public class EditMqSpecialismState : IRegisterJourney
+public class EditMqSpecialismState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.EditMqSpecialism,
-        typeof(EditMqSpecialismState),
-        requestDataKeys: ["qualificationId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public MandatoryQualificationSpecialism? CurrentSpecialism { get; set; }
 
     public MandatoryQualificationSpecialism? Specialism { get; set; }
@@ -27,22 +17,4 @@ public class EditMqSpecialismState : IRegisterJourney
     public string? AdditionalInformation { get; set; }
 
     public bool? ProvideAdditionalInformation { get; set; }
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(Specialism), nameof(ChangeReason))]
-    public bool IsComplete => Specialism is not null &&
-                              (ChangeReason == MqChangeSpecialismReasonOption.AnotherReason && !string.IsNullOrEmpty(ChangeReasonDetail) || ChangeReason != MqChangeSpecialismReasonOption.AnotherReason && string.IsNullOrEmpty(ChangeReasonDetail)) &&
-                              (ProvideAdditionalInformation == true && !string.IsNullOrWhiteSpace(AdditionalInformation) || ProvideAdditionalInformation != true && string.IsNullOrWhiteSpace(AdditionalInformation)) &&
-        Evidence.IsComplete;
-
-    public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        Specialism = CurrentSpecialism = qualificationInfo.MandatoryQualification.Specialism;
-        Initialized = true;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/specialism/{handler?}"
+@page "/mqs/{qualificationId}/specialism"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism.IndexModel
 @{
     ViewBag.Title = "Specialism";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons.PersonDetail.Qualifications(Model.PersonId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -27,7 +30,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.Specialism.Cancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Index.cshtml.cs
@@ -5,19 +5,29 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqSpecialism), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceController) : PageModel
+[Journey(JourneyNames.EditMqSpecialism), StartsJourney]
+public class IndexModel(
+    EditMqSpecialismJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceController) : PageModel
 {
     private readonly InlineValidator<IndexModel> _validator = new()
     {
         v => v.RuleFor(m => m.Specialism)
+            .Cascade(CascadeMode.Stop)
             .NotNull().WithMessage("Select a specialism")
+            .Must((m, specialism) => m.Specialisms!.Any(s => s.Value == specialism)).WithMessage("Select a valid specialism")
     };
 
-    public JourneyInstance<EditMqSpecialismState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -30,32 +40,27 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        Specialism = JourneyInstance!.State.Specialism;
+        Specialism = journey.State.Specialism;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (Specialism is MandatoryQualificationSpecialism specialism && !Specialisms!.Any(s => s.Value == specialism))
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(Specialism), "Select a valid specialism");
+            return await CancelAsync();
         }
 
-        _validator.ValidateAndThrow(this);
+        await _validator.ValidateAndThrowAsync(this);
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
-
-        await JourneyInstance!.UpdateStateAsync(state => state.Specialism = Specialism);
-
-        return Redirect(linkGenerator.Mqs.EditMq.Specialism.Reason(QualificationId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.EditMq.Specialism.Reason(journey.InstanceId),
+            state => state.Specialism = Specialism);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
@@ -64,8 +69,6 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         var qualificationInfo = context.HttpContext.GetCurrentMandatoryQualificationFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        JourneyInstance!.State.EnsureInitialized(qualificationInfo);
-
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
 
@@ -73,6 +76,8 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
             MandatoryQualificationSpecialismRegistry.GetByDqtValue(dqtSpecialismValue).IsLegacy();
 
         Specialisms = MandatoryQualificationSpecialismRegistry.GetAll(includeLegacy: migratedFromDqtWithLegacySpecialism);
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Qualifications(PersonId);
 
         await next();
     }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/specialism/reason/{handler?}"
+@page "/mqs/{qualificationId}/specialism/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism.ReasonModel
 @{
     ViewBag.Title = Html.DisplayNameFor(m => m.ChangeReason);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.EditMq.Specialism.Index(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -54,7 +57,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.Specialism.ReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/Specialism/Reason.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqSpecialism), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditMqSpecialism)]
+public class ReasonModel(
+    EditMqSpecialismJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -23,10 +26,15 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<EditMqSpecialismState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -49,11 +57,7 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.Specialism is null)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.EditMq.Specialism.Index(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -63,40 +67,42 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        Evidence = JourneyInstance.State.Evidence;
-        ChangeReasonDetail = ChangeReason == MqChangeSpecialismReasonOption.AnotherReason ? JourneyInstance.State.ChangeReasonDetail : null;
-        AdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation == true ? JourneyInstance.State.AdditionalInformation : null;
-        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
+        ChangeReason = journey.State.ChangeReason;
+        Evidence = journey.State.Evidence;
+        ChangeReasonDetail = ChangeReason == MqChangeSpecialismReasonOption.AnotherReason ? journey.State.ChangeReasonDetail : null;
+        AdditionalInformation = journey.State.ProvideAdditionalInformation == true ? journey.State.AdditionalInformation : null;
+        ProvideAdditionalInformation = journey.State.ProvideAdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail = ChangeReason == MqChangeSpecialismReasonOption.AnotherReason ? ChangeReasonDetail : null;
-            state.Evidence = Evidence;
-            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
-            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Mqs.EditMq.Specialism.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.EditMq.Specialism.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.ChangeReasonDetail = ChangeReason == MqChangeSpecialismReasonOption.AnotherReason ? ChangeReasonDetail : null;
+                state.Evidence = Evidence;
+                state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+                state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -195,7 +195,7 @@ else
                     <row-actions>
                         @if (Model.CanEdit)
                         {
-                            <action href="@LinkGenerator.Mqs.EditMq.Specialism.Index(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="specialism" data-testid="specialism-change-link-@mq.QualificationId">Change</action>
+                            <action href="@LinkGenerator.Mqs.EditMq.Specialism.Index(mq.QualificationId)" class="govuk-link" visually-hidden-text="specialism" data-testid="specialism-change-link-@mq.QualificationId">Change</action>
                         }
                     </row-actions>
                 </row>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/CheckAnswersTests.cs
@@ -4,31 +4,8 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Specialism;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : EditMqSpecialismTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqSpecialismState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/specialism?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(MqChangeSpecialismReasonOption.ChangeOfSpecialism, null, false)]
     [InlineData(MqChangeSpecialismReasonOption.AnotherReason, "Some reason", true)]
@@ -46,7 +23,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism,
                 CurrentSpecialism = oldMqSpecialism,
                 ChangeReason = changeReason,
@@ -91,32 +67,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqSpecialismState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/specialism?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Post_Confirm_UpdatesMqCreatesEventCompletesJourneyAndRedirectsWithFlashMessage()
     {
         // Arrange
@@ -136,7 +86,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism,
                 CurrentSpecialism = oldMqSpecialism,
                 ChangeReason = changeReason,
@@ -163,8 +112,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var redirectDoc = await redirectResponse.GetDocumentAsync();
         AssertEx.HtmlDocumentHasFlashNotificationBanner(redirectDoc, "Mandatory qualification changed");
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -205,7 +153,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism,
                 ChangeReason = MqChangeSpecialismReasonOption.ChangeOfSpecialism,
                 ChangeReasonDetail = null,
@@ -216,9 +163,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 }
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -227,8 +174,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -256,7 +202,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism,
                 ChangeReason = MqChangeSpecialismReasonOption.ChangeOfSpecialism,
                 ChangeReasonDetail = "Some reason",
@@ -276,9 +221,4 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<EditMqSpecialismState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqSpecialismState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqSpecialism,
-            state ?? new EditMqSpecialismState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/EditMqSpecialismTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/EditMqSpecialismTestBase.cs
@@ -1,0 +1,27 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Specialism;
+
+public abstract class EditMqSpecialismTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<EditMqSpecialismJourneyCoordinator> CreateJourneyInstanceAsync(Guid qualificationId, EditMqSpecialismState? state = null) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<EditMqSpecialismJourneyCoordinator>(
+            JourneyNames.EditMqSpecialism,
+            new RouteValueDictionary { ["qualificationId"] = qualificationId },
+            _ => Task.FromResult<object>(state ?? new EditMqSpecialismState()),
+            pathUrls:
+            [
+                $"/mqs/{qualificationId}/specialism",
+                $"/mqs/{qualificationId}/specialism/reason",
+                $"/mqs/{qualificationId}/specialism/check-answers",
+            ]);
+
+    protected EditMqSpecialismState? GetJourneyInstanceState(EditMqSpecialismJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (EditMqSpecialismState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/IndexTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Specialism;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : EditMqSpecialismTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
@@ -22,18 +22,18 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    public async Task Get_NewJourneyInstance_PopulatesModelFromDatabase()
     {
         // Arrange
         var databaseSpecialism = MandatoryQualificationSpecialism.Hearing;
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithSpecialism(databaseSpecialism)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Starts the journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
@@ -45,7 +45,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithInitializedJourneyState_PopulatesModelFromJourneyState()
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
         var databaseSpecialism = MandatoryQualificationSpecialism.Hearing;
@@ -56,7 +56,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = journeySpecialism
             });
 
@@ -88,7 +87,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = specialism
             });
 
@@ -121,7 +119,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = specialism
             });
 
@@ -196,7 +193,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = oldSpecialism
             });
 
@@ -227,13 +223,12 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = specialism
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -242,8 +237,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -264,7 +258,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = specialism
             });
 
@@ -277,9 +270,4 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<EditMqSpecialismState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqSpecialismState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqSpecialism,
-            state ?? new EditMqSpecialismState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/Specialism/ReasonTests.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.Specialism;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.Specialism;
 
-public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ReasonTests(HostFixture hostFixture) : EditMqSpecialismTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
@@ -21,29 +21,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqSpecialismState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/specialism/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/specialism?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_ReturnsOK()
     {
         // Arrange
@@ -55,7 +32,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
@@ -96,7 +72,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
@@ -127,7 +102,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
@@ -159,7 +133,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
@@ -191,7 +164,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
@@ -223,7 +195,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
@@ -258,13 +229,12 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/reason/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/specialism/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -273,8 +243,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -296,7 +265,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqSpecialismState
             {
-                Initialized = true,
                 Specialism = newMqSpecialism
             });
 
@@ -322,9 +290,4 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         return multipartContent;
     }
 
-    private async Task<JourneyInstance<EditMqSpecialismState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqSpecialismState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqSpecialism,
-            state ?? new EditMqSpecialismState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }


### PR DESCRIPTION
Follows #3637 and #3638. Third of the MQ journeys.

## What

Migrates the **Edit MQ Specialism** journey from `FormFlow` to `GovUk.Questions.AspNetCore`.

## Changes

- Add `EditMqSpecialismJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.EditMqSpecialism, ["qualificationId"])]`); drop FormFlow's `IRegisterJourney` from `EditMqSpecialismState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys and a form-field `Cancel` submit in place of the `/cancel` handler URLs.
- Rewrite `EditMqSpecialismLinkGenerator` onto the shared `GetJourneyPage` extension; update the person qualifications page entry link.
- Seed the starting state from the qualification in the coordinator's `GetStartingState`, so `Initialized` / `EnsureInitialized` are deleted.
- **Validation:** Index's "Select a valid specialism" `ModelState` error moves into the `InlineValidator` as a `Cascade(CascadeMode.Stop)` chain after `NotNull` — the two messages were already mutually exclusive (one needs a null value, the other a non-null one), so behaviour is unchanged. Reason moves off the `ValidateAndThrow` + `PageWithErrors` mix and uploads evidence *before* validating.
- `IsComplete` and the Reason/CheckAnswers state guards are dropped — the library's path validation already stops users reaching a step they haven't advanced to. Their three redirect tests go with them.
- Test journey seeding moves into a shared `EditMqSpecialismTestBase`.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- EditMq/Specialism tests: **28 passed** (31 before, minus the 3 removed guard tests). All `PageTests.Mqs` + person qualifications tests: **255 passed**.
- Route paths (`/mqs/{qualificationId}/specialism`, `/specialism/reason`, `/specialism/check-answers`) preserved, so the E2E MQ journey tests need no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)