### PR TITLE
Fix Back link and Cancel not using returnUrl in the resolve One Login journey

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ConfirmReject.cshtml.cs
@@ -11,8 +11,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching
 public class ConfirmReject(
     ResolveOneLoginUserMatchingJourneyCoordinator journey,
     OneLoginUserMatchingSupportTaskService supportTaskService,
-    TimeProvider timeProvider,
-    SupportUiLinkGenerator linkGenerator) : PageModel
+    TimeProvider timeProvider) : PageModel
 {
     private SupportTask? _supportTask;
 
@@ -41,7 +40,7 @@ public class ConfirmReject(
         {
             journey.DeleteInstance();
 
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
+            return Redirect(journey.State.CompletionUrl);
         }
 
         var processContext = new ProcessContext(ProcessType.OneLoginUserIdVerificationSupportTaskCompleting, timeProvider.UtcNow, User.GetUserId());
@@ -63,7 +62,7 @@ public class ConfirmReject(
             $"Request closed for {data.StatedFirstName} {data.StatedLastName}. We’ve sent them an email confirming we could not verify their identity.",
             notificationBannerType: NotificationBannerType.Default);
 
-        return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
+        return Redirect(journey.State.CompletionUrl);
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Reject.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Reject.cshtml.cs
@@ -43,7 +43,7 @@ public class Reject(
         {
             journey.DeleteInstance();
 
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
+            return Redirect(journey.State.CompletionUrl);
         }
 
         await _validator.ValidateAndThrowAsync(this);

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
@@ -48,7 +48,7 @@ public class VerifyModel(
         {
             journey.DeleteInstance();
 
-            return Redirect(linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification());
+            return Redirect(journey.State.CompletionUrl);
         }
 
         await _validator.ValidateAndThrowAsync(this);
@@ -66,7 +66,7 @@ public class VerifyModel(
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        BackLink = journey.GetBackLink() ?? linkGenerator.SupportTasks.OneLoginUserMatching.IdVerification();
+        BackLink = journey.GetBackLink() ?? journey.State.CompletionUrl;
 
         var supportTask = HttpContext.GetCurrentSupportTaskFeature().SupportTask;
         var oneLoginUser = supportTask.OneLoginUser!;

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/IndexTests.cs
@@ -65,12 +65,14 @@ public class IndexTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTe
             response.Headers.Location?.OriginalString);
     }
 
-    [Fact]
-    public async Task Get_WithReturnUrl_JourneyCompletesToReturnUrl()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Get_WithReturnUrl_JourneyCompletesToReturnUrl(bool isRecordMatchingOnlySupportTask)
     {
         // Arrange
         var returnUrl = "/support-tasks/active?keyword=test";
-        var (_, firstStepUrl) = await StartJourneyAsync(returnUrl);
+        var (_, firstStepUrl) = await StartJourneyAsync(returnUrl, isRecordMatchingOnlySupportTask);
 
         var request = new HttpRequestMessage(HttpMethod.Post, firstStepUrl)
         {
@@ -85,11 +87,13 @@ public class IndexTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTe
         Assert.Equal(returnUrl, response.Headers.Location?.OriginalString);
     }
 
-    [Fact]
-    public async Task Get_WithNonLocalReturnUrl_JourneyCompletesToListPage()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Get_WithNonLocalReturnUrl_JourneyCompletesToListPage(bool isRecordMatchingOnlySupportTask)
     {
         // Arrange
-        var (supportTask, firstStepUrl) = await StartJourneyAsync("https://evil.example.com/");
+        var (supportTask, firstStepUrl) = await StartJourneyAsync("https://evil.example.com/", isRecordMatchingOnlySupportTask);
 
         var request = new HttpRequestMessage(HttpMethod.Post, firstStepUrl)
         {
@@ -147,10 +151,14 @@ public class IndexTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingTe
     /// <summary>
     /// Starts the journey the way the "View task" link does and returns the URL of its first page.
     /// </summary>
-    private async Task<(SupportTask SupportTask, string FirstStepUrl)> StartJourneyAsync(string returnUrl)
+    private async Task<(SupportTask SupportTask, string FirstStepUrl)> StartJourneyAsync(
+        string returnUrl,
+        bool isRecordMatchingOnlySupportTask = true)
     {
-        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: true);
-        var supportTask = await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject);
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: isRecordMatchingOnlySupportTask);
+        var supportTask = isRecordMatchingOnlySupportTask ?
+            await TestData.CreateOneLoginUserRecordMatchingSupportTaskAsync(oneLoginUser.Subject) :
+            await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
 
         var request = new HttpRequestMessage(
             HttpMethod.Get,

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
@@ -296,4 +296,64 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
 
         Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
+
+    [Fact]
+    public async Task Get_JourneyStartedWithReturnUrl_RendersBackLinkToReturnUrl()
+    {
+        // Arrange
+        var returnUrl = "/support-tasks/active?keyword=test";
+        var verifyUrl = await StartJourneyAsync(returnUrl);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, verifyUrl);
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        Assert.Equal(returnUrl, doc.GetElementsByClassName("govuk-back-link").Single().GetAttribute("href"));
+    }
+
+    [Fact]
+    public async Task Post_Cancel_JourneyStartedWithReturnUrl_RedirectsToReturnUrl()
+    {
+        // Arrange
+        var returnUrl = "/support-tasks/active?keyword=test";
+        var verifyUrl = await StartJourneyAsync(returnUrl);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, verifyUrl)
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "Cancel", "True" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(returnUrl, response.Headers.Location?.OriginalString);
+    }
+
+    /// <summary>
+    /// Starts the journey the way the "View task" link does and returns the URL of this page.
+    /// </summary>
+    private async Task<string> StartJourneyAsync(string returnUrl)
+    {
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(oneLoginUser.Subject);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve?returnUrl={Uri.EscapeDataString(returnUrl)}");
+
+        var response = await HttpClient.SendAsync(request);  // Initializes journey
+        response = await response.FollowRedirectAsync(HttpClient);
+
+        return response.Headers.Location!.OriginalString;
+    }
 }


### PR DESCRIPTION
### Context

Starting the resolve One Login user matching journey with a `returnUrl` (e.g. from the support task list with filters applied) should send the user back where they came from when they use Back or Cancel. For ID verification tasks it didn't: the first page of the journey always sent them to the ID verification list page.

The journey stores the validated `returnUrl` as `State.CompletionUrl` (set in `ResolveOneLoginUserMatchingJourneyCoordinator.GetStartingStateAsync`). #3659 moved most of the journey's pages onto it, but the `Verify` branch was missed.

### Changes proposed in this pull request

- `Verify` (the first step for ID verification tasks): Back link fallback and Cancel now use `journey.State.CompletionUrl` instead of a hardcoded link to the ID verification list page.
- `Reject`: same fix for its Cancel button.
- `ConfirmReject`: same fix for its Cancel button and for the redirect after the request is rejected. Its now-unused `SupportUiLinkGenerator` constructor parameter has been removed.

Tests:

- Two new `VerifyTests` cases covering the Back link and Cancel when the journey is started with a `returnUrl` (both fail without the fix).
- The two existing `returnUrl` tests in `IndexTests` are now parameterised over both task types, so the ID verification path is covered alongside record matching.

### Guidance to review

`CompletionUrl` is the validated value — `GetReturnUrlOrDefault` falls back to the list page when the `returnUrl` isn't a local URL — so this doesn't widen where these links can point.

`GetFirstStepUrl` still doesn't pass `returnUrl` through to the `Verify` link, unlike the `Matches`/`NoMatches` branches. That query parameter isn't needed here: `CompletionUrl` covers both the Back link and Cancel.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)