### PR TITLE
Fix One Login disconnect entry point and journey redirect loop

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="GovUk.OneLogin.AspNetCore" Version="0.4.3" />
-    <PackageVersion Include="GovUk.Questions.AspNetCore" Version="1.0.3" />
-    <PackageVersion Include="GovUk.Questions.AspNetCore.Testing" Version="1.0.3" />
+    <PackageVersion Include="GovUk.Questions.AspNetCore" Version="1.0.4" />
+    <PackageVersion Include="GovUk.Questions.AspNetCore.Testing" Version="1.0.4" />
     <PackageVersion Include="GovukNotify" Version="8.1.0" />
     <PackageVersion Include="GovUk.Frontend.AspNetCore" Version="4.4.0" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.24" />

--- a/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
+++ b/src/TeachingRecordSystem.AuthorizeAccess/packages.lock.json
@@ -37,9 +37,9 @@
       },
       "GovUk.Questions.AspNetCore": {
         "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "AHmac3NlLQ4FaOwBR/u6yh/erZtKzySq0UsMnpoaCwl0+3SGs7CONX2rnsSvPHHAU9BbW5XqynkoCT2yHH5CCA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "pgdXnplkIlBFzRfmDyW1f/Y24FNtVgnPOIcBqg14VvIJahlLyE51Hd+auEzIpMxBUnrF9GSKFfIrqWPLpUpYWQ==",
         "dependencies": {
           "UUID": "1.1.1"
         }

--- a/src/TeachingRecordSystem.SupportUi/LinkGeneratorExtensions.cs
+++ b/src/TeachingRecordSystem.SupportUi/LinkGeneratorExtensions.cs
@@ -40,11 +40,11 @@ public static class LinkGeneratorExtensions
         return NormalizePath(url);
     }
 
