### PR TITLE
Share a helper for building journey coordinators in tests

### DIFF
--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingTestBase.cs
@@ -68,8 +68,6 @@ public abstract class ResolveOneLoginUserMatchingTestBase(HostFixture hostFixtur
                 $"{basePath}/confirm-not-connecting",
                 $"{basePath}/confirm-connect"
             ],
-            // JourneyHelper activates coordinators with Activator.CreateInstance, which can't supply
-            // this one's constructor dependencies.
-            coordinatorFactory: () => ActivatorUtilities.CreateInstance<ResolveOneLoginUserMatchingJourneyCoordinator>(HostFixture.Services));
+            coordinatorFactory: CreateJourneyCoordinator<ResolveOneLoginUserMatchingJourneyCoordinator>);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TeacherPensions/Resolve/ResolveTeacherPensionsPotentialDuplicateTestBase.cs
@@ -35,9 +35,7 @@ public abstract class ResolveTeacherPensionsPotentialDuplicateTestBase(HostFixtu
             new RouteValueDictionary { ["supportTaskReference"] = supportTaskReference },
             _ => Task.FromResult<object>(state),
             pathUrls: pathUrls,
-            // JourneyHelper activates coordinators with Activator.CreateInstance, which can't supply
-            // this one's constructor dependencies.
-            coordinatorFactory: () => ActivatorUtilities.CreateInstance<ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator>(HostFixture.Services));
+            coordinatorFactory: CreateJourneyCoordinator<ResolveTeacherPensionsPotentialDuplicateJourneyCoordinator>);
     }
 
     protected ResolveTeacherPensionsPotentialDuplicateState? GetJourneyInstanceState(

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/TrnRequests/Resolve/ResolveApiTrnRequestTestBase.cs
@@ -35,9 +35,7 @@ public abstract class ResolveApiTrnRequestTestBase(HostFixture hostFixture) : Te
             new RouteValueDictionary { ["supportTaskReference"] = supportTaskReference },
             _ => Task.FromResult<object>(state),
             pathUrls: pathUrls,
-            // JourneyHelper activates coordinators with Activator.CreateInstance, which can't supply
-            // this one's constructor dependencies.
-            coordinatorFactory: () => ActivatorUtilities.CreateInstance<ResolveTrnRequestJourneyCoordinator>(HostFixture.Services));
+            coordinatorFactory: CreateJourneyCoordinator<ResolveTrnRequestJourneyCoordinator>);
     }
 
     protected ResolveTrnRequestState? GetJourneyInstanceState(ResolveTrnRequestJourneyCoordinator coordinator)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/TestBase.cs
@@ -15,8 +15,10 @@ using User = TeachingRecordSystem.Core.DataStore.Postgres.Models.User;
 
 namespace TeachingRecordSystem.SupportUi.Tests;
 
-public abstract class TestBase
+public abstract class TestBase : IDisposable
 {
+    private readonly List<IDisposable> _disposables = new();
+
     protected TestBase(HostFixture hostFixture)
     {
         HostFixture = hostFixture;
@@ -59,6 +61,19 @@ public abstract class TestBase
     protected Mock<IFileService> FileServiceMock => TestScopedServices.GetCurrent().BlobStorageFileServiceMock;
 
     protected TrnRequestOptions TrnRequestOptions => TestScopedServices.GetCurrent().TrnRequestOptions;
+
+    public virtual void Dispose()
+    {
+        _disposables.ForEach(x => x.Dispose());
+        _disposables.Clear();
+    }
+
+    protected T CreateJourneyCoordinator<T>()
+    {
+        var scope = HostFixture.Services.CreateScope();
+        _disposables.Add(scope);
+        return ActivatorUtilities.CreateInstance<T>(scope.ServiceProvider);
+    }
 
     protected Task<JourneyInstance<TState>> CreateJourneyInstance<TState>(
         string journeyName,


### PR DESCRIPTION
### Context

Three journey test bases each needed a `coordinatorFactory` because `JourneyHelper` activates coordinators with `Activator.CreateInstance`, which can't supply constructor dependencies. Each one had built its own `ActivatorUtilities.CreateInstance<T>(HostFixture.Services)` lambda, with the same explanatory comment copy-pasted alongside.

### Changes proposed in this pull request

- Add `TestBase.CreateJourneyCoordinator<T>()` and use it as a method group in `ResolveOneLoginUserMatchingTestBase`, `ResolveTeacherPensionsPotentialDuplicateTestBase` and `ResolveApiTrnRequestTestBase`.
- The helper resolves from a **scope** rather than the root provider, so a coordinator's scoped dependencies (`DbContext` and friends) get a fresh scope instead of being resolved as root singletons.
- `TestBase` now implements `IDisposable` and tracks the scopes it creates, disposing them when the test finishes. The coordinator's dependencies stay valid for as long as the test uses them, and nothing leaks past it.

### Guidance to review

`Dispose` is `virtual`, so any derived test class that wants its own cleanup needs to call `base.Dispose()`.

Four open migration PRs (#3648, #3647, #3645, #3643) add a `coordinatorFactory` of their own. They're left alone deliberately — the helper doesn't exist on their branches, so they'll be switched over once this lands on `main`.

### Testing

- `just build` — no errors, no warnings (only the pre-existing `NU1903` transitive advisories).
- The three affected `Resolve` test namespaces: **227 passed**.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
