### PR TITLE
Fix flaky person search email-case test

### DIFF
--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/IndexTests.cs
@@ -161,9 +161,11 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync();
-        var emailAddress = "Test.User@Example.Com";
+        // The address has to be unique per run, otherwise every previous run's person matches the
+        // search too and this run's person gets pushed off the first page of results.
+        var emailAddress = $"Test.User{Guid.NewGuid():N}@Example.Com";
         await TestData.CreateOneLoginUserAsync(person, email: Option.Some<string?>(emailAddress));
-        var search = "test.user@example.com";
+        var search = emailAddress.ToLowerInvariant();
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/persons?search={search}");
 


### PR DESCRIPTION
## The failure

`Persons.IndexTests.Get_WithSearchThatLooksLikeAnEmailAddressWithDifferentCase_DisplaysMatchOnOneLoginUserEmail` fails on any run after the first against a database that hasn't been wiped:

```
Assert.Single() Failure: The collection was empty
   at ...IndexTests.Get_WithSearchThatLooksLikeAnEmailAddressWithDifferentCase_DisplaysMatchOnOneLoginUserEmail() in IndexTests.cs:line 177
```

## Why

The test created a OneLogin user with the **hardcoded** address `Test.User@Example.Com` and searched for `test.user@example.com`. The test data is committed and `IndexTests` has no `[ClearDbBeforeTest]`, so every run leaves behind another person matching that address. Once enough have accumulated, the search returns them all and the run's *own* person is no longer on the first page of results — so `person-{personId}` matches nothing and the failing assert is `Assert.Single(personResults)` (line 177), not either of the email asserts.

It's self-poisoning rather than order-dependent: the run that fails is poisoned by the runs before it, which is why it looks intermittent and why wiping the schema cache "fixes" it for exactly one run.

The sibling `Get_WithSearchThatLooksLikeAnEmailAddress_...` test doesn't have the problem because it uses `Faker.Internet.Email()`.

## The fix

Give the address a per-run unique local part and derive the search term from it. The test still stores a mixed-case address and searches for a differently-cased one — the behaviour it's actually covering — so nothing is weakened; it just stops colliding with itself.

## Testing

- Reproduced first: the test failed on `main` against the already-poisoned database.
- With the fix, **three consecutive runs pass against that same poisoned database** (the old `Test.User@Example.Com` rows are still in there), then the full `PageTests.Persons.IndexTests` class passes twice back to back — 12 passed each time.
- `just build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)