### PR TITLE
Make UseTestContainers actually use the test container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ When working in a git worktree, set the following environment variables before r
 - `UseTestContainers` to `true`, so the tests spin up their own postgres container.
 - `TestContainersPostgresPort` to a random free port, so the container doesn't clash with the ones other worktrees are using.
 
+These two are sufficient — when `UseTestContainers` is set the container's connection string (database `trs` on
+`TestContainersPostgresPort`) overrides any `ConnectionStrings:DefaultConnection` from user secrets or the environment, so don't
+set `ConnectionStrings__DefaultConnection` as well.
+
 ### Resetting the database schema and data
 
 The test database schema is cached in a `.tests-schema-version.txt` file at the root of the repository (this file is git-ignored, so each

--- a/tests/TeachingRecordSystem.TestCommon/TestConfiguration.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestConfiguration.cs
@@ -32,6 +32,9 @@ public static class TestConfiguration
             // variables *after* the configuration we hand them via UseConfiguration, so an environment variable would
             // override the value above for those hosts only. Overwriting it here keeps every configuration built in
             // this process pointing at the container.
+            // Both variables have to be set: setting only the connection string would make a subsequent call here take
+            // the other branch, and DbHelper would then never build the container to connect to.
+            Environment.SetEnvironmentVariable("UseTestContainers", "true");
             Environment.SetEnvironmentVariable($"ConnectionStrings__{TrsDbContext.ConnectionName}", connectionString);
         }
 

--- a/tests/TeachingRecordSystem.TestCommon/TestConfiguration.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestConfiguration.cs
@@ -14,7 +14,12 @@ public static class TestConfiguration
             .AddEnvironmentVariables();
 
         var connectionString = configuration.GetConnectionString(TrsDbContext.ConnectionName);
-        if (connectionString is null)
+
+        // When UseTestContainers is set the testcontainer's connection string always wins over any configured
+        // connection string; otherwise we'd start a container that nothing connects to and run the tests against
+        // whatever database happens to be configured in user secrets.
+        // Not having a connection string configured at all implies testcontainers.
+        if (configuration.GetValue<bool>("UseTestContainers") || connectionString is null)
         {
             connectionString = DbHelper.GetTestContainersConnectionString(DbHelper.GetTestContainersPostgresPort(configuration));
 
@@ -22,6 +27,12 @@ public static class TestConfiguration
                 KeyValuePair.Create($"ConnectionStrings:{TrsDbContext.ConnectionName}", (string?)connectionString),
                 KeyValuePair.Create("UseTestContainers", (string?)"true")
             ]);
+
+            // The hosts that the test WebApplicationFactorys create build their own configuration and add environment
+            // variables *after* the configuration we hand them via UseConfiguration, so an environment variable would
+            // override the value above for those hosts only. Overwriting it here keeps every configuration built in
+            // this process pointing at the container.
+            Environment.SetEnvironmentVariable($"ConnectionStrings__{TrsDbContext.ConnectionName}", connectionString);
         }
 
         return configuration;


### PR DESCRIPTION
### Context

`AGENTS.md` tells agents working in a git worktree to set `UseTestContainers=true` and `TestContainersPostgresPort=<free port>` so each worktree gets its own test database. That instruction silently did nothing.

`TestConfiguration.GetConfiguration()` only fell back to the testcontainer connection string when `ConnectionStrings:DefaultConnection` was **unset**. Configuration is built from the `TeachingRecordSystemTests` user secrets and then environment variables, and on a dev machine those user secrets set `ConnectionStrings:DefaultConnection` to local postgres — so the branch never ran. Meanwhile `DbHelper.CreateInstance()` reads `UseTestContainers` separately and *does* build and start a `PostgreSqlContainer`.

Net effect: `UseTestContainers=true` started a container that nothing connected to, while every test still ran against the shared local `trs_tests`. Worktrees therefore shared one database and interfered with each other, which is exactly what the instruction is meant to prevent. This recently caused a full test run to corrupt the shared local database (postgres marked it invalid, `pg_database.datconnlimit = -2`, and every subsequent run failed with `55000: cannot connect to invalid database`).

The workaround until now was to also export `ConnectionStrings__DefaultConnection` pointing at the container.

