### PR TITLE
Task assignment snag fixes

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/AssignSupportTasksOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/AssignSupportTasksOptions.cs
@@ -3,5 +3,5 @@ namespace TeachingRecordSystem.Core.Services.SupportTasks;
 public record AssignSupportTasksOptions
 {
     public required IEnumerable<string> SupportTaskReferences { get; init; }
-    public required Guid UserId { get; init; }
+    public required Guid? UserId { get; init; }
 }

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
@@ -10,7 +10,7 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
     public async Task<IReadOnlyCollection<AssignableUserInfo>> GetAssignableUsersAsync()
     {
         return await dbContext.Users
-            .Where(u => u.Role == UserRoles.AccessManager || u.Role == UserRoles.RecordManager)
+            .Where(u => u.Role == UserRoles.AccessManager || u.Role == UserRoles.RecordManager || u.Role == UserRoles.Administrator)
             .OrderBy(u => u.Name)
             .Select(u => new AssignableUserInfo(u.UserId, u.Name))
             .ToArrayAsync();

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Active.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Active.cshtml
@@ -48,6 +48,8 @@
                           select-class="govuk-!-width-full">
                 <govuk-select-label class="govuk-label--s">Assigned to</govuk-select-label>
                 <govuk-select-item value="">All owners</govuk-select-item>
+                <govuk-select-item value="@Model.UnassignedUserId">Unassigned</govuk-select-item>
+                <govuk-select-item value="@Model.CurrentUserId">Myself</govuk-select-item>
                 @foreach (var user in Model.AssignToOptions!)
                 {
                     <govuk-select-item value="@user.UserId">
@@ -107,7 +109,7 @@ else
     <table class="govuk-table trs-table-layout-fixed" sortable data-module="moj-multi-select" data-id-prefix="AssignSupportTask-">
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header trs-!-width-25"></th>
+                <th scope="col" class="govuk-table__header trs-!-width-35"></th>
                 <th scope="col" class="govuk-table__header"
                     sort-direction="@(Model.SortBy == SupportTasksSortByOption.Subject ? Model.SortDirection : null)"
                     link-template="@(direction => LinkGenerator.SupportTasks.Active(Model.Type, Model.AssignedToUserId, Model.Status, SupportTasksSortByOption.Subject, direction))"
@@ -163,7 +165,7 @@ else
             {
                 <tr class="govuk-table__row" data-testid="task:@result.SupportTaskReference">
                     <td class="govuk-table__cell">
-                        <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">
+                        <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox trs-select-row">
                             <input type="checkbox"
                                    class="govuk-checkboxes__input"
                                    id="AssignSupportTask-@(result.SupportTaskReference)"
@@ -192,8 +194,8 @@ else
                     <td class="govuk-table__cell" data-testid="status">
                         <support-task-status-tag status="@result.Status"/>
                     </td>
-                    <td class="govuk-table__cell" data-testid="assigned-to" use-empty-fallback="Not assigned">
-                        @result.AssignedToName
+                    <td class="govuk-table__cell" data-testid="assigned-to" use-empty-fallback="Unassigned">
+                        @(result.AssignedToUserId == Model.CurrentUserId ? "Myself" : result.AssignedToName)
                     </td>
                     <td class="govuk-table__cell">
                         <a href="@LinkGenerator.SupportTasks.SupportTaskDetail.Index(result.SupportTaskReference)"
@@ -219,7 +221,7 @@ else
 <div id="selected-tasks-banner" aria-live="polite" aria-atomic="true"></div>
 
 @section ContainerEnd {
-    <div aria-atomic="true" aria-live="polite" role="status" id="status" class="govuk-visually-hidden" hx-preserve hx-swap-oob="innerHTML">
+    <div aria-atomic="true" aria-live="polite" role="status" id="status" class="govuk-visually-hidden" hx-swap-oob="innerHTML">
         @if (Model.Results!.Count == 0)
         {
             <text>No matching tasks found.</text>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Active.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Active.cshtml.cs
@@ -39,6 +39,10 @@ public class Active(SupportTaskSearchService searchService, SupportTaskService s
 
     public IReadOnlyCollection<AssignableUserInfo>? AssignToOptions { get; set; }
 
+    public Guid UnassignedUserId => SupportTaskSearchService.UnassignedUserId;
+
+    public Guid CurrentUserId => User.GetUserId();
+
     public string? OrderedByLabel { get; set; }
 
     public string? OrderDirectionLabel { get; set; }
@@ -60,7 +64,9 @@ public class Active(SupportTaskSearchService searchService, SupportTaskService s
             Results,
             pageNumber => linkGenerator.SupportTasks.Active(Type, AssignedToUserId, Status, sortBy, sortDirection, pageNumber));
 
-        AssignToOptions = await supportTaskService.GetAssignableUsersAsync();
+        AssignToOptions = (await supportTaskService.GetAssignableUsersAsync())
+            .Where(u => u.UserId != CurrentUserId)
+            .AsReadOnly();
 
         OrderedByLabel = sortBy switch
         {

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Assign.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Assign.cshtml
@@ -45,8 +45,10 @@
 
 <form method="post">
     <govuk-select for="AssignToUserId" select-class="govuk-!-width-one-third">
-        <govuk-select-label class="govuk-label--s">Who do you want to assign these tasks to?</govuk-select-label>
+        <govuk-select-label class="govuk-label--s govuk-!-margin-bottom-2">Who do you want to assign these tasks to?</govuk-select-label>
         <govuk-select-item value=""></govuk-select-item>
+        <govuk-select-item value="@Model.UnassignedUserId">Unassigned</govuk-select-item>
+        <govuk-select-item value="@Model.CurrentUserId">Myself</govuk-select-item>
         @foreach (var assignOption in Model.AssignToOptions!)
         {
             <govuk-select-item value="@assignOption.UserId">@assignOption.UserName</govuk-select-item>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Assign.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/Assign.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.SupportUi.Services.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks;
 
@@ -18,7 +19,7 @@ public class Assign(
         v => v
             .RuleFor(m => m.AssignToUserId)
             .NotNull()
-            .WithMessage("Select a user to assign the tasks to")
+            .WithMessage("Select who to assign the tasks to")
     };
 
     [FromQuery(Name = "SupportTaskReference")]
@@ -27,6 +28,10 @@ public class Assign(
     public IReadOnlyCollection<TaskInfo>? Tasks { get; set; }
 
     public IReadOnlyCollection<AssignableUserInfo>? AssignToOptions { get; set; }
+
+    public Guid UnassignedUserId => SupportTaskSearchService.UnassignedUserId;
+
+    public Guid CurrentUserId => User.GetUserId();
 
     [BindProperty]
     public Guid? AssignToUserId { get; set; }
@@ -42,8 +47,8 @@ public class Assign(
         await _validator.ValidateAndThrowAsync(this);
 
         // Belt & braces check that user assignment is valid
-        var userName = AssignToOptions!.SingleOrDefault(a => a.UserId == AssignToUserId)?.UserName;
-        if (userName is null)
+        var validAssignmentIds = AssignToOptions!.Select(u => u.UserId).Concat([CurrentUserId, UnassignedUserId]);
+        if (!validAssignmentIds.Contains(AssignToUserId!.Value))
         {
             return BadRequest();
         }
@@ -54,14 +59,18 @@ public class Assign(
             new AssignSupportTasksOptions
             {
                 SupportTaskReferences = Tasks!.Select(t => t.SupportTaskReference),
-                UserId = AssignToUserId!.Value
+                UserId = AssignToUserId == UnassignedUserId ? null : AssignToUserId
             },
             processContext);
 
+        var taskCountMessage = $"{Tasks!.Count} task{(Tasks.Count is 1 ? "" : "s")}";
         TempData.SetFlashNotificationBanner(
-            $"{Tasks!.Count} tasks assigned to {userName}");
+            AssignToUserId == UnassignedUserId
+                ? $"{taskCountMessage} unassigned"
+                : $"{taskCountMessage} assigned to " +
+                    $"{(AssignToUserId == CurrentUserId ? "you" : AssignToOptions!.Single(a => a.UserId == AssignToUserId).UserName)}");
 
-        return Redirect(linkGenerator.SupportTasks.Active());
+        return Redirect(BackLink!);
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
@@ -73,12 +82,15 @@ public class Assign(
         }
 
         // Explicit SQL query for the 'for update' addition
-        Tasks = await dbContext.SupportTasks.FromSql(
+        var tasks = await dbContext.SupportTasks.FromSql(
                 $"select * from support_tasks where support_task_reference = any({SupportTaskReferences}) and deleted_on is null for update")
             .Where(t => t.IsOutstanding)  // Exclude any tasks that may have been Completed since the initial selection
             .OrderBy(t => t.CreatedOn)
             .Select(t => new TaskInfo(t.SupportTaskReference, t.CreatedOn, t.SubjectName, t.SubjectEmailAddress, t.AssignedTo != null ? t.AssignedTo.Name : null, t.SupportTaskType, t.Status))
             .ToArrayAsync();
+
+        // Re-order so that tasks are in the order they were specified in
+        Tasks = tasks.OrderBy(t => SupportTaskReferences.IndexOf(t.SupportTaskReference)).AsReadOnly();
 
         if (Tasks.Count == 0)
         {
@@ -86,7 +98,9 @@ public class Assign(
             return;
         }
 
-        AssignToOptions = await supportTaskService.GetAssignableUsersAsync();
+        AssignToOptions = (await supportTaskService.GetAssignableUsersAsync())
+            .Where(u => u.UserId != CurrentUserId)
+            .AsReadOnly();
 
         BackLink = this.GetReturnUrlOrDefault(linkGenerator.SupportTasks.Active());
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml
@@ -65,7 +65,8 @@
                 <div class="trs-support-task__overview-actions">
                     <govuk-select for="AssignedToUserId">
                         <govuk-select-label>Assigned to</govuk-select-label>
-                        <govuk-select-item value=""></govuk-select-item>
+                        <govuk-select-item value="@Model.UnassignedUserId">Unassigned</govuk-select-item>
+                        <govuk-select-item value="@Model.CurrentUserId">Myself</govuk-select-item>
                         @foreach (var option in Model.AssignToOptions!)
                         {
                             <govuk-select-item value="@option.UserId">@option.UserName</govuk-select-item>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Services.SupportTasks;
+using TeachingRecordSystem.SupportUi.Services.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.SupportTaskDetail;
 
@@ -54,6 +55,10 @@ public class Index(
 
     public IReadOnlyCollection<AssignableUserInfo>? AssignToOptions { get; set; }
 
+    public Guid UnassignedUserId => SupportTaskSearchService.UnassignedUserId;
+
+    public Guid CurrentUserId => User.GetUserId();
+
     public void OnGet()
     {
         AssignedToUserId = _supportTask!.AssignedToUserId;
@@ -68,8 +73,9 @@ public class Index(
         }
 
         // Belt & braces check that status and user assignments are valid
-        if (Status is not SupportTaskStatus.InProgress and not SupportTaskStatus.Open ||
-            AssignedToUserId is not null && !AssignToOptions!.Any(o => o.UserId == AssignedToUserId))
+        var validAssignmentIds = AssignToOptions!.Select(u => u.UserId).Concat([CurrentUserId, UnassignedUserId]);
+        if ((Status is not SupportTaskStatus.InProgress and not SupportTaskStatus.Open) ||
+            (AssignedToUserId is not null && !validAssignmentIds.Contains(AssignedToUserId.Value)))
         {
             return BadRequest();
         }
@@ -81,7 +87,7 @@ public class Index(
             {
                 SupportTaskReference = SupportTaskReference,
                 Status = Status,
-                AssignToUserId = AssignedToUserId
+                AssignToUserId = AssignedToUserId == UnassignedUserId ? null : AssignedToUserId
             },
             processContext);
 
@@ -116,7 +122,9 @@ public class Index(
             .Select(t => new Note(t.Content, t.CreatedOn, t.CreatedBy!.Name))
             .ToArrayAsync();
 
-        AssignToOptions = await supportTaskService.GetAssignableUsersAsync();
+        AssignToOptions = (await supportTaskService.GetAssignableUsersAsync())
+            .Where(u => u.UserId != CurrentUserId)
+            .AsReadOnly();
 
         BackLink = this.GetReturnUrlOrDefault(
             IsOutstanding ? linkGenerator.SupportTasks.Active() : linkGenerator.SupportTasks.Completed());

--- a/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/SupportTaskSearchService.cs
+++ b/src/TeachingRecordSystem.SupportUi/Services/SupportTasks/SupportTaskSearchService.cs
@@ -11,6 +11,8 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
 {
     private static readonly SupportTaskType[] _allChangeRequestTypes = [SupportTaskType.ChangeNameRequest, SupportTaskType.ChangeDateOfBirthRequest];
 
+    public static Guid UnassignedUserId => Guid.Empty;
+
     public async Task<TrnRequestsSearchResult> SearchTrnRequestsAsync(TrnRequestsSearchOptions options, PaginationOptions paginationOptions)
     {
         var search = options.Search?.Trim() ?? string.Empty;
@@ -493,7 +495,9 @@ public class SupportTaskSearchService(TrsDbContext dbContext)
 
         if (searchOptions.AssignedToUserId is { } assignedToUserId)
         {
-            tasks = tasks.Where(t => t.AssignedToUserId == assignedToUserId);
+            tasks = assignedToUserId == UnassignedUserId ?
+                tasks.Where(t => t.AssignedToUserId == null) :
+                tasks.Where(t => t.AssignedToUserId == assignedToUserId);
         }
 
         if (searchOptions.Statuses is { Count: not 0 } statuses)

--- a/src/TeachingRecordSystem.SupportUi/Styles/app.scss
+++ b/src/TeachingRecordSystem.SupportUi/Styles/app.scss
@@ -76,7 +76,7 @@
   display: inline;
 }
 
-@each $size in 25, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 180, 200 {
+@each $size in 25, 35, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 180, 200 {
   .trs-\!-width-#{$size} {
     width: #{$size}px !important;
   }
@@ -523,4 +523,8 @@
 
 tr:has([data-selects-row]):has(:checked) {
   background-color: #f0f4f9;
+}
+
+.trs-select-row {
+  margin-left: 10px !important;
 }

--- a/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/SupportTaskServiceTests.cs
+++ b/tests/TeachingRecordSystem.Core.Tests/Services/SupportTasks/SupportTaskServiceTests.cs
@@ -809,12 +809,13 @@ public class SupportTaskServiceTests(ServiceFixture fixture) : ServiceTestBase(f
     }
 
     [Fact]
-    public async Task GetAssignableUsersAsync_ReturnsAccessManagersAndRecordManagersOrderedByNameAndExcludesOtherRoles()
+    public async Task GetAssignableUsersAsync_ReturnsAccessManagersRecordManagersAndAdministratorsOrderedByNameAndExcludesOtherRoles()
     {
         // Arrange
         var accessManager = await TestData.CreateUserAsync(name: "ZZZ Assignable AccessManager", role: UserRoles.AccessManager);
         var recordManager = await TestData.CreateUserAsync(name: "AAA Assignable RecordManager", role: UserRoles.RecordManager);
-        var viewer = await TestData.CreateUserAsync(name: "MMM Assignable Viewer", role: UserRoles.Viewer);
+        var administrator = await TestData.CreateUserAsync(name: "MMM Assignable Administrator", role: UserRoles.Administrator);
+        var viewer = await TestData.CreateUserAsync(name: "NNN Assignable Viewer", role: UserRoles.Viewer);
 
         // Act
         var result = await WithServiceAsync<SupportTaskService, IReadOnlyCollection<AssignableUserInfo>>(
@@ -823,13 +824,14 @@ public class SupportTaskServiceTests(ServiceFixture fixture) : ServiceTestBase(f
         // Assert
         Assert.Contains(result, u => u.UserId == accessManager.UserId && u.UserName == accessManager.Name);
         Assert.Contains(result, u => u.UserId == recordManager.UserId && u.UserName == recordManager.Name);
+        Assert.Contains(result, u => u.UserId == administrator.UserId && u.UserName == administrator.Name);
         Assert.DoesNotContain(result, u => u.UserId == viewer.UserId);
 
         var createdUsersInResult = result
-            .Where(u => u.UserId == accessManager.UserId || u.UserId == recordManager.UserId)
+            .Where(u => u.UserId == accessManager.UserId || u.UserId == recordManager.UserId || u.UserId == administrator.UserId)
             .Select(u => u.UserId)
             .ToArray();
-        Assert.Equal(new[] { recordManager.UserId, accessManager.UserId }, createdUsersInResult);
+        Assert.Equal(new[] { recordManager.UserId, administrator.UserId, accessManager.UserId }, createdUsersInResult);
     }
 
     private record DummyJourneyState;

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ActiveTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/ActiveTests.cs
@@ -76,7 +76,7 @@ public class ActiveTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_UnassignedTask_ShowsNotAssigned()
+    public async Task Get_UnassignedTask_ShowsUnassigned()
     {
         // Arrange
         var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
@@ -91,7 +91,106 @@ public class ActiveTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var row = doc.GetElementByTestId($"task:{supportTask.SupportTaskReference}");
         Assert.NotNull(row);
-        Assert.Equal("Not assigned", row.GetElementByTestId("assigned-to")!.TrimmedText());
+        Assert.Equal("Unassigned", row.GetElementByTestId("assigned-to")!.TrimmedText());
+    }
+
+    [Fact]
+    public async Task Get_TaskAssignedToCurrentUser_ShowsMyself()
+    {
+        // Arrange
+        var currentUser = await CreateAndSetCurrentUserAsync();
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+        await AssignToUserAsync(supportTask, currentUser.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/active");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var row = doc.GetElementByTestId($"task:{supportTask.SupportTaskReference}");
+        Assert.NotNull(row);
+        Assert.Equal("Myself", row.GetElementByTestId("assigned-to")!.TrimmedText());
+    }
+
+    [Fact]
+    public async Task Get_AssignedToFilterOptions_IncludeUnassignedAndMyselfAndExcludeCurrentUserFromUserList()
+    {
+        // Arrange
+        var currentUser = await CreateAndSetCurrentUserAsync(name: "Current User");
+        var otherUser = await TestData.CreateUserAsync(name: "Other User", role: UserRoles.RecordManager);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/support-tasks/active");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var options = ((IHtmlSelectElement)doc.GetElementById("AssignedToUserId")!)
+            .Options
+            .Select(o => (o.Value, Text: o.TrimmedText()))
+            .ToArray();
+
+        Assert.Equal(
+            [
+                ("", "All owners"),
+                (SupportTaskSearchService.UnassignedUserId.ToString(), "Unassigned"),
+                (currentUser.UserId.ToString(), "Myself"),
+                (otherUser.UserId.ToString(), "Other User")
+            ],
+            options);
+    }
+
+    [Fact]
+    public async Task Get_FilterByUnassignedUserId_ShowsOnlyTasksThatAreNotAssigned()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(name: "User A");
+        var tasks = new SupportTaskLookup
+        {
+            ["ST1"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 20))),
+            ["ST2"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 21))),
+            ["ST3"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 22))),
+        };
+        await AssignToUserAsync(tasks["ST2"], user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"/support-tasks/active?assignedToUserId={SupportTaskSearchService.UnassignedUserId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        Assert.Equal(["ST1", "ST3"], GetResultTaskKeys(doc, tasks));
+    }
+
+    [Fact]
+    public async Task Get_FilterByCurrentUserId_ShowsOnlyTasksAssignedToCurrentUser()
+    {
+        // Arrange
+        var currentUser = await CreateAndSetCurrentUserAsync();
+        var otherUser = await TestData.CreateUserAsync(name: "Other User");
+        var tasks = new SupportTaskLookup
+        {
+            ["ST1"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 20))),
+            ["ST2"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 21))),
+        };
+        await AssignToUserAsync(tasks["ST1"], currentUser.UserId);
+        await AssignToUserAsync(tasks["ST2"], otherUser.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/active?assignedToUserId={currentUser.UserId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        Assert.Equal(["ST1"], GetResultTaskKeys(doc, tasks));
     }
 
     [Fact]
@@ -301,6 +400,15 @@ public class ActiveTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
         Assert.Single(GetResultTaskReferences(doc));
+    }
+
+    private async Task<User> CreateAndSetCurrentUserAsync(string? name = null)
+    {
+        // The current user from HostFixture isn't in the database once it's been cleared,
+        // so create a user we can assign tasks to and sign in as them
+        var user = await TestData.CreateUserAsync(name: name, role: UserRoles.RecordManager);
+        SetCurrentUser(user);
+        return user;
     }
 
     private Task AssignToUserAsync(SupportTask task, Guid userId) =>

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/AssignTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/AssignTests.cs
@@ -1,3 +1,6 @@
+using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Services.SupportTasks;
+
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks;
 
 public class AssignTests(HostFixture hostFixture) : TestBase(hostFixture)
@@ -39,6 +42,57 @@ public class AssignTests(HostFixture hostFixture) : TestBase(hostFixture)
             .Select(o => o.GetAttribute("value"))
             .ToArray();
         Assert.Contains(user.UserId.ToString(), optionValues);
+    }
+
+    [Fact]
+    public async Task Get_AssignToOptions_StartWithUnassignedAndMyselfAndExcludeCurrentUserFromUserList()
+    {
+        // Arrange
+        var currentUser = await CreateAndSetCurrentUserAsync(name: "Current User");
+        var otherUser = await TestData.CreateUserAsync(name: "Other User", role: UserRoles.RecordManager);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetAssignUrl(supportTask.SupportTaskReference));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var options = doc.GetElementById("AssignToUserId")!
+            .QuerySelectorAll("option")
+            .Select(o => (Value: o.GetAttribute("value"), Text: o.TrimmedText()))
+            .ToArray();
+
+        Assert.Equal(
+            [
+                ("", ""),
+                (SupportTaskSearchService.UnassignedUserId.ToString(), "Unassigned"),
+                (currentUser.UserId.ToString(), "Myself")
+            ],
+            options.Take(3));
+        Assert.Contains((otherUser.UserId.ToString(), "Other User"), options);
+        Assert.DoesNotContain(options, o => o.Value == currentUser.UserId.ToString() && o.Text != "Myself");
+    }
+
+    [Fact]
+    public async Task Get_ShowsTasksInTheOrderTheyWereSelected()
+    {
+        // Arrange
+        var olderTask = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 20)));
+        var newerTask = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 21)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, GetAssignUrl(newerTask.SupportTaskReference, olderTask.SupportTaskReference));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var references = doc.QuerySelectorAll("[data-testid=task-reference]").Select(e => e.TrimmedText()).ToArray();
+        Assert.Equal([newerTask.SupportTaskReference, olderTask.SupportTaskReference], references);
     }
 
     [Fact]
@@ -94,7 +148,7 @@ public class AssignTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasErrorAsync(response, "AssignToUserId", "Select a user to assign the tasks to");
+        await AssertEx.HtmlResponseHasErrorAsync(response, "AssignToUserId", "Select who to assign the tasks to");
         Events.AssertNoEventsPublished();
     }
 
@@ -178,6 +232,111 @@ public class AssignTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
+    public async Task Post_SelectedUserIsCurrentUser_AssignsTasksToCurrentUser()
+    {
+        // Arrange
+        var currentUser = await CreateAndSetCurrentUserAsync();
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetAssignUrl(supportTask.SupportTaskReference))
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignToUserId", currentUser.UserId.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(currentUser.UserId, dbTask.AssignedToUserId);
+        });
+
+        var nextPage = await response.FollowRedirectAsync(HttpClient);
+        var nextPageDoc = await nextPage.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, "1 task assigned to you");
+    }
+
+    [Fact]
+    public async Task Post_UnassignedSelected_RemovesTheAssignmentFromTasks()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+        await AssignToUserAsync(supportTask.SupportTaskReference, user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, GetAssignUrl(supportTask.SupportTaskReference))
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignToUserId", SupportTaskSearchService.UnassignedUserId.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Null(dbTask.AssignedToUserId);
+        });
+
+        Events.AssertProcessesCreated(p =>
+        {
+            Assert.Equal(ProcessType.SupportTasksAssigning, p.ProcessContext.ProcessType);
+            Assert.Collection(
+                p.Events,
+                e =>
+                {
+                    var updatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                    Assert.Equal(supportTask.SupportTaskReference, updatedEvent.SupportTaskReference);
+                    Assert.Null(updatedEvent.SupportTask.AssignedToUserId);
+                    Assert.Equal(SupportTaskUpdatedEventChanges.AssignedToUserId, updatedEvent.Changes);
+                });
+        });
+
+        var nextPage = await response.FollowRedirectAsync(HttpClient);
+        var nextPageDoc = await nextPage.GetDocumentAsync();
+        AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, "1 task unassigned");
+    }
+
+    [Fact]
+    public async Task Post_WithReturnUrl_RedirectsToReturnUrl()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+        var returnUrl = "/support-tasks/active?status=InProgress";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"{GetAssignUrl(supportTask.SupportTaskReference)}&returnUrl={Uri.EscapeDataString(returnUrl)}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignToUserId", user.UserId.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(returnUrl, response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Post_TaskAlreadyAssignedToSelectedUser_DoesNotPublishEventForThatTask()
     {
         // Arrange
@@ -211,6 +370,15 @@ public class AssignTests(HostFixture hostFixture) : TestBase(hostFixture)
                     Assert.Equal(unassignedTask.SupportTaskReference, updatedEvent.SupportTaskReference);
                 });
         });
