### PR TITLE
Task Zendesk URLs page snagging fixes

### DIFF
--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/SupportTaskService.cs
@@ -319,16 +319,31 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
         }
     }
 
-    public async Task UpdateZendeskUrlsAsync(string supportTaskReference, string[] zendeskUrls, ProcessContext processContext)
+    public async Task<bool> UpdateZendeskUrlsAsync(UpdateZendeskUrlsOptions options, ProcessContext processContext)
     {
-        var supportTask = await dbContext.SupportTasks.FindOrThrowAsync(supportTaskReference);
+        var supportTask = await dbContext.SupportTasks.FindOrThrowAsync(options.SupportTaskReference);
+
+        var zendeskUrls = options.ZendeskUrls.ToArray();
+
+        if (zendeskUrls.SequenceEqual(supportTask.ZendeskTickets))
+        {
+            return false;
+        }
 
         var oldSupportTaskEventModel = EventModels.SupportTask.FromModel(supportTask);
 
+        var urlsHaveBeenAdded = zendeskUrls.Except(supportTask.ZendeskTickets).Any();
+
         supportTask.UpdatedOn = processContext.Now;
-        supportTask.ZendeskTickets = zendeskUrls
-            .Where(ticket => !string.IsNullOrEmpty(ticket))
-            .ToArray();
+        supportTask.ZendeskTickets = zendeskUrls;
+
+        var changes = SupportTaskUpdatedEventChanges.ZendeskTicketUrls;
+
+        if (urlsHaveBeenAdded && supportTask.Status is SupportTaskStatus.Open)
+        {
+            supportTask.Status = SupportTaskStatus.InProgress;
+            changes |= SupportTaskUpdatedEventChanges.Status;
+        }
 
         await dbContext.SaveChangesAsync();
 
@@ -336,14 +351,16 @@ public class SupportTaskService(TrsDbContext dbContext, IEventPublisher eventPub
             new SupportTaskUpdatedEvent
             {
                 EventId = Guid.NewGuid(),
-                SupportTaskReference = supportTaskReference,
-                Changes = SupportTaskUpdatedEventChanges.ZendeskTicketUrls,
+                SupportTaskReference = options.SupportTaskReference,
+                Changes = changes,
                 SupportTask = EventModels.SupportTask.FromModel(supportTask),
                 OldSupportTask = oldSupportTaskEventModel,
                 Comments = null,
                 RejectionReason = null
             },
             processContext);
+
+        return true;
     }
 }
 

