### PR TITLE
Migrate Delete Route journey to GOV.UK Questions

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml
@@ -1,4 +1,4 @@
-@page "/routes/{qualificationId}/delete/check-answers/{handler?}"
+@page "/routes/{qualificationId}/delete/check-answers"
 @model CheckAnswersModel
 @{
     ViewBag.Title = "Check details before deleting route";
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form method="post">
-            <span class="govuk-caption-l">Delete route - @Model.PersonName</span>
+            <span class="govuk-caption-l">@Model.PageCaption</span>
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
             <partial name="_RouteDetail" model="@Model.RouteDetail" />
 
@@ -21,22 +21,24 @@
                     <key>Reason</key>
                     <value>@Model.ChangeReason?.GetDisplayName()</value>
                     <row-actions>
-                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
-                                                       visually-hidden-text="reason">Change</action>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.InstanceId, Model.ReturnUrl)"
+                                visually-hidden-text="reason">Change</action>
                     </row-actions>
                 </row>
                 <row>
                     <key>Reason details</key>
                     <value use-empty-fallback>@Model.ChangeReasonDetail.ChangeReasonDetail</value>
                     <row-actions>
-                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"  visually-hidden-text="additional information">Change</action>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.InstanceId, Model.ReturnUrl)"
+                                visually-hidden-text="additional information">Change</action>
                     </row-actions>
                 </row>
                 <row>
                     <key>Additional information</key>
                     <value use-empty-fallback>@Model.ChangeReasonDetail.AdditionalInformation</value>
                     <row-actions>
-                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"  visually-hidden-text="additional information">Change</action>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.InstanceId, Model.ReturnUrl)"
+                                visually-hidden-text="additional information">Change</action>
                     </row-actions>
                 </row>
                 <row>
@@ -45,15 +47,14 @@
                         <vc:evidence-file-link evidence-file="@Model.ChangeReasonDetail.Evidence.UploadedEvidenceFile" />
                     </value>
                     <row-actions>
-                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.QualificationId, Model.JourneyInstance!.InstanceId, fromCheckAnswers: true)"
-                                                       visually-hidden-text="evidence">Change</action>
+                        <action href="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(Model.InstanceId, Model.ReturnUrl)"
+                                visually-hidden-text="evidence">Change</action>
                     </row-actions>
-
                 </row>
             </govuk-summary-list>
             <div class="govuk-button-group">
                 <govuk-button class="govuk-button--warning" type="submit" data-testid="confirm-button">Confirm and delete route</govuk-button>
