### PR TITLE
Split GCP policy tags

### DIFF
--- a/src/TeachingRecordSystem.Api/Program.cs
+++ b/src/TeachingRecordSystem.Api/Program.cs
@@ -1,7 +1,9 @@
+using Dfe.Analytics.EFCore;
 using Microsoft.AspNetCore.Mvc;
 using TeachingRecordSystem.Api.Endpoints;
 using TeachingRecordSystem.Api.Infrastructure.Logging;
 using TeachingRecordSystem.Api.Infrastructure.Middleware;
+using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.WebCommon;
 using TeachingRecordSystem.WebCommon.Infrastructure.Logging;
 
@@ -55,6 +57,8 @@ public class Program
         }
 
         app.MapWebhookJwks();
+
+        app.MapDfeAnalyticsDbConfiguration<TrsDbContext>();
 
         app.MapControllers();
 

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/AlertMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/AlertMapping.cs
@@ -13,8 +13,8 @@ public class AlertMapping : IEntityTypeConfiguration<Alert>
         builder.HasKey(x => x.AlertId);
         builder.HasQueryFilter(q => EF.Property<DateTime?>(q, nameof(Alert.DeletedOn)) == null);
         builder.Property(x => x.AlertTypeId).IsRequired();
-        builder.Property(x => x.PersonId).IsRequired();
-        builder.Property(x => x.Details).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(x => x.PersonId).IsRequired().ConfigureAnalyticsSync(hidden: true);
+        builder.Property(x => x.Details).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.HasIndex(x => x.AlertTypeId).HasDatabaseName(Alert.AlertTypeIdIndexName);
         builder.HasOne(x => x.AlertType).WithMany().HasForeignKey(x => x.AlertTypeId).HasConstraintName(Alert.AlertTypeForeignKeyName);
         builder.Navigation(x => x.AlertType).AutoInclude();

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/EventMapping.cs
@@ -13,10 +13,11 @@ public class EventMapping : IEntityTypeConfiguration<Event>
         builder.Property(e => e.EventName).IsRequired().HasMaxLength(200);
         builder.Property(e => e.Created).IsRequired();
         builder.Property(e => e.Inserted).IsRequired();
-        builder.Property(e => e.Payload).IsRequired().HasColumnType("jsonb").ConfigureAnalyticsSync(hidden: true);
+        builder.Property(e => e.Payload).IsRequired().HasColumnType("jsonb").ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(e => e.Published);
         builder.HasKey(e => e.EventId);
-        builder.Property(e => e.PersonIds);
+        builder.Property(e => e.PersonId).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(e => e.PersonIds).ConfigureAnalyticsSync(hidden: true);
         builder.HasIndex(e => new { e.PersonId, e.EventName }).HasFilter("person_id is not null");
         builder.HasIndex(e => new { e.PersonIds, e.EventName }).HasDatabaseName("ix_events_person_ids").HasMethod("gin").IsCreatedConcurrently();
         builder.HasIndex(e => new { e.EventName, e.Created }).IsCreatedConcurrently();

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/NoteMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/NoteMapping.cs
@@ -12,9 +12,9 @@ public class NoteMapping : IEntityTypeConfiguration<Note>
         builder.ToTable("notes");
         builder.HasKey(x => x.NoteId);
         builder.Property(x => x.NoteId);