### Changes proposed in this pull request

`TestConfiguration.GetConfiguration()` now checks `UseTestContainers` first and lets the container's connection string override whatever is configured:

```csharp
if (configuration.GetValue<bool>("UseTestContainers") || connectionString is null)
```

The existing "no connection string configured at all" fallback is preserved, so CI behaviour is unchanged. When `UseTestContainers` is not set, behaviour is identical to before.

The same branch also sets `UseTestContainers` and `ConnectionStrings__DefaultConnection` as process environment variables. This covers a second, subtler leak: the test `HostFixture` classes hand configuration to the hosts via `builder.UseConfiguration(...)`, but `WebApplicationBuilder` adds `AddEnvironmentVariables()` *after* host configuration. Without this, an exported `ConnectionStrings__DefaultConnection` would still win inside the web hosts only, leaving `DbHelper` talking to the container while the hosts talked to local postgres.

Both variables have to be set together, so that `GetConfiguration()` stays idempotent. Setting only the connection string is what the first push got wrong, and CI caught it: with no user secrets and no environment variables the first call took the "no connection string configured" branch and exported the connection string, then the second call found a connection string but no `UseTestContainers`, took the other branch, and left `UseTestContainers` false — so `DbHelper.CreateInstance()` never built the container. Whichever component happened to call `GetConfiguration()` first then decided whether the container existed at all, which is why Core.Tests, Cli.Tests and Api.UnitTests failed with connection refused to `127.0.0.1:43007` while the projects that touch `DbHelper.Instance` first still passed.

`AGENTS.md` keeps the two documented environment variables — they are now genuinely sufficient — and gains a note that the container's `trs` database overrides user secrets, so `ConnectionStrings__DefaultConnection` should not also be set.

### Guidance to review

`TestConfiguration.GetConfiguration()` is the single chokepoint for this. It is the only place under `tests/` that calls `AddUserSecrets`/`AddEnvironmentVariables`, and all five `HostFixture` classes plus `ServiceProviderFixture` and `DbHelper.CreateInstance` route through it. `configuration.GetPostgresConnectionString()` just reads `ConnectionStrings:DefaultConnection`, so it picks the override up automatically, and no `appsettings*.json` defines `DefaultConnection`.

Verified by running with `UseTestContainers=true TestContainersPostgresPort=<free port>` and **without** `ConnectionStrings__DefaultConnection`:

| Project | Result |
| --- | --- |
| AuthorizeAccess.Tests | 82 passed |
| Core.Tests | 1079 passed |
| SupportUi.Tests | 3937 passed, 3 skipped |
| Api.IntegrationTests (fresh container) | 3820 passed, 1 skipped |

The local server was untouched — `pg_database` gained no `trs_tests`. The container held all the data: 62 tables, 1213 persons, 578 users.

The CI regression above was also reproduced and fixed locally, by running with `HOME` pointed at an empty directory so the user secrets don't resolve — that reproduces CI's "no user secrets, no environment variables" state exactly, down to the same `Failed to connect to 127.0.0.1:43007` error. Core.Tests, Cli.Tests and Api.UnitTests all pass under that environment with the fix, and the local postgres data directory is provably untouched by those runs.

Note that `just test-changed` reports nothing to run for this change: Incrementalist only sees committed changes, and its filter drops any project not ending in `Tests`, so `TestCommon` never matches. The projects above were run directly instead.

Two pre-existing issues surfaced while verifying. Neither is caused by this change and neither is addressed here:

1. Running Core.Tests and Api.IntegrationTests against the *same* database makes `SetProfessionalStatusTests.Put_TrainingProviderUkprnDoesNotMapToIttProvider_ReturnsBadRequest` fail (expected 400, actual 204). `RefreshTrainingProvidersJobTests` inserts UKPRN `12345678` into `training_providers`, which is in Respawn's `TablesToIgnore` and so is never cleared; the API test hardcodes the same UKPRN and assumes it is absent. On a fresh database the project passes in full.
2. `.tests-schema-version.txt` caches only the schema hash and not which database it was built against, so changing `TestContainersPostgresPort` within a worktree silently skips schema creation. `just remove-tests-schema-cache` works around it.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