-    // The journey library identifies a step by the URL of the request that reached it, which ASP.NET Core
-    // reports with only the characters that are illegal in a path escaped (a One Login subject's ':' stays
-    // as-is). Link generation escapes route values far more aggressively (':' becomes "%3A"), so a step
-    // pushed from a generated URL would never match the request it redirects to and the browser would
-    // bounce between the two forever. Re-encode generated URLs the way the request will arrive.
+    // Link generation escapes route values far more aggressively than ASP.NET Core does when it reports a
+    // request's path: a One Login subject's ':' becomes "%3A" on the way out but stays as-is on the way in.
+    // Both forms address the same page, and GovUk.Questions 1.0.4 matches journey steps across the two, so
+    // this is about consistency rather than correctness — without it the same URL is spelled two different
+    // ways depending on where it came from, in the address bar and in anything that compares URLs.
     private static string NormalizePath(string url)
     {
         var queryIndex = url.IndexOf('?', StringComparison.Ordinal);

--- a/src/TeachingRecordSystem.SupportUi/LinkGeneratorExtensions.cs
+++ b/src/TeachingRecordSystem.SupportUi/LinkGeneratorExtensions.cs
@@ -6,7 +6,8 @@ public static class LinkGeneratorExtensions
 {
     public static string GetRequiredPathByPage(this LinkGenerator linkGenerator, string page, string? handler = null, object? routeValues = null, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId = null)
     {
-        var url = linkGenerator.GetPathByPage(page, handler, values: routeValues) ?? throw new InvalidOperationException("Page was not found.");
+        var url = NormalizePath(
+            linkGenerator.GetPathByPage(page, handler, values: routeValues) ?? throw new InvalidOperationException("Page was not found."));
 
         if (journeyInstanceId?.UniqueKey is string journeyInstanceUniqueKey)
         {
@@ -34,6 +35,22 @@ public static class LinkGeneratorExtensions
 
         routeValues[JourneyInstanceId.KeyRouteValueName] = journeyInstanceId.Key;
 
-        return linkGenerator.GetPathByPage(page, values: routeValues) ?? throw new InvalidOperationException("Page was not found.");
+        var url = linkGenerator.GetPathByPage(page, values: routeValues) ?? throw new InvalidOperationException("Page was not found.");
+
+        return NormalizePath(url);
+    }
+
+    // The journey library identifies a step by the URL of the request that reached it, which ASP.NET Core
+    // reports with only the characters that are illegal in a path escaped (a One Login subject's ':' stays
+    // as-is). Link generation escapes route values far more aggressively (':' becomes "%3A"), so a step
+    // pushed from a generated URL would never match the request it redirects to and the browser would
+    // bounce between the two forever. Re-encode generated URLs the way the request will arrive.
+    private static string NormalizePath(string url)
+    {
+        var queryIndex = url.IndexOf('?', StringComparison.Ordinal);
+        var path = queryIndex == -1 ? url : url[..queryIndex];
+        var query = queryIndex == -1 ? "" : url[queryIndex..];
+
+        return PathString.FromUriComponent(path).ToUriComponent() + query;
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/Index.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/OneLogins/OneLoginDetail/Index.cshtml
@@ -98,7 +98,7 @@
 <div class="govuk-button-group">
     @if (Model.ConnectedPerson is not null)
     {
-        <govuk-button-link data-testid="disconnect-record-button" href="#" class="govuk-button--secondary">
+        <govuk-button-link data-testid="disconnect-record-button" href="@LinkGenerator.OneLogins.OneLoginDetail.DisconnectPerson.Index(Model.OneLoginUserSubject, Model.ConnectedPerson.PersonId)" class="govuk-button--secondary">
             Disconnect record
         </govuk-button-link>
     }

--- a/src/TeachingRecordSystem.SupportUi/packages.lock.json
+++ b/src/TeachingRecordSystem.SupportUi/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "GovUk.Questions.AspNetCore": {
         "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "AHmac3NlLQ4FaOwBR/u6yh/erZtKzySq0UsMnpoaCwl0+3SGs7CONX2rnsSvPHHAU9BbW5XqynkoCT2yHH5CCA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "pgdXnplkIlBFzRfmDyW1f/Y24FNtVgnPOIcBqg14VvIJahlLyE51Hd+auEzIpMxBUnrF9GSKFfIrqWPLpUpYWQ==",
         "dependencies": {
           "UUID": "1.1.1"
         }

--- a/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.AuthorizeAccess.Tests/packages.lock.json
@@ -4,11 +4,11 @@
     "net10.0": {
       "GovUk.Questions.AspNetCore.Testing": {
         "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "bjHk2zosZ+sY62WraeS9Rc2VLN82AUMU46QNyQYI25qbS238G2ilv8+m5JskwXbrxBduYmMJoXluTYZPIT0ODA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "a+K8ueYB5mNXtNMhkARMcJpgXKEkxwnYx9XSAgH0+3m2M/arIA0NGc+QLlJNywLDH2A6FdcCQRCwLjSyKqLBqA==",
         "dependencies": {
-          "GovUk.Questions.AspNetCore": "1.0.3"
+          "GovUk.Questions.AspNetCore": "1.0.4"
         }
       },
       "JetBrains.Annotations": {
@@ -1069,7 +1069,7 @@
           "DfeAnalytics.AspNetCore": "[0.6.1, )",
           "GovUk.Frontend.AspNetCore": "[4.4.0, )",
           "GovUk.OneLogin.AspNetCore": "[0.4.3, )",
-          "GovUk.Questions.AspNetCore": "[1.0.3, )",
+          "GovUk.Questions.AspNetCore": "[1.0.4, )",
           "Humanizer.Core": "[3.0.10, )",
           "JetBrains.Annotations": "[2026.2.0, )",
           "Joonasw.AspNetCore.SecurityHeaders": "[6.0.0, )",
@@ -1366,9 +1366,9 @@
       },
       "GovUk.Questions.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "AHmac3NlLQ4FaOwBR/u6yh/erZtKzySq0UsMnpoaCwl0+3SGs7CONX2rnsSvPHHAU9BbW5XqynkoCT2yHH5CCA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "pgdXnplkIlBFzRfmDyW1f/Y24FNtVgnPOIcBqg14VvIJahlLyE51Hd+auEzIpMxBUnrF9GSKFfIrqWPLpUpYWQ==",
         "dependencies": {
           "UUID": "1.1.1"
         }

--- a/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.EndToEndTests/packages.lock.json
@@ -1736,7 +1736,7 @@
           "DfeAnalytics.AspNetCore": "[0.6.1, )",
           "GovUk.Frontend.AspNetCore": "[4.4.0, )",
           "GovUk.OneLogin.AspNetCore": "[0.4.3, )",
-          "GovUk.Questions.AspNetCore": "[1.0.3, )",
+          "GovUk.Questions.AspNetCore": "[1.0.4, )",
           "Humanizer.Core": "[3.0.10, )",
           "JetBrains.Annotations": "[2026.2.0, )",
           "Joonasw.AspNetCore.SecurityHeaders": "[6.0.0, )",
@@ -1806,7 +1806,7 @@
         "dependencies": {
           "AspNetCore.SassCompiler": "[1.102.0, )",
           "GovUk.Frontend.AspNetCore": "[4.4.0, )",
-          "GovUk.Questions.AspNetCore": "[1.0.3, )",
+          "GovUk.Questions.AspNetCore": "[1.0.4, )",
           "Htmx": "[1.12.0, )",
           "Htmx.TagHelpers": "[1.12.0, )",
           "Humanizer.Core": "[3.0.10, )",
@@ -2069,9 +2069,9 @@
       },
       "GovUk.Questions.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "AHmac3NlLQ4FaOwBR/u6yh/erZtKzySq0UsMnpoaCwl0+3SGs7CONX2rnsSvPHHAU9BbW5XqynkoCT2yHH5CCA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "pgdXnplkIlBFzRfmDyW1f/Y24FNtVgnPOIcBqg14VvIJahlLyE51Hd+auEzIpMxBUnrF9GSKFfIrqWPLpUpYWQ==",
         "dependencies": {
           "UUID": "1.1.1"
         }

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/OneLogins/DisconnectPersonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/OneLogins/DisconnectPersonTests.cs
@@ -5,16 +5,21 @@ namespace TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.OneLogins;
 public class DisconnectPersonTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
     [Theory]
-    [InlineData(DisconnectPersonReason.NewInformation, null)]
-    [InlineData(DisconnectPersonReason.AnotherReason, "Test disconnection reason details")]
-    public async Task DisconnectPerson_Success(DisconnectPersonReason reason, string? reasonDetail)
+    [InlineData(DisconnectPersonReason.NewInformation, null, DisconnectPersonStayVerified.Yes)]
+    [InlineData(DisconnectPersonReason.AnotherReason, "Test disconnection reason details", DisconnectPersonStayVerified.No)]
+    public async Task DisconnectPerson_FromOneLoginDetailPage_Success(
+        DisconnectPersonReason reason,
+        string? reasonDetail,
+        DisconnectPersonStayVerified stayVerified)
     {
         var person = await TestData.CreatePersonAsync();
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.GoToDisconnectPersonAsync(oneLogin.Subject, person.PersonId);
+        await page.GoToOneLoginDetailPageAsync(oneLogin.Subject);
+        await page.ClickDisconnectRecordButtonAsync();
+
         await page.AssertOnDisconnectPersonIndexPageAsync(oneLogin.Subject, person.PersonId);
         await page.ClickRadioAsync(reason.ToString());
 
@@ -26,14 +31,48 @@ public class DisconnectPersonTests(HostFixture hostFixture) : TestBase(hostFixtu
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnDisconnectPersonVerifiedPageAsync(oneLogin.Subject, person.PersonId);
-        await page.ClickRadioAsync(nameof(DisconnectPersonStayVerified.Yes));
+        await page.ClickRadioAsync(stayVerified.ToString());
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnDisconnectPersonCheckYourAnswersPageAsync(oneLogin.Subject, person.PersonId);
         await page.ClickButtonAsync("Confirm and disconnect");
-        await page.WaitForUrlPathAsync($"/one-logins/{oneLogin.Subject}");
 
-        await page.AssertFlashMessageAsync($"{person.FirstName} {person.LastName}\u2019s record disconnected from GOV.UK One Login");
+        await page.AssertOnOneLoginDetailPageAsync(oneLogin.Subject);
+        await page.AssertFlashMessageAsync($"{person.FirstName} {person.LastName}’s record disconnected from GOV.UK One Login");
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updated = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLogin.Subject);
+            Assert.Null(updated.PersonId);
+            Assert.Equal(stayVerified == DisconnectPersonStayVerified.Yes, updated.VerifiedOn is not null);
+        });
+    }
+
+    [Fact]
+    public async Task DisconnectPerson_Cancel_ReturnsToOneLoginDetailPage()
+    {
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToOneLoginDetailPageAsync(oneLogin.Subject);
+        await page.ClickDisconnectRecordButtonAsync();
+
+        await page.AssertOnDisconnectPersonIndexPageAsync(oneLogin.Subject, person.PersonId);
+        await page.ClickRadioAsync(nameof(DisconnectPersonReason.NewInformation));
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnDisconnectPersonVerifiedPageAsync(oneLogin.Subject, person.PersonId);
+        await page.ClickButtonAsync("Cancel");
+
+        await page.AssertOnOneLoginDetailPageAsync(oneLogin.Subject);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updated = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLogin.Subject);
+            Assert.Equal(person.PersonId, updated.PersonId);
+        });
     }
 
     [Fact]
@@ -44,7 +83,9 @@ public class DisconnectPersonTests(HostFixture hostFixture) : TestBase(hostFixtu
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.GoToDisconnectPersonAsync(oneLogin.Subject, person.PersonId);
+        await page.GoToOneLoginDetailPageAsync(oneLogin.Subject);
+        await page.ClickDisconnectRecordButtonAsync();
+
         await page.AssertOnDisconnectPersonIndexPageAsync(oneLogin.Subject, person.PersonId);
         await page.ClickRadioAsync(nameof(DisconnectPersonReason.ConnectedIncorrectly));
         await page.ClickContinueButtonAsync();
@@ -57,13 +98,15 @@ public class DisconnectPersonTests(HostFixture hostFixture) : TestBase(hostFixtu
         await page.ClickBackLinkAsync();
 
         await page.AssertOnDisconnectPersonVerifiedPageAsync(oneLogin.Subject, person.PersonId);
-        var stayVerifiedValue = await page.IsCheckedAsync($"input[value='{nameof(DisconnectPersonStayVerified.Yes)}']");
-        Assert.True(stayVerifiedValue);
+        Assert.True(await page.IsCheckedAsync($"input[value='{nameof(DisconnectPersonStayVerified.Yes)}']"));
 
         await page.ClickBackLinkAsync();
 
         await page.AssertOnDisconnectPersonIndexPageAsync(oneLogin.Subject, person.PersonId);
-        var reasonValue = await page.IsCheckedAsync($"input[value='{nameof(DisconnectPersonReason.ConnectedIncorrectly)}']");
-        Assert.True(reasonValue);
+        Assert.True(await page.IsCheckedAsync($"input[value='{nameof(DisconnectPersonReason.ConnectedIncorrectly)}']"));
+
+        await page.ClickBackLinkAsync();
+
+        await page.AssertOnOneLoginDetailPageAsync(oneLogin.Subject);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/OneLogins/OneLoginExtensions.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/OneLogins/OneLoginExtensions.cs
@@ -9,4 +9,7 @@ public static class OneLoginExtensions
 
     public static Task AssertOnOneLoginDetailPageAsync(this IPage page, string subject) =>
         page.WaitForUrlPathAsync($"/one-logins/{subject}");
+
+    public static Task ClickDisconnectRecordButtonAsync(this IPage page) =>
+        page.ClickLinkForElementWithTestIdAsync("disconnect-record-button");
 }

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/DisconnectOneLoginTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/DisconnectOneLoginTests.cs
@@ -1,45 +1,84 @@
-using System.Text.RegularExpressions;
 using TeachingRecordSystem.Core.Services.Persons;
 
 namespace TeachingRecordSystem.SupportUi.EndToEndTests.JourneyTests.Persons;
 
 public class DisconnectOneLoginTests(HostFixture hostFixture) : TestBase(hostFixture)
 {
-    [Fact]
-    public async Task DisconnectOneLoginVerify_StayVerified()
+    [Theory]
+    [InlineData(DisconnectOneLoginStayVerified.Yes)]
+    [InlineData(DisconnectOneLoginStayVerified.No)]
+    public async Task DisconnectOneLogin_FromPersonDetailPage_Success(DisconnectOneLoginStayVerified stayVerified)
     {
         var person = await TestData.CreatePersonAsync();
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.GoToDisconnectOneLoginAsync(person.PersonId, oneLogin.Subject);
+        await page.GoToPersonDetailPageAsync(person.PersonId);
+        await page.ClickDisconnectOneLoginLinkAsync(oneLogin.EmailAddress!);
+
         await page.AssertOnDisconnectOneLoginIndexPageAsync(person.PersonId, oneLogin.Subject);
         await page.ClickRadioAsync(nameof(DisconnectOneLoginReason.NewInformation));
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnDisconnectOneLoginVerifiedPageAsync(person.PersonId, oneLogin.Subject);
-        await page.ClickRadioAsync(nameof(DisconnectOneLoginStayVerified.Yes));
+        await page.ClickRadioAsync(stayVerified.ToString());
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnDisconnectOneLoginCheckYourAnswersPageAsync(person.PersonId, oneLogin.Subject);
         await page.ClickButtonAsync("Confirm and disconnect");
-        await page.WaitForURLAsync(new Regex(@"/persons/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"));
 
+        await page.AssertOnPersonDetailPageAsync(person.PersonId);
         await page.AssertFlashMessageAsync($"GOV.UK One Login disconnected from {person.FirstName} {person.LastName}’s record");
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updated = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLogin.Subject);
+            Assert.Null(updated.PersonId);
+            Assert.Equal(stayVerified == DisconnectOneLoginStayVerified.Yes, updated.VerifiedOn is not null);
+        });
     }
 
     [Fact]
