### PR TITLE
Content update to one login verification screen

### DIFF
--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingVerifyOption.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/ResolveOneLoginUserMatchingVerifyOption.cs
@@ -4,7 +4,7 @@ namespace TeachingRecordSystem.SupportUi.Pages.SupportTasks.OneLoginUserMatching
 
 public enum ResolveOneLoginUserMatchingVerifyOption
 {
-    [Display(Name = "Yes, find a matching record")]
+    [Display(Name = "Yes, verify and find a matching record (if applicable)")]
     Verified,
     [Display(Name = "No, reject this request")]
     NotVerified,

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml
@@ -58,7 +58,7 @@
             <govuk-radios for="Verified" data-testid="reason-options">
                 <govuk-radios-fieldset-legend data-testid="reason-options-legend" class="govuk-fieldset__legend--m">Can you verify this person’s identity?</govuk-radios-fieldset-legend>
                 <govuk-radios-item value="@true">
-                    Yes, find a matching record
+                    Yes, verify and find a matching record (if applicable)
                 </govuk-radios-item>
                 <govuk-radios-item value="@false">
                     No, reject this request

--- a/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
+++ b/src/TeachingRecordSystem.SupportUi/Pages/SupportTasks/OneLoginUserMatching/Resolve/Verify.cshtml.cs
@@ -55,13 +55,39 @@ public class VerifyModel(
 
         var resolveLinkGenerator = linkGenerator.SupportTasks.OneLoginUserMatching.Resolve;
 
-        var nextStepUrl = Verified is false ?
-            resolveLinkGenerator.Reject(journey.InstanceId) :
-            string.IsNullOrWhiteSpace(Trn) || journey.State.MatchedPersons.Count == 0 ?
-            resolveLinkGenerator.NoMatches(journey.InstanceId) :
-            resolveLinkGenerator.Matches(journey.InstanceId);
+        // if verification is false Move to reject screen if
+        // if there is only one match Move to confirm screen
+        // if there is 0 matches Move to no matches screen
+        // else move to matches screen
+        string nextStepUrl;
+        if (Verified is false)
+        {
+            nextStepUrl = resolveLinkGenerator.Reject(journey.InstanceId);
+        }
+        else if (journey.State.MatchedPersons.Count == 1)
+        {
+            nextStepUrl = resolveLinkGenerator.ConfirmConnect(journey.InstanceId);
+        }
+        else if (string.IsNullOrWhiteSpace(Trn) || journey.State.MatchedPersons.Count == 0)
+        {
+            nextStepUrl = resolveLinkGenerator.NoMatches(journey.InstanceId);
+        }
+        else
+        {
+            nextStepUrl = resolveLinkGenerator.Matches(journey.InstanceId);
+        }
 
-        return journey.AdvanceTo(nextStepUrl, state => state.Verified = Verified);
+        return journey.AdvanceTo(
+            nextStepUrl,
+            state =>
+            {
+                state.Verified = Verified;
+
+                if (Verified is true && journey.State.MatchedPersons.Count == 1)
+                {
+                    state.MatchedPersonId = journey.State.MatchedPersons.Single().PersonId;
+                }
+            });
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserIdVerificationTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.EndToEndTests/JourneyTests/SupportTasks/OneLoginUserIdVerificationTests.cs
@@ -29,11 +29,7 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
         await page.ClickAsync($".trs-task-link__name{TextIsSelector($"{firstName} {lastName}")}");
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/verify");
 
-        await page.ClickRadioByLabelAsync("Yes, find a matching record");
-        await page.ClickContinueButtonAsync();
-
-        await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches");
-        await page.ClickRadioByLabelAsync("Connect it to Record A", exact: false);
+        await page.ClickRadioByLabelAsync("Yes, verify and find a matching record (if applicable)");
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect");
@@ -60,7 +56,7 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
         await page.ClickAsync($".trs-task-link__name{TextIsSelector($"{firstName} {lastName}")}");
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/verify");
 
-        await page.ClickRadioByLabelAsync("Yes, find a matching record");
+        await page.ClickRadioByLabelAsync("Yes, verify and find a matching record (if applicable)");
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/no-matches");
@@ -72,16 +68,21 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
     [Fact]
     public async Task VerifyAndNotConnecting()
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        var matchedPerson1 = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        await TestData.CreatePersonAsync(p => p
+            .WithFirstName(matchedPerson1.FirstName)
+            .WithLastName(matchedPerson1.LastName)
+            .WithDateOfBirth(matchedPerson1.DateOfBirth!.Value)
+            .WithNationalInsuranceNumber(matchedPerson1.NationalInsuranceNumber!));
 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
 
         var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
             oneLoginUser.Subject, t => t
-                .WithStatedFirstName(matchedPerson.FirstName)
-                .WithStatedLastName(matchedPerson.LastName)
-                .WithStatedDateOfBirth(matchedPerson.DateOfBirth!.Value)
-                .WithStatedTrn(matchedPerson.Trn));
+                .WithStatedFirstName(matchedPerson1.FirstName)
+                .WithStatedLastName(matchedPerson1.LastName)
+                .WithStatedDateOfBirth(matchedPerson1.DateOfBirth!.Value)
+                .WithStatedTrn(matchedPerson1.Trn));
         var taskData = supportTask.GetData<OneLoginUserIdVerificationData>();
         var firstName = taskData.StatedFirstName;
         var lastName = taskData.StatedLastName;
