### PR TITLE
Assign User ID to Sentry scope

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Infrastructure/Middleware/AssignUserToSentryScopeMiddleware.cs
+++ b/src/TeachingRecordSystem.SupportUi/Infrastructure/Middleware/AssignUserToSentryScopeMiddleware.cs
@@ -1,0 +1,19 @@
+using System.Security.Claims;
+using TeachingRecordSystem.SupportUi.Infrastructure.Security;
+
+namespace TeachingRecordSystem.SupportUi.Infrastructure.Middleware;
+
+public class AssignUserToSentryScopeMiddleware(RequestDelegate next)
+{
+    public Task InvokeAsync(HttpContext context)
+    {
+        var userId = context.User.FindFirstValue(CustomClaims.UserId);
+
+        if (userId is not null)
+        {
+            SentrySdk.ConfigureScope(scope => scope.User = new SentryUser { Id = userId });
+        }
+
+        return next(context);
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Program.cs
+++ b/src/TeachingRecordSystem.SupportUi/Program.cs
@@ -2,6 +2,7 @@ using Hangfire;
 using Htmx.TagHelpers;
 using Joonasw.AspNetCore.SecurityHeaders;
 using TeachingRecordSystem.SupportUi.Endpoints;
+using TeachingRecordSystem.SupportUi.Infrastructure.Middleware;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 using TeachingRecordSystem.WebCommon.Infrastructure.Logging;
 using TeachingRecordSystem.WebCommon.Middleware;
@@ -78,6 +79,7 @@ public class Program
         app.UseSession();
 
         app.UseAuthentication();
+        app.UseMiddleware<AssignUserToSentryScopeMiddleware>();
         app.UseAuthorization();
 
         app.MapHtmxAntiforgeryScript();


### PR DESCRIPTION
With this we know which user triggered any Sentry issues for the support console.