-                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.CheckAnswersCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers.cshtml.cs
@@ -2,78 +2,50 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeachingRecordSystem.Core.Services.RoutesToProfessionalStatus;
-using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
-using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DeleteRouteToProfessionalStatus), RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
+[Journey(JourneyNames.DeleteRouteToProfessionalStatus)]
 public class CheckAnswersModel(
+    DeleteRouteJourneyCoordinator journey,
     SupportUiLinkGenerator linkGenerator,
     ReferenceDataCache referenceDataCache,
-    EvidenceUploadManager evidenceController,
     RoutesToProfessionalStatusService routesToProfessionalStatusService) : PageModel
 {
-    public JourneyInstance<DeleteRouteState>? JourneyInstance { get; set; }
+    public JourneyInstanceId InstanceId => journey.InstanceId;
+
+    public string PageCaption => journey.PageCaption;
+
+    public string? BackLink { get; set; }
+
+    // The URL a change link brings the user back to once they've answered the question again.
+    public string ReturnUrl { get; set; } = null!;
 
     public RouteDetailViewModel RouteDetail { get; set; } = null!;
 
-    public string? PersonName { get; set; }
     public Guid PersonId { get; private set; }
 
     public ChangeReasonOption? ChangeReason { get; set; }
-    public ChangeReasonDetailsState ChangeReasonDetail { get; set; } = new();
 
-    public string BackLink => linkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(QualificationId, JourneyInstance!.InstanceId);
+    public ChangeReasonDetailsState ChangeReasonDetail { get; set; } = new();
 
     [FromRoute]
     public Guid QualificationId { get; set; }
 
-    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    [BindProperty]
+    public bool Cancel { get; set; }
+
+    public void OnGet()
     {
-        if (!JourneyInstance!.State.IsComplete)
-        {
-            context.Result = Redirect(linkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(QualificationId, JourneyInstance.InstanceId));
-            return;
-        }
-
-        var personInfo = context.HttpContext.GetCurrentPersonFeature();
-        PersonName = personInfo.Name;
-        PersonId = personInfo.PersonId;
-
-        var routeInfo = context.HttpContext.GetCurrentProfessionalStatusFeature();
-        RouteDetail = new RouteDetailViewModel()
-        {
-            RouteToProfessionalStatusType = routeInfo.RouteToProfessionalStatus.RouteToProfessionalStatusType!,
-            HoldsFrom = routeInfo.RouteToProfessionalStatus.HoldsFrom,
-            DegreeTypeId = routeInfo.RouteToProfessionalStatus.DegreeTypeId,
-            IsExemptFromInduction = routeInfo.RouteToProfessionalStatus.ExemptFromInduction,
-            Status = routeInfo.RouteToProfessionalStatus.Status,
-            QualificationId = routeInfo.RouteToProfessionalStatus.QualificationId,
-            TrainingAgeSpecialismType = routeInfo.RouteToProfessionalStatus.TrainingAgeSpecialismType,
-            TrainingAgeSpecialismRangeFrom = routeInfo.RouteToProfessionalStatus.TrainingAgeSpecialismRangeFrom,
-            TrainingAgeSpecialismRangeTo = routeInfo.RouteToProfessionalStatus.TrainingAgeSpecialismRangeTo,
-            TrainingCountryId = routeInfo.RouteToProfessionalStatus.TrainingCountryId,
-            TrainingEndDate = routeInfo.RouteToProfessionalStatus.TrainingEndDate,
-            TrainingProviderId = routeInfo.RouteToProfessionalStatus.TrainingProviderId,
-            TrainingStartDate = routeInfo.RouteToProfessionalStatus.TrainingStartDate,
-            TrainingSubjectIds = routeInfo.RouteToProfessionalStatus.TrainingSubjectIds
-        };
-
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        ChangeReasonDetail = JourneyInstance!.State.ChangeReasonDetail;
-    }
-
-    public async Task OnGetAsync()
-    {
-        RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is not null ? (await referenceDataCache.GetTrainingProviderByIdAsync(RouteDetail.TrainingProviderId!.Value))?.Name : null;
-        RouteDetail.TrainingCountry = RouteDetail.TrainingCountryId is not null ? (await referenceDataCache.GetTrainingCountryByIdAsync(RouteDetail.TrainingCountryId))?.Name : null;
-        RouteDetail.DegreeType = RouteDetail.DegreeTypeId is not null ? (await referenceDataCache.GetDegreeTypeByIdAsync(RouteDetail.DegreeTypeId!.Value))?.Name : null;
-        RouteDetail.TrainingSubjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(RouteDetail.TrainingSubjectIds, referenceDataCache);
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return Redirect(await journey.CancelAsync());
+        }
+
         await routesToProfessionalStatusService.DeleteRouteToProfessionalStatusAsync(
             new DeleteRouteToProfessionalStatusOptions
             {
@@ -85,17 +57,53 @@ public class CheckAnswersModel(
                 AdditionalInformation = ChangeReasonDetail.AdditionalInformation
             });
 
-        await JourneyInstance!.CompleteAsync();
+        journey.DeleteInstance();
 
         TempData.SetFlashNotificationBanner("Route to professional status deleted");
 
         return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        await evidenceController.DeleteUploadedFileAsync(JourneyInstance!.State.ChangeReasonDetail.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
+        ReturnUrl = linkGenerator.RoutesToProfessionalStatus.DeleteRoute.CheckAnswers(journey.InstanceId);
+        BackLink = journey.GetBackLink();
+
+        PersonId = context.HttpContext.GetCurrentPersonFeature().PersonId;
+
+        var route = context.HttpContext.GetCurrentProfessionalStatusFeature().RouteToProfessionalStatus;
+        RouteDetail = new RouteDetailViewModel()
+        {
+            RouteToProfessionalStatusType = route.RouteToProfessionalStatusType!,
+            HoldsFrom = route.HoldsFrom,
+            DegreeTypeId = route.DegreeTypeId,
+            IsExemptFromInduction = route.ExemptFromInduction,
+            Status = route.Status,
+            QualificationId = route.QualificationId,
+            TrainingAgeSpecialismType = route.TrainingAgeSpecialismType,
+            TrainingAgeSpecialismRangeFrom = route.TrainingAgeSpecialismRangeFrom,
+            TrainingAgeSpecialismRangeTo = route.TrainingAgeSpecialismRangeTo,
+            TrainingCountryId = route.TrainingCountryId,
+            TrainingEndDate = route.TrainingEndDate,
+            TrainingProviderId = route.TrainingProviderId,
+            TrainingStartDate = route.TrainingStartDate,
+            TrainingSubjectIds = route.TrainingSubjectIds
+        };
+
+        RouteDetail.TrainingProvider = RouteDetail.TrainingProviderId is Guid trainingProviderId
+            ? (await referenceDataCache.GetTrainingProviderByIdAsync(trainingProviderId))?.Name
+            : null;
+        RouteDetail.TrainingCountry = RouteDetail.TrainingCountryId is string trainingCountryId
+            ? (await referenceDataCache.GetTrainingCountryByIdAsync(trainingCountryId))?.Name
+            : null;
+        RouteDetail.DegreeType = RouteDetail.DegreeTypeId is Guid degreeTypeId
+            ? (await referenceDataCache.GetDegreeTypeByIdAsync(degreeTypeId))?.Name
+            : null;
+        RouteDetail.TrainingSubjects = await SubjectDisplayHelper.GetFormattedSubjectNamesAsync(RouteDetail.TrainingSubjectIds, referenceDataCache);
+
+        ChangeReason = journey.State.ChangeReason;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail;
+
+        await base.OnPageHandlerExecutionAsync(context, next);
     }
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Conventions.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Conventions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 using TeachingRecordSystem.SupportUi.Infrastructure.Security;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
@@ -12,6 +13,7 @@ public class Conventions : IConfigureFolderConventions
             this.GetFolderPathFromNamespace(),
             model =>
             {
+                model.Filters.Add(new CheckRouteToProfessionalStatusExistsFilterFactory());
                 model.EndpointMetadata.Add(new AuthorizeAttribute()
                 {
                     Policy = AuthorizationPolicies.NonPersonOrAlertDataEdit

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteJourneyCoordinator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteJourneyCoordinator.cs
@@ -1,0 +1,23 @@
+using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
+
+namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
+
+[JourneyCoordinator(JourneyNames.DeleteRouteToProfessionalStatus, routeValueKeys: ["qualificationId"])]
+public class DeleteRouteJourneyCoordinator(
+    SupportUiLinkGenerator linkGenerator,
+    EvidenceUploadManager evidenceUploadManager) : JourneyCoordinator<DeleteRouteState>
+{
+    public Guid PersonId => HttpContext.GetCurrentPersonFeature().PersonId;
+
+    public string PageCaption => $"Delete route - {HttpContext.GetCurrentPersonFeature().Name}";
+
+    public override DeleteRouteState GetStartingState() => new();
+
+    // Returns the URL to send the user back to.
+    public async Task<string> CancelAsync()
+    {
+        await evidenceUploadManager.DeleteUploadedFileAsync(State.ChangeReasonDetail.Evidence.UploadedEvidenceFile);
+        DeleteInstance();
+        return linkGenerator.Persons.PersonDetail.Qualifications(PersonId);
+    }
+}

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteLinkGenerator.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteLinkGenerator.cs
@@ -4,12 +4,10 @@ public class DeleteRouteLinkGenerator(LinkGenerator linkGenerator)
 {
     public string Index(Guid qualificationId) =>
         linkGenerator.GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/Index", routeValues: new { qualificationId });
-    public string Reason(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId, bool? fromCheckAnswers = null) =>
-        linkGenerator.GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/Reason", routeValues: new { qualificationId, fromCheckAnswers }, journeyInstanceId: journeyInstanceId);
-    public string ReasonCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/Reason", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string CheckAnswers(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
-    public string CheckAnswersCancel(Guid qualificationId, TeachingRecordSystem.WebCommon.FormFlow.JourneyInstanceId? journeyInstanceId) =>
-        linkGenerator.GetRequiredPathByPage("/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers", "cancel", routeValues: new { qualificationId }, journeyInstanceId: journeyInstanceId);
+
+    public string Reason(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/RoutesToProfessionalStatus/DeleteRoute/Reason", journeyInstanceId, returnUrl);
+
+    public string CheckAnswers(JourneyInstanceId journeyInstanceId, string? returnUrl = null) =>
+        linkGenerator.GetJourneyPage("/RoutesToProfessionalStatus/DeleteRoute/CheckAnswers", journeyInstanceId, returnUrl);
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteState.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteState.cs
@@ -1,20 +1,8 @@
-using System.Text.Json.Serialization;
-
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
-public class DeleteRouteState : IRegisterJourney
+public class DeleteRouteState
 {
-    public static JourneyDescriptor Journey => new(
-        JourneyNames.DeleteRouteToProfessionalStatus,
-        typeof(DeleteRouteState),
-        requestDataKeys: ["qualificationId"],
-        appendUniqueKey: true);
-
-    public bool Initialized { get; set; }
-
     public ChangeReasonOption? ChangeReason { get; set; }
-    public ChangeReasonDetailsState ChangeReasonDetail { get; set; } = new();
 
-    [JsonIgnore]
-    public bool IsComplete => ChangeReason is not null && ChangeReasonDetail.IsComplete;
+    public ChangeReasonDetailsState ChangeReasonDetail { get; set; } = new();
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Index.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Index.cshtml.cs
@@ -1,16 +1,13 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DeleteRouteToProfessionalStatus), ActivatesJourney, RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
-public class IndexModel(SupportUiLinkGenerator linkGenerator) : PageModel
+[Journey(JourneyNames.DeleteRouteToProfessionalStatus), StartsJourney]
+public class IndexModel(DeleteRouteJourneyCoordinator journey, SupportUiLinkGenerator linkGenerator) : PageModel
 {
-    public JourneyInstance<DeleteRouteState>? JourneyInstance { get; set; }
-
-    [FromRoute]
-    public Guid QualificationId { get; set; }
-
-    public IActionResult OnGet() => Redirect(linkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(QualificationId, JourneyInstance!.InstanceId));
+    public IActionResult OnGet() =>
+        journey.AdvanceTo(
+            linkGenerator.RoutesToProfessionalStatus.DeleteRoute.Reason(journey.InstanceId),
+            new PushStepOptions { SetAsFirstStep = true });
 }

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml
@@ -1,4 +1,4 @@
-@page "/routes/{qualificationId}/delete/reason/{handler?}"
+@page "/routes/{qualificationId}/delete/reason"
 @using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus
 @model TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute.ReasonModel
 @{
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <form method="post">
-            <span class="govuk-caption-l">Delete route - @Model.PersonName</span>
+            <span class="govuk-caption-l">@Model.PageCaption</span>
             <govuk-radios for="ChangeReason" data-testid="reason-options">
                 <govuk-radios-fieldset-legend data-testid="reason-options-legend" class="govuk-fieldset__legend--l" is-page-heading="true">
                     @ViewBag.Title
@@ -54,9 +54,8 @@
 
             <div class="govuk-button-group">
                 <govuk-button type="submit" data-testid="continue-button">Continue</govuk-button>
-                <govuk-button data-testid="cancel-button" formaction="@LinkGenerator.RoutesToProfessionalStatus.DeleteRoute.ReasonCancel(Model.QualificationId, Model.JourneyInstance!.InstanceId)" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
+                <govuk-button data-testid="cancel-button" name="Cancel" value="true" class="govuk-button--secondary" type="submit">Cancel and return to record</govuk-button>
             </div>
         </form>
     </div>
 </div>
-

--- a/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/RoutesToProfessionalStatus/DeleteRoute/Reason.cshtml.cs
@@ -1,14 +1,15 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeachingRecordSystem.SupportUi.Infrastructure.Filters;
 using TeachingRecordSystem.SupportUi.Pages.Persons.PersonDetail.SetStatus;
 using TeachingRecordSystem.SupportUi.Pages.Shared.Evidence;
 
 namespace TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
-[TeachingRecordSystem.WebCommon.FormFlow.Journey(JourneyNames.DeleteRouteToProfessionalStatus), RequireJourneyInstance, CheckRouteToProfessionalStatusExistsFilterFactory()]
-public class ReasonModel(SupportUiLinkGenerator linkGenerator,
+[Journey(JourneyNames.DeleteRouteToProfessionalStatus)]
+public class ReasonModel(
+    DeleteRouteJourneyCoordinator journey,
+    SupportUiLinkGenerator linkGenerator,
     EvidenceUploadManager evidenceUploadManager) : PageModel
 {
     private readonly InlineValidator<ReasonModel> _validator = new()
@@ -19,7 +20,7 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
             .NotEmpty().WithMessage("Enter a reason")
             .When(m => m.ChangeReason == ChangeReasonOption.AnotherReason),
         v => v.RuleFor(m => m.ProvideAdditionalInformation)
-            .NotNull().WithMessage("Select yes if you want to add more information about why you\u2019re deleting this route"),
+            .NotNull().WithMessage("Select yes if you want to add more information about why you’re deleting this route"),
         v => v.RuleFor(m => m.AdditionalInformation)
             .MaximumLength(UiDefaults.ReasonDetailsMaxCharacterCount)
                 .WithMessage($"Additional detail {UiDefaults.ReasonDetailsMaxCharacterCountErrorMessage}"),
@@ -29,15 +30,12 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
         v => v.RuleFor(m => m.Evidence).Evidence()
     };
 
-    public string? PersonName { get; set; }
-    public Guid PersonId { get; private set; }
-    public JourneyInstance<DeleteRouteState>? JourneyInstance { get; set; }
+    public string PageCaption => journey.PageCaption;
 
-    [FromQuery]
-    public bool? FromCheckAnswers { get; set; }
+    public string? BackLink { get; set; }
 
-    [FromRoute]
-    public Guid QualificationId { get; set; }
+    [BindProperty]
+    public bool Cancel { get; set; }
 
     [BindProperty]
     public ChangeReasonOption? ChangeReason { get; set; }
@@ -49,56 +47,50 @@ public class ReasonModel(SupportUiLinkGenerator linkGenerator,
     public string? ChangeReasonDetail { get; set; }
 
     [BindProperty]
-    public EvidenceUploadModel Evidence { get; set; } = new();
-
-    [BindProperty]
     public string? AdditionalInformation { get; set; }
 
-    public string NextPage => linkGenerator.RoutesToProfessionalStatus.DeleteRoute.CheckAnswers(QualificationId, JourneyInstance!.InstanceId);
-
-    public string BackLink => FromCheckAnswers == true
-        ? linkGenerator.RoutesToProfessionalStatus.DeleteRoute.CheckAnswers(QualificationId, JourneyInstance!.InstanceId)
-        : linkGenerator.Persons.PersonDetail.Qualifications(PersonId);
-
-    public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
-    {
-        var personInfo = context.HttpContext.GetCurrentPersonFeature();
-        PersonId = personInfo.PersonId;
-        PersonName = personInfo.Name;
-
-        return next();
-    }
+    [BindProperty]
+    public EvidenceUploadModel Evidence { get; set; } = new();
 
     public void OnGet()
     {
-        ChangeReason = JourneyInstance!.State.ChangeReason;
-        ProvideAdditionalInformation = JourneyInstance.State.ChangeReasonDetail.ProvideAdditionalInformation;
-        ChangeReasonDetail = JourneyInstance.State.ChangeReasonDetail.ChangeReasonDetail;
-        Evidence = JourneyInstance.State.ChangeReasonDetail.Evidence;
-        AdditionalInformation = JourneyInstance.State.ChangeReasonDetail.AdditionalInformation;
+        ChangeReason = journey.State.ChangeReason;
+        ProvideAdditionalInformation = journey.State.ChangeReasonDetail.ProvideAdditionalInformation;
+        ChangeReasonDetail = journey.State.ChangeReasonDetail.ChangeReasonDetail;
+        AdditionalInformation = journey.State.ChangeReasonDetail.AdditionalInformation;
+        Evidence = journey.State.ChangeReasonDetail.Evidence;
     }
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (Cancel)
+        {
+            return Redirect(await journey.CancelAsync());
+        }
+
+        // Upload the evidence file before validating so that it's retained if the form is re-rendered
+        // with errors.
         await evidenceUploadManager.ValidateAndUploadAsync<ReasonModel>(m => m.Evidence, ViewData);
+
         await this.ThrowIfInvalidAsync(_validator);
 
-        await JourneyInstance!.UpdateStateAsync(state =>
-        {
-            state.ChangeReason = ChangeReason;
-            state.ChangeReasonDetail.ProvideAdditionalInformation = ProvideAdditionalInformation;
-            state.ChangeReasonDetail.ChangeReasonDetail = ChangeReasonDetail;
-            state.ChangeReasonDetail.Evidence = Evidence;
-            state.ChangeReasonDetail.AdditionalInformation = AdditionalInformation;
-        });
-
-        return Redirect(NextPage);
+        return journey.AdvanceTo(
+            linkGenerator.RoutesToProfessionalStatus.DeleteRoute.CheckAnswers(journey.InstanceId),
+            state =>
+            {
+                state.ChangeReason = ChangeReason;
+                state.ChangeReasonDetail.ProvideAdditionalInformation = ProvideAdditionalInformation;
+                state.ChangeReasonDetail.ChangeReasonDetail = ChangeReasonDetail;
+                state.ChangeReasonDetail.AdditionalInformation = AdditionalInformation;
+                state.ChangeReasonDetail.Evidence = Evidence;
+            });
     }
 
-    public async Task<IActionResult> OnPostCancelAsync()
+    public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
-        await evidenceUploadManager.DeleteUploadedFileAsync(JourneyInstance!.State.ChangeReasonDetail.Evidence.UploadedEvidenceFile);
-        await JourneyInstance!.DeleteAsync();
-        return Redirect(linkGenerator.Persons.PersonDetail.Qualifications(PersonId));
+        // The reason is the journey's first step, so there's nothing within the journey to go back to.
+        BackLink = journey.GetBackLink() ?? linkGenerator.Persons.PersonDetail.Qualifications(journey.PersonId);
+
+        return base.OnPageHandlerExecutionAsync(context, next);
     }
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/CheckYourAnswersTests.cs
@@ -1,14 +1,13 @@
-using AngleSharp.Html.Dom;
 using TeachingRecordSystem.Core.DataStore.Postgres.Models;
 using TeachingRecordSystem.Core.Events.Legacy;
 using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.DeleteRoute;
 
-public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class CheckYourAnswersTests(HostFixture hostFixture) : DeleteRouteTestBase(hostFixture)
 {
     [Fact]
-    public async Task Cancel_DeletesJourneyAndRedirectsToExpectedPage()
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToExpectedPage()
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
@@ -16,7 +15,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
-        var qualificationid = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
         var deleteRouteState = new DeleteRouteState
         {
             ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
@@ -25,29 +24,55 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationid,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationid}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/qualifications", response.Headers.Location?.OriginalString);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
+
+        await WithDbContextAsync(async dbContext =>
+            Assert.NotNull(await dbContext.RouteToProfessionalStatuses.FirstOrDefaultAsync(p => p.QualificationId == qualificationId)));
+    }
+
+    [Fact]
+    public async Task Get_BackLinkReturnsToReason()
+    {
+        // Arrange
+        var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithRouteToProfessionalStatus(r => r
+                .WithRouteType(route.RouteToProfessionalStatusTypeId)
+                .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
+        var deleteRouteState = new DeleteRouteState
+        {
+            ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
+            ChangeReasonDetail = new ChangeReasonStateBuilder()
+                .WithValidChangeReasonDetail()
+                .Build()
+        };
+
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         var doc = await AssertEx.HtmlResponseAsync(response);
-        var cancelButton = doc.GetElementByTestId("cancel-button") as IHtmlButtonElement;
-
-        // Act
-        var redirectRequest = new HttpRequestMessage(HttpMethod.Post, cancelButton!.FormAction);
-        var redirectResponse = await HttpClient.SendAsync(redirectRequest);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)redirectResponse.StatusCode);
-        var location = redirectResponse.Headers.Location?.OriginalString;
-        Assert.Equal($"/persons/{person.PersonId}/qualifications", location);
-        Assert.Null(await ReloadJourneyInstance(journeyInstance));
+        Assert.Equal(
+            $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}",
+            doc.GetElementByTestId("back-link")!.GetAttribute("href"));
     }
 
     [Fact]
@@ -59,7 +84,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
-        var qualificationid = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
         var deleteRouteState = new DeleteRouteState
         {
             ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
@@ -68,12 +93,9 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationid,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationid}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -111,7 +133,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .WithDegreeTypeId(degreeType.DegreeTypeId)
                 .WithInductionExemption(true)));
 
-        var qualificationid = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
         var deleteRouteState = new DeleteRouteState
         {
             ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
@@ -120,12 +142,9 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationid,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationid}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -154,7 +173,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
-        var qualificationid = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
         var deleteRouteState = new DeleteRouteState
         {
             ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
@@ -163,12 +182,9 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationid,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationid}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -183,8 +199,9 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
     }
 
     [Fact]
-    public async Task Post_Confirm_DeletesRecordCreatesEventCompletesJourneyAndRedirectsWithFlashMessage()
+    public async Task Post_Confirm_DeletesRecordCreatesEventDeletesJourneyAndRedirectsWithFlashMessage()
     {
+        // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).SingleRandom();
 
         var person = await TestData.CreatePersonAsync(p => p
@@ -202,10 +219,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -221,27 +235,25 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
 
         await WithDbContextAsync(async dbContext => Assert.Null(await dbContext.RouteToProfessionalStatuses.FirstOrDefaultAsync(p => p.QualificationId == qualificationId)));
 
-        var RaisedBy = GetCurrentUserId();
-
         EventObserver.AssertEventsSaved(e =>
         {
             var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
 
             Assert.Equal(TimeProvider.UtcNow, deletedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, deletedEvent.PersonId);
-            Assert.Equal(journeyInstance.State.ChangeReason!.GetDisplayName(), deletedEvent.DeletionReason);
-            Assert.Equal(journeyInstance.State.ChangeReasonDetail.ChangeReasonDetail, deletedEvent.DeletionReasonDetail);
+            Assert.Equal(deleteRouteState.ChangeReason!.GetDisplayName(), deletedEvent.DeletionReason);
+            Assert.Equal(deleteRouteState.ChangeReasonDetail.ChangeReasonDetail, deletedEvent.DeletionReasonDetail);
             Assert.Null(deletedEvent.EvidenceFile);
             Assert.Equal(RouteToProfessionalStatusDeletedEventChanges.None, deletedEvent.Changes);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
     public async Task Post_Confirm_WithHoldsQtsRouteTypeUpdatesPersonQtsDateAndHasChangesInEvent()
     {
+        // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
             .SingleRandom();
@@ -263,10 +275,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -277,12 +286,12 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         var updatedPerson = await WithDbContextAsync(dbContext => dbContext.Persons.SingleAsync(p => p.PersonId == person.PersonId));
         Assert.Null(updatedPerson.QtsDate);
 
-        var RaisedByUserId = GetCurrentUserId();
+        var raisedByUserId = GetCurrentUserId();
 
         EventObserver.AssertEventsSaved(e =>
         {
             var deletedEvent = Assert.IsType<RouteToProfessionalStatusDeletedEvent>(e);
-            Assert.Equal(RaisedByUserId, deletedEvent.RaisedBy.UserId);
+            Assert.Equal(raisedByUserId, deletedEvent.RaisedBy.UserId);
             Assert.Equal(TimeProvider.UtcNow, deletedEvent.CreatedUtc);
             Assert.Equal(person.PersonId, deletedEvent.PersonId);
             Assert.Equal(qtsDate, deletedEvent.OldPersonAttributes.QtsDate);
@@ -290,13 +299,13 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             Assert.True(deletedEvent.Changes.HasFlag(RouteToProfessionalStatusDeletedEventChanges.PersonQtsDate));
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Fact]
     public async Task Post_Confirm_WithHoldsQtsRouteType_UpdatesPersonQtsDateWithOlderRouteDateAndHasChangesInEvent()
     {
+        // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .Where(r => r.ProfessionalStatusType == ProfessionalStatusType.QualifiedTeacherStatus)
             .SingleRandom();
@@ -314,7 +323,6 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         EventObserver.Clear();
 
         var qualificationIdEarliestDate = person.Qualifications!.OfType<RouteToProfessionalStatus>().Single(p => p.HoldsFrom == holdsFromEarliest).QualificationId;
-        var qualificationIdLatestDate = person.Qualifications!.OfType<RouteToProfessionalStatus>().Single(p => p.HoldsFrom == holdsFromLatest).QualificationId;
         var deleteRouteState = new DeleteRouteState
         {
             ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
@@ -323,10 +331,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationIdEarliestDate,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationIdEarliestDate, deleteRouteState);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationIdEarliestDate}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -347,8 +352,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             Assert.Equal(RouteToProfessionalStatusDeletedEventChanges.PersonQtsDate, deletedEvent.Changes);
         });
 
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.Completed);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -367,7 +371,7 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
             person.Status = PersonStatus.Deactivated;
             await dbContext.SaveChangesAsync();
         });
-        var qualificationid = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
         var deleteRouteState = new DeleteRouteState
         {
             ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
@@ -376,12 +380,9 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationid,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
-        var request = new HttpRequestMessage(httpMethod, $"/routes/{qualificationid}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -389,10 +390,4 @@ public class CheckYourAnswersTests(HostFixture hostFixture) : TestBase(hostFixtu
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
-
-    private Task<JourneyInstance<DeleteRouteState>> CreateJourneyInstanceAsync(Guid qualificationId, DeleteRouteState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DeleteRouteToProfessionalStatus,
-            state ?? new DeleteRouteState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteTestBase.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/DeleteRouteTestBase.cs
@@ -1,0 +1,27 @@
+using GovUk.Questions.AspNetCore.State;
+using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRoute;
+
+namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.DeleteRoute;
+
+public abstract class DeleteRouteTestBase(HostFixture hostFixture) : TestBase(hostFixture)
+{
+    protected Task<DeleteRouteJourneyCoordinator> CreateJourneyInstanceAsync(Guid qualificationId, DeleteRouteState? state = null) =>
+        // Seed the whole journey path so that any page under test is reachable (the real journey builds
+        // this path up as the user advances through the steps).
+        JourneyHelper.CreateInstanceAsync<DeleteRouteJourneyCoordinator>(
+            JourneyNames.DeleteRouteToProfessionalStatus,
+            new RouteValueDictionary { ["qualificationId"] = qualificationId },
+            _ => Task.FromResult<object>(state ?? new DeleteRouteState()),
+            pathUrls:
+            [
+                $"/routes/{qualificationId}/delete/reason",
+                $"/routes/{qualificationId}/delete/check-answers"
+            ],
+            coordinatorFactory: CreateJourneyCoordinator<DeleteRouteJourneyCoordinator>);
+
+    protected DeleteRouteState? GetJourneyInstanceState(DeleteRouteJourneyCoordinator coordinator)
+    {
+        var stateStorage = HostFixture.Services.GetRequiredService<IJourneyStateStorage>();
+        return (DeleteRouteState?)stateStorage.GetState(coordinator.InstanceId, coordinator.Journey)?.State;
+    }
+}

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/ReasonTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/DeleteRoute/ReasonTests.cs
@@ -6,7 +6,7 @@ using TeachingRecordSystem.SupportUi.Pages.RoutesToProfessionalStatus.DeleteRout
 
 namespace TeachingRecordSystem.SupportUi.Tests.PageTests.RoutesToProfessionalStatus.DeleteRoute;
 
-public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
+public class ReasonTests(HostFixture hostFixture) : DeleteRouteTestBase(hostFixture)
 {
     [Fact]
     public async Task Get_WithPreviouslyStoredChoices_ShowsChoices()
@@ -26,10 +26,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
+
         var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
@@ -81,10 +79,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .Build()
         };
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId, deleteRouteState);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
@@ -113,6 +108,29 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     }
 
     [Fact]
+    public async Task Get_BackLinkReturnsToQualifications()
+    {
+        // Arrange
+        var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
+        var person = await TestData.CreatePersonAsync(p => p
+            .WithRouteToProfessionalStatus(r => r
+                .WithRouteType(route.RouteToProfessionalStatusTypeId)
+                .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
+
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await AssertEx.HtmlResponseAsync(response);
+        Assert.Equal($"/persons/{person.PersonId}/qualifications", doc.GetElementByTestId("back-link")!.GetAttribute("href"));
+    }
+
+    [Fact]
     public async Task Post_SetValidChangeReasonDetails_PersistsDetailsAndRedirects()
     {
         // Arrange
@@ -125,11 +143,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
         var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
-        var deleteRouteState = new DeleteRouteState();
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -146,9 +161,9 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.Equal(changeReason.GetDisplayName(), journeyInstance.State.ChangeReason!.GetDisplayName());
-        Assert.Equal(changeReasonDetails, journeyInstance.State.ChangeReasonDetail.ChangeReasonDetail);
+        var state = GetJourneyInstanceState(journeyInstance);
+        Assert.Equal(changeReason.GetDisplayName(), state!.ChangeReason!.GetDisplayName());
+        Assert.Equal(changeReasonDetails, state.ChangeReasonDetail.ChangeReasonDetail);
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/routes/{qualificationId}/delete/check-answers?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
     }
@@ -163,11 +178,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
         var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
-        var deleteRouteState = new DeleteRouteState();
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -189,6 +201,7 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
     [Fact]
     public async Task Post_AdditionalDetailYes_NoDetailAdded_ReturnsError()
     {
+        // Arrange
         var changeReason = ChangeReasonOption.CreatedInError;
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync()).Where(r => r.Name == "Northern Irish Recognition").Single();
         var person = await TestData.CreatePersonAsync(p => p
@@ -196,11 +209,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
         var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
-        var deleteRouteState = new DeleteRouteState();
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -231,11 +241,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
         var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
-        var deleteRouteState = new DeleteRouteState();
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -266,11 +273,8 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
         var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
-        var deleteRouteState = new DeleteRouteState();
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationId,
-            deleteRouteState
-            );
+
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
         var postRequest = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
         {
@@ -287,50 +291,37 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         var response = await HttpClient.SendAsync(postRequest);
 
         // Assert
-        journeyInstance = await ReloadJourneyInstance(journeyInstance);
-        Assert.True(journeyInstance.State.ChangeReasonDetail.Evidence.UploadEvidence);
-        Assert.Equal(evidenceFileName, journeyInstance.State.ChangeReasonDetail.Evidence.UploadedEvidenceFile!.FileName);
+        var state = GetJourneyInstanceState(journeyInstance);
+        Assert.True(state!.ChangeReasonDetail.Evidence.UploadEvidence);
+        Assert.Equal(evidenceFileName, state.ChangeReasonDetail.Evidence.UploadedEvidenceFile!.FileName);
     }
 
     [Fact]
-    public async Task Cancel_deletesJourneyAndRedirectsToExpectedPage()
+    public async Task Post_Cancel_DeletesJourneyAndRedirectsToExpectedPage()
     {
         // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .SingleRandom();
-        var status = ProfessionalStatusStatusRegistry.All
-            .SingleRandom()
-            .Value;
         var person = await TestData.CreatePersonAsync(p => p
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
                 .WithStatus(RouteToProfessionalStatusStatus.Deferred)));
-        var qualificationid = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
-        var deleteRouteState = new DeleteRouteState();
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationid,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/routes/{qualificationid}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().Add("Cancel", bool.TrueString)
+        };
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        var doc = await AssertEx.HtmlResponseAsync(response);
-        var cancelButton = doc.GetElementByTestId("cancel-button") as IHtmlButtonElement;
-
-        // Act
-        var redirectRequest = new HttpRequestMessage(HttpMethod.Post, cancelButton!.FormAction);
-        var redirectResponse = await HttpClient.SendAsync(redirectRequest);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)redirectResponse.StatusCode);
-        var location = redirectResponse.Headers.Location?.OriginalString;
-        Assert.Equal($"/persons/{person.PersonId}/qualifications", location);
-        Assert.Null(await ReloadJourneyInstance(journeyInstance));
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/persons/{person.PersonId}/qualifications", response.Headers.Location?.OriginalString);
+        Assert.Null(GetJourneyInstanceState(journeyInstance));
     }
 
     [Theory]
@@ -340,9 +331,6 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Arrange
         var route = (await ReferenceDataCache.GetRouteToProfessionalStatusTypesAsync())
             .SingleRandom();
-        var status = ProfessionalStatusStatusRegistry.All
-            .SingleRandom()
-            .Value;
         var person = await TestData.CreatePersonAsync(p => p
             .WithRouteToProfessionalStatus(r => r
                 .WithRouteType(route.RouteToProfessionalStatusTypeId)
@@ -353,15 +341,11 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
             person.Status = PersonStatus.Deactivated;
             await dbContext.SaveChangesAsync();
         });
-        var qualificationid = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
-        var deleteRouteState = new DeleteRouteState();
+        var qualificationId = person.Qualifications!.OfType<RouteToProfessionalStatus>().First().QualificationId;
 
-        var journeyInstance = await CreateJourneyInstanceAsync(
-            qualificationid,
-            deleteRouteState
-            );
+        var journeyInstance = await CreateJourneyInstanceAsync(qualificationId);
 
-        var request = new HttpRequestMessage(httpMethod, $"/routes/{qualificationid}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
+        var request = new HttpRequestMessage(httpMethod, $"/routes/{qualificationId}/delete/reason?{journeyInstance.GetUniqueIdQueryParameter()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -369,10 +353,4 @@ public class ReasonTests(HostFixture hostFixture) : TestBase(hostFixture)
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
-
-    private Task<JourneyInstance<DeleteRouteState>> CreateJourneyInstanceAsync(Guid qualificationId, DeleteRouteState? state = null) =>
-        CreateJourneyInstance(
-            JourneyNames.DeleteRouteToProfessionalStatus,
-            state ?? new DeleteRouteState(),
-            new KeyValuePair<string, object>("qualificationId", qualificationId));
 }

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/PermissionsTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/RoutesToProfessionalStatus/EditRoute/PermissionsTests.cs
@@ -66,29 +66,22 @@ public class PermissionsTests(HostFixture hostFixture) : TestBase(hostFixture), 
         // Arrange
         SetCurrentUser(await TestData.CreateUserAsync(role: userRole));
 
-        JourneyInstance journey = journeyName switch
+        // Edit Route is still on FormFlow, so the two journeys are seeded differently.
+        var journeyQueryParameter = journeyName switch
         {
-            JourneyNames.EditRouteToProfessionalStatus => await CreateJourneyInstance(
-                JourneyNames.EditRouteToProfessionalStatus,
-                new EditRouteStateBuilder()
-                    .WithRouteToProfessionalStatusId(_route!.RouteToProfessionalStatusTypeId)
-                    .WithStatus(_status)
-                    .Build(),
-                new KeyValuePair<string, object>("qualificationId", _qualificationId)),
+            JourneyNames.EditRouteToProfessionalStatus =>
+                (await CreateJourneyInstance(
+                    JourneyNames.EditRouteToProfessionalStatus,
+                    new EditRouteStateBuilder()
+                        .WithRouteToProfessionalStatusId(_route!.RouteToProfessionalStatusTypeId)
+                        .WithStatus(_status)
+                        .Build(),
+                    new KeyValuePair<string, object>("qualificationId", _qualificationId))).GetUniqueIdQueryParameter(),
 
-            _ => await CreateJourneyInstance(
-                JourneyNames.DeleteRouteToProfessionalStatus,
-                new DeleteRouteState
-                {
-                    ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
-                    ChangeReasonDetail = new ChangeReasonStateBuilder()
-                        .WithValidChangeReasonDetail()
-                        .Build()
-                },
-                new KeyValuePair<string, object>("qualificationId", _qualificationId))
+            _ => (await CreateDeleteRouteJourneyInstanceAsync()).GetUniqueIdQueryParameter()
         };
 
-        var page = string.Format(pageFormat, _qualificationId, journey.GetUniqueIdQueryParameter(), _personId);
+        var page = string.Format(pageFormat, _qualificationId, journeyQueryParameter, _personId);
         var request = new HttpRequestMessage(HttpMethod.Get, page);
 
         // Act
@@ -104,6 +97,25 @@ public class PermissionsTests(HostFixture hostFixture) : TestBase(hostFixture), 
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
     }
+
+    // Seeds the whole path so that every Delete Route page is reachable.
+    private Task<DeleteRouteJourneyCoordinator> CreateDeleteRouteJourneyInstanceAsync() =>
+        JourneyHelper.CreateInstanceAsync<DeleteRouteJourneyCoordinator>(
+            JourneyNames.DeleteRouteToProfessionalStatus,
+            new RouteValueDictionary { ["qualificationId"] = _qualificationId },
+            _ => Task.FromResult<object>(new DeleteRouteState
+            {
+                ChangeReason = ChangeReasonOption.RemovedQtlsStatus,
+                ChangeReasonDetail = new ChangeReasonStateBuilder()
+                    .WithValidChangeReasonDetail()
+                    .Build()
+            }),
+            pathUrls:
+            [
+                $"/routes/{_qualificationId}/delete/reason",
+                $"/routes/{_qualificationId}/delete/check-answers"
+            ],
+            coordinatorFactory: CreateJourneyCoordinator<DeleteRouteJourneyCoordinator>);
 
     public static (string JourneyName, string PageFormat, string? UserRole, bool CanViewPage)[] GetData()
     {


### PR DESCRIPTION
### Context

Continues the move off `WebCommon.FormFlow` onto `GovUk.Questions.AspNetCore` (DFE issue #369).
This one is Delete Route to professional status.

Delete Route is the simplest of the three route journeys — a linear walk of Index → Reason →
Check answers — so it follows Add Route (#3685) rather than the hub-and-spoke path model Edit
Route (#3691) needed. Nothing here is novel; it's worth reading mainly for the two things I
deleted rather than ported.

Based on `main`, not on #3691. The only file the two branches share is
`EditRoute/PermissionsTests`, which covers both journeys — see below.

### Changes proposed in this pull request

**`DeleteRouteJourneyCoordinator` holds what the pages shared** — the page caption, the person
id, and `CancelAsync` (delete the uploaded evidence file, drop the instance, return to the
record). `DeleteRouteState` loses `IRegisterJourney`, its `Initialized` flag and its
`IsComplete` computed property, and is now plain data.

**Index is `[StartsJourney]`** and advances to Reason with `SetAsFirstStep`, so Reason is step 0
— its back link is null and falls back to the person's qualifications — and the redirect page
doesn't stay in the path.

**The check answers completeness guard is gone.** Unlike Edit Route, where the detail page is a
hub and the user can go straight to check answers at any point, here the page is reachable only
by posting the reason page, which path validation already enforces. Same reasoning as Add Route,
and the opposite conclusion to Edit Route — worth being explicit about, since the three journeys
now differ on this.

**Cancel is a form field, not a handler.** Both `/cancel` handler routes are gone, and with them
the `{handler?}` segments from the two page routes: the library validates the request URL against
the journey path, so a distinct path or query is an invalid step and redirects forever. The
buttons now POST to the same URL with `name="Cancel" value="true"`.

**Change links use the library's `returnUrl`** in place of the `fromCheckAnswers` flag, so
`DeleteRouteLinkGenerator` drops `qualificationId` from its arguments — scoping route values come
from `InstanceId.RouteValues` — and `CheckAnswers` loads its reference data in
`OnPageHandlerExecutionAsync` rather than a separate `OnGetAsync`.

**`CheckRouteToProfessionalStatusExistsFilterFactory` moves from per-page attributes into the
folder's `Conventions`**, matching Edit Route.

### Guidance to review

**I did not take #3691's `IOrderedFilter`/`-200` change to
`CheckRouteToProfessionalStatusExistsFilter`.** That change exists so Edit Route's coordinator can
seed its state from the route before the journey filter runs. Delete Route's state is just the
reason, so `GetStartingState()` needs nothing from the request, and the filter running at its
default order is fine. Leaving the shared file alone keeps these two branches from touching it —
whichever lands second, that file merges cleanly.

**`EditRoute/PermissionsTests` will conflict with #3691.** It's a single file covering both
journeys' pages, and both branches change how the delete journey is seeded in it. The conflict is
confined to one switch expression; I've kept the change as small as it can be. Whichever merges
second takes the other's Edit Route arm and keeps its own Delete Route arm.

**Test content.** The two page test classes move onto a new `DeleteRouteTestBase` that seeds the
path via `JourneyHelper`; cancel tests POST `Cancel=true` instead of following a `formaction`; and
journey-deletion assertions read `IJourneyStateStorage` rather than `JourneyInstance.Completed`,
since the library has no notion of completing an instance. I added back link coverage for both
pages, which nothing asserted before.

Verified locally:

| Suite | Result |
| --- | --- |
| SupportUi.Tests | 3880 passed, 3 skipped |
| SupportUi.Tests, `RoutesToProfessionalStatus` | 597 passed, 2 skipped |
| SupportUi.EndToEndTests, `RoutesToProfessionalStatus` | 26 passed |

Two flakes worth naming, neither in Delete Route. One E2E run failed
`EditRouteToProfessionalStatusTests.EditEachField_Cya_ShowsEditedContent` on a training provider
name — it passes in isolation and on re-run, and looks like the usual committed-test-data
interaction. One full SupportUi.Tests run reported a single failure whose name I didn't capture
before two subsequent clean full runs.

No emitted events change, so `docs/process-type-events.md` is untouched.

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