@@ -94,20 +95,11 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
         await page.ClickAsync($".trs-task-link__name{TextIsSelector($"{firstName} {lastName}")}");
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/verify");
 
-        await page.ClickRadioByLabelAsync("Yes, find a matching record");
+        await page.ClickRadioByLabelAsync("Yes, verify and find a matching record (if applicable)");
         await page.ClickContinueButtonAsync();
 
-        await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches");
-        await page.ClickRadioByLabelAsync("Do not connect it to a record");
-        await page.ClickContinueButtonAsync();
-
-        await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/not-connecting");
-        await page.ClickRadioByLabelAsync("There is no matching record");
-        await page.ClickContinueButtonAsync();
-
-        await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-not-connecting");
-        await page.ClickButtonAsync("Confirm and continue");
-
+        await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect");
+        await page.ClickButtonAsync("Cancel");
         await page.WaitForUrlPathAsync("/support-tasks/one-login-user-matching/id-verification");
     }
 
@@ -144,16 +136,21 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
     [Fact]
     public async Task StartVerifyAndComeBackLater()
     {
-        var matchedPerson = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        var matchedPerson1 = await TestData.CreatePersonAsync(p => p.WithNationalInsuranceNumber().WithEmailAddress());
+        await TestData.CreatePersonAsync(p => p.WithFirstName(matchedPerson1.FirstName).WithLastName(matchedPerson1.LastName).WithNationalInsuranceNumber(matchedPerson1.NationalInsuranceNumber!));
+        await TestData.CreatePersonAsync(p => p
+            .WithFirstName(matchedPerson1.FirstName)
+            .WithLastName(matchedPerson1.LastName)
+            .WithDateOfBirth(matchedPerson1.DateOfBirth!.Value)
+            .WithNationalInsuranceNumber(matchedPerson1.NationalInsuranceNumber!));
 
         var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
 
         var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
             oneLoginUser.Subject, t => t
-                .WithStatedFirstName(matchedPerson.FirstName)
-                .WithStatedLastName(matchedPerson.LastName)
-                .WithStatedDateOfBirth(matchedPerson.DateOfBirth!.Value)
-                .WithStatedTrn(matchedPerson.Trn));
+                .WithStatedFirstName(matchedPerson1.FirstName)
+                .WithStatedLastName(matchedPerson1.LastName)
+                .WithStatedDateOfBirth(matchedPerson1.DateOfBirth!.Value));
         var taskData = supportTask.GetData<OneLoginUserIdVerificationData>();
         var firstName = taskData.StatedFirstName;
         var lastName = taskData.StatedLastName;
@@ -166,7 +163,7 @@ public class OneLoginUserIdVerificationTests(HostFixture hostFixture) : TestBase
         await page.ClickAsync($".trs-task-link__name{TextIsSelector($"{firstName} {lastName}")}");
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/verify");
 
