### PR TITLE
Add ChangeHistoryEntryContext to ChangeHistoryEntryViewModel

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/ChangeHistoryContext.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/ChangeHistoryContext.cs
@@ -1,0 +1,22 @@
+namespace TeachingRecordSystem.SupportUi.Pages.Shared.Components.ChangeHistoryEntry;
+
+public sealed record ChangeHistoryContext
+{
+    private ChangeHistoryContext() { }
+
+    public static ChangeHistoryContext ForPerson(Guid personId) => new()
+    {
+        ContextType = ChangeHistoryContextType.Person,
+        PersonId = personId
+    };
+
+    public ChangeHistoryContextType ContextType { get; private set; }
+
+    public Guid PersonId
+    {
+        get => ContextType is ChangeHistoryContextType.Person
+            ? field
+            : throw new InvalidOperationException($"{nameof(ContextType)} does not have a {nameof(PersonId)}.");
+        private set;
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/ChangeHistoryContextType.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/ChangeHistoryContextType.cs
@@ -1,6 +1,6 @@
 namespace TeachingRecordSystem.SupportUi.Pages.Shared.Components.ChangeHistoryEntry;
 
-public enum ChangeHistoryViewType
+public enum ChangeHistoryContextType
 {
     Person
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/ChangeHistoryEntryViewModel.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/ChangeHistoryEntryViewModel.cs
@@ -5,15 +5,13 @@ namespace TeachingRecordSystem.SupportUi.Pages.Shared.Components.ChangeHistoryEn
 
 public record ChangeHistoryEntryViewModel
 {
-    public required ChangeHistoryViewType ViewType { get; init; }
+    public required ChangeHistoryContext Context { get; init; }
     public required DateTime Timestamp { get; init; }
     public required string UserName { get; init; }
     public required Guid ProcessId { get; init; }
     public required ProcessType ProcessType { get; init; }
     public required IChangeReasonInfo? ChangeReason { get; init; }
     public required IReadOnlyCollection<IEvent> Events { get; init; }
-    public required IReadOnlyDictionary<Guid, PersonInfo>? PersonInfo { get; init; }
-    public required Guid? PersonId { get; init; }
 
     public bool ContainsEvent<T>() where T : IEvent => Events.OfType<T>().Any();
 

--- a/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/Processes/PersonMergingInDqt.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/Shared/Components/ChangeHistoryEntry/Processes/PersonMergingInDqt.cshtml
@@ -1,16 +1,17 @@
 @using System.Diagnostics
 @model ChangeHistoryEntryViewModel
+@inject PersonInfoCache PersonInfoCache
 @{
     var deactivatedEvent = Model.GetEvent<PersonDeactivatedEvent>();
     Debug.Assert(deactivatedEvent.MergedWithPersonId is not null);
 
     var updatedEvent = Model.ContainsEvent<PersonUpdatedInDqtEvent>() ? Model.GetEvent<PersonUpdatedInDqtEvent>() : null ;
 
-    var thisRecordWasDeactivated = Model.PersonId == deactivatedEvent.PersonId;
+    var thisRecordWasDeactivated = Model.Context.PersonId == deactivatedEvent.PersonId;
 
     var title = !thisRecordWasDeactivated
-        ? $"Record merged{(Model.PersonInfo!.TryGetValue(deactivatedEvent.PersonId, out var childRecordInfo) ? $" with TRN {childRecordInfo.Trn}" : null)}"
-        : $"Record merged{(Model.PersonInfo!.TryGetValue(deactivatedEvent.MergedWithPersonId!.Value, out var masterRecordInfo) ? $" with TRN {masterRecordInfo.Trn}" : null)}" + " and deactivated";
+        ? $"Record merged{(await PersonInfoCache.GetPersonInfoAsync(deactivatedEvent.PersonId) is { } childRecordInfo ? $" with TRN {childRecordInfo.Trn}" : null)}"
+        : $"Record merged{(await PersonInfoCache.GetPersonInfoAsync(deactivatedEvent.MergedWithPersonId!.Value) is { } masterRecordInfo ? $" with TRN {masterRecordInfo.Trn}" : null)}" + " and deactivated";
 }
 
 <timeline-entry title="@title" by="@Model.UserName" timestamp="@Model.Timestamp" data-process-id="@Model.ProcessId">

--- a/src/TeachingRecordSystem.SupportUi/Services/ChangeHistory/ChangeHistoryService.cs
+++ b/src/TeachingRecordSystem.SupportUi/Services/ChangeHistory/ChangeHistoryService.cs
@@ -10,7 +10,6 @@ namespace TeachingRecordSystem.SupportUi.Services.ChangeHistory;
 public class ChangeHistoryService(
     TrsDbContext dbContext,
     ReferenceDataCache referenceDataCache,
-    PersonInfoCache personInfoCache,
     IAuthorizationService authorizationService)
 {
     public async Task<ResultPage<TimelineItem>> GetChangeHistoryByPersonAsync(
@@ -165,16 +164,8 @@ public class ChangeHistoryService(
                 || (dqtSanctionCode is not null && dqtSanctionCodesWithReadPermission.Contains(dqtSanctionCode.Value));
         }).ToList();
 
-        var personInfo = await filteredProcesses
-            .SelectMany(p => p.PersonIds)
-            .Distinct()
-            .ToAsyncEnumerable()
-            .Select(async (Guid id, CancellationToken _) => await personInfoCache.GetPersonInfoAsync(id))
-            .Where(i => i is not null)
-            .ToDictionaryAsync(i => i!.PersonId, i => i!);
-
         var allResults = eventsWithUser.Select(e => MapLegacyEvent(e, personId))
-            .Concat(filteredProcesses.Select(p => MapProcess(p, personId, personInfo)))
+            .Concat(filteredProcesses.Select(p => MapProcess(p, personId)))
             .ToArray();
 
         var pageNumber = paginationOptions.PageNumber ?? 1;
@@ -209,12 +200,12 @@ public class ChangeHistoryService(
         return (TimelineItem)Activator.CreateInstance(timelineItemType, TimelineItemType.LegacyEvent, personId, timelineEvent.Event.CreatedUtc, timelineEvent)!;
     }
 
-    private TimelineItem MapProcess(Process process, Guid personId, IReadOnlyDictionary<Guid, PersonInfo> personInfo) =>
+    private TimelineItem MapProcess(Process process, Guid personId) =>
         new TimelineItem<ProcessChangeHistoryEntry>(
             TimelineItemType.Process,
             personId,
             process.CreatedOn,
-            new ProcessChangeHistoryEntry(process, new RaisedByUserInfo { Name = process.DqtUserName ?? process.User?.Name! }, personInfo));
+            new ProcessChangeHistoryEntry(process, new RaisedByUserInfo { Name = process.DqtUserName ?? process.User?.Name! }));
 
     private record EventWithUser
     {

--- a/src/TeachingRecordSystem.SupportUi/Services/ChangeHistory/ProcessChangeHistoryEntry.cs
+++ b/src/TeachingRecordSystem.SupportUi/Services/ChangeHistory/ProcessChangeHistoryEntry.cs
@@ -4,7 +4,7 @@ using TeachingRecordSystem.SupportUi.Pages.Shared.Components.ChangeHistoryEntry;
 
 namespace TeachingRecordSystem.SupportUi.Services.ChangeHistory;
 
-public record ProcessChangeHistoryEntry(Process Process, RaisedByUserInfo RaisedByUser, IReadOnlyDictionary<Guid, PersonInfo> PersonInfo)
+public record ProcessChangeHistoryEntry(Process Process, RaisedByUserInfo RaisedByUser)
 {
     public bool ContainsEvent<T>() where T : IEvent => Process.Events!.Select(pe => pe.Payload).OfType<T>().Any();
 
@@ -25,14 +25,12 @@ public static class ProcessChangeHistoryEntryExtensions
     public static ChangeHistoryEntryViewModel ToChangeHistoryEntryViewModel(this TimelineItem<ProcessChangeHistoryEntry> timelineItem) =>
         new()
         {
-            ViewType = ChangeHistoryViewType.Person,
+            Context = ChangeHistoryContext.ForPerson(timelineItem.PersonId),
             Timestamp = timelineItem.Timestamp,
             UserName = timelineItem.ItemModel.RaisedByUser.Name,
             ProcessId = timelineItem.ItemModel.Process.ProcessId,
             ProcessType = timelineItem.ItemModel.Process.ProcessType,
             ChangeReason = timelineItem.ItemModel.Process.ChangeReason,
-            Events = timelineItem.ItemModel.Process.Events!.Select(e => e.Payload).AsReadOnly(),
-            PersonInfo = timelineItem.ItemModel.PersonInfo,
-            PersonId = timelineItem.PersonId
+            Events = timelineItem.ItemModel.Process.Events!.Select(e => e.Payload).AsReadOnly()
         };
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/ViewTests/ChangeHistoryEntries/ChangeHistoryEntryTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/ViewTests/ChangeHistoryEntries/ChangeHistoryEntryTestBase.cs
@@ -4,24 +4,10 @@ namespace TeachingRecordSystem.SupportUi.Tests.ViewTests.ChangeHistoryEntries;
 
 public abstract class ChangeHistoryEntryTestBase(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    protected async Task<IHtmlElement> GetEntryHtmlAsync(Guid processId)
+    protected async Task<IHtmlElement> GetEntryHtmlAsync(Guid processId, Guid? personId = null)
     {
-        var response = await HttpClient.GetAsync($"_change-history-entry/{processId}");
-        response.EnsureSuccessStatusCode();
-        var doc = await response.GetDocumentAsync();
-        return doc.QuerySelector(".moj-timeline__item") as IHtmlElement ?? throw new InvalidOperationException("Element not found.");
-    }
-
-    protected async Task<IHtmlElement> GetEntryHtmlAsync(Guid processId, IReadOnlyDictionary<string, object?> modelProperties)
-    {
-        var response = await HttpClient.PostAsJsonAsync(
-            "_change-history-entry",
-            new
-            {
-                processId,
-                modelProperties
-            });
-
+        var url = $"_change-history-entry/{processId}" + (personId is not null ? $"?personId={personId}" : "");
+        var response = await HttpClient.GetAsync(url);
         response.EnsureSuccessStatusCode();
         var doc = await response.GetDocumentAsync();
         return doc.QuerySelector(".moj-timeline__item") as IHtmlElement ?? throw new InvalidOperationException("Element not found.");

--- a/tests/TeachingRecordSystem.SupportUi.Tests/ViewTests/ChangeHistoryEntries/ChangeHistoryEntryViewTestController.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/ViewTests/ChangeHistoryEntries/ChangeHistoryEntryViewTestController.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using TeachingRecordSystem.Core.DataStore.Postgres;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Components.ChangeHistoryEntry;
@@ -8,10 +6,8 @@ namespace TeachingRecordSystem.SupportUi.Tests.ViewTests.ChangeHistoryEntries;
 
 public class ChangeHistoryEntryViewTestController(TrsDbContext dbContext) : Controller
 {
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
-
     [HttpGet("_change-history-entry/{processId:guid}")]
-    public async Task<IActionResult> ChangeHistoryEntry(Guid processId)
+    public async Task<IActionResult> ChangeHistoryEntry(Guid processId, [FromQuery] Guid? personId)
     {
         var process = await dbContext.Processes
             .Include(p => p.Events)
@@ -23,70 +19,17 @@ public class ChangeHistoryEntryViewTestController(TrsDbContext dbContext) : Cont
             return NotFound();
         }
 
-        var vm = CreateViewModel(process);
-
-        return View("/ViewTests/ChangeHistoryEntries/ChangeHistoryEntry.cshtml", vm);
-    }
-
-    [HttpPost("_change-history-entry")]
-    public async Task<IActionResult> ChangeHistoryEntry([FromBody] ChangeHistoryEntryRequest request)
-    {
-        var process = await dbContext.Processes
-            .Include(p => p.Events)
-            .Include(p => p.User)
-            .SingleOrDefaultAsync(p => p.ProcessId == request.ProcessId);
-
-        if (process is null)
+        var vm = new ChangeHistoryEntryViewModel
         {
-            return NotFound();
-        }
-
-        var vm = CreateViewModel(process, request.ModelProperties);
-
-        return View("/ViewTests/ChangeHistoryEntries/ChangeHistoryEntry.cshtml", vm);
-    }
-
-    private static ChangeHistoryEntryViewModel CreateViewModel(
-        TeachingRecordSystem.Core.DataStore.Postgres.Models.Process process,
-        IReadOnlyDictionary<string, JsonElement>? modelProperties = null)
-    {
-        var viewModel = new ChangeHistoryEntryViewModel
-        {
-            ViewType = ChangeHistoryViewType.Person,
+            Context = ChangeHistoryContext.ForPerson(personId ?? Guid.Empty),
             Timestamp = process.CreatedOn,
             UserName = process.User?.Name ?? process.DqtUserName!,
             ProcessId = process.ProcessId,
             ProcessType = process.ProcessType,
             ChangeReason = process.ChangeReason,
-            Events = process.Events!.Select(e => e.Payload).AsReadOnly(),
-            PersonInfo = null,
-            PersonId = null
+            Events = process.Events!.Select(e => e.Payload).AsReadOnly()
         };
 
-        if (modelProperties is null)
-        {
-            return viewModel;
-        }
-
-        foreach (var (propertyName, propertyValue) in modelProperties)
-        {
-            var property = typeof(ChangeHistoryEntryViewModel).GetProperty(
-                propertyName,
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-
-            if (property is null || property.SetMethod is null)
-            {
-                throw new InvalidOperationException($"Unknown change history entry model property '{propertyName}'.");
-            }
-
-            var value = propertyValue.Deserialize(property.PropertyType, JsonSerializerOptions);
-            property.SetValue(viewModel, value);
-        }
-
-        return viewModel;
+        return View("/ViewTests/ChangeHistoryEntries/ChangeHistoryEntry.cshtml", vm);
     }
-
-    public sealed record ChangeHistoryEntryRequest(
-        Guid ProcessId,
-        IReadOnlyDictionary<string, JsonElement>? ModelProperties);
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/ViewTests/ChangeHistoryEntries/Processes/PersonMergingInDqtTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/ViewTests/ChangeHistoryEntries/Processes/PersonMergingInDqtTests.cs
@@ -1,5 +1,4 @@
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
-using TeachingRecordSystem.SupportUi.Pages.Shared.Components.ChangeHistoryEntry;
 
 namespace TeachingRecordSystem.SupportUi.Tests.ViewTests.ChangeHistoryEntries.Processes;
 
@@ -34,17 +33,7 @@ public class PersonMergingInDqtTests(HostFixture hostFixture) : ChangeHistoryEnt
 
 
         // Act
-        var entry = await GetEntryHtmlAsync(
-            process.ProcessId,
-            new Dictionary<string, object?>
-            {
-                [nameof(ChangeHistoryEntryViewModel.PersonId)] = person.PersonId,
-                [nameof(ChangeHistoryEntryViewModel.PersonInfo)] = new Dictionary<Guid, TeachingRecordSystem.Core.PersonInfo>()
-                {
-                    [person.PersonId] = new(person.PersonId, person.Trn),
-                    [mergedWithPerson.PersonId] = new(mergedWithPerson.PersonId, mergedWithPerson.Trn)
-                }
-            });
+        var entry = await GetEntryHtmlAsync(process.ProcessId, person.PersonId);
 
         // Assert
         AssertTitle(entry, $"Record merged with TRN {mergedWithPerson.Trn} and deactivated");
@@ -79,17 +68,7 @@ public class PersonMergingInDqtTests(HostFixture hostFixture) : ChangeHistoryEnt
         var process = await TestData.CreateProcessAsync(ProcessType.PersonMergingInDqt, user.UserId, changeReason: null, @event);
 
         // Act
-        var entry = await GetEntryHtmlAsync(
-            process.ProcessId,
-            new Dictionary<string, object?>
-            {
-                [nameof(ChangeHistoryEntryViewModel.PersonId)] = mergedWithPerson.PersonId,
-                [nameof(ChangeHistoryEntryViewModel.PersonInfo)] = new Dictionary<Guid, TeachingRecordSystem.Core.PersonInfo>()
-                {
-                    [person.PersonId] = new(person.PersonId, person.Trn),
-                    [mergedWithPerson.PersonId] = new(mergedWithPerson.PersonId, mergedWithPerson.Trn)
-                }
-            });
+        var entry = await GetEntryHtmlAsync(process.ProcessId, mergedWithPerson.PersonId);
 
         // Assert
         AssertTitle(entry, $"Record merged with TRN {person.Trn}");


### PR DESCRIPTION
We'll shortly be adding Change History views to One Logins and support tasks. This adds a ChangeHistoryEntryContext to the ChangeHistoryEntryViewModel that contains the entity the current Change History view is targeting.