+    }
+
+    private async Task<User> CreateAndSetCurrentUserAsync(string? name = null)
+    {
+        // The current user from HostFixture isn't in the database once it's been cleared,
+        // so create a user we can assign tasks to and sign in as them
+        var user = await TestData.CreateUserAsync(name: name, role: UserRoles.RecordManager);
+        SetCurrentUser(user);
+        return user;
     }
 
     private static string GetAssignUrl(params string[] supportTaskReferences)

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/IndexTests.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
+using TeachingRecordSystem.SupportUi.Services.SupportTasks;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.SupportTasks.SupportTaskDetail;
 
@@ -68,12 +69,13 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
-    public async Task Get_AssignToOptions_OnlyIncludesAccessManagerAndRecordManagerUsers()
+    public async Task Get_AssignToOptions_OnlyIncludesAccessManagerRecordManagerAndAdministratorUsers()
     {
         // Arrange
         var recordManager = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
         var accessManager = await TestData.CreateUserAsync(role: UserRoles.AccessManager);
         var administrator = await TestData.CreateUserAsync(role: UserRoles.Administrator);
+        var viewer = await TestData.CreateUserAsync(role: UserRoles.Viewer);
 
         var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
 
@@ -92,7 +94,41 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         Assert.Contains(recordManager.UserId.ToString(), optionValues);
         Assert.Contains(accessManager.UserId.ToString(), optionValues);
-        Assert.DoesNotContain(administrator.UserId.ToString(), optionValues);
+        Assert.Contains(administrator.UserId.ToString(), optionValues);
+        Assert.DoesNotContain(viewer.UserId.ToString(), optionValues);
+    }
+
+    [Fact]
+    public async Task Get_AssignToOptions_StartWithUnassignedAndMyselfAndExcludeCurrentUserFromUserList()
+    {
+        // Arrange
+        var currentUser = await TestData.CreateUserAsync(name: "Current User", role: UserRoles.RecordManager);
+        SetCurrentUser(currentUser);
+        var otherUser = await TestData.CreateUserAsync(name: "Other User", role: UserRoles.RecordManager);
+
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/support-tasks/{supportTask.SupportTaskReference}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+
+        var options = ((IHtmlSelectElement)doc.GetElementById("AssignedToUserId")!)
+            .Options
+            .Select(o => (o.Value, Text: o.TrimmedText()))
+            .ToArray();
+
+        Assert.Equal(
+            [
+                (SupportTaskSearchService.UnassignedUserId.ToString(), "Unassigned"),
+                (currentUser.UserId.ToString(), "Myself")
+            ],
+            options.Take(2));
+        Assert.Contains((otherUser.UserId.ToString(), "Other User"), options);
+        Assert.DoesNotContain(options, o => o.Value == currentUser.UserId.ToString() && o.Text != "Myself");
     }
 
     [Fact]