-        await page.ClickRadioByLabelAsync("Yes, find a matching record");
+        await page.ClickRadioByLabelAsync("Yes, verify and find a matching record (if applicable)");
         await page.ClickContinueButtonAsync();
 
         await page.WaitForUrlPathAsync($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches");

--- a/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
+++ b/tests/TeachingRecordSystem.SupportUi.Tests/PageTests/SupportTasks/OneLoginUserMatching/Resolve/VerifyTests.cs
@@ -37,6 +37,7 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
         Assert.Equal(oneLoginUser.EmailAddress, doc.GetSummaryListValueByKey("Email address"));
         Assert.Equal(TrnHelper.NormalizeTrn(requestData.StatedTrn), doc.GetSummaryListValueByKey("TRN"));
         Assert.Equal(CoreNationalInsuranceNumber.Normalize(requestData.StatedNationalInsuranceNumber), doc.GetSummaryListValueByKey("National Insurance number"));
+        Assert.Contains("Yes, verify and find a matching record (if applicable)", doc.Body!.TextContent);
         if (evidenceIsPdf)
         {
             Assert.NotNull(doc.GetElementByTestId($"pdf-{requestData.EvidenceFileId}"));
@@ -224,7 +225,7 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
     }
 
     [Fact]
-    public async Task Post_VerifiedIsTrueAndMatches_UpdatesStateAndRedirectsToMatchesPage()
+    public async Task Post_VerifiedIsTrueAndOneMatch_UpdatesStateAndRedirectsToConfirmConnectPage()
     {
         // Arrange
         var matchedPerson = await TestData.CreatePersonAsync();
@@ -264,10 +265,69 @@ public class VerifyTests(HostFixture hostFixture) : ResolveOneLoginUserMatchingT
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/confirm-connect?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
+
+        var journeyState = GetJourneyInstanceState(journeyInstance);
+        Assert.True(journeyState!.Verified);
+        Assert.Equal(matchedPerson.PersonId, journeyState.MatchedPersonId);
+    }
+
+    [Fact]
+    public async Task Post_VerifiedIsTrueAndMultipleMatches_UpdatesStateAndRedirectsToMatchesPage()
+    {
+        // Arrange
+        var matchedPerson1 = await TestData.CreatePersonAsync();
+        var matchedPerson2 = await TestData.CreatePersonAsync();
+        var oneLoginUser = await TestData.CreateOneLoginUserAsync(verified: false);
+        var supportTask = await TestData.CreateOneLoginUserIdVerificationSupportTaskAsync(
+            oneLoginUser.Subject, t => t
+                .WithStatedFirstName(matchedPerson1.FirstName)
+                .WithStatedLastName(matchedPerson1.LastName)
+                .WithStatedDateOfBirth(matchedPerson1.DateOfBirth!.Value)
+                .WithStatedTrn(matchedPerson1.Trn!));
+
+        var journeyInstance = await CreateJourneyInstanceWithMatchedPersonsAsync(
+            supportTask,
+            configureState: null,
+            new MatchPersonResult(
+                matchedPerson1.PersonId,
+                matchedPerson1.Trn,
+                [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson1.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson1.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson1.DateOfBirth!.Value.ToString("yyyy-MM-dd")),
+                    KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson1.Trn)
+                ]),
+            new MatchPersonResult(
+                matchedPerson2.PersonId,
+                matchedPerson2.Trn,
+                [
+                    KeyValuePair.Create(PersonMatchedAttribute.FirstName, matchedPerson2.FirstName),
+                    KeyValuePair.Create(PersonMatchedAttribute.LastName, matchedPerson2.LastName),
+                    KeyValuePair.Create(PersonMatchedAttribute.DateOfBirth, matchedPerson2.DateOfBirth!.Value.ToString("yyyy-MM-dd")),
+                    KeyValuePair.Create(PersonMatchedAttribute.Trn, matchedPerson2.Trn)
+                ]));
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/verify?{journeyInstance.GetUniqueIdQueryParameter()}")
+        {
+            Content = new FormUrlEncodedContentBuilder
+            {
+                { "Verified", "True" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/support-tasks/one-login-user-matching/{supportTask.SupportTaskReference}/resolve/matches?{journeyInstance.GetUniqueIdQueryParameter()}", response.Headers.Location?.OriginalString);
 
         var journeyState = GetJourneyInstanceState(journeyInstance);
         Assert.True(journeyState!.Verified);
+        Assert.Null(journeyState.MatchedPersonId);
     }
 
     [Fact]


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/teaching-record-team-project-board/issues/396

content update to one login verification screen.
- Change radio button wording for yes.
- Update advance to next screen login, 
  -  If there is one match, skip the matches screen.
  - if there is more than one match, progress to matches screen as it already did.

### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally