### PR TITLE
Migrate Add MQ journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqJourneyCoordinator.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
+
+[JourneyCoordinator(JourneyNames.AddMq, routeValueKeys: ["personId"])]
+public class AddMqJourneyCoordinator : JourneyCoordinator<AddMqState>
+{
+    public override AddMqState GetStartingState() => new();
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqLinkGenerator.cs
@@ -5,40 +5,21 @@ public class AddMqLinkGenerator(LinkGenerator linkGenerator)
     public string Index(Guid personId) =>
         linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Index", routeValues: new { personId });
 
-    public string Provider(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Provider", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Provider(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/AddMq/Provider", journeyInstanceId, returnUrl);
 
-    public string ProviderCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Provider", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+    public string Specialism(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/AddMq/Specialism", journeyInstanceId, returnUrl);
 
-    public string Specialism(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Specialism", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string StartDate(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/AddMq/StartDate", journeyInstanceId, returnUrl);
 
-    public string SpecialismCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Specialism", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
+    public string Status(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/AddMq/Status", journeyInstanceId, returnUrl);
 
-    public string StartDate(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/StartDate", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/Mqs/AddMq/Reason", journeyInstanceId, returnUrl);
 
-    public string StartDateCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/StartDate", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
-
-    public string Status(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Status", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-
-    public string StatusCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Status", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
-
-    public string Reason(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Reason", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-
-    public string ReasonCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/Reason", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswers(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/CheckAnswers", routeValues: new { personId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-
-    public string CheckAnswersCancel(Guid personId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/Mqs/AddMq/CheckAnswers", "cancel", routeValues: new { personId }, journeyInstanceId: journeyInstanceId);
-
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId) =>
+        linkGenerator.GetJourneyPage("/Mqs/AddMq/CheckAnswers", journeyInstanceId);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/AddMqState.cs
@@ -1,17 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-public class AddMqState : IRegisterJourney
+public class AddMqState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.AddMq,
-        typeof(AddMqState),
-        requestDataKeys: ["personId"],
-        appendUniqueKey: true);
-
     public Guid? ProviderId { get; set; }
 
     public MandatoryQualificationSpecialism? Specialism { get; set; }
@@ -31,21 +23,4 @@ public class AddMqState : IRegisterJourney
     public EvidenceUploadModel Evidence { get; set; } = new();
 
     public string? AdditionalInformation { get; set; }
-
-    [JsonIgnore]
-    [MemberNotNullWhen(true, nameof(ProviderId), nameof(Specialism), nameof(StartDate), nameof(Status))]
-    public bool IsComplete =>
-        ProviderId.HasValue &&
-        Specialism.HasValue &&
-        StartDate.HasValue &&
-        Status.HasValue &&
-        (Status != MandatoryQualificationStatus.Passed ||
-         (Status == MandatoryQualificationStatus.Passed && EndDate.HasValue)) &&
-        AddReason.HasValue &&
-        (AddReason == AddMqReasonOption.AnotherReason && !string.IsNullOrEmpty(AddReasonDetail) ||
-         AddReason != AddMqReasonOption.AnotherReason && string.IsNullOrEmpty(AddReasonDetail)) &&
-         ProvideAdditionalInformation is bool proveAdditionalInfo &&
-         (proveAdditionalInfo == true && !string.IsNullOrEmpty(AdditionalInformation) ||
-          proveAdditionalInfo == false && string.IsNullOrEmpty(AdditionalInformation)) &&
-         Evidence.IsComplete;
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml
@@ -1,11 +1,16 @@
-@page "/mqs/add/check-answers/{handler?}"
+@page "/mqs/add/check-answers"
+@using Microsoft.AspNetCore.Http.Extensions
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq.CheckAnswersModel
 @{
+    var returnUrl = Request.GetEncodedPathAndQuery();
     ViewBag.Title = "Check details before adding mandatory qualification";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.Mqs.AddMq.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId)" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -19,35 +24,35 @@
                     <key>Training provider</key>
                     <value data-testid="provider">@Model.ProviderName</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Provider(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="training provider">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Provider(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="training provider">Change</action>
                     </row-actions>
                 </row>
                 <row>
                     <key>Specialism</key>
                     <value data-testid="specialism">@Model.Specialism.GetTitle()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Specialism(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="specialism">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Specialism(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="specialism">Change</action>
                     </row-actions>
                 </row>
                 <row>
                     <key>Start date</key>
                     <value data-testid="start-date">@Model.StartDate.ToString(WebConstants.DateDisplayFormat)</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.StartDate(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="start date">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.StartDate(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="start date">Change</action>
                     </row-actions>
                 </row>
                 <row>
                     <key>Status</key>
                     <value data-testid="status">@Model.Status.GetTitle()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Status(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="status">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Status(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="status">Change</action>
                     </row-actions>
                 </row>
                 <row>
                     <key>End date</key>
                     <value data-testid="end-date">@(Model.EndDate.HasValue ? Model.EndDate.Value.ToString(WebConstants.DateDisplayFormat) : "None")</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Status(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="end date">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Status(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="end date">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
@@ -59,7 +64,7 @@
                     <key>Reason</key>
                     <value>@Model.AddReason.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason for adding">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason for adding">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -75,7 +80,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -91,7 +96,7 @@
                         }
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="reason details">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="reason details">Change</action>
                     </row-actions>
                 </row>
 
@@ -101,14 +106,14 @@
                         <vc:evidence-file-link evidence-file="@Model.EvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.PersonId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)" visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.Mqs.AddMq.Reason(Model.InstanceId, returnUrl: returnUrl)" visually-hidden-text="evidence">Change</action>
                     </row-actions>
                 </row>
             </govuk-summary-list>
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Confirm and add mandatory qualification</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.AddMq.CheckAnswersCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/CheckAnswers.cshtml.cs
@@ -8,17 +8,23 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.AddMq), RequireJourneyInstance]
+[Journey(JourneyNames.AddMq)]
 public class CheckAnswersModel(
+    AddMqJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     TimeProvider timeProvider,
     EvidenceUploadManager evidenceUploadManager,
     MandatoryQualificationService mandatoryQualificationService) : PageModel
 {
-    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromQuery]
     public Guid PersonId { get; set; }
+
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
@@ -45,6 +51,11 @@ public class CheckAnswersModel(
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
+
         var processContext = new ProcessContext(
             ProcessType.MandatoryQualificationCreating,
             timeProvider.UtcNow,
@@ -69,40 +80,35 @@ public class CheckAnswersModel(
             },
             processContext);
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
         TempData.SetFlashNotificationBanner("Mandatory qualification added");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Index(PersonId));
     }
 
-    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.AddMq.Provider(PersonId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        ProviderId = JourneyInstance.State.ProviderId.Value;
+        ProviderId = journey.State.ProviderId!.Value;
         ProviderName = MandatoryQualificationProvider.GetById(ProviderId).Name;
-        Specialism = JourneyInstance.State.Specialism.Value;
-        StartDate = JourneyInstance.State.StartDate.Value;
-        Status = JourneyInstance.State.Status.Value;
-        EndDate = JourneyInstance.State.EndDate;
-        AddReason = JourneyInstance.State.AddReason!.Value;
-        AddReasonDetail = JourneyInstance.State.AddReasonDetail;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
-        EvidenceFile = JourneyInstance.State.Evidence.UploadedEvidenceFile;
-        await next();
+        Specialism = journey.State.Specialism!.Value;
+        StartDate = journey.State.StartDate!.Value;
+        Status = journey.State.Status!.Value;
+        EndDate = journey.State.EndDate;
+        AddReason = journey.State.AddReason!.Value;
+        AddReasonDetail = journey.State.AddReasonDetail;
+        AdditionalInformation = journey.State.AdditionalInformation;
+        EvidenceFile = journey.State.Evidence.UploadedEvidenceFile;
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Index.cshtml.cs
@@ -3,13 +3,14 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.AddMq), ActivatesJourney, RequireJourneyInstance]
-public class IndexModel(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.AddMq), StartsJourney]
+public class IndexModel(AddMqJourneyCoordinator journey, SupportUiLinkGenerator linkGenerator) : PageModel
 {
-    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
-
     [FromQuery]
     public Guid PersonId { get; set; }
 
-    public IActionResult OnGet() => Redirect(linkGenerator.Mqs.AddMq.Provider(PersonId, JourneyInstance!.InstanceId));
+    public IActionResult OnGet() =>
+        journey.AdvanceTo(
+            linkGenerator.Mqs.AddMq.Provider(journey.InstanceId),
+            new PushStepOptions { SetAsFirstStep = true });
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml
@@ -1,4 +1,4 @@
-@page "/mqs/add/provider/{handler?}"
+@page "/mqs/add/provider"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq.ProviderModel
 @addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
 @{
@@ -17,7 +17,10 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers? LinkGenerator.Mqs.AddMq.CheckAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Persons.PersonDetail.Qualifications(Model.PersonId))">Back</govuk-back-link>
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink">Back</govuk-back-link>
+    }
 }
 
 <div class="govuk-grid-row">
@@ -37,7 +40,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.AddMq.ProviderCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Provider.cshtml.cs
@@ -6,8 +6,9 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.AddMq), RequireJourneyInstance]
+[Journey(JourneyNames.AddMq)]
 public class ProviderModel(
+    AddMqJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager) : PageModel
 {
@@ -17,13 +18,15 @@ public class ProviderModel(
             .NotNull().WithMessage("Select a training provider")
     };
 
-    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromQuery]
     public Guid PersonId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
@@ -34,24 +37,27 @@ public class ProviderModel(
 
     public void OnGet()
     {
-        ProviderId = JourneyInstance!.State.ProviderId;
+        ProviderId = journey.State.ProviderId;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        _validator.ValidateAndThrow(this);
+        if (Cancel)
+        {
+            return await CancelAsync();
+        }
 
-        await JourneyInstance!.UpdateStateAsync(state => state.ProviderId = ProviderId);
+        await _validator.ValidateAndThrowAsync(this);
 
-        return Redirect(FromCheckAnswers ?
-            linkGenerator.Mqs.AddMq.CheckAnswers(PersonId, JourneyInstance.InstanceId) :
-            linkGenerator.Mqs.AddMq.Specialism(PersonId, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.AddMq.Specialism(journey.InstanceId),
+            state => state.ProviderId = ProviderId);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
@@ -61,6 +67,8 @@ public class ProviderModel(
 
         PersonName = personInfo.Name;
         Providers = MandatoryQualificationProvider.All.Select(p => new ProviderInfo(p.MandatoryQualificationProviderId, p.Name)).ToArray();
+
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Qualifications(PersonId);
     }
 
     public record ProviderInfo(Guid MandatoryQualificationProviderId, string Name);

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/add/reason/{handler?}"
+@page "/mqs/add/reason"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq.ReasonModel
 @{
     ViewBag.Title = "Why are you adding this mandatory qualification?";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers? LinkGenerator.Mqs.AddMq.CheckAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Mqs.AddMq.Status(Model.PersonId, Model.JourneyInstance!.InstanceId))" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -54,7 +57,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.Mqs.AddMq.ReasonCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Reason.cshtml.cs
@@ -5,8 +5,9 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.AddMq), RequireJourneyInstance]
+[Journey(JourneyNames.AddMq)]
 public class ReasonModel(
+    AddMqJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager) : PageModel
 {
@@ -28,13 +29,15 @@ public class ReasonModel(
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromQuery]
     public Guid PersonId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
@@ -55,49 +58,48 @@ public class ReasonModel(
 
     public void OnGet()
     {
-        AddReason = JourneyInstance!.State.AddReason;
-        ProvideAdditionalInformation = JourneyInstance.State.ProvideAdditionalInformation;
-        AddReasonDetail = JourneyInstance.State.AddReasonDetail;
-        Evidence = JourneyInstance.State.Evidence;
-        AdditionalInformation = JourneyInstance.State.AdditionalInformation;
+        AddReason = journey.State.AddReason;
+        ProvideAdditionalInformation = journey.State.ProvideAdditionalInformation;
+        AddReasonDetail = journey.State.AddReasonDetail;
+        Evidence = journey.State.Evidence;
+        AdditionalInformation = journey.State.AdditionalInformation;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
-        _validator.ValidateAndThrow(this);
-
-        if (!ModelState.IsValid)
+        if (Cancel)
         {
-            return this.PageWithErrors();
+            return await CancelAsync();
         }
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.AddReason = AddReason;
-            state.ProvideAdditionalInformation = ProvideAdditionalInformation;
-            state.AddReasonDetail = AddReason == AddMqReasonOption.AnotherReason ? AddReasonDetail : null;
-            state.Evidence = Evidence;
-            state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
-        });
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
+        await evidenceUploadManager.UploadAsync(Evidence);
 
-        return Redirect(linkGenerator.Mqs.AddMq.CheckAnswers(PersonId, JourneyInstance.InstanceId));
+        await _validator.ValidateAndThrowAsync(this);
+
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.AddMq.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.AddReason = AddReason;
+                state.ProvideAdditionalInformation = ProvideAdditionalInformation;
+                state.AddReasonDetail = AddReason == AddMqReasonOption.AnotherReason ? AddReasonDetail : null;
+                state.Evidence = Evidence;
+                state.AdditionalInformation = ProvideAdditionalInformation == true ? AdditionalInformation : null;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.Status is null)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.AddMq.Status(PersonId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
         PersonName = personInfo.Name;

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/add/specialism/{handler?}"
+@page "/mqs/add/specialism"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq.SpecialismModel
 @{
     ViewBag.Title = Html.DisplayNameFor(m => m.Specialism);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Mqs.AddMq.CheckAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Mqs.AddMq.Provider(Model.PersonId, Model.JourneyInstance!.InstanceId))" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -27,7 +30,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.AddMq.SpecialismCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Specialism.cshtml.cs
@@ -5,24 +5,29 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.AddMq), RequireJourneyInstance]
+[Journey(JourneyNames.AddMq)]
 public class SpecialismModel(
+    AddMqJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<SpecialismModel> _validator = new()
     {
         v => v.RuleFor(m => m.Specialism)
+            .Cascade(CascadeMode.Stop)
             .NotNull().WithMessage("Select a specialism")
+            .Must((m, specialism) => m.Specialisms!.Any(s => s.Value == specialism)).WithMessage("Select a valid specialism")
     };
 
-    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromQuery]
     public Guid PersonId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
@@ -33,44 +38,33 @@ public class SpecialismModel(
 
     public void OnGet()
     {
-        Specialism = JourneyInstance!.State.Specialism;
+        Specialism = journey.State.Specialism;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (Specialism is MandatoryQualificationSpecialism specialism && !Specialisms!.Any(s => s.Value == specialism))
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(Specialism), "Select a valid specialism");
+            return await CancelAsync();
         }
 
-        _validator.ValidateAndThrow(this);
+        await _validator.ValidateAndThrowAsync(this);
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
-
-        await JourneyInstance!.UpdateStateAsync(state => state.Specialism = Specialism);
-
-        return Redirect(FromCheckAnswers ?
-            linkGenerator.Mqs.AddMq.CheckAnswers(PersonId, JourneyInstance.InstanceId) :
-            linkGenerator.Mqs.AddMq.StartDate(PersonId, JourneyInstance.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.AddMq.StartDate(journey.InstanceId),
+            state => state.Specialism = Specialism);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.ProviderId is null)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.AddMq.Provider(PersonId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/add/start-date/{handler?}"
+@page "/mqs/add/start-date"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq.StartDateModel
 @{
     ViewBag.Title = Html.DisplayNameFor(m => m.StartDate);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Mqs.AddMq.CheckAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Mqs.AddMq.Specialism(Model.PersonId, Model.JourneyInstance!.InstanceId))" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -22,7 +25,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.AddMq.StartDateCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/StartDate.cshtml.cs
@@ -5,73 +5,71 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.AddMq), RequireJourneyInstance]
+[Journey(JourneyNames.AddMq)]
 public class StartDateModel(
+    AddMqJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<StartDateModel> _validator = new()
     {
         v => v.RuleFor(m => m.StartDate)
+            .Cascade(CascadeMode.Stop)
             .NotNull().WithMessage("Enter a start date")
+            .Must((m, startDate) => !(m.EndDate is DateOnly endDate && startDate >= endDate))
+                .WithMessage("Start date must be after end date")
     };
 
-    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromQuery]
     public Guid PersonId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
     [BindProperty]
     public DateOnly? StartDate { get; set; }
 
+    public DateOnly? EndDate { get; set; }
+
     public void OnGet()
     {
-        StartDate = JourneyInstance!.State.StartDate;
+        StartDate = journey.State.StartDate;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (StartDate.HasValue && JourneyInstance!.State.EndDate is DateOnly endDate && StartDate >= endDate)
+        if (Cancel)
         {
-            ModelState.AddModelError(nameof(StartDate), "Start date must be after end date");
+            return await CancelAsync();
         }
 
-        _validator.ValidateAndThrow(this);
+        await _validator.ValidateAndThrowAsync(this);
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
-
-        await JourneyInstance!.UpdateStateAsync(state => state.StartDate = StartDate);
-
-        return Redirect(FromCheckAnswers ?
-            linkGenerator.Mqs.AddMq.CheckAnswers(PersonId, JourneyInstance.InstanceId) :
-            linkGenerator.Mqs.AddMq.Status(PersonId, JourneyInstance!.InstanceId));
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.AddMq.Status(journey.InstanceId),
+            state => state.StartDate = StartDate);
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.Specialism is null)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.AddMq.Specialism(PersonId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
+        EndDate = journey.State.EndDate;
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml
@@ -1,11 +1,14 @@
-@page "/mqs/add/status/{handler?}"
+@page "/mqs/add/status"
 @model TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq.StatusModel
 @{
     ViewBag.Title = Html.DisplayNameFor(m => m.Status);
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@(Model.FromCheckAnswers ? LinkGenerator.Mqs.AddMq.CheckAnswers(Model.PersonId, Model.JourneyInstance!.InstanceId) : LinkGenerator.Mqs.AddMq.StartDate(Model.PersonId, Model.JourneyInstance!.InstanceId))" />
+    @if (Model.BackLink is not null)
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-grid-row">
@@ -47,7 +50,7 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit">Continue</govuk-button>
-                <govuk-button formaction="@LinkGenerator.Mqs.AddMq.StatusCancel(Model.PersonId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Mqs/AddMq/Status.cshtml.cs
@@ -6,24 +6,32 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.AddMq), RequireJourneyInstance]
+[Journey(JourneyNames.AddMq)]
 public class StatusModel(
+    AddMqJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<StatusModel> _validator = new()
     {
+        v => v.RuleFor(m => m.EndDate)
+            .Cascade(CascadeMode.Stop)
+            .NotNull().WithMessage("Enter an end date")
+            .Must((m, endDate) => !(endDate <= m.StartDate)).WithMessage("End date must be after start date")
+            .When(m => m.Status == MandatoryQualificationStatus.Passed),
         v => v.RuleFor(m => m.Status)
             .NotNull().WithMessage("Select a status")
     };
 
-    public JourneyInstance<AddMqState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string? BackLink { get; set; }
 
     [FromQuery]
     public Guid PersonId { get; set; }
 
-    [FromQuery]
-    public bool FromCheckAnswers { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     public string? PersonName { get; set; }
 
@@ -38,59 +46,42 @@ public class StatusModel(
 
     public void OnGet()
     {
-        Status = JourneyInstance!.State.Status;
-        EndDate = JourneyInstance!.State.EndDate;
+        Status = journey.State.Status;
+        EndDate = journey.State.EndDate;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (Status == MandatoryQualificationStatus.Passed)
+        if (Cancel)
         {
-            if (EndDate is null)
-            {
-                ModelState.AddModelError(nameof(EndDate), "Enter an end date");
-            }
-            else if (EndDate <= StartDate)
-            {
-                ModelState.AddModelError(nameof(EndDate), "End date must be after start date");
-            }
+            return await CancelAsync();
         }
 
-        _validator.ValidateAndThrow(this);
+        await _validator.ValidateAndThrowAsync(this);
 
-        if (!ModelState.IsValid)
-        {
-            return this.PageWithErrors();
-        }
-
-        await JourneyInstance!.UpdateStateAsync(
+        return journey.AdvanceTo(
+            linkGenerator.Mqs.AddMq.Reason(journey.InstanceId),
             state =>
             {
                 state.Status = Status;
                 state.EndDate = Status == MandatoryQualificationStatus.Passed ? EndDate : null;
             });
-
-        return Redirect(linkGenerator.Mqs.AddMq.Reason(PersonId, JourneyInstance.InstanceId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    private async Task<IActionResult> CancelAsync()
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
+        await evidenceUploadManager.DeleteUploadedFileAsync(journey.State.Evidence.UploadedEvidenceFile);
+        journey.DeleteInstance();
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (JourneyInstance!.State.StartDate is null)
-        {
-            context.Result = Redirect(linkGenerator.Mqs.AddMq.StartDate(PersonId, JourneyInstance.InstanceId));
-            return;
-        }
+        BackLink = journey.GetBackLink();
 
         var personInfo = context.HttpContext.GetCurrentPersonFeature();
 
         PersonName = personInfo.Name;
-        StartDate = JourneyInstance!.State.StartDate;
+        StartDate = journey.State.StartDate;
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/AddMqTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/AddMqTestBase.cs
@@ -1,0 +1,30 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
+
+public abstract class AddMqTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<AddMqJourneyCoordinator> CreateJourneyInstanceForStateAsync(Guid personId, AddMqState state) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<AddMqJourneyCoordinator>(
+            JourneyNames.AddMq,
+            new RouteValueDictionary { ["personId"] = personId },
+            _ => Task.FromResult<object>(state),
+            pathUrls:
+            [
+                $"/mqs/add/provider?personId={personId}",
+                $"/mqs/add/specialism?personId={personId}",
+                $"/mqs/add/start-date?personId={personId}",
+                $"/mqs/add/status?personId={personId}",
+                $"/mqs/add/reason?personId={personId}",
+                $"/mqs/add/check-answers?personId={personId}",
+            ]);
+
+    protected AddMqState? GetJourneyInstanceState(AddMqJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (AddMqState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/CheckAnswersTests.cs
@@ -5,7 +5,7 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckAnswersTests(HostFixture hostFixture) : AddMqTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
@@ -212,8 +212,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         var redirectDoc = await redirectResponse.GetDocumentAsync();
         AssertEx.HtmlDocumentHasFlashNotificationBanner(redirectDoc, "Mandatory qualification added");
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         Guid qualificationId = default;
         await WithDbContextAsync(async dbContext =>
@@ -291,9 +290,9 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
                 Evidence = evidence
             });
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/check-answers/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/check-answers?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
         {
-            Content = new FormUrlEncodedContentBuilder()
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
         };
 
         // Act
@@ -302,8 +301,7 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
 
         await WithDbContextAsync(async dbContext =>
         {
@@ -350,9 +348,6 @@ public class CheckAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    private async Task<JourneyInstance<AddMqState>> CreateJourneyInstanceAsync(Guid personId, AddMqState? state = null) =>
-        await CreateJourneyInstance(
-            JourneyNames.AddMq,
-            state ?? new AddMqState(),
-            new KeyValuePair<string, object>("personId", personId));
+    private Task<AddMqJourneyCoordinator> CreateJourneyInstanceAsync(Guid personId, AddMqState? state = null) =>
+        CreateJourneyInstanceForStateAsync(personId, state ?? new AddMqState());
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ProviderTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ProviderTests.cs
@@ -4,7 +4,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class ProviderTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ProviderTests(HostFixture hostFixture) : AddMqTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
@@ -163,7 +163,10 @@ public class ProviderTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/provider/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/provider?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -172,18 +175,14 @@ public class ProviderTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}/qualifications", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
-    private Task<JourneyInstance<AddMqState>> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
+    private Task<AddMqJourneyCoordinator> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
     {
         var state = new AddMqState();
         configureState?.Invoke(state);
 
-        return CreateJourneyInstance(
-            JourneyNames.AddMq,
-            state,
-            new KeyValuePair<string, object>("personId", personId));
+        return CreateJourneyInstanceForStateAsync(personId, state);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/ReasonTests.cs
@@ -5,7 +5,7 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ReasonTests(HostFixture hostFixture) : AddMqTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
@@ -21,25 +21,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_WithStatusMissingFromState_RedirectsToStatusPage()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            person.PersonId,
-            state => state.Status = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/reason?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -126,25 +107,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Post_WithStatusMissingFromState_RedirectsToStatusPage()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            person.PersonId,
-            state => state.Status = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/reason?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -349,7 +311,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/mqs/add/check-answers?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(addReason, journeyInstance.State.AddReason);
         Assert.Equal(hasAdditionalReasonDetail, journeyInstance.State.ProvideAdditionalInformation);
         Assert.Equal(addReasonDetail, journeyInstance.State.AddReasonDetail);
@@ -386,7 +347,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/mqs/add/check-answers?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
         Assert.Equal(addReason, journeyInstance.State.AddReason);
         Assert.False(journeyInstance.State.ProvideAdditionalInformation);
         Assert.Null(journeyInstance.State.AddReasonDetail);
@@ -426,7 +386,10 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/reason/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/reason?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -435,11 +398,10 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}/qualifications", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
-    private Task<JourneyInstance<AddMqState>> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
+    private Task<AddMqJourneyCoordinator> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
     {
         var state = new AddMqState
         {
@@ -451,9 +413,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         };
         configureState?.Invoke(state);
 
-        return CreateJourneyInstance(
-            JourneyNames.AddMq,
-            state,
-            new KeyValuePair<string, object>("personId", personId));
+        return CreateJourneyInstanceForStateAsync(personId, state);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/SpecialismTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class SpecialismTests(HostFixture hostFixture) : AddMqTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
@@ -20,24 +20,6 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_ProviderMissingFromState_RedirectsToProvider()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-
-        var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId, state => state.ProviderId = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/provider?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -85,31 +67,6 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Post_ProviderMissingFromState_RedirectsToProvider()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var specialism = MandatoryQualificationSpecialism.Hearing;
-
-        var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId, state => state.ProviderId = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder
-            {
-                { "Specialism", specialism }
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/provider?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -189,7 +146,10 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -198,11 +158,10 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}/qualifications", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
-    private Task<JourneyInstance<AddMqState>> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
+    private Task<AddMqJourneyCoordinator> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
     {
         var state = new AddMqState
         {
@@ -210,9 +169,6 @@ public class SpecialismTests(HostFixture hostFixture) : TestBase(hostFixture)
         };
         configureState?.Invoke(state);
 
-        return CreateJourneyInstance(
-            JourneyNames.AddMq,
-            state,
-            new KeyValuePair<string, object>("personId", personId));
+        return CreateJourneyInstanceForStateAsync(personId, state);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StartDateTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StartDateTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class StartDateTests(HostFixture hostFixture) : AddMqTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
@@ -20,24 +20,6 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_SpecialismMissingFromState_RedirectsToSpecialism()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-
-        var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId, state => state.Specialism = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -104,33 +86,6 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Post_SpecialismMissingFromState_RedirectToSpecialism()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var startDate = new DateOnly(2021, 11, 5);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId, state => state.Specialism = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder
-            {
-                { "StartDate.Day", $"{startDate:%d}" },
-                { "StartDate.Month", $"{startDate:%M}" },
-                { "StartDate.Year", $"{startDate:yyyy}" }
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/specialism?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -240,7 +195,10 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/start-date/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -249,11 +207,10 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}/qualifications", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
-    private Task<JourneyInstance<AddMqState>> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
+    private Task<AddMqJourneyCoordinator> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
     {
         var state = new AddMqState
         {
@@ -262,9 +219,6 @@ public class StartDateTests(HostFixture hostFixture) : TestBase(hostFixture)
         };
         configureState?.Invoke(state);
 
-        return CreateJourneyInstance(
-            JourneyNames.AddMq,
-            state,
-            new KeyValuePair<string, object>("personId", personId));
+        return CreateJourneyInstanceForStateAsync(personId, state);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Mqs/AddMq/StatusTests.cs
@@ -3,7 +3,7 @@ using TeachingRecordSystem.SupportUi.Pages.Mqs.AddMq;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.Mqs.AddMq;
 
-public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class StatusTests(HostFixture hostFixture) : AddMqTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithPersonIdForNonExistentPerson_ReturnsNotFound()
@@ -19,26 +19,6 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Get_StartDateMissingFromState_RedirectsToStartDate()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            person.PersonId,
-            state => state.StartDate = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -117,35 +97,6 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
-    }
-
-    [Fact]
-    public async Task Post_StartDateMissingFromState_RedirectsToStartDate()
-    {
-        // Arrange
-        var person = await TestData.CreatePersonAsync();
-        var status = MandatoryQualificationStatus.Passed;
-        var endDate = new DateOnly(2021, 11, 5);
-
-        var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId, state => state.StartDate = null);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
-        {
-            Content = new FormUrlEncodedContentBuilder
-            {
-                { "Status", status.ToString() },
-                { "EndDate.Day", $"{endDate:%d}" },
-                { "EndDate.Month", $"{endDate:%M}" },
-                { "EndDate.Year", $"{endDate:yyyy}" }
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/mqs/add/start-date?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -291,7 +242,10 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
         var person = await TestData.CreatePersonAsync();
         var journeyInstance = await CreateJourneyInstanceAsync(person.PersonId);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/status/cancel?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/mqs/add/status?personId={person.PersonId}&{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -300,11 +254,10 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/persons/{person.PersonId}/qualifications", response.Headers.Location?.OriginalString);
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Null(journeyInstance);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
-    private Task<JourneyInstance<AddMqState>> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
+    private Task<AddMqJourneyCoordinator> CreateJourneyInstanceAsync(Guid personId, Action<AddMqState>? configureState = null)
     {
         var state = new AddMqState
         {
@@ -314,9 +267,6 @@ public class StatusTests(HostFixture hostFixture) : TestBase(hostFixture)
         };
         configureState?.Invoke(state);
 
-        return CreateJourneyInstance(
-            JourneyNames.AddMq,
-            state,
-            new KeyValuePair<string, object>("personId", personId));
+        return CreateJourneyInstanceForStateAsync(personId, state);
     }
 }


### PR DESCRIPTION
Follows #3637, #3638, #3639, #3640 and #3641. **Last of the MQ journeys** — with this merged, `Pages/Mqs` is entirely off FormFlow.

## What

Migrates the **Add MQ** journey (Index → Provider → Specialism → StartDate → Status → Reason → CheckAnswers) from `FormFlow` to `GovUk.Questions.AspNetCore`.

## Changes

- Add `AddMqJourneyCoordinator` (`[JourneyCoordinator(JourneyNames.AddMq, ["personId"])]`); drop FormFlow's `IRegisterJourney` from `AddMqState`.
- `Index` keeps its redirect-only role, now as the `[StartsJourney]` entry page: it `AdvanceTo`s Provider with `new PushStepOptions { SetAsFirstStep = true }` so Provider becomes step 0 (no back link into the redirect page), same as Add Alert.
- Rewrite the six question pages to inject the coordinator and use `AdvanceTo` / `GetBackLink` / `DeleteInstance`, with `_jid` keys and a form-field `Cancel` submit in place of the `/cancel` handler URLs.
- CheckAnswers' "Change" links use the library's `returnUrl` query parameter; the `fromCheckAnswers` flag and the hand-rolled conditional back links are gone.
- Rewrite `AddMqLinkGenerator` onto the shared `GetJourneyPage` extension.
- **Validation → FluentValidation:** Specialism's "Select a valid specialism", StartDate's "Start date must be after end date" and Status's end-date rules move from `ModelState` into the `InlineValidator`s as `Cascade(CascadeMode.Stop)` chains. Each added condition is written as the negation of the original comparison so null dates behave exactly as before, and rule order preserves the error-summary ordering. Reason moves off the `ValidateAndThrow` + `PageWithErrors` mix and uploads evidence *before* validating.
- `IsComplete` and the five state guards (Specialism/StartDate/Status/Reason/CheckAnswers) are dropped — the library's path validation already stops users reaching a step they haven't advanced to. Their eight redirect tests go with them.
- Test journey seeding moves into a shared `AddMqTestBase`. Note the seeded `pathUrls` must carry `?personId=…`: unlike the Edit/Delete journeys, this journey's scoping value is a query parameter rather than a route segment, and the library's StepId only strips `_jid` and `returnUrl`.

## Behaviour note

On `main`, the Status page's `OnPost` ignored `FromCheckAnswers` and always redirected to Reason, so the "Change status"/"Change end date" links on the check answers page dropped you back into the middle of the journey — unlike every other Change link. Under the library, `AdvanceTo` honours `returnUrl` uniformly, so those links now return to check answers like the rest. This is the only intentional behaviour change in the PR; no test covered the old path.

## Testing

- `just build` — no errors, no new warnings (only the pre-existing `NU1903` transitive-dependency advisories on `main`).
- AddMq tests: **69 passed** (77 before, minus the 8 removed guard tests). All `PageTests.Mqs` + person qualifications tests: **250 passed**.
- Route paths (`/mqs/add`, `/mqs/add/provider`, `/specialism`, `/start-date`, `/status`, `/reason`, `/check-answers`) preserved, so the E2E `AddMq` journey test needs no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)