### PR TITLE
Migrate Edit MQ Start Date journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/start-date/check-answers/{handler?}"
+@page "/mqs/{qualificationId}/start-date/check-answers"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate.CheckAnswersModel
 @{
     ViewBag.Title = "Check details before editing mandatory qualification";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.EditMq.StartDate.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -48,7 +51,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and update qualification</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.StartDate.CheckAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/CheckAnswers.cshtml.cs
@@ -8,17 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqStartDate), RequireJourneyInstance]
+[Journey(JourneyNames.EditMqStartDate)]
 public class CheckAnswersModel(
+    EditMqStartDateJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceController,
     TimeProvider timeProvider,
     MandatoryQualificationService mandatoryQualificationService) : PageModel
 {
-    public JourneyInstance<EditMqStartDateState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -38,26 +44,27 @@ public class CheckAnswersModel(
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.EditMq.StartDate.Index(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
-        CurrentStartDate = JourneyInstance.State.CurrentStartDate;
-        NewStartDate ??= JourneyInstance.State.StartDate;
-        ChangeReason = JourneyInstance.State.ChangeReason!.Value;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
+        CurrentStartDate = journey.State.CurrentStartDate;
+        NewStartDate = journey.State.StartDate;
+        ChangeReason = journey.State.ChangeReason!.Value;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
+        AdditionalInformation = journey.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var qualification = HttpContext.GetCurrentMandatoryQualificationFeature().MandatoryQualification;
 
         var processContext = new ProcessContext(
@@ -80,16 +87,16 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Mandatory qualification changed");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceController.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateJourneyCoordinator.cs
@@ -1,0 +1,16 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
+
+[JourneyCoordinator(JourneyNames.EditMqStartDate, routeValueKeys: ["qualificationId"])]
+public class EditMqStartDateJourneyCoordinator : JourneyCoordinator<EditMqStartDateState>
+{
+    public override EditMqStartDateState GetStartingState()
+    {
+        var qualificationInfo = HttpContext.GetCurrentMandatoryQualificationFeature();
+
+        return new EditMqStartDateState
+        {
+            CurrentStartDate = qualificationInfo.MandatoryQualification.StartDate,
+            StartDate = qualificationInfo.MandatoryQualification.StartDate
+        };
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateLinkGenerator.cs
@@ -2,21 +2,15 @@ namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 public class EditMqStartDateLinkGenerator(LinkGenerator linkGenerator)
 {
-    public string Index(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/StartDate/Index", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(Guid qualificationId) =>
+        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/StartDate/Index", routeValues: new { qualificationId });
 
-    public string Cancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/StartDate/Index", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Index(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/StartDate/Index", journeyInstanceId, returnUrl);
 
-    public string Reason(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/StartDate/Reason", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/StartDate/Reason", journeyInstanceId, returnUrl);
 
-    public string ReasonCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/StartDate/Reason", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/StartDate/CheckAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/EditMq/StartDate/CheckAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Mqs/EditMq/StartDate/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/EditMqStartDateState.cs
@@ -1,19 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
-public class EditMqStartDateState : IRegisterJourney
+public class EditMqStartDateState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.EditMqStartDate,
-        typeof(EditMqStartDateState),
-        requestDataKeys: ["qualificationId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public DateOnly? CurrentStartDate { get; set; }
 
     public DateOnly? StartDate { get; set; }
@@ -27,23 +17,4 @@ public class EditMqStartDateState : IRegisterJourney
     public bool? ProvideAdditionalInformation { get; set; }
 
     public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(StartDate), nameof(ChangeReason))]
-    public bool IsComplete => StartDate is not null &&
-        ChangeReason.HasValue &&
-        (ProvideAdditionalInformation == true && !string.IsNullOrWhiteSpace(AdditionalInformation) || (ProvideAdditionalInformation == false && string.IsNullOrWhiteSpace(AdditionalInformation))) &&
-        (ChangeReason == MqChangeStartDateReasonOption.AnotherReason && !string.IsNullOrWhiteSpace(ChangeReasonDetail) || (ChangeReason != MqChangeStartDateReasonOption.AnotherReason && string.IsNullOrWhiteSpace(ChangeReasonDetail))) &&
-        Evidence.IsComplete;
-
-    public void EnsureInitialized(CurrentMandatoryQualificationFeature qualificationInfo)
-    {
-        if (Initialized)
-        {
-            return;
-        }
-
-        StartDate = CurrentStartDate = qualificationInfo.MandatoryQualification.StartDate;
-        Initialized = true;
-    }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/start-date/{handler?}"
+@page "/mqs/{qualificationId}/start-date"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate.IndexModel
 @{
     ViewBag.Title = "Start date";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Persons.PersonDetail.Qualifications(Model.PersonId)">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -22,7 +25,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.StartDate.Cancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Index.cshtml.cs
@@ -5,13 +5,29 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqStartDate), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditMqStartDate), StartsJourney]
+public class IndexModel(
+    EditMqStartDateJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
-    public JourneyInstance<EditMqStartDateState>? JourneyInstance { get; set; }
+    private readonly InlineValidator<IndexModel> _validator = new()
+    {
+        v => v.RuleFor(m => m.StartDate)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Enter a start date")
+            .Must((m, startDate) => !(startDate >= m.EndDate)).WithMessage("Start date must be after end date")
+    };
+
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -24,34 +40,27 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
 
     public void OnGet()
     {
-        StartDate = JourneyInstance!.State.StartDate;
+        StartDate = journey.State.StartDate;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (StartDate is null)
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(StartDate), "Enter a start date");
-        }
-        else if (StartDate >= EndDate)
-        {
-            ModelState.AddModelError(nameof(StartDate), "Start date must be after end date");
+            return await CancelAsync();
         }
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
+        await _validator.ValidateAndThrowAsync(this);
 
-        await JourneyInstance!.UpdateStateAsync(state => state.StartDate = StartDate);
-
-        return Redirect(linkGenerator.Mqs.EditMq.StartDate.Reason(QualificationId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.EditMq.StartDate.Reason(journey.InstanceId),
+            state => state.StartDate = StartDate);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
@@ -60,10 +69,10 @@ public class IndexModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMana
         var qualificationInfo = context.HttpContext.GetCurrentMandatoryQualificationFeature();
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
-        JourneyInstance!.State.EnsureInitialized(qualificationInfo);
-
         PersonId = personInfo.PersonId;
         PersonName = personInfo.Name;
         EndDate = qualificationInfo.MandatoryQualification.EndDate;
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Qualifications(PersonId);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/{qualificationId}/start-date/reason/{handler?}"
+@page "/mqs/{qualificationId}/start-date/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate.ReasonModel
 @{
     ViewBag.Title = Html.DisplayNameFor(m => m.ChangeReason);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.EditMq.StartDate.Index(Model.QualificationId, Model.JourneyInstance!.InstanceId)" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -57,7 +60,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.EditMq.StartDate.ReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/EditMq/StartDate/Reason.cshtml.cs
@@ -5,8 +5,11 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.EditMqStartDate), RequireJourneyInstance]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadManager evidenceUploadManager) : PageModel
+[Journey(JourneyNames.EditMqStartDate)]
+public class ReasonModel(
+    EditMqStartDateJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
     {
@@ -26,10 +29,15 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<EditMqStartDateState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromRoute]
     public Guid QualificationId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public Guid PersonId { get; set; }
 
@@ -52,11 +60,7 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.StartDate is null)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.EditMq.StartDate.Index(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
@@ -66,40 +70,42 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator, EvidenceUploadMan
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        ChangeReasonDetail = ChangeReason == MqChangeStartDateReasonOption.AnotherReason ? JourneyInstance.State.ChangeReasonDetail : null;
-        Evidence = JourneyInstance.State.Evidence;
-        AdditionalInformation = JourneyInstance!.State.ProvideAdditionalInformation == true ? JourneyInstance!.State.AdditionalInformation : null;
-        ProvideAdditionalInformation = JourneyInstance!.State.ProvideAdditionalInformation;
+        ChangeReason = journey.State.ChangeReason;
+        ChangeReasonDetail = ChangeReason == MqChangeStartDateReasonOption.AnotherReason ? journey.State.ChangeReasonDetail : null;
+        Evidence = journey.State.Evidence;
+        AdditionalInformation = journey.State.ProvideAdditionalInformation == true ? journey.State.AdditionalInformation : null;
+        ProvideAdditionalInformation = journey.State.ProvideAdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail = ChangeReason == MqChangeStartDateReasonOption.AnotherReason ? ChangeReasonDetail : null;
-            state.Evidence = Evidence;
-            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
-            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        });
+        await _validator.ValidateAndThrowAsync(this);
 
-        return Redirect(linkGenerator.Mqs.EditMq.StartDate.CheckAnswers(QualificationId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.EditMq.StartDate.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.ChangeReasonDetail = ChangeReason == MqChangeStartDateReasonOption.AnotherReason ? ChangeReasonDetail : null;
+                state.Evidence = Evidence;
+                state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+                state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Persons/PersonDetail/Qualifications.cshtml
@@ -205,7 +205,7 @@ else
                     <row-actions>
                         @if (Model.CanEdit)
                         {
-                            <action href="@LinkGenerator.Mqs.EditMq.StartDate.Index(mq.QualificationId, null)" class="govuk-link" visually-hidden-text="start date" data-testid="start-date-change-link-@mq.QualificationId">Change</action>
+                            <action href="@LinkGenerator.Mqs.EditMq.StartDate.Index(mq.QualificationId)" class="govuk-link" visually-hidden-text="start date" data-testid="start-date-change-link-@mq.QualificationId">Change</action>
                         }
                     </row-actions>
                 </row>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/CheckAnswersTests.cs
@@ -4,31 +4,8 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.StartDate;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : EditMqStartDateTestBase(hostFixture)
 {
-    [Fact]
-    public async Task Get_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqStartDateState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
     [Theory]
     [InlineData(MqChangeStartDateReasonOption.IncorrectStartDate, null, false, true, "additional information")]
     [InlineData(MqChangeStartDateReasonOption.AnotherReason, "Some reason", true, false, null)]
@@ -48,7 +25,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate,
                 ChangeReason = changeReason,
@@ -95,32 +71,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Post_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqStartDateState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Post_Confirm_UpdatesMqCreatesEventCompletesJourneyAndRedirectsWithFlashMessage()
     {
         // Arrange
@@ -140,7 +90,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate,
                 ChangeReason = changeReason,
@@ -167,8 +116,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var redirectDoc = await redirectResponse.GetDocumentAsync();
         AssertEx.HtmlDocumentHasFlashNotificationBanner(redirectDoc, "Mandatory qualification changed");
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -209,7 +157,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate,
                 ChangeReason = MqChangeStartDateReasonOption.IncorrectStartDate,
@@ -222,9 +169,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 AdditionalInformation = null
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/check-answers/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -233,8 +180,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -262,7 +208,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate,
                 ChangeReason = MqChangeStartDateReasonOption.IncorrectStartDate,
@@ -282,9 +227,4 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<EditMqStartDateState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqStartDateState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqStartDate,
-            state ?? new EditMqStartDateState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/EditMqStartDateTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/EditMqStartDateTestBase.cs
@@ -1,0 +1,27 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.StartDate;
+
+public abstract class EditMqStartDateTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<EditMqStartDateJourneyCoordinator> CreateJourneyInstanceAsync(Guid qualificationId, EditMqStartDateState? state = null) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<EditMqStartDateJourneyCoordinator>(
+            JourneyNames.EditMqStartDate,
+            new RouteValueDictionary { ["qualificationId"] = qualificationId },
+            _ => Task.FromResult<object>(state ?? new EditMqStartDateState()),
+            pathUrls:
+            [
+                $"/mqs/{qualificationId}/start-date",
+                $"/mqs/{qualificationId}/start-date/reason",
+                $"/mqs/{qualificationId}/start-date/check-answers",
+            ]);
+
+    protected EditMqStartDateState? GetJourneyInstanceState(EditMqStartDateJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (EditMqStartDateState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/IndexTests.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.StartDate;
 
-public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class IndexTests(HostFixture hostFixture) : EditMqStartDateTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
@@ -21,18 +21,18 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithUninitializedJourneyState_PopulatesModelFromDatabase()
+    public async Task Get_NewJourneyInstance_PopulatesModelFromDatabase()
     {
         // Arrange
         var databaseStartDate = new DateOnly(2021, 10, 5);
         var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification(q => q.WithStartDate(databaseStartDate)));
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/start-date");
 
         // Act
-        var response = await HttpClient.SendAsync(request);
+        var response = await HttpClient.SendAsync(request);  // Starts the journey
+        response = await response.FollowRedirectAsync(HttpClient);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
@@ -42,7 +42,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithInitializedJourneyState_PopulatesModelFromJourneyState()
+    public async Task Get_ValidRequestWithPopulatedDataInJourneyState_PopulatesModelFromJourneyState()
     {
         // Arrange
         var databaseStartDate = new DateOnly(2021, 10, 5);
@@ -53,7 +53,6 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = journeyStartDate
             });
 
@@ -179,9 +178,9 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var qualificationId = person.MandatoryQualifications.Single().QualificationId;
         var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -190,8 +189,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -219,9 +217,4 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<EditMqStartDateState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqStartDateState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqStartDate,
-            state ?? new EditMqStartDateState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/EditMq/StartDate/ReasonTests.cs
@@ -2,7 +2,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.EditMq.StartDate;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.EditMq.StartDate;
 
-public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ReasonTests(HostFixture hostFixture) : EditMqStartDateTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithQualificationIdForNonExistentQualification_ReturnsNotFound()
@@ -21,29 +21,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_MissingDataInJourneyState_Redirects()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync(b => b.WithMandatoryQualification());
-        var qualificationId = person.MandatoryQualifications.Single().QualificationId;
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            new EditMqStartDateState
-            {
-                Initialized = true
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/{qualificationId}/start-date/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/{qualificationId}/start-date?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
     public async Task Get_ValidRequestWithPopulatedDataInJourneyState_ReturnsOK()
     {
         // Arrange
@@ -55,7 +32,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -97,7 +73,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -129,7 +104,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -162,7 +136,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -195,7 +168,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -228,7 +200,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -264,14 +235,13 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/reason/cancel?{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/{qualificationId}/start-date/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -280,8 +250,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -303,7 +272,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             qualificationId,
             new EditMqStartDateState
             {
-                Initialized = true,
                 StartDate = newStartDate,
                 CurrentStartDate = oldStartDate
             });
@@ -330,9 +298,4 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         return multipartContent;
     }
 
-    private async Task<JourneyInstance<EditMqStartDateState>> CreateJourneyInstanceAsync(Guid qualificationId, EditMqStartDateState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.EditMqStartDate,
-            state ?? new EditMqStartDateState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }


### PR DESCRIPTION
Follows #3637, #3638 and #3639. Fourth of the MQ journeys.

## What

Migrates the **Edit MQ Start Date** journey from `FormFlow` to `GovUk.Questions.AspNetCore`.

## Changes

- Add `EditMqStartDateJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.EditMqStartDate, ["qualificationId"])]`); drop FormFlow's `IRegisterJourney` from `EditMqStartDateState`.
- Rewrite Index, Reason and CheckAnswers to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys and a form-field `Cancel` submit in place of the `/cancel` handler URLs.
- Rewrite `EditMqStartDateLinkGenerator` onto the shared `GetJourneyPage` extension; update the person qualifications page entry link.
- Seed the starting state from the qualification in the coordinator's `GetStartingState`, so `Initialized` / `EnsureInitialized` are deleted.
- **Validation → FluentValidation:** Index's `if (StartDate is null) … else if (StartDate >= EndDate) …` becomes a `Cascade(CascadeMode.Stop)` chain — `NotNull` then `Must(… => !(startDate >= m.EndDate))`. The condition is written as the negation of the original rather than `startDate < EndDate` so that a null `EndDate` still passes, exactly as before.
- `IsComplete` and the Reason/CheckAnswers state guards are dropped — the library's path validation already stops users reaching a step they haven't advanced to. Their three redirect tests go with them.
- Test journey seeding moves into a shared `EditMqStartDateTestBase`.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- EditMq/StartDate tests: **28 passed** (31 before, minus the 3 removed guard tests). All `PageTests.Mqs` + person qualifications tests: **255 passed**.
- Route paths (`/mqs/{qualificationId}/start-date`, `/start-date/reason`, `/start-date/check-answers`) preserved, so the E2E MQ journey tests need no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)