@@ -236,6 +272,83 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         var nextPage = await response.FollowRedirectAsync(HttpClient);
         var nextPageDoc = await nextPage.GetDocumentAsync();
         AssertEx.HtmlDocumentHasFlashNotificationBanner(nextPageDoc, "Task updated");
+    }
+
+    [Fact]
+    public async Task Post_AssignedToCurrentUser_AssignsTaskToCurrentUser()
+    {
+        // Arrange
+        var currentUser = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        SetCurrentUser(currentUser);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignedToUserId", currentUser.UserId.ToString() },
+                { "Status", SupportTaskStatus.InProgress.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Equal(currentUser.UserId, dbTask.AssignedToUserId);
+        });
+    }
+
+    [Fact]
+    public async Task Post_UnassignedUserId_RemovesTheAssignment()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(role: UserRoles.RecordManager);
+        var supportTask = await TestData.CreateChangeNameRequestSupportTaskAsync();
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            dbTask.AssignedToUserId = user.UserId;
+            dbTask.Status = SupportTaskStatus.InProgress;
+            await dbContext.SaveChangesAsync();
+        });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/support-tasks/{supportTask.SupportTaskReference}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "AssignedToUserId", SupportTaskSearchService.UnassignedUserId.ToString() },
+                { "Status", SupportTaskStatus.InProgress.ToString() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var dbTask = await dbContext.SupportTasks.SingleAsync(t => t.SupportTaskReference == supportTask.SupportTaskReference);
+            Assert.Null(dbTask.AssignedToUserId);
+        });
+
+        Events.AssertProcessesCreated(p =>
+        {
+            Assert.Collection(p.Events, e =>
+            {
+                var updatedEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.Equal(supportTask.SupportTaskReference, updatedEvent.SupportTaskReference);
+                Assert.Null(updatedEvent.SupportTask.AssignedToUserId);
+                Assert.Equal(SupportTaskUpdatedEventChanges.AssignedToUserId, updatedEvent.Changes);
+            });
+        });
     }
 
     [Fact]