--- a/src/TeachingRecordSystem.Core/Services/SupportTasks/UpdateZendeskUrlsOptions.cs
+++ b/src/TeachingRecordSystem.Core/Services/SupportTasks/UpdateZendeskUrlsOptions.cs
@@ -1,0 +1,7 @@
+namespace TeachingRecordSystem.Core.Services.SupportTasks;
+
+public record UpdateZendeskUrlsOptions
+{
+    public required string SupportTaskReference { get; init; }
+    public required IEnumerable<string> ZendeskUrls { get; init; }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/Index.cshtml
@@ -94,7 +94,7 @@
 
             @if (Model.Notes!.Count == 0)
             {
-                <p class="govuk-body" data-testid="no-notes">There are no notes associated with this task</p>
+                <p class="govuk-body" data-testid="no-notes">There are no notes associated with this task.</p>
             }
             else
             {
@@ -124,11 +124,15 @@
 
             <p class="govuk-body">View and add Zendesk tickets related to this task.</p>
 
-            <govuk-details>
-                <govuk-details-summary>View tickets</govuk-details-summary>
-                <govuk-details-text>
-                    @if (Model.ZendeskTickets?.Any() == true)
-                    {
+            @if (Model.ZendeskTickets!.Count == 0)
+            {
+                <p class="govuk-body">No Zendesk tickets have been added yet.</p>
+            }
+            else
+            {
+                <govuk-details>
+                    <govuk-details-summary>View tickets</govuk-details-summary>
+                    <govuk-details-text>
                         <ul class="govuk-list">
                             @foreach (var ticket in Model.ZendeskTickets)
                             {
@@ -139,13 +143,9 @@
                                 </li>
                             }
                         </ul>
-                    }
-                    else
-                    {
-                        <p class="govuk-body">No Zendesk tickets have been added yet.</p>
-                    }
-                </govuk-details-text>
-            </govuk-details>
+                    </govuk-details-text>
+                </govuk-details>
+            }
 
             <govuk-button-link href="@LinkGenerator.SupportTasks.SupportTaskDetail.ZendeskTickets(Model.SupportTaskReference, returnUrl: returnUrl)"
                                class="govuk-button--secondary">

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml
@@ -1,28 +1,28 @@
 @page "/support-tasks/{supportTaskReference}/zendesk-tickets"
-@using TeachingRecordSystem.Core.DataStore.Postgres.Models
 @model TeachingRecordSystem.SupportUi.Pages.SupportTasks.SupportTaskDetail.ZendeskTickets
-
 @{
     ViewBag.Title = "Zendesk tickets";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.BackLink" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <form method="post">
-            <govuk-back-link href="@LinkGenerator.SupportTasks.SupportTaskDetail.Index(Model.SupportTaskReference)" />
-
             <span class="govuk-caption-l">@Model.SupportTaskTypeTitle</span>
             <span class="govuk-caption-m">@Model.SupportTaskReference</span>
 
-            <h1 class="govuk-heading-l govuk-!-margin-bottom-2">
+            <h1 class="govuk-heading-l">
                 Add a Zendesk ticket
             </h1>
 
             <div id="zendesk-tickets-container">
-                <table class="govuk-table trs-table-layout-fixed">
+                <table class="govuk-table trs-table-layout-fixed trs-zendesk-links-table">
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
-                            <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">
+                            <th scope="col" class="govuk-table__header govuk-!-width-one-half">
                                 Link to ticket
                             </th>
                             <th scope="col" class="govuk-table__header">
@@ -32,91 +32,114 @@
                     </thead>
 
                     <tbody class="govuk-table__body">
-                        @if (Model.TicketUrls is null || Model.TicketUrls.Count == 0)
+                        @for (var i = 0; i < Model.TicketUrls!.Count; i++)
                         {
-                            <tr class="govuk-table__row" data-testid="no-tickets">
-                                <td class="govuk-table__cell" colspan="2">
-                                    No tickets added
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <govuk-input
+                                        data-testid="zendesk-ticket-@i"
+                                        for="TicketUrls[@i]"
+                                        name="@Html.NameFor(m => m.TicketUrls)"
+                                        id="TicketUrls-@i"
+                                        type="url"
+                                        class="trs-zendesk-links-table__link-input"
+                                        input-class="govuk-!-width-full">
+                                        <govuk-input-label class="govuk-label--s govuk-visually-hidden">
+                                            Zendesk URL
+                                        </govuk-input-label>
+                                    </govuk-input>
+                                </td>
+
+                                <td class="govuk-table__cell">
+                                    <div class="trs-zendesk-links-table__actions-container">
+                                        <div class="trs-zendesk-links-table__actions">
+                                            <govuk-button
+                                                type="button"
+                                                class="govuk-button--secondary trs-requires-js"
+                                                data-testid="remove-ticket-@i"
+                                                hx-post
+                                                hx-page-handler="RemoveTicket"
+                                                hx-route-index="@i"
+                                                hx-include="closest form"
+                                                hx-target="main"
+                                                hx-select="main"
+                                                hx-swap="outerHTML">
+                                                Remove
+                                            </govuk-button>
+
+                                            @if (!string.IsNullOrEmpty(Model.TicketUrls[i]))
+                                            {
+                                                <a
+                                                    href="@Model.TicketUrls[i]"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    class="govuk-link">
+                                                    View ticket (opens in new tab)
+                                                </a>
+                                            }
+                                        </div>
+                                    </div>
                                 </td>
                             </tr>
                         }
-                        else
+                        @if (!HttpContext.Request.IsHtmx())
                         {
-                            @for (var i = 0; i < Model.TicketUrls.Count; i++)
-                            {
+                            <noscript>
                                 <tr class="govuk-table__row">
                                     <td class="govuk-table__cell">
                                         <govuk-input
-                                            data-testid="zendesk-ticket-@i"
-                                            for="TicketUrls[@i]"
+                                            data-testid="zendesk-ticket-new"
+                                            name="TicketUrls"
                                             type="url"
+                                            class="trs-zendesk-links-table__link-input"
                                             input-class="govuk-!-width-full">
-                                            <govuk-input-label class="govuk-label--s">
-                                                <span class="govuk-visually-hidden">Zendesk URL</span>
+                                            <govuk-input-label class="govuk-label--s govuk-visually-hidden">
+                                                Zendesk URL
                                             </govuk-input-label>
                                         </govuk-input>
                                     </td>
 
                                     <td class="govuk-table__cell">
-                                        <govuk-button
-                                            type="submit"
-                                            asp-page-handler="RemoveTicket"
-                                            asp-route-removeIndex="@i"
-                                            class="govuk-button--secondary"
-                                            data-testid="remove-ticket-@i"
-                                            hx-post
-                                            hx-page-handler="RemoveTicket"
-                                            hx-route-removeIndex="@i"
-                                            hx-include="closest form"
-                                            hx-target="#zendesk-tickets-container"
-                                            hx-select="#zendesk-tickets-container"
-                                            hx-swap="outerHTML">
-                                            Remove
-                                        </govuk-button>
-
-                                        <span class="trs-link-separator" aria-hidden="true">｜</span>
-
-                                        <a
-                                            href="@Model.TicketUrls[i]"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            class="govuk-link">
-                                            View ticket
-                                        </a>
+                                        <div class="trs-zendesk-links-table__actions-container">
+                                            <div class="trs-zendesk-links-table__actions">
+                                                <govuk-button
+                                                    type="button"
+                                                    class="govuk-button--secondary trs-requires-js"
+                                                    hx-post
+                                                    hx-page-handler="RemoveTicket"
+                                                    hx-route-index="@Model.TicketUrls.Count"
+                                                    hx-include="closest form"
+                                                    hx-target="main"
+                                                    hx-select="main"
+                                                    hx-swap="outerHTML">
+                                                    Remove
+                                                </govuk-button>
+                                            </div>
+                                        </div>
                                     </td>
                                 </tr>
-                            }
+                            </noscript>
                         }
                     </tbody>
                 </table>
 
-                <div class="govuk-!-margin-top-4">
+                <div class="govuk-!-margin-top-4 trs-requires-js">
                     <govuk-button
-                        type="submit"
-                        asp-page-handler="AddTicket"
+                        type="button"
                         class="govuk-button--secondary"
+                        hx-post
                         hx-page-handler="AddTicket"
-                        hx-include="closest form"
-                        hx-target="#zendesk-tickets-container"
-                        hx-select="#zendesk-tickets-container"
-                        hx-swap="outerHTML">
+                        hx-target="#zendesk-tickets-container tbody"
+                        hx-select="#zendesk-tickets-container tbody tr:last-child"
+                        hx-swap="beforeend">
                         Add another
                     </govuk-button>
                 </div>
             </div>
 
             <div class="govuk-button-group govuk-!-margin-top-4">
-                <govuk-button
-                    type="submit"
-                    asp-page-handler="Save">
-                    Continue
-                </govuk-button>
-
-                <govuk-button-link
-                    href="@LinkGenerator.SupportTasks.SupportTaskDetail.Index(Model.SupportTaskReference)"
-                    class="govuk-button--secondary">
-                    Cancel
-                </govuk-button-link>
+                <govuk-button type="submit">Save</govuk-button>
+                <govuk-button-link href="@Model.BackLink" class="govuk-button--secondary">Cancel</govuk-button-link>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/SupportTaskDetail/ZendeskTickets.cshtml.cs
@@ -21,27 +21,69 @@ public class ZendeskTickets(
             .When(m => m.TicketUrls is not null)
     };
 
-    [FromRoute] public string SupportTaskReference { get; set; } = null!;
+    private SupportTask? _supportTask;
+
+    [FromRoute]
+    public string SupportTaskReference { get; set; } = null!;
 
     public string SupportTaskTypeTitle { get; set; } = null!;
 
     public SupportTaskType SupportTaskType { get; set; }
 
-    [BindProperty] public List<string>? TicketUrls { get; set; }
+    [BindProperty]
+    public List<string>? TicketUrls { get; set; }
 
-    private SupportTask? _supportTask { get; set; }
+    public string? BackLink { get; set; }
 
     public void OnGet()
     {
-        var supportTask = HttpContext
-            .GetCurrentSupportTaskFeature()
-            .SupportTask;
-
-        TicketUrls = supportTask.ZendeskTickets?.ToList() ?? [];
+        TicketUrls = _supportTask!.ZendeskTickets.ToList();
     }
 
-    public override void OnPageHandlerExecuting(
-        PageHandlerExecutingContext context)
+    public async Task<IActionResult> OnPostAsync()
+    {
+        await _validator.ValidateAndThrowAsync(this);
+
+        var sanitizedTicketUrls = (TicketUrls ?? []).Where(url => !string.IsNullOrEmpty(url));
+
+        var processContext = new ProcessContext(ProcessType.SupportTaskZendeskUrlsUpdating, timeProvider.UtcNow, SystemUser.SystemUserId);
+
+        var updated = await supportTaskService.UpdateZendeskUrlsAsync(
+            new UpdateZendeskUrlsOptions
+            {
+                SupportTaskReference = SupportTaskReference,
+                ZendeskUrls = sanitizedTicketUrls
+            },
+            processContext);
+
+        if (updated)
+        {
+            TempData.SetFlashNotificationBanner("Zendesk tickets updated");
+        }
+
+        return Redirect(BackLink!);
+    }
+
+    public IActionResult OnPostRemoveTicket(int index)
+    {
+        TicketUrls!.RemoveAt(index);
+
+        if (TicketUrls.Count == 0)
+        {
+            TicketUrls.Add(string.Empty);
+        }
+
+        return Page();
+    }
+
+    public IActionResult OnPostAddTicket()
+    {
+        TicketUrls!.Add(string.Empty);
+
+        return Page();
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         _supportTask = HttpContext
             .GetCurrentSupportTaskFeature()
@@ -49,51 +91,8 @@ public class ZendeskTickets(
 
         SupportTaskType = _supportTask.SupportTaskType;
         SupportTaskTypeTitle = _supportTask.SupportTaskType.GetTitle();
-    }
 
-    public IActionResult OnPostAddTicket()
-    {
-        TicketUrls ??= [];
-        TicketUrls.Add(string.Empty);
-
-        ModelState.Clear();
-
-        return Page();
-    }
-
-    public IActionResult OnPostRemoveTicket(int removeIndex)
-    {
-        TicketUrls ??= [];
-
-        if (removeIndex >= 0 && removeIndex < TicketUrls.Count)
-        {
-            TicketUrls.RemoveAt(removeIndex);
-        }
-
-        foreach (var key in ModelState.Keys
-                     .Where(k => k.StartsWith(nameof(TicketUrls) + "["))
-                     .ToList())
-        {
-            ModelState.Remove(key);
-        }
-
-        return Page();
-    }
-
-    public async Task<IActionResult> OnPostAsync()
-    {
-        await _validator.ValidateAndThrowAsync(this);
-
-        var processContext = new ProcessContext(ProcessType.SupportTaskZendeskUrlsUpdating, timeProvider.UtcNow, SystemUser.SystemUserId);
-
-        await supportTaskService.UpdateZendeskUrlsAsync(SupportTaskReference, TicketUrls?.ToArray() ?? [], processContext);
-
-        TempData.SetFlashNotificationBanner(
-            "Zendesk tickets updated");
-
-        return Redirect(
-            linkGenerator.SupportTasks.SupportTaskDetail.Index(
-                SupportTaskReference));
+        BackLink = this.GetReturnUrlOrDefault(linkGenerator.SupportTasks.SupportTaskDetail.Index(SupportTaskReference));
     }
 
     private static bool IsValidZendeskUrl(string? value)

--- a/src/TeachingRecordSystem.SupportUi/Styles/app.scss
+++ b/src/TeachingRecordSystem.SupportUi/Styles/app.scss
@@ -553,3 +553,32 @@ tr:has([data-selects-row]):has(:checked) {
 .trs-select-row {
   margin-left: 10px !important;
 }
+
+.trs-zendesk-links-table {
+  height: 1px;  // Hack so that height: 100% works in __actions-container
+
+  &__actions-container {
+    height: 100%;
+    display: flex;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    column-gap: 15px;
+    height: 40px;
+    margin-top: auto;
+
+    .govuk-button {
+      margin: 0;
+    }
+  }
+
+  &__link-input {
+    margin: 0;
+  }
+}
+
+body:not(.js-enabled) .trs-requires-js {
+  @extend .govuk-visually-hidden;
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/IndexTests.cs
@@ -175,7 +175,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var noNotesMessage = doc.GetElementByTestId("no-notes");
         Assert.NotNull(noNotesMessage);
-        Assert.Equal("There are no notes associated with this task", noNotesMessage.TrimmedText());
+        Assert.Equal("There are no notes associated with this task.", noNotesMessage.TrimmedText());
         Assert.Null(doc.GetElementByTestId("notes"));
     }
 

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/ZendeskTicketsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/SupportTaskDetail/ZendeskTicketsTests.cs
@@ -20,7 +20,7 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
     }
 
     [Fact]
-    public async Task Get_NoZendeskTickets_ShowsNoTicketsAdded()
+    public async Task Get_NoZendeskTickets_ShowsNoTicketRows()
     {
         // Arrange
         var applicationUser = await TestData.CreateApplicationUserAsync();
@@ -49,10 +49,8 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         // Assert
         var document = await AssertEx.HtmlResponseAsync(response);
 
-        var noTickets = document.GetElementByTestId("no-tickets");
-
-        Assert.NotNull(noTickets);
-        Assert.Equal("No tickets added", noTickets.TrimmedText());
+        Assert.Null(document.GetElementByTestId("zendesk-ticket-0"));
+        Assert.NotNull(document.GetElementByTestId("zendesk-ticket-new"));
     }
 
     [Fact]
@@ -69,8 +67,8 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         {
             Content = new FormUrlEncodedContentBuilder
             {
-                { "TicketUrls[0]", "" },
-                { "TicketUrls[1]", ticketUrl2 }
+                { "TicketUrls", "" },
+                { "TicketUrls", ticketUrl2 }
             }
         };
 
@@ -106,10 +104,11 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         // Assert
         var document = await AssertEx.HtmlResponseAsync(response);
 
-        var ticketInput = document.QuerySelector(
-            "input[name='TicketUrls[0]']");
+        var ticketInput = document.QuerySelector("input#TicketUrls-0");
 
         Assert.NotNull(ticketInput);
+        Assert.Equal("TicketUrls", ticketInput.GetAttribute("name"));
+        Assert.True(string.IsNullOrEmpty(ticketInput.GetAttribute("value")));
     }
 
     [Fact]
@@ -127,8 +126,8 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         {
             Content = new FormUrlEncodedContentBuilder
             {
-                { "TicketUrls[0]", ticketUrl1 },
-                { "TicketUrls[1]", ticketUrl2 }
+                { "TicketUrls", ticketUrl1 },
+                { "TicketUrls", ticketUrl2 }
             }
         };
 
@@ -190,7 +189,7 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         {
             Content = new FormUrlEncodedContentBuilder
             {
-                { "TicketUrls[0]", updatedTicketUrl }
+                { "TicketUrls", updatedTicketUrl }
             }
         };
 
@@ -256,7 +255,7 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         {
             Content = new FormUrlEncodedContentBuilder
             {
-                { "TicketUrls[0]", "" },
+                { "TicketUrls", "" },
             }
         };
 
@@ -323,8 +322,8 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         {
             Content = new FormUrlEncodedContentBuilder
             {
-                { "TicketUrls[0]", updatedTicketUrl1 },
-                { "TicketUrls[1]", updatedTicketUrl2 }
+                { "TicketUrls", updatedTicketUrl1 },
+                { "TicketUrls", updatedTicketUrl2 }
             }
         };
 
@@ -353,6 +352,182 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
                 Assert.Contains(updatedTicketUrl1, supportTaskZendeskEvent.SupportTask.ZendeskTickets);
                 Assert.Contains(updatedTicketUrl2, supportTaskZendeskEvent.SupportTask.ZendeskTickets);
                 Assert.Contains(existingTicketUrl, supportTaskZendeskEvent.OldSupportTask.ZendeskTickets);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_TicketsAreUnchanged_DoesNotPublishEventOrShowNotification()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(
+            personId: null,
+            email: Option.Some<string?>(TestData.GenerateUniqueEmail()),
+            verifiedInfo: null);
+
+        var existingTicketUrl =
+            "https://example.zendesk.com/agent/tickets/123";
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser1.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId)
+                    .WithZendeskTickets(existingTicketUrl));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls", existingTicketUrl }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var redirectResponse = await response.FollowRedirectAsync(HttpClient);
+        var redirectDoc = await redirectResponse.GetDocumentAsync();
+
+        Assert.Empty(redirectDoc.GetElementsByClassName("govuk-notification-banner"));
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTaskReference));
+
+        Assert.Equal([existingTicketUrl], updatedSupportTask.ZendeskTickets);
+
+        Events.AssertNoEventsPublished();
+    }
+
+    [Fact]
+    public async Task Post_TicketIsAddedToOpenSupportTask_SetsStatusToInProgress()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(
+            personId: null,
+            email: Option.Some<string?>(TestData.GenerateUniqueEmail()),
+            verifiedInfo: null);
+
+        var addedTicketUrl =
+            "https://example.zendesk.com/agent/tickets/123";
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser1.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId)
+                    .WithStatus(SupportTaskStatus.Open));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls", addedTicketUrl }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTaskReference));
+
+        Assert.Equal(SupportTaskStatus.InProgress, updatedSupportTask.Status);
+
+        Events.AssertProcessesCreated(x =>
+        {
+            Assert.Equal(ProcessType.SupportTaskZendeskUrlsUpdating, x.ProcessContext.ProcessType);
+            Assert.Collection(x.Events, e =>
+            {
+                var supportTaskZendeskEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.Equal(
+                    SupportTaskUpdatedEventChanges.ZendeskTicketUrls | SupportTaskUpdatedEventChanges.Status,
+                    supportTaskZendeskEvent.Changes);
+                Assert.Equal(SupportTaskStatus.Open, supportTaskZendeskEvent.OldSupportTask.Status);
+                Assert.Equal(SupportTaskStatus.InProgress, supportTaskZendeskEvent.SupportTask.Status);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Post_TicketIsRemovedFromOpenSupportTask_LeavesStatusUnchanged()
+    {
+        // Arrange
+        var applicationUser = await TestData.CreateApplicationUserAsync();
+
+        var oneLoginUser1 = await TestData.CreateOneLoginUserAsync(
+            personId: null,
+            email: Option.Some<string?>(TestData.GenerateUniqueEmail()),
+            verifiedInfo: null);
+
+        var existingTicketUrl1 =
+            "https://example.zendesk.com/agent/tickets/123";
+
+        var existingTicketUrl2 =
+            "https://example.zendesk.com/agent/tickets/456";
+
+        var supportTask =
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+                oneLoginUser1.Subject,
+                configure => configure
+                    .WithStatedFirstName("Alphie")
+                    .WithStatedLastName("Smith")
+                    .WithCreatedOn(new DateTime(2025, 1, 22, 1, 1, 1))
+                    .WithClientApplicationUserId(applicationUser.UserId)
+                    .WithStatus(SupportTaskStatus.Open)
+                    .WithZendeskTickets(existingTicketUrl1, existingTicketUrl2));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/{supportTask.SupportTaskReference}/zendesk-tickets")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "TicketUrls", existingTicketUrl1 }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        var updatedSupportTask = await WithDbContextAsync(dbContext =>
+            dbContext.SupportTasks.SingleAsync(
+                t => t.SupportTaskReference == supportTask.SupportTaskReference));
+
+        Assert.Equal([existingTicketUrl1], updatedSupportTask.ZendeskTickets);
+        Assert.Equal(SupportTaskStatus.Open, updatedSupportTask.Status);
+
+        Events.AssertProcessesCreated(x =>
+        {
+            Assert.Equal(ProcessType.SupportTaskZendeskUrlsUpdating, x.ProcessContext.ProcessType);
+            Assert.Collection(x.Events, e =>
+            {
+                var supportTaskZendeskEvent = Assert.IsType<SupportTaskUpdatedEvent>(e);
+                Assert.Equal(SupportTaskUpdatedEventChanges.ZendeskTicketUrls, supportTaskZendeskEvent.Changes);
+                Assert.Equal(SupportTaskStatus.Open, supportTaskZendeskEvent.SupportTask.Status);
             });
         });
     }
@@ -392,9 +567,9 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         {
             Content = new FormUrlEncodedContentBuilder
             {
-                { "TicketUrls[0]", ticketUrl1 },
-                { "TicketUrls[1]", ticketUrl2 },
-                { "TicketUrls[2]", invalidTicketUrl }
+                { "TicketUrls", ticketUrl1 },
+                { "TicketUrls", ticketUrl2 },
+                { "TicketUrls", invalidTicketUrl }
             }
         };
 
@@ -404,7 +579,7 @@ public class ZendeskTicketsTests(HostFixture hostFixture) : TestBase(hostFixture
         // Assert
         await AssertEx.HtmlResponseHasErrorAsync(
             response,
-            "TicketUrls_2_",
+            "TicketUrls-2",
             "Enter a valid Zendesk URL");
     }
 }


### PR DESCRIPTION
Don't show flash message if URLs were not changed.
Don't emit an event if URLs were not changed.
Various HTMX and style fixes.
Set the task to 'in progress' if any URLs where added or updated.

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/390