-    public async Task DisconnectOneLoginVerify_DoNotStayVerified()
+    public async Task DisconnectOneLogin_Cancel_ReturnsToPersonDetailPage()
     {
         var person = await TestData.CreatePersonAsync();
         var oneLogin = await TestData.CreateOneLoginUserAsync(person);
         await using var context = await HostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.GoToDisconnectOneLoginAsync(person.PersonId, oneLogin.Subject);
+        await page.GoToPersonDetailPageAsync(person.PersonId);
+        await page.ClickDisconnectOneLoginLinkAsync(oneLogin.EmailAddress!);
+
         await page.AssertOnDisconnectOneLoginIndexPageAsync(person.PersonId, oneLogin.Subject);
         await page.ClickRadioAsync(nameof(DisconnectOneLoginReason.NewInformation));
+        await page.ClickContinueButtonAsync();
+
+        await page.AssertOnDisconnectOneLoginVerifiedPageAsync(person.PersonId, oneLogin.Subject);
+        await page.ClickButtonAsync("Cancel");
+
+        await page.AssertOnPersonDetailPageAsync(person.PersonId);
+
+        await WithDbContextAsync(async dbContext =>
+        {
+            var updated = await dbContext.OneLoginUsers.SingleAsync(u => u.Subject == oneLogin.Subject);
+            Assert.Equal(person.PersonId, updated.PersonId);
+        });
+    }
+
+    [Fact]
+    public async Task DisconnectOneLogin_NavigateBack()
+    {
+        var person = await TestData.CreatePersonAsync();
+        var oneLogin = await TestData.CreateOneLoginUserAsync(person);
+        await using var context = await HostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToPersonDetailPageAsync(person.PersonId);
+        await page.ClickDisconnectOneLoginLinkAsync(oneLogin.EmailAddress!);
+
+        await page.AssertOnDisconnectOneLoginIndexPageAsync(person.PersonId, oneLogin.Subject);
+        await page.ClickRadioAsync(nameof(DisconnectOneLoginReason.ConnectedIncorrectly));
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnDisconnectOneLoginVerifiedPageAsync(person.PersonId, oneLogin.Subject);
@@ -47,9 +86,18 @@ public class DisconnectOneLoginTests(HostFixture hostFixture) : TestBase(hostFix
         await page.ClickContinueButtonAsync();
 
         await page.AssertOnDisconnectOneLoginCheckYourAnswersPageAsync(person.PersonId, oneLogin.Subject);
-        await page.ClickButtonAsync("Confirm and disconnect");
-        await page.WaitForURLAsync(new Regex(@"/persons/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"));
+        await page.ClickBackLinkAsync();
 
-        await page.AssertFlashMessageAsync($"GOV.UK One Login disconnected from {person.FirstName} {person.LastName}’s record");
+        await page.AssertOnDisconnectOneLoginVerifiedPageAsync(person.PersonId, oneLogin.Subject);
+        Assert.True(await page.IsCheckedAsync($"input[value='{nameof(DisconnectOneLoginStayVerified.Yes)}']"));
+
+        await page.ClickBackLinkAsync();
+
+        await page.AssertOnDisconnectOneLoginIndexPageAsync(person.PersonId, oneLogin.Subject);
+        Assert.True(await page.IsCheckedAsync($"input[value='{nameof(DisconnectOneLoginReason.ConnectedIncorrectly)}']"));
+
+        await page.ClickBackLinkAsync();
+
+        await page.AssertOnPersonDetailPageAsync(person.PersonId);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/OneLoginExtensions.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/Persons/OneLoginExtensions.cs
@@ -9,6 +9,13 @@ public static class OneLoginExtensions
         return page.GotoAsync($"/persons/{personId}/disconnect-one-login/{subject}");
     }
 
+    public static Task ClickDisconnectOneLoginLinkAsync(this IPage page, string emailAddress)
+    {
+        return page.GetByTestId("associated-one-login-users")
+            .GetByRole(AriaRole.Link, new() { Name = $"Disconnect {emailAddress}" })
+            .ClickAsync();
+    }
+
     public static Task AssertOnDisconnectOneLoginIndexPageAsync(this IPage page, Guid personId, string subject)
     {
         return page.WaitForUrlPathAsync($"/persons/{personId}/disconnect-one-login/{subject}");

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/packages.lock.json
@@ -1088,7 +1088,7 @@
         "dependencies": {
           "AspNetCore.SassCompiler": "[1.102.0, )",
           "GovUk.Frontend.AspNetCore": "[4.4.0, )",
-          "GovUk.Questions.AspNetCore": "[1.0.3, )",
+          "GovUk.Questions.AspNetCore": "[1.0.4, )",
           "Htmx": "[1.12.0, )",
           "Htmx.TagHelpers": "[1.12.0, )",
           "Humanizer.Core": "[3.0.10, )",
@@ -1318,9 +1318,9 @@
       },
       "GovUk.Questions.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "AHmac3NlLQ4FaOwBR/u6yh/erZtKzySq0UsMnpoaCwl0+3SGs7CONX2rnsSvPHHAU9BbW5XqynkoCT2yHH5CCA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "pgdXnplkIlBFzRfmDyW1f/Y24FNtVgnPOIcBqg14VvIJahlLyE51Hd+auEzIpMxBUnrF9GSKFfIrqWPLpUpYWQ==",
         "dependencies": {
           "UUID": "1.1.1"
         }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/OneLogins/OneLoginDetail/IndexTests.cs
@@ -161,6 +161,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
 
         var disconnectButton = doc.GetElementByTestId("disconnect-record-button");
         Assert.NotNull(disconnectButton);
+        Assert.Equal($"/one-logins/{user.Subject}/disconnect-person/{person.PersonId}", disconnectButton.GetAttribute("href"));
         var connectButton = doc.GetElementByTestId("connect-to-record-button");
         Assert.Null(connectButton);
     }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/Persons/PersonDetail/IndexTests.cs
@@ -707,7 +707,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
     {
         // Arrange
         var person = await TestData.CreatePersonAsync(b => b.WithDateOfBirth(new DateOnly(1990, 1, 1)).WithEmailAddress());
-        await TestData.CreateOneLoginUserAsync(personId: person.PersonId, email: Option.Some(person.EmailAddress), verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth!.Value));
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(personId: person.PersonId, email: Option.Some(person.EmailAddress), verifiedInfo: ([person.FirstName, person.LastName], person.DateOfBirth!.Value));
 
         if (currentStatus == PersonStatus.Deactivated)
         {
@@ -730,6 +730,7 @@ public class IndexTests(HostFixture hostFixture) : TestBase(hostFixture)
         if (expectDisconnectLinkToBeShown)
         {
             Assert.NotNull(disconnectLink);
+            Assert.Equal($"/persons/{person.PersonId}/disconnect-one-login/{oneLoginUser.Subject}", disconnectLink.GetAttribute("href"));
         }
         else
         {

--- a/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/packages.lock.json
@@ -4,11 +4,11 @@
     "net10.0": {
       "GovUk.Questions.AspNetCore.Testing": {
         "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "bjHk2zosZ+sY62WraeS9Rc2VLN82AUMU46QNyQYI25qbS238G2ilv8+m5JskwXbrxBduYmMJoXluTYZPIT0ODA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "a+K8ueYB5mNXtNMhkARMcJpgXKEkxwnYx9XSAgH0+3m2M/arIA0NGc+QLlJNywLDH2A6FdcCQRCwLjSyKqLBqA==",
         "dependencies": {
-          "GovUk.Questions.AspNetCore": "1.0.3"
+          "GovUk.Questions.AspNetCore": "1.0.4"
         }
       },
       "JetBrains.Annotations": {
@@ -1091,7 +1091,7 @@
         "dependencies": {
           "AspNetCore.SassCompiler": "[1.102.0, )",
           "GovUk.Frontend.AspNetCore": "[4.4.0, )",
-          "GovUk.Questions.AspNetCore": "[1.0.3, )",
+          "GovUk.Questions.AspNetCore": "[1.0.4, )",
           "Htmx": "[1.12.0, )",
           "Htmx.TagHelpers": "[1.12.0, )",
           "Humanizer.Core": "[3.0.10, )",
@@ -1329,9 +1329,9 @@
       },
       "GovUk.Questions.AspNetCore": {
         "type": "CentralTransitive",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "AHmac3NlLQ4FaOwBR/u6yh/erZtKzySq0UsMnpoaCwl0+3SGs7CONX2rnsSvPHHAU9BbW5XqynkoCT2yHH5CCA==",
+        "requested": "[1.0.4, )",
+        "resolved": "1.0.4",
+        "contentHash": "pgdXnplkIlBFzRfmDyW1f/Y24FNtVgnPOIcBqg14VvIJahlLyE51Hd+auEzIpMxBUnrF9GSKFfIrqWPLpUpYWQ==",
         "dependencies": {
           "UUID": "1.1.1"
         }

--- a/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUser.cs
+++ b/tests/TeachingRecordSystem.TestCommon/TestData.CreateOneLoginUser.cs
@@ -70,7 +70,9 @@ public partial class TestData
         });
     }
 
-    public string CreateOneLoginUserSubject() => Guid.NewGuid().ToString("N");
+    // Matches the shape of a real GOV.UK One Login subject; the reserved characters matter since
+    // subjects appear in URL path segments.
+    public string CreateOneLoginUserSubject() => $"urn:fdc:gov.uk:2022:{Guid.NewGuid():N}";
 
     public JsonDocument CreateOneLoginCoreIdentityVc(string firstName, string lastName, DateOnly dateOfBirth) =>
         JsonDocument.Parse(


### PR DESCRIPTION
### Context

Two bugs in the One Login disconnect journeys:

1. The **Disconnect record** button on the One Login detail page had `href="#"`, so clicking it did nothing.
2. Completing a disconnect journey started from the person detail page ended in `ERR_TOO_MANY_REDIRECTS`.

The second turned out not to be about the completion redirect at all, and not to be a TRS bug. It affected **any** GOV.UK Questions journey scoped by a route value containing reserved characters — i.e. every journey scoped by a One Login subject (`urn:fdc:gov.uk:2022:…`), so the connect journeys were broken too:

- `LinkGenerator.GetPathByPage` escapes a route value's `:` as `%3A`, so `AdvanceTo` pushed a step id of `…/urn%3Afdc%3A…/verified`.
- The library derives the step id of an incoming request from `HttpRequest.GetEncodedPathAndQuery()`, which leaves `:` as-is: `…/urn:fdc:…/verified`.
- The two never matched, so `ValidateJourneyFilter` treated every hop as an invalid step and redirected to it again, forever.

That is fixed upstream in [x-govuk/govuk-questions-aspnetcore#17](https://github.com/x-govuk/govuk-questions-aspnetcore/pull/17), released as 1.0.4, which this branch takes.

Nothing caught either bug because `TestData.CreateOneLoginUserSubject()` returned a plain GUID (no reserved characters), and the disconnect e2e tests navigated straight to the journey URL instead of going through the detail page.

### Changes proposed in this pull request

- `OneLogins/OneLoginDetail/Index.cshtml`: the Disconnect record button links to the DisconnectPerson journey.
- `GovUk.Questions.AspNetCore` 1.0.3 → 1.0.4, which is what actually fixes the redirect loop.
- `LinkGeneratorExtensions` normalizes generated URLs into the encoding the request will arrive in. See the note below — this is now about URL consistency, not correctness.
- `TestData.CreateOneLoginUserSubject()` emits the real `urn:fdc:gov.uk:2022:…` shape so the whole suite exercises reserved characters in a path segment.
- Disconnect e2e tests (both entry points) now start from the detail page's link/button and cover success (stay-verified yes/no), cancel and back navigation, asserting the exact landing URL and the resulting DB state. Connect e2e tests already entered via the detail pages and now exercise realistic subjects.
- Person detail and One Login detail page tests assert the entry-point hrefs rather than just that the link exists.

### Guidance to review

**On keeping `NormalizePath`.** The plan was to delete it once 1.0.4 landed, since the library now matches steps across both spellings. I tried that, and it isn't the better end state: with it gone, URLs that echo the request (the journey-start redirect, a caller-supplied `returnUrl`) keep the `:`, while URLs from link generation carry `%3A` — so the app emits two spellings of the same URL depending on provenance. That showed up as 24 page tests needing per-assertion knowledge of which spelling a given URL happens to use, and it means support staff see escaped subjects in the address bar. Keeping the helper collapses both to one readable form, and its comment now says so instead of citing the redirect loop. Happy to drop it if you'd rather have the smaller app surface — it's a one-line revert plus those 24 assertions.

To confirm the library fix stands on its own: packages built from the upstream branch, with `NormalizePath` removed, take the four One Login connect/disconnect journeys from all-failing to all-passing in the browser end-to-end suite. Correctness no longer depends on anything in this repo.

Test runs (local, testcontainers): SupportUi 3878, SupportUi e2e 142, AuthorizeAccess 82, Core 1079, Api integration 3821 — all green. The pre-existing `AuthorizeAccess OidcTests` failures are unrelated and unchanged.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)