--- a/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchSupportTasksAsync.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/Services/SupportTasks/SupportTaskSearchServiceTests.SearchSupportTasksAsync.cs
@@ -125,6 +125,28 @@ public partial class SupportTaskSearchServiceTests
         Assert.Equal(["ST1", "ST3"], tasks.GetKeysFor(result.SearchResults));
     }
 
+    [Fact]
+    public async Task SearchSupportTasksAsync_FilterByUnassignedUserId_ReturnsOnlyTasksThatAreNotAssigned()
+    {
+        // Arrange
+        var user = await TestData.CreateUserAsync(name: "User A");
+        var tasks = new SupportTaskLookup
+        {
+            ["ST1"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 20))),
+            ["ST2"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 21))),
+            ["ST3"] = await TestData.CreateChangeNameRequestSupportTaskAsync(r => r.WithCreatedOn(new DateTime(2025, 1, 22))),
+        };
+        await AssignToUserAsync(tasks["ST2"], user.UserId);
+
+        // Act
+        var result = await SearchSupportTasksAsync(assignedToUserId: SupportTaskSearchService.UnassignedUserId);
+
+        // Assert
+        Assert.Equal(2, result.TotalTaskCount);
+        Assert.Equal(2, result.SearchResults.TotalItemCount);
+        Assert.Equal(["ST1", "ST3"], tasks.GetKeysFor(result.SearchResults));
+    }
+
     [Theory]
     [InlineData(new[] { SupportTaskStatus.Open }, new[] { "ST1" })]
     [InlineData(new[] { SupportTaskStatus.InProgress }, new[] { "ST2" })]


### PR DESCRIPTION
Allow unassigning in both bulk and singular task assignment.
Use 'myself' for tasks assigned to the current user.
Fix task order in bulk assignment to mirror order on the selection page.

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/390