### PR TITLE
Fix missing CompletionUrl in persisted journey states

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingJourneyCoordinator.cs
@@ -81,6 +81,7 @@ public class ResolveOneLoginUserMatchingJourneyCoordinator(
             existingState with
             {
                 MatchedPersons = suggestedMatches,
+                CompletionUrl = completionUrl,
                 SavedJourneyState = supportTask.ResolveJourneySavedState
             } :
             new ResolveOneLoginUserMatchingState

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingState.cs
@@ -8,7 +8,7 @@ public record ResolveOneLoginUserMatchingState : IJourneyWithSavedState
     public static Guid NotMatchedPersonIdSentinel => Guid.Empty;
 
     public required IReadOnlyCollection<MatchPersonResult> MatchedPersons { get; init; }
-    public required string CompletionUrl { get; init; }
+    public string CompletionUrl { get; init; } = null!;  // Work-around persisted states without CompletionUrl set
 
     public SavedJourneyState? SavedJourneyState { get; set; }
     public bool? Verified { get; set; }


### PR DESCRIPTION
We recently added `CompletionUrl` to `ResolveOneLoginUserMatchingState` but we have some persisted instances without that property set. This removes the `required` modifier from the property and ensures the journey coordinator always populates it.

Fixes https://dfe-teacher-services.sentry.io/issues/7639844599/events/abdd5ebcd9874ddb8a7ddef05a4759f2/?project=6165440