### PR TITLE
Don't treat records with mismatched TRNs as definite match

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/OneLogin/MatchPersonOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/MatchPersonOptions.cs
@@ -1,9 +1,0 @@
-namespace TeachingRecordSystem.Core.Services.OneLogin;
-
-public record MatchPersonOptions(
-    IEnumerable<string[]> Names,
-    IEnumerable<DateOnly> DatesOfBirth,
-    string? EmailAddress,
-    string? NationalInsuranceNumber,
-    string? Trn,
-    string? TrnTokenTrnHint);

--- a/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
+++ b/src/TeachingRecordSystem.Core/Services/OneLogin/OneLoginService.cs
@@ -318,25 +318,29 @@ public class OneLoginService(
             ["reason"] = reason
         };
 
-    public virtual async Task<MatchPersonResult?> MatchPersonAsync(MatchPersonOptions options)
+    public virtual async Task<MatchPersonResult?> MatchPersonAsync(GetSuggestedPersonMatchesOptions matchOptions)
     {
         var suggestedMatches = await GetSuggestedPersonMatchesAsync(
             new GetSuggestedPersonMatchesOptions(
-                options.Names,
-                options.DatesOfBirth,
-                options.EmailAddress,
-                options.NationalInsuranceNumber,
-                options.Trn,
-                options.TrnTokenTrnHint));
+                matchOptions.Names,
+                matchOptions.DatesOfBirth,
+                matchOptions.EmailAddress,
+                matchOptions.NationalInsuranceNumber,
+                matchOptions.Trn,
+                matchOptions.TrnTokenTrnHint));
 
-        return MatchPerson(suggestedMatches);
+        return MatchPerson(matchOptions, suggestedMatches);
     }
 