-        builder.Property(x => x.PersonId).IsRequired();
-        builder.Property(x => x.Content).ConfigureAnalyticsSync(hidden: true);
-        builder.Property(x => x.ContentHtml).IsRequired(false).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(x => x.PersonId).IsRequired().ConfigureAnalyticsSync(hidden: true);
+        builder.Property(x => x.Content).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(x => x.ContentHtml).IsRequired(false).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(x => x.OriginalFileName).ConfigureAnalyticsSync(included: false);
         builder.Property(x => x.CreatedByDqtUserId).IsRequired(false).ConfigureAnalyticsSync(included: false);
         builder.Property(x => x.CreatedByDqtUserName).IsRequired(false).ConfigureAnalyticsSync(included: false);

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/OneLoginUserMapping.cs
@@ -13,10 +13,10 @@ public class OneLoginUserMapping : IEntityTypeConfiguration<OneLoginUser>
     {
         builder.IncludeInAnalyticsSync(includeAllColumns: false);
         builder.HasKey(o => o.Subject);
-        builder.Property(o => o.Subject).HasMaxLength(255).ConfigureAnalyticsSync(hidden: true);
-        builder.Property(o => o.EmailAddress).HasMaxLength(200).UseCollation(Collations.CaseInsensitive).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(o => o.Subject).HasMaxLength(255).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(o => o.EmailAddress).HasMaxLength(200).UseCollation(Collations.CaseInsensitive).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.HasIndex(o => o.EmailAddress).IsCreatedConcurrently();
-        builder.Property(o => o.PersonId).ConfigureAnalyticsSync(included: true, hidden: false);
+        builder.Property(o => o.PersonId).ConfigureAnalyticsSync(included: true, hidden: true);
         builder.HasOne(o => o.Person).WithMany(p => p.OneLoginUsers).HasForeignKey(o => o.PersonId);
         builder.Property(o => o.VerifiedNames)
             .HasColumnType("jsonb")

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PersonMapping.cs
@@ -11,9 +11,8 @@ public class PersonMapping : IEntityTypeConfiguration<Person>
         builder.IncludeInAnalyticsSync(includeAllColumns: false);
         builder.ToTable("persons");
         builder.HasKey(p => p.PersonId);
-        builder.Property(p => p.PersonId).ConfigureAnalyticsSync(included: true, hidden: false);
         builder.HasQueryFilter(p => p.Status == PersonStatus.Active);
-        builder.Property(p => p.PersonId).ConfigureAnalyticsSync(included: true, hidden: false);
+        builder.Property(p => p.PersonId).ConfigureAnalyticsSync(included: true, hidden: true);
         builder.HasIndex(p => p.DqtContactId).HasFilter("dqt_contact_id is not null").IsUnique();
         builder.Property(p => p.DqtContactId);
         builder.HasIndex(p => p.MergedWithPersonId).HasFilter("merged_with_person_id is not null");
@@ -28,24 +27,24 @@ public class PersonMapping : IEntityTypeConfiguration<Person>
         builder.Property(p => p.FirstName)
             .HasMaxLength(Person.FirstNameMaxLength)
             .UseCollation(Collations.CaseInsensitive)
-            .ConfigureAnalyticsSync(included: true, hidden: true);
+            .ConfigureAnalyticsSync(included: true, policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(p => p.MiddleName)
             .HasMaxLength(Person.MiddleNameMaxLength)
             .UseCollation(Collations.CaseInsensitive)
-            .ConfigureAnalyticsSync(included: true, hidden: true);
+            .ConfigureAnalyticsSync(included: true, policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(p => p.LastName)
             .HasMaxLength(Person.LastNameMaxLength)
             .UseCollation(Collations.CaseInsensitive)
-            .ConfigureAnalyticsSync(included: true, hidden: true);
+            .ConfigureAnalyticsSync(included: true, policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(p => p.EmailAddress)
             .HasMaxLength(Person.EmailAddressMaxLength)
             .UseCollation(Collations.CaseInsensitive)
-            .ConfigureAnalyticsSync(included: true, hidden: true);
+            .ConfigureAnalyticsSync(included: true, policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(p => p.NationalInsuranceNumber)
             .HasMaxLength(Person.NationalInsuranceNumberMaxLength)
             .IsFixedLength()
-            .ConfigureAnalyticsSync(included: true, hidden: true);
-        builder.Property(p => p.Gender).ConfigureAnalyticsSync(included: true, hidden: true);
+            .ConfigureAnalyticsSync(included: true, policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(p => p.Gender).ConfigureAnalyticsSync(included: true, hidden: false);
         builder.Property(p => p.DqtFirstName).HasMaxLength(100).UseCollation(Collations.CaseInsensitive);
         builder.Property(p => p.DqtMiddleName).HasMaxLength(100).UseCollation(Collations.CaseInsensitive);
         builder.Property(p => p.DqtLastName).HasMaxLength(100).UseCollation(Collations.CaseInsensitive);
@@ -69,12 +68,12 @@ public class PersonMapping : IEntityTypeConfiguration<Person>
         builder.Property(p => p.HasEyps).ConfigureAnalyticsSync(included: true, hidden: false);
         builder.Property(p => p.PqtsDate).ConfigureAnalyticsSync(included: true, hidden: false);
         builder.Property(p => p.CreatedByTps).IsRequired().HasDefaultValue(false);
-        builder.Property(p => p.MergedWithPersonId).ConfigureAnalyticsSync(included: true, hidden: false);
+        builder.Property(p => p.MergedWithPersonId).ConfigureAnalyticsSync(included: true, hidden: true);
         builder.HasOne(p => p.MergedWithPerson).WithMany().HasForeignKey(p => p.MergedWithPersonId);
         builder.Property(p => p.SourceApplicationUserId).ConfigureAnalyticsSync(included: true, hidden: false);
         builder.Property(p => p.SourceTrnRequestId).ConfigureAnalyticsSync(included: true, hidden: false);
         builder.HasOne<TrnRequestMetadata>().WithMany().HasForeignKey(p => new { p.SourceApplicationUserId, p.SourceTrnRequestId });
-        builder.Property(p => p.DateOfDeath).ConfigureAnalyticsSync(included: true, hidden: true);
+        builder.Property(p => p.DateOfDeath).ConfigureAnalyticsSync(included: true, policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property<string[]>("names").HasColumnType("varchar[]").UseCollation(Collations.CaseInsensitive);
         builder.Property<string[]>("last_names").HasColumnType("varchar[]").UseCollation(Collations.CaseInsensitive);
         builder.Property<string[]>("national_insurance_numbers").HasColumnType("varchar[]").UseCollation(Collations.CaseInsensitive);

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PreviousNameMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/PreviousNameMapping.cs
@@ -8,14 +8,25 @@ public class PreviousNameMapping : IEntityTypeConfiguration<PreviousName>
 {
     public void Configure(EntityTypeBuilder<PreviousName> builder)
     {
-        builder.IncludeInAnalyticsSync(hidden: true);
+        builder.IncludeInAnalyticsSync(includeAllColumns: false);
         builder.ToTable("previous_names");
         builder.HasKey(p => p.PreviousNameId);
         builder.Property(p => p.PreviousNameId).ConfigureAnalyticsSync(hidden: false);
-        builder.Property(p => p.PersonId).ConfigureAnalyticsSync(hidden: false);
-        builder.Property(p => p.FirstName).HasMaxLength(Person.FirstNameMaxLength).UseCollation(Collations.CaseInsensitive);
-        builder.Property(p => p.MiddleName).HasMaxLength(Person.MiddleNameMaxLength).UseCollation(Collations.CaseInsensitive);
-        builder.Property(p => p.LastName).HasMaxLength(Person.LastNameMaxLength).UseCollation(Collations.CaseInsensitive);
+        builder.Property(p => p.PersonId).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(p => p.FirstName)
+            .HasMaxLength(Person.FirstNameMaxLength)
+            .UseCollation(Collations.CaseInsensitive)
+            .ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(p => p.MiddleName)
+            .HasMaxLength(Person.MiddleNameMaxLength)
+            .UseCollation(Collations.CaseInsensitive)
+            .ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(p => p.LastName)
+            .HasMaxLength(Person.LastNameMaxLength)
+            .UseCollation(Collations.CaseInsensitive)
+            .ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(p => p.CreatedOn).ConfigureAnalyticsSync(hidden: false);
+        builder.Property(p => p.DeletedOn).ConfigureAnalyticsSync(hidden: false);
         builder.HasIndex(x => x.PersonId).HasDatabaseName(PreviousName.PersonIdIndexName);
         builder.HasOne(x => x.Person).WithMany(p => p.PreviousNames).HasForeignKey(x => x.PersonId).HasConstraintName(PreviousName.PersonForeignKeyName);
     }

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessEventMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessEventMapping.cs
@@ -17,8 +17,11 @@ public class ProcessEventMapping : IEntityTypeConfiguration<ProcessEvent>
             .HasConversion(
                 v => JsonSerializer.Serialize(v, IEvent.SerializerOptions),
                 v => JsonSerializer.Deserialize<IEvent>(v, IEvent.SerializerOptions)!)
+            .ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(e => e.OneLoginUserSubjects)
+            .HasColumnType("varchar(255)[]")
             .ConfigureAnalyticsSync(hidden: true);
-        builder.Property(e => e.OneLoginUserSubjects).HasColumnType("varchar(255)[]");
+        builder.Property(e => e.PersonIds).ConfigureAnalyticsSync(hidden: true);
         builder.HasOne<Process>().WithMany(a => a.Events).HasForeignKey(ae => ae.ProcessId).HasConstraintName("fk_process_events_process_process_id");
         builder.HasIndex(e => new { e.PersonIds, e.EventName }).HasMethod("GIN").IsCreatedConcurrently();
         builder.HasIndex(e => new { e.OneLoginUserSubjects, e.EventName }).HasMethod("GIN").IsCreatedConcurrently();

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/ProcessMapping.cs
@@ -12,6 +12,8 @@ public class ProcessMapping : IEntityTypeConfiguration<Process>
     {
         builder.IncludeInAnalyticsSync(hidden: false);
         builder.ToTable("processes");
+        builder.Property(p => p.PersonIds).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(p => p.OneLoginUserSubjects).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.HasOne(p => p.User).WithMany().HasForeignKey(p => p.UserId);
         builder.HasIndex(p => p.ProcessType);
         builder.HasIndex(p => p.PersonIds).HasMethod("GIN");
@@ -23,5 +25,6 @@ public class ProcessMapping : IEntityTypeConfiguration<Process>
                 v => JsonSerializer.Serialize(v, IChangeReasonInfo.SerializerOptions),
                 v => JsonSerializer.Deserialize<IChangeReasonInfo>(v, IChangeReasonInfo.SerializerOptions)!)
             .ConfigureAnalyticsSync(hidden: true);
+        builder.Property(p => p.DqtUserName).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
     }
 }

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/QualificationMapping.cs
@@ -15,6 +15,7 @@ public class QualificationMapping : IEntityTypeConfiguration<Qualification>
         builder.HasDiscriminator(q => q.QualificationType)
             .HasValue<MandatoryQualification>(QualificationType.MandatoryQualification)
             .HasValue<RouteToProfessionalStatus>(QualificationType.RouteToProfessionalStatus);
+        builder.Property(q => q.PersonId).ConfigureAnalyticsSync(hidden: true);
         builder.HasOne(q => q.Person).WithMany(p => p.Qualifications).HasForeignKey(q => q.PersonId).HasConstraintName(Qualification.PersonForeignKeyName);
         builder.HasIndex(q => q.PersonId);
     }

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskMapping.cs
@@ -19,13 +19,15 @@ public class SupportTaskMapping : IEntityTypeConfiguration<SupportTask>
         builder.HasOne(t => t.Person).WithMany().HasForeignKey(p => p.PersonId).HasConstraintName("fk_support_tasks_person");
         builder.HasIndex(t => t.OneLoginUserSubject);
         builder.HasIndex(t => t.PersonId);
+        builder.Property(t => t.PersonId).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(t => t.OneLoginUserSubject).ConfigureAnalyticsSync(hidden: true);
         builder.Property(t => t.Data)
             .HasColumnType("jsonb")
             .IsRequired()
             .HasConversion(
                 v => JsonSerializer.Serialize(v, ISupportTaskData.SerializerOptions),
                 v => JsonSerializer.Deserialize<ISupportTaskData>(v, ISupportTaskData.SerializerOptions)!)
-            .ConfigureAnalyticsSync(hidden: true);
+            .ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.HasOne(t => t.TrnRequestMetadata).WithMany().HasForeignKey(p => new { p.TrnRequestApplicationUserId, p.TrnRequestId });
         builder.HasOne<SupportTaskTypeInfo>().WithMany().HasForeignKey(t => t.SupportTaskType);
         builder.Property(t => t.ResolveJourneySavedState)

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskNoteMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/SupportTaskNoteMapping.cs
@@ -13,7 +13,10 @@ public class SupportTaskNoteMapping : IEntityTypeConfiguration<SupportTaskNote>
         builder.HasKey(x => x.SupportTaskNoteId);
         builder.Property(x => x.SupportTaskNoteId);
         builder.Property(x => x.SupportTaskReference).HasMaxLength(16).IsRequired();
-        builder.Property(x => x.Content).HasMaxLength(SupportTaskNote.ContentMaxLength).IsRequired().ConfigureAnalyticsSync(hidden: true);
+        builder.Property(x => x.Content)
+            .HasMaxLength(SupportTaskNote.ContentMaxLength)
+            .IsRequired()
+            .ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(x => x.CreatedOn).IsRequired();
         builder.HasOne(x => x.CreatedBy).WithMany().HasForeignKey(x => x.CreatedByUserId);
         builder.HasOne<SupportTask>().WithMany().HasForeignKey(x => x.SupportTaskReference);

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEmploymentMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TpsEmploymentMapping.cs
@@ -19,11 +19,12 @@ public class TpsEmploymentMapping : IEntityTypeConfiguration<TpsEmployment>
         builder.Property(e => e.CreatedOn).IsRequired();
         builder.Property(e => e.UpdatedOn).IsRequired();
         builder.Property(e => e.Key).HasMaxLength(50).IsRequired();
-        builder.Property(e => e.NationalInsuranceNumber).HasMaxLength(9).IsFixedLength().ConfigureAnalyticsSync(hidden: true);
-        builder.Property(e => e.PersonPostcode).HasMaxLength(10).ConfigureAnalyticsSync(hidden: true);
-        builder.Property(e => e.PersonEmailAddress).HasMaxLength(100).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(e => e.NationalInsuranceNumber).HasMaxLength(9).IsFixedLength().ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(e => e.PersonPostcode).HasMaxLength(10).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(e => e.PersonEmailAddress).HasMaxLength(100).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(e => e.EmployerPostcode).HasMaxLength(10);
         builder.Property(e => e.EmployerEmailAddress).HasMaxLength(100);
+        builder.Property(e => e.PersonId).ConfigureAnalyticsSync(hidden: true);
         builder.HasIndex(e => e.Key).HasDatabaseName(TpsEmployment.KeyIndexName);
         builder.HasIndex(e => e.PersonId).HasDatabaseName(TpsEmployment.PersonIdIndexName);
         builder.HasIndex(e => e.EstablishmentId).HasDatabaseName(TpsEmployment.EstablishmentIdIndexName);

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/TrnRequestMetadataMapping.cs
@@ -8,15 +8,30 @@ public class TrnRequestMetadataMapping : IEntityTypeConfiguration<TrnRequestMeta
 {
     public void Configure(EntityTypeBuilder<TrnRequestMetadata> builder)
     {
-        builder.IncludeInAnalyticsSync(hidden: true);
+        builder.IncludeInAnalyticsSync(includeAllColumns: false);
         builder.HasKey(r => new { r.ApplicationUserId, r.RequestId });
+        builder.Property(r => r.ResolvedPersonId).ConfigureAnalyticsSync(hidden: true);
         builder.Property(r => r.ApplicationUserId).ConfigureAnalyticsSync(hidden: false);
         builder.Property(r => r.RequestId).IsRequired().HasMaxLength(TrnRequest.RequestIdMaxLength).ConfigureAnalyticsSync(hidden: false);
         builder.Property(r => r.CreatedOn).ConfigureAnalyticsSync(hidden: false);
         builder.Property(r => r.IdentityVerified).ConfigureAnalyticsSync(hidden: false);
-        builder.Property(r => r.OneLoginUserSubject).HasMaxLength(255);
-        builder.Property(r => r.ResolvedPersonId).ConfigureAnalyticsSync(hidden: false);
+        builder.Property(r => r.OneLoginUserSubject).HasMaxLength(255).ConfigureAnalyticsSync(hidden: true);
+        builder.Property(r => r.ResolvedPersonId).ConfigureAnalyticsSync(hidden: true);
         builder.Property(r => r.Status).ConfigureAnalyticsSync(hidden: false);
+        builder.Property(r => r.AddressLine1).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.AddressLine2).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.AddressLine3).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.City).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.Country).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.Postcode).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.FirstName).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.MiddleName).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.LastName).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.PreviousFirstName).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.PreviousMiddleName).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.PreviousLastName).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.DateOfBirth).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(r => r.EmailAddress).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.HasIndex(r => r.OneLoginUserSubject);
         builder.HasIndex(r => r.EmailAddress);
         builder.HasOne(r => r.ApplicationUser).WithMany().HasForeignKey(r => r.ApplicationUserId);

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/Mappings/UserMapping.cs
@@ -26,7 +26,8 @@ public class UserMapping : IEntityTypeConfiguration<User>
     public void Configure(EntityTypeBuilder<User> builder)
     {
         builder.IncludeInAnalyticsSync(hidden: false);
-        builder.Property(e => e.Email).HasMaxLength(User.EmailMaxLength);
+        builder.Property(e => e.Email).HasMaxLength(User.EmailMaxLength).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
+        builder.Property(e => e.Name).ConfigureAnalyticsSync(policyTag: PolicyTagNames.SensitiveHidden);
         builder.Property(e => e.AzureAdUserId).HasMaxLength(User.AzureAdUserIdMaxLength);
         builder.Property(e => e.Role).HasMaxLength(User.RoleMaxLength);
         builder.Property(e => e.DqtUserId).ConfigureAnalyticsSync(included: false);

--- a/src/TeachingRecordSystem.Core/DataStore/Postgres/PolicyTagNames.cs
+++ b/src/TeachingRecordSystem.Core/DataStore/Postgres/PolicyTagNames.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.DataStore.Postgres;
+
+internal static class PolicyTagNames
+{
+    public const string Hidden = "hidden";
+    public const string SensitiveHidden = "sensitive_hidden";
+}

--- a/terraform/aks/airbyte.tf
+++ b/terraform/aks/airbyte.tf
@@ -24,11 +24,14 @@ module "airbyte" {
   cluster           = var.cluster
   namespace         = var.namespace
   gcp_taxonomy_id   = "4953620268226784157"
-  gcp_policy_tag_id = "2818002780538442239"
-  gcp_keyring       = "trs-key-ring"
-  gcp_key           = "trs-key"
-  gcp_bq_sa         = module.infrastructure_secrets.map.AIRBYTE-BQ-SA
-  skip_policy_tags  = var.skip_bq_policy_tags
+  gcp_policy_tag_id = "2792096618541600484"
+  additional_policy_tags = {
+    "sensitive_hidden" : "2818002780538442239"
+  }
+  gcp_keyring      = "trs-key-ring"
+  gcp_key          = "trs-key"
+  gcp_bq_sa        = module.infrastructure_secrets.map.AIRBYTE-BQ-SA
+  skip_policy_tags = var.skip_bq_policy_tags
 
   gcp_dataset_internal = "airbyte_internal"
 


### PR DESCRIPTION
We have two GCP policy tags for classifying data in BQ. This amends the column mappings to apply the right tag.

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/363