-    public virtual MatchPersonResult? MatchPerson(IReadOnlyCollection<MatchPersonResult> suggestedMatches)
+    public virtual MatchPersonResult? MatchPerson(
+        GetSuggestedPersonMatchesOptions matchOptions,
+        IReadOnlyCollection<MatchPersonResult> suggestedMatches)
     {
         // A One Login is matched if there is exactly one Person with a matching
         // first name, last name, DOB AND either NINO or TRN *OR*
         // first name, DOB, NINO and TRN.
+        //
+        // If TRN was specified but does not match, don't return that record.
 
         var candidates = new List<MatchPersonResult>();
 
@@ -351,8 +355,11 @@ public class OneLoginService(
             var nationalInsuranceNumberMatched = matchedAttributeTypes.Contains(PersonMatchedAttribute.NationalInsuranceNumber);
             var trnMatched = matchedAttributeTypes.Contains(PersonMatchedAttribute.Trn);
 
-            if ((firstNameMatched && lastNameMatched && dateOfBirthMatched && (nationalInsuranceNumberMatched || trnMatched)) ||
-                (firstNameMatched && dateOfBirthMatched && nationalInsuranceNumberMatched && trnMatched))
+            var trnSpecified = !string.IsNullOrEmpty(matchOptions.Trn);
+
+            if ((trnMatched || !trnSpecified) && (
+                (firstNameMatched && lastNameMatched && dateOfBirthMatched && (nationalInsuranceNumberMatched || trnMatched)) ||
+                (firstNameMatched && dateOfBirthMatched && nationalInsuranceNumberMatched && trnMatched)))
             {
                 candidates.Add(new MatchPersonResult(
                     match.PersonId,

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
@@ -61,15 +61,17 @@ public class ResolveOneLoginUserMatchingJourneyCoordinator(
         }
         else
         {
-            suggestedMatches = await oneLoginService.GetSuggestedPersonMatchesAsync(new(
+            var matchOptions = new GetSuggestedPersonMatchesOptions(
                 Names: requestData.VerifiedOrStatedNames!,
                 DatesOfBirth: requestData.VerifiedOrStatedDatesOfBirth!,
                 NationalInsuranceNumber: requestData.StatedNationalInsuranceNumber,
                 EmailAddress: emailAddress,
                 Trn: requestData.StatedTrn,
-                TrnTokenTrnHint: requestData.TrnTokenTrn));
+                TrnTokenTrnHint: requestData.TrnTokenTrn);
 
-            var matchResult = oneLoginService.MatchPerson(suggestedMatches);
+            suggestedMatches = await oneLoginService.GetSuggestedPersonMatchesAsync(matchOptions);
+
+            var matchResult = oneLoginService.MatchPerson(matchOptions, suggestedMatches);
             if (matchResult is not null)
             {
                 suggestedMatches = [matchResult];

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/SignInJourneyCoordinatorTests.cs
@@ -923,7 +923,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 clientApplicationUserId: default,
                 recordMatchingPolicy: RecordMatchingPolicy.Required),
             m => m
-                .Setup(mock => mock.MatchPersonAsync(It.IsAny<MatchPersonOptions>()))
+                .Setup(mock => mock.MatchPersonAsync(It.IsAny<GetSuggestedPersonMatchesOptions>()))
                 .ReturnsAsync(value: null),
             async coordinator =>
             {
@@ -970,7 +970,7 @@ public class SignInJourneyCoordinatorTests(HostFixture hostFixture) : TestBase(h
                 clientApplicationUserId: default,
                 recordMatchingPolicy: RecordMatchingPolicy.Required),
             m => m
-                .Setup(mock => mock.MatchPersonAsync(It.IsAny<MatchPersonOptions>()))
+                .Setup(mock => mock.MatchPersonAsync(It.IsAny<GetSuggestedPersonMatchesOptions>()))
                 .ReturnsAsync(new MatchPersonResult(
                     person.PersonId,
                     person.Trn,

--- a/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/OneLogin/OneLoginServiceTests_Matching.cs
@@ -95,14 +95,42 @@ public partial class OneLoginServiceTests
         var firstName = TestData.GenerateFirstName();
         var lastName = TestData.GenerateLastName();
         var dateOfBirth = TestData.GenerateDateOfBirth();
+        var nationalInsuranceNumber = TestData.GenerateNationalInsuranceNumber();
 
-        var person1 = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
-        var person2 = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber(nationalInsuranceNumber).WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+        await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber(nationalInsuranceNumber).WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
 
         string[][] names = [[firstName, lastName]];
         DateOnly[] datesOfBirth = [dateOfBirth];
-        var nationalInsuranceNumber = person1.NationalInsuranceNumber!;
-        var trn = person2.Trn;
+        string? trn = null;
+
+        // Act
+        var result = await WithServiceAsync(
+            s => s.MatchPersonAsync(new(names, datesOfBirth, EmailAddress: null, nationalInsuranceNumber, trn, TrnTokenTrnHint: null)));
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task MatchPersonAsync_WithTrnSpecifiedThatDoesNotMatchOtherwiseMatchingPerson_ReturnsNull()
+    {
+        // Arrange
+        var firstName = TestData.GenerateFirstName();
+        var lastName = TestData.GenerateLastName();
+        var dateOfBirth = TestData.GenerateDateOfBirth();
+
+        // Person who matches on name, DOB and NINO but whose TRN is not the one specified
+        var person = await TestData.CreatePersonAsync(
+            p => p.WithNationalInsuranceNumber().WithFirstName(firstName).WithLastName(lastName).WithDateOfBirth(dateOfBirth));
+
+        // Person whose TRN is specified but who matches on nothing else
+        var otherPerson = await TestData.CreatePersonAsync();
+
+        string[][] names = [[firstName, lastName]];
+        DateOnly[] datesOfBirth = [dateOfBirth];
+        var nationalInsuranceNumber = person.NationalInsuranceNumber!;
+        var trn = otherPerson.Trn;
 
         // Act
         var result = await WithServiceAsync(
@@ -469,16 +497,6 @@ public partial class OneLoginServiceTests
             _matchNameDobAndNinoAttributes
         },
 
-        // Single name, single DOB, person NINO match but TRN doesn't match
-        {
-            OneLogin.NameArgumentOption.MatchesPersonName,
-            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
-            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
-            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
-            /*expectMatch: */ true,
-            _matchNameDobAndNinoAttributes
-        },
-
         // Single name, single DOB, TRN match but no NINO
         {
             OneLogin.NameArgumentOption.MatchesPersonName,
@@ -519,16 +537,6 @@ public partial class OneLoginServiceTests
             _matchNameDobAndNinoAttributes
         },
 
-        // Single name, single DOB, employment NINO match but TRN doesn't match
-        {
-            OneLogin.NameArgumentOption.MatchesPersonName,
-            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
-            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesEmploymentNino,
-            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
-            /*expectMatch: */ true,
-            _matchNameDobAndNinoAttributes
-        },
-
         // Single name with alias, single DOB, person NINO and TRN all match
         {
             OneLogin.NameArgumentOption.MatchesAlias,
@@ -545,16 +553,6 @@ public partial class OneLoginServiceTests
             OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
             OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
             OneLogin.TrnArgumentOption.NotSpecified,
-            /*expectMatch: */ true,
-            _matchNameDobAndNinoAttributes
-        },
-
-        // Single name with alias, single DOB, person NINO match but TRN doesn't match
-        {
-            OneLogin.NameArgumentOption.MatchesAlias,
-            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
-            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
-            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
             /*expectMatch: */ true,
             _matchNameDobAndNinoAttributes
         },
@@ -599,16 +597,6 @@ public partial class OneLoginServiceTests
             _matchNameDobAndNinoAttributes
         },
 
-        // Single name with alias, single DOB, employment NINO match but TRN doesn't match
-        {
-            OneLogin.NameArgumentOption.MatchesAlias,
-            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
-            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesEmploymentNino,
-            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
-            /*expectMatch: */ true,
-            _matchNameDobAndNinoAttributes
-        },
-
         // Multiple names with one match, single DOB, person NINO and TRN all match
         {
             OneLogin.NameArgumentOption.MultipleSpecifiedAndOneMatchesPersonName,
@@ -625,16 +613,6 @@ public partial class OneLoginServiceTests
             OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
             OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
             OneLogin.TrnArgumentOption.NotSpecified,
-            /*expectMatch: */ true,
-            _matchNameDobAndNinoAttributes
-        },
-
-        // Multiple names with one match, single DOB, person NINO match but TRN doesn't match
-        {
-            OneLogin.NameArgumentOption.MultipleSpecifiedAndOneMatchesPersonName,
-            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
-            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
-            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
             /*expectMatch: */ true,
             _matchNameDobAndNinoAttributes
         },
@@ -675,16 +653,6 @@ public partial class OneLoginServiceTests
             OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
             OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesEmploymentNino,
             OneLogin.TrnArgumentOption.NotSpecified,
-            /*expectMatch: */ true,
-            _matchNameDobAndNinoAttributes
-        },
-
-        // Multiple names with one match, single DOB, employment NINO match but TRN doesn't match
-        {
-            OneLogin.NameArgumentOption.MultipleSpecifiedAndOneMatchesPersonName,
-            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
-            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesEmploymentNino,
-            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
             /*expectMatch: */ true,
             _matchNameDobAndNinoAttributes
         },
@@ -787,6 +755,66 @@ public partial class OneLoginServiceTests
             OneLogin.NameArgumentOption.MatchesPersonName,
             OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
             OneLogin.NationalInsuranceNumberArgumentOption.NotSpecified,
+            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
+            /*expectMatch: */ false,
+            null
+        },
+
+        // Single name, single DOB, person NINO match but TRN doesn't match
+        {
+            OneLogin.NameArgumentOption.MatchesPersonName,
+            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
+            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
+            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
+            /*expectMatch: */ false,
+            null
+        },
+
+        // Single name, single DOB, employment NINO match but TRN doesn't match
+        {
+            OneLogin.NameArgumentOption.MatchesPersonName,
+            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
+            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesEmploymentNino,
+            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
+            /*expectMatch: */ false,
+            null
+        },
+
+        // Single name with alias, single DOB, person NINO match but TRN doesn't match
+        {
+            OneLogin.NameArgumentOption.MatchesAlias,
+            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
+            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
+            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
+            /*expectMatch: */ false,
+            null
+        },
+
+        // Single name with alias, single DOB, employment NINO match but TRN doesn't match
+        {
+            OneLogin.NameArgumentOption.MatchesAlias,
+            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
+            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesEmploymentNino,
+            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
+            /*expectMatch: */ false,
+            null
+        },
+
+        // Multiple names with one match, single DOB, person NINO match but TRN doesn't match
+        {
+            OneLogin.NameArgumentOption.MultipleSpecifiedAndOneMatchesPersonName,
+            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
+            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesPersonNino,
+            OneLogin.TrnArgumentOption.SpecifiedButDifferent,
+            /*expectMatch: */ false,
+            null
+        },
+
+        // Multiple names with one match, single DOB, employment NINO match but TRN doesn't match
+        {
+            OneLogin.NameArgumentOption.MultipleSpecifiedAndOneMatchesPersonName,
+            OneLogin.DateOfBirthArgumentOption.MatchesPersonDateOfBirth,
+            OneLogin.NationalInsuranceNumberArgumentOption.SpecifiedAndMatchesEmploymentNino,
             OneLogin.TrnArgumentOption.SpecifiedButDifferent,
             /*expectMatch: */ false,
             null


### PR DESCRIPTION
We have some occurrences where people have multiple TRNs (thanks to TPS) and we're automatically matching on the TPS record rather than the record that has QTS. This is because the TPS record has a NINO and we're asking for that before we ask for TRN.

This tweaks the matching rules so that when we have a TRN we require it to match before declaring a definite match. It won't help the interactive matching journey but it will help matching from